### PR TITLE
fix: replace copilot swe agent assignment with langgraph dispatch in …

### DIFF
--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -97,7 +97,7 @@ Post **exactly** this as **last action** — nothing after:
 APPROVED
 ```
 
-Triggers `auto-merge-copilot.yml` → squash-merge. No push, edit, or tool call after APPROVED.
+Triggers `langgraph-agent.yml` → PR merge. No push, edit, or tool call after APPROVED.
 
 ## Key References
 

--- a/.github/skills/autonomous-pipeline/SKILL.md
+++ b/.github/skills/autonomous-pipeline/SKILL.md
@@ -1,32 +1,28 @@
 ---
 name: autonomous-pipeline
 description: >
-  Guide for the fully autonomous AI development pipeline using GitHub Copilot: repository settings,
-  automation workflows, code review strategy, issue management, budget, and troubleshooting.
+  Guide for the fully autonomous AI development pipeline using LangGraph: repository settings,
+  automation workflows, code review strategy, issue management, and troubleshooting.
   Use when setting up, debugging, or modifying the CI/CD automation pipeline.
 ---
 
 ## Pipeline Flow
 
-`ready` label → **auto-assign-next.yml** assigns issue to @copilot → coding agent reads instructions + runs CI + opens PR → **Copilot code review**: pass → auto-approve + squash-merge + close issue + assign next `ready`; fail → comment `@copilot fix X` or label `blocked` → human review.
+`ready` label → **scheduled-assign.yml** (manual) or **auto-assign-next.yml** (PR merge) dispatches **langgraph-agent.yml** → LangGraph agent runs TDD pipeline (plan → tests → implement → review → PR) → PR merged → next `ready` issue auto-assigned.
 
 ## Repository Settings (One-Time Setup)
 
-1. **Enable Copilot Coding Agent:** Settings → Copilot → Coding agent → Enable
-2. **Disable CI Approval Requirement:** Settings → Copilot → Coding agent → Actions workflow approval → Disable "Require approval"
-3. **Enable Auto-Merge:** Settings → General → Pull Requests → Allow auto-merge
-4. **Enable Copilot Code Review:** Settings → Copilot → Code review → Enable + ruleset requiring Copilot review on `main`
-5. **Workflow Permissions:** Settings → Actions → General → Read and write + Allow create/approve PRs
-6. **PAT Token:** Fine-grained PAT with Issues, Pull requests, Contents permissions → store as `PAT_TOKEN_COPILOT_AUTOMATION` secret
+1. **Workflow Permissions:** Settings → Actions → General → Read and write + Allow create/approve PRs
+2. **Enable Auto-Merge:** Settings → General → Pull Requests → Allow auto-merge
 
 ## Automation Workflows
 
 | Workflow | File | Trigger | Purpose |
 |----------|------|---------|---------|
-| Auto-assign next | `auto-assign-next.yml` | PR closed (merged) | Close done issue, assign next `ready` issue to Copilot |
-| Auto-merge | `auto-merge-copilot.yml` | CI completed **or** Copilot agent check run completed **or** PR comment created **or** manual dispatch | Auto-approve + squash-merge passing Copilot PRs |
+| Auto-assign next | `auto-assign-next.yml` | PR closed (merged) | Close done issue, dispatch LangGraph for next `ready` issue |
 | Handle failure | `handle-failure.yml` | Issue labeled `blocked` | Comment + notify maintainer |
-| Manual kickstart | `scheduled-assign.yml` | Manual dispatch only | Kick off pipeline manually |
+| Manual kickstart | `scheduled-assign.yml` | Manual dispatch only | Kick off LangGraph pipeline manually |
+| LangGraph agent | `langgraph-agent.yml` | Issue comment (`@langgraph`) or workflow dispatch | Run the autonomous TDD pipeline |
 | CI | `ci.yml` | Push / PR | Standard CI checks |
 | Setup steps | `copilot-setup-steps.yml` | Agent session | Pre-install dependencies for agent |
 
@@ -52,25 +48,6 @@ Review flow:
 
 `APPROVED` comment is session termination signal. Nothing must follow it.
 
-### Merge Loop (closed-loop, fully autonomous)
-
-```
-Agent posts APPROVED comment
-  → issue_comment:created fires immediately (most reliable path)
-  → auto-merge-copilot.yml wakes up
-  → verifies CI green + no agent running → squash-merge
-
-Fallback paths (if issue_comment trigger misses):
-  → check_run:completed fires when agent session ends (app 1143301)
-  → workflow_run:completed fires when CI passes (defers if agent still running)
-  → workflow_dispatch: maintainer triggers manually from Actions tab
-```
-
-**Agent-still-running guard** runs on ALL paths (including draft PRs) to prevent the review
-request from firing while the implementation session is still active.
-
-Review is only requested AFTER the agent session ends — not on the first CI pass.
-
 ## Writing Good Issues
 
 As **Customer**: Write "what" + "why"
@@ -78,27 +55,15 @@ As **Lead Developer**: Write "how" + testing commands
 
 Better issues → more autonomous pipeline. Use agent-task template.
 
-## Budget (Copilot Pro $10/mo)
-
-- ~100-150 tasks/month with 300 premium requests
-- Public repos: unlimited Actions minutes
-- Extra requests: $0.04 each
-
 ## Security Notes
 
 - CI auto-approval means unreviewed code runs Actions. Scope secrets tightly.
-- Auto-merge safety net = required Copilot code review
 - Use fine-grained PAT scoped to this repo only
-- Coding agent only pushes to `copilot/*` branches
 
 ## Troubleshooting
 
 | Problem | Solution |
 |---------|----------|
-| Agent doesn't pick up issue | Verify coding agent enabled, issue assigned to `copilot`, check quota |
-| CI requires manual approval | Disable "Require approval" in Copilot settings |
-| Auto-merge doesn't fire | Enable auto-merge in settings, verify PAT has `contents: write`; use `workflow_dispatch` as escape hatch |
-| Review comment posted too early | Guard in workflow prevents this — review is only requested after agent session ends (agent-still-running check runs before draft block) |
 | Pipeline stalls | Manually trigger scheduled-assign.yml from Actions tab |
 | Agent keeps failing | Label `blocked`, review logs, add context, consider splitting task |
 | PR doesn't reference issue | Ensure instructions stress "Closes #<number>" in PR body |

--- a/.github/workflows/auto-assign-next.yml
+++ b/.github/workflows/auto-assign-next.yml
@@ -1,29 +1,23 @@
-name: "Pipeline: assign next issue to Copilot"
+name: "Pipeline: assign next issue to LangGraph"
 
 on:
   pull_request:
     types: [closed]
 
-permissions: {}
+permissions:
+  issues: write
+  contents: write
+  actions: write
 
 jobs:
   chain-next-task:
-    # Temporarily disabled — set back to `github.event.pull_request.merged == true` to re-enable
-    if: false
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - name: Check PAT_TOKEN_COPILOT_AUTOMATION is configured
-        env:
-          TOKEN: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
-        run: |
-          if [ -z "$TOKEN" ]; then
-            echo "::error::PAT_TOKEN_COPILOT_AUTOMATION secret is not set. Add it in Settings → Secrets → Actions."
-            exit 1
-          fi
-      - name: Close done issue + assign next to Copilot
+      - name: Close done issue + assign next ready issue to LangGraph
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -40,12 +34,6 @@ jobs:
             const n = issueNum ? parseInt(issueNum) : null;
             if (n) {
               console.log(`Updating labels for issue #${n} (closed by native GitHub auto-close).`);
-
-              // Note: we do NOT call issues.update(state:'closed') here.
-              // The PR body contains "Closes #N", so GitHub natively closes the issue on merge.
-              // Calling the API explicitly was redundant and caused double-close race conditions.
-              // This workflow only manages labels and pipeline state (backlog + next assignment).
-
               await github.rest.issues.addLabels({ owner, repo, issue_number: n, labels: ['done'] }).catch(() => {});
               await github.rest.issues.removeLabel({ owner, repo, issue_number: n, name: 'in-progress' }).catch(() => {});
             }
@@ -115,8 +103,8 @@ jobs:
                 }
               }
 
-              // Assign to Copilot
-              console.log(`Assigning #${issue.number} to Copilot.`);
+              // Label as in-progress
+              console.log(`Assigning #${issue.number} to LangGraph pipeline.`);
               await github.rest.issues.removeLabel({
                 owner, repo,
                 issue_number: issue.number,
@@ -128,21 +116,24 @@ jobs:
                 labels: ['in-progress']
               });
 
-              // Assign Copilot coding agent to the issue
-              await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/assignees', {
+              // Acknowledge on the issue
+              await github.rest.issues.createComment({
                 owner, repo,
                 issue_number: issue.number,
-                assignees: ['copilot-swe-agent[bot]'],
-                agent_assignment: {
-                  target_repo: `${owner}/${repo}`,
-                  base_branch: 'main',
-                  custom_instructions: '',
-                  custom_agent: '',
-                  model: ''
-                },
-                headers: { 'X-GitHub-Api-Version': '2022-11-28' }
+                body: `🤖 LangGraph agent picking this up (chained from merged PR #${context.payload.pull_request.number})…`
               });
-              console.log(`Issue #${issue.number} assigned to Copilot coding agent.`);
+
+              // Dispatch the LangGraph pipeline workflow
+              await github.rest.actions.createWorkflowDispatch({
+                owner, repo,
+                workflow_id: 'langgraph-agent.yml',
+                ref: 'main',
+                inputs: {
+                  issue_number: String(issue.number),
+                  comment_body: 'auto-assigned from merged PR'
+                }
+              });
+              console.log(`LangGraph pipeline dispatched for issue #${issue.number}.`);
 
               return; // Only assign one at a time
             }

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,11 +1,11 @@
-name: "Copilot Setup Steps"
+name: "Setup Steps"
 on: workflow_dispatch
 
 permissions:
   contents: read
 
 jobs:
-  copilot-setup-steps:
+  setup-steps:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/handle-failure.yml
+++ b/.github/workflows/handle-failure.yml
@@ -3,11 +3,9 @@ name: "Pipeline: handle agent failure"
 on:
   issues:
     types: [labeled]
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
 
-permissions: {}
+permissions:
+  issues: write
 
 jobs:
   notify:
@@ -17,86 +15,20 @@ jobs:
       - name: Comment and notify
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
               body: [
-                '🚨 **Pipeline paused — agent blocked on this issue.**',
+                '🚨 **Pipeline paused — LangGraph agent blocked on this issue.**',
                 '',
                 '@Nico2398 — please review:',
                 '1. The PR and agent session logs',
                 '2. Add clarification to this issue',
-                '3. Remove `blocked`, add `ready`, and re-assign to `copilot` to resume',
+                '3. Remove `blocked`, add `ready`, and trigger the kickstart workflow to resume',
                 '',
                 'Or complete the task manually and the pipeline will auto-continue on merge.'
               ].join('\n')
             });
-
-  ci-failure-fix:
-    name: Re-engage Copilot on CI failure
-    if: |
-      github.event_name == 'workflow_run' &&
-      github.event.workflow_run.conclusion == 'failure' &&
-      github.event.workflow_run.head_branch != 'main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Comment on PR to trigger Copilot fix
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const prs = context.payload.workflow_run.pull_requests;
-
-            if (!prs || prs.length === 0) {
-              console.log('No PRs associated with this failed CI run.');
-              return;
-            }
-
-            const prNumber = prs[0].number;
-            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
-
-            const expectedAuthors = ['copilot[bot]', 'github-copilot[bot]', 'Copilot'];
-            if (!expectedAuthors.includes(pr.user.login)) {
-              console.log(`PR #${prNumber} not by Copilot (author: ${pr.user.login}), skipping.`);
-              return;
-            }
-            if (!pr.head.ref.startsWith('copilot/')) {
-              console.log(`Branch ${pr.head.ref} is not a Copilot branch, skipping.`);
-              return;
-            }
-            if (pr.merged || pr.state === 'closed') {
-              console.log(`PR #${prNumber} already merged/closed, skipping.`);
-              return;
-            }
-
-            // Guard: skip if the Copilot agent session is still running.
-            // Posting a new @copilot comment while a session is active would spawn
-            // a second concurrent session — the running one will observe CI itself.
-            const COPILOT_SWE_APP_ID = 1143301;
-            const { data: checksData } = await github.rest.checks.listForRef({
-              owner, repo,
-              ref: context.payload.workflow_run.head_sha,
-              app_id: COPILOT_SWE_APP_ID,
-              per_page: 100
-            });
-            const activeStatuses = new Set(['queued', 'in_progress', 'waiting', 'requested']);
-            const agentStillRunning = checksData.check_runs.some(run =>
-              activeStatuses.has(run.status)
-            );
-            if (agentStillRunning) {
-              console.log(`Copilot agent session still active on PR #${prNumber}. Skipping — the running session will handle CI.`);
-              return;
-            }
-
-            const runUrl = context.payload.workflow_run.html_url;
-            await github.rest.issues.createComment({
-              owner, repo,
-              issue_number: prNumber,
-              body: `@copilot CI is failing on this PR. Please investigate the failure and push a fix: ${runUrl}`
-            });
-            console.log(`Posted CI failure comment on PR #${prNumber}`);

--- a/.github/workflows/scheduled-assign.yml
+++ b/.github/workflows/scheduled-assign.yml
@@ -3,24 +3,18 @@ name: "Pipeline: scheduled kickstart"
 on:
   workflow_dispatch:  # manual trigger only
 
-permissions: {}
+permissions:
+  issues: write
+  actions: write
 
 jobs:
   kickstart:
     runs-on: ubuntu-latest
     steps:
-      - name: Check PAT_TOKEN_COPILOT_AUTOMATION is configured
-        env:
-          TOKEN: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
-        run: |
-          if [ -z "$TOKEN" ]; then
-            echo "::error::PAT_TOKEN_COPILOT_AUTOMATION secret is not set. Add it in Settings → Secrets → Actions."
-            exit 1
-          fi
       - name: Check for idle ready issues
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -66,7 +60,7 @@ jobs:
                 }
               }
 
-              console.log(`Kickstarting pipeline with issue #${issue.number}`);
+              console.log(`Kickstarting LangGraph pipeline with issue #${issue.number}`);
 
               await github.rest.issues.removeLabel({
                 owner, repo,
@@ -79,23 +73,26 @@ jobs:
                 labels: ['in-progress']
               });
 
-              // Assign Copilot coding agent to the issue
-              await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/assignees', {
+              // Acknowledge on the issue
+              await github.rest.issues.createComment({
                 owner, repo,
                 issue_number: issue.number,
-                assignees: ['copilot-swe-agent[bot]'],
-                agent_assignment: {
-                  target_repo: `${owner}/${repo}`,
-                  base_branch: 'main',
-                  custom_instructions: '',
-                  custom_agent: '',
-                  model: ''
-                },
-                headers: { 'X-GitHub-Api-Version': '2022-11-28' }
+                body: `🤖 LangGraph agent picking this up via scheduled kickstart…`
               });
-              console.log(`Issue #${issue.number} assigned to Copilot coding agent.`);
 
-              return; // Only assign one at a time
+              // Dispatch the LangGraph pipeline workflow
+              await github.rest.actions.createWorkflowDispatch({
+                owner, repo,
+                workflow_id: 'langgraph-agent.yml',
+                ref: 'main',
+                inputs: {
+                  issue_number: String(issue.number),
+                  comment_body: 'scheduled kickstart'
+                }
+              });
+              console.log(`LangGraph pipeline dispatched for issue #${issue.number}.`);
+
+              return; // Only start one at a time
             }
 
             console.log('No assignable ready issues (all have unmet dependencies). Pipeline idle.');


### PR DESCRIPTION
…kickstart workflows

- scheduled-assign.yml: remove copilot-swe-agent[bot] assignment, dispatch langgraph-agent.yml workflow_dispatch instead, fix permissions
- auto-assign-next.yml: same treatment, re-enable (was if: false)
- handle-failure.yml: remove ci-failure-fix job (copilot-specific), update notify job for langgraph pipeline
- copilot-setup-steps.yml: rename to generic setup steps
- autonomous-pipeline/SKILL.md: replace copilot references with langgraph
- reviewer.agent.md: update merge trigger reference