### PR TITLE
fix(pipeline): tighten skeleton_writer prompt to prevent full impl over-delivery

### DIFF
--- a/.langgraph/nodes/skeleton_writer.py
+++ b/.langgraph/nodes/skeleton_writer.py
@@ -99,6 +99,11 @@ def _build_context(state: dict) -> str:
         "TASK: Write EMPTY TypeScript stubs only. No implementation logic.",
         "- Add exported function/class/interface skeletons to the correct src/ files.",
         "- Each stub body must be `throw new Error('not implemented')` or `return undefined`.",
+        "- For constants: use `undefined as any` or `0 // TODO` — never the real value.",
+        "- Do NOT add JSDoc, comments or documentation strings.",
+        "- Do NOT write test code (no describe/it/expect blocks).",
+        "- Do NOT restore deleted code — the implementer will do that.",
+        "- Only touch files listed in the issue's `files` field.",
         "- Do NOT write any real logic. Do NOT write tests.",
         "- Commit nothing — the graph will commit after you finish.",
     ]


### PR DESCRIPTION
The skeleton_writer agent was told to write empty stubs only, but for simple issues it consistently wrote full implementations (restoring deleted constants with real values, writing test assertions, adding JSDoc/documentation, modifying unrelated files).

This left the downstream test_writer and implementer agents with nothing to do, producing PRs with only 2 commits (skeleton + empty cherry-pick) instead of the expected 4-5.

**Fix:** Added explicit prohibitions to the skeleton_writer prompt:
- For constants: use `undefined as any` or `0 // TODO` — never the real value
- Do NOT add JSDoc, comments or documentation strings
- Do NOT write test code (no describe/it/expect blocks)
- Do NOT restore deleted code — the implementer will do that
- Only touch files listed in the issue's `files` field

Closes the underlying pipeline issue observed in PRs #163 and #164.