### PR TITLE
Prevent duplicate events within a level

### DIFF
--- a/src/core/events/EventSystem.ts
+++ b/src/core/events/EventSystem.ts
@@ -26,6 +26,8 @@ export interface EventSystemState {
   pendingEvent: FiredEvent | null;
   /** Queue of follow-up events to fire. */
   followUpQueue: string[];
+  /** IDs of events that have already fired this level — each fires at most once. */
+  firedEventIds: string[];
 }
 
 export interface FiredEvent {
@@ -43,6 +45,7 @@ export function createEventSystemState(): EventSystemState {
     })),
     pendingEvent: null,
     followUpQueue: [],
+    firedEventIds: [],
   };
 }
 
@@ -63,11 +66,14 @@ export function tickEventSystem(
   // Don't fire new events while one is pending
   if (state.pendingEvent) return null;
 
-  // Check follow-up queue first
-  if (state.followUpQueue.length > 0) {
+  // Check follow-up queue first, skipping already-fired events
+  while (state.followUpQueue.length > 0) {
     const eventId = state.followUpQueue.shift()!;
-    state.pendingEvent = { eventId, firedAtTick: ctx.tickCount };
-    return state.pendingEvent;
+    if (!state.firedEventIds.includes(eventId)) {
+      state.firedEventIds.push(eventId);
+      state.pendingEvent = { eventId, firedAtTick: ctx.tickCount };
+      return state.pendingEvent;
+    }
   }
 
   for (const timer of state.timers) {
@@ -77,9 +83,10 @@ export function tickEventSystem(
       // Reset timer with score-modulated interval
       timer.remaining = getModulatedInterval(timer.category, ctx.scores, timer.baseInterval);
 
-      // Try to fire an event from this category
-      const event = selectEvent(timer.category, ctx, rng);
+      // Try to fire an event from this category (already-fired events excluded)
+      const event = selectEvent(timer.category, ctx, rng, state.firedEventIds);
       if (event) {
+        state.firedEventIds.push(event.id);
         state.pendingEvent = { eventId: event.id, firedAtTick: ctx.tickCount };
         return state.pendingEvent;
       }
@@ -109,9 +116,10 @@ export function selectEvent(
   category: EventCategory,
   ctx: EventContext,
   rng: Random,
+  firedEventIds: string[] = [],
 ): EventDef | null {
   const events = getEventsByCategory(category);
-  const available = events.filter(e => e.canFire(ctx));
+  const available = events.filter(e => !firedEventIds.includes(e.id) && e.canFire(ctx));
 
   if (available.length === 0) return null;
 

--- a/src/core/state/SaveLoad.ts
+++ b/src/core/state/SaveLoad.ts
@@ -71,5 +71,11 @@ export function deserialize(json: string): GameState {
     }
   }
 
+  // Ensure firedEventIds exists for saves created before it was added
+  const eventsRaw = obj['events'] as Record<string, unknown> | undefined;
+  if (eventsRaw && !Array.isArray(eventsRaw['firedEventIds'])) {
+    eventsRaw['firedEventIds'] = [];
+  }
+
   return obj as unknown as GameState;
 }

--- a/tests/unit/events/EventSystem.test.ts
+++ b/tests/unit/events/EventSystem.test.ts
@@ -124,6 +124,67 @@ describe('Event system engine', () => {
     expect(selected?.id).toBe('open');
   });
 
+  it('same event cannot fire twice in a level', () => {
+    registerEvents([makeEvent('once_only', 'union')]);
+    const state = createEventSystemState();
+    const unionTimer = state.timers.find(t => t.category === 'union')!;
+
+    // Fire the event once
+    unionTimer.remaining = 1;
+    const first = tickEventSystem(state, makeCtx(), new Random(42));
+    expect(first?.eventId).toBe('once_only');
+    clearPendingEvent(state);
+
+    // Attempt to fire again
+    unionTimer.remaining = 1;
+    const second = tickEventSystem(state, makeCtx(), new Random(42));
+    expect(second).toBeNull();
+    expect(state.firedEventIds).toContain('once_only');
+  });
+
+  it('firedEventIds survives JSON round-trip (save/load)', () => {
+    const state = createEventSystemState();
+    state.firedEventIds.push('persist_test');
+
+    const serialized = JSON.stringify(state);
+    const restored = JSON.parse(serialized) as typeof state;
+    expect(restored.firedEventIds).toEqual(['persist_test']);
+  });
+
+  it('follow-up events are also deduplicated', () => {
+    registerEvents([makeEvent('followup_ev', 'union')]);
+    const state = createEventSystemState();
+
+    // Queue the follow-up twice
+    queueFollowUp(state, 'followup_ev');
+    queueFollowUp(state, 'followup_ev');
+
+    const first = tickEventSystem(state, makeCtx(), new Random(42));
+    expect(first?.eventId).toBe('followup_ev');
+    clearPendingEvent(state);
+
+    // Second attempt should be skipped (already fired)
+    const second = tickEventSystem(state, makeCtx(), new Random(42));
+    expect(second).toBeNull();
+  });
+
+  it('firedEventIds resets to empty on createEventSystemState', () => {
+    const state = createEventSystemState();
+    expect(state.firedEventIds).toEqual([]);
+  });
+
+  it('selectEvent excludes already-fired events', () => {
+    registerEvents([
+      makeEvent('fired_ev', 'union'),
+      makeEvent('fresh_ev', 'union'),
+    ]);
+    const ctx = makeCtx();
+    const rng = new Random(42);
+
+    const result = selectEvent('union', ctx, rng, ['fired_ev']);
+    expect(result?.id).toBe('fresh_ev');
+  });
+
   it('timer reset interval depends on player scores', () => {
     registerEvents([makeEvent('test1', 'union')]);
     const state = createEventSystemState();


### PR DESCRIPTION
Each event can now fire at most once per level. `EventSystemState` gains
a `firedEventIds: string[]` field that records every event ID the moment
it fires (from a timer or from the follow-up queue). `selectEvent` and
the follow-up dispatch both skip any event whose ID is already in that
list. Because `firedEventIds` lives inside `GameState`, it is fully
serialised on save and restored on load, so the constraint survives a
save/reload cycle. Starting a new level calls `createEventSystemState()`
which initialises an empty list, resetting the constraint cleanly.

https://claude.ai/code/session_01SVrxn2kyhAGW9jHFWBU6sa