### PR TITLE
restore(pipeline): bring back distinct assignment + agent-start comments

### DIFF
--- a/.github/workflows/agentic-trigger.yml
+++ b/.github/workflows/agentic-trigger.yml
@@ -74,11 +74,11 @@ jobs:
                 labels: ['in-progress']
               });
 
-              // Acknowledge on the issue
+              // Acknowledge assignment on the issue
               await github.rest.issues.createComment({
                 owner, repo,
                 issue_number: issue.number,
-                body: '🤖 Agent picking this up via manual trigger…'
+                body: '⚙️ Assigned via manual trigger'
               });
 
               // Dispatch the agent pipeline workflow

--- a/.github/workflows/auto-assign-next.yml
+++ b/.github/workflows/auto-assign-next.yml
@@ -145,15 +145,22 @@ jobs:
                 labels: ['in-progress']
               });
 
+              // Acknowledge assignment on the issue
+              await github.rest.issues.createComment({
+                owner, repo,
+                issue_number: issue.number,
+                body: `⚙️ Auto-assigned from merged PR #${context.payload.pull_request.number}`
+              });
+
               // Dispatch the LangGraph pipeline workflow
               await github.rest.actions.createWorkflowDispatch({
                 owner, repo,
                 workflow_id: 'langgraph-agent.yml',
                 ref: 'main',
-                inputs: {
-                  issue_number: String(issue.number),
-                  comment_body: 'auto-assigned from merged PR'
-                }
+                 inputs: {
+                   issue_number: String(issue.number),
+                   comment_body: `auto-assigned from merged PR #${context.payload.pull_request.number}`
+                 }
               });
               console.log(`LangGraph pipeline dispatched for issue #${issue.number}.`);
 


### PR DESCRIPTION
- auto-assign: '⚙️ Auto-assigned from merged PR #N' (assignment trigger with link)
- manual: '⚙️ Assigned via manual trigger' (assignment trigger)
- langgraph-agent: '👀 LangGraph agent picking this up…' (agent work start)

Also passes full PR link info in comment_body input to runner.

This restores 2-comment pattern from before f727181 but with non-overlapping content: one about assignment/trigger context, one about agent work beginning.