### PR TITLE
fix: gate AGENTIC_AUTO_ASSIGN_ENABLED on auto-assign only, not manual…

### DIFF
--- a/.github/workflows/agentic-trigger.yml
+++ b/.github/workflows/agentic-trigger.yml
@@ -9,7 +9,6 @@ permissions:
 
 jobs:
   kickstart:
-    if: vars.LANGGRAPH_AUTO_ASSIGN_ENABLED != 'false'
     runs-on: ubuntu-latest
     steps:
       - name: Check for idle ready issues

--- a/.github/workflows/auto-assign-next.yml
+++ b/.github/workflows/auto-assign-next.yml
@@ -11,11 +11,13 @@ permissions:
 
 jobs:
   chain-next-task:
-    if: github.event.pull_request.merged == true && vars.LANGGRAPH_AUTO_ASSIGN_ENABLED != 'false' && github.event.pull_request.user.type == 'Bot'
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Close done issue + assign next ready issue to LangGraph
         uses: actions/github-script@v7
+        env:
+          AGENTIC_AUTO_ASSIGN_ENABLED: ${{ vars.AGENTIC_AUTO_ASSIGN_ENABLED }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -28,7 +30,7 @@ jobs:
             const issueNum = closesMatch?.[1];
 
             if (!issueNum) {
-              console.log('No explicit close directive found in PR body. Skipping issue close — will still assign next ready issue.');
+              console.log('No explicit close directive found in PR body. Skipping issue close.');
             }
 
             const n = issueNum ? parseInt(issueNum) : null;
@@ -78,93 +80,102 @@ jobs:
               console.log('No backlog-id in issue body — skipping backlog update.');
             }
 
-            // --- 2.5 Check for stalled in-progress issues ---
-            const { data: inProgress } = await github.rest.issues.listForRepo({
-              owner, repo,
-              labels: 'in-progress',
-              state: 'open',
-              per_page: 10
-            });
+            // --- Auto-assign next issue (only when enabled + bot PR) ---
+            const autoAssignEnabled = (process.env.AGENTIC_AUTO_ASSIGN_ENABLED || 'false') === 'true';
+            const isBot = context.payload.pull_request.user.type === 'Bot';
 
-            for (const stuck of inProgress) {
-              if (stuck.number === n) continue;
-
-              const { data: events } = await github.rest.issues.listEventsForTimeline({
+            if (autoAssignEnabled && isBot) {
+              // --- 2.5 Check for stalled in-progress issues ---
+              const { data: inProgress } = await github.rest.issues.listForRepo({
                 owner, repo,
-                issue_number: stuck.number,
-                per_page: 100
+                labels: 'in-progress',
+                state: 'open',
+                per_page: 10
               });
 
-              const hasPR = events.some(e => e.event === 'cross-referenced' && e.source?.issue?.pull_request);
-              if (!hasPR) {
-                console.log(`Issue #${stuck.number} is in-progress but has no linked PR. Halting chain.`);
-                await github.rest.issues.createComment({
+              for (const stuck of inProgress) {
+                if (stuck.number === n) continue;
+
+                const { data: events } = await github.rest.issues.listEventsForTimeline({
                   owner, repo,
                   issue_number: stuck.number,
-                  body: '⏸️ Pipeline halted — this issue was marked **in-progress** but no linked PR was created. Please diagnose manually, then either close it or remove `in-progress` and add `ready`.'
+                  per_page: 100
                 });
-                return;
-              }
-            }
 
-            // --- 3. Find next ready issue (oldest first) ---
-            const { data: ready } = await github.rest.issues.listForRepo({
-              owner, repo,
-              labels: 'ready',
-              state: 'open',
-              sort: 'created',
-              direction: 'asc',
-              per_page: 10
-            });
-
-            ready.sort((a, b) => a.number - b.number);
-
-            for (const issue of ready) {
-              // Check dependencies
-              const depMatch = issue.body?.match(/[Dd]epends?\s+on:?\s*#(\d+)/);
-              if (depMatch) {
-                const dep = await github.rest.issues.get({
-                  owner, repo, issue_number: parseInt(depMatch[1])
-                });
-                if (dep.data.state !== 'closed') {
-                  console.log(`#${issue.number}: dependency #${depMatch[1]} not closed, skipping.`);
-                  continue;
+                const hasPR = events.some(e => e.event === 'cross-referenced' && e.source?.issue?.pull_request);
+                if (!hasPR) {
+                  console.log(`Issue #${stuck.number} is in-progress but has no linked PR. Halting chain.`);
+                  await github.rest.issues.createComment({
+                    owner, repo,
+                    issue_number: stuck.number,
+                    body: '⏸️ Pipeline halted — this issue was marked **in-progress** but no linked PR was created. Please diagnose manually, then either close it or remove `in-progress` and add `ready`.'
+                  });
+                  return;
                 }
               }
 
-              // Label as in-progress
-              console.log(`Assigning #${issue.number} to LangGraph pipeline.`);
-              await github.rest.issues.removeLabel({
+              // --- 3. Find next ready issue (oldest first) ---
+              const { data: ready } = await github.rest.issues.listForRepo({
                 owner, repo,
-                issue_number: issue.number,
-                name: 'ready'
-              }).catch(() => {});
-              await github.rest.issues.addLabels({
-                owner, repo,
-                issue_number: issue.number,
-                labels: ['in-progress']
+                labels: 'ready',
+                state: 'open',
+                sort: 'created',
+                direction: 'asc',
+                per_page: 10
               });
 
-              // Acknowledge assignment on the issue
-              await github.rest.issues.createComment({
-                owner, repo,
-                issue_number: issue.number,
-                body: `⚙️ Auto-assigned from merged PR #${context.payload.pull_request.number}`
-              });
+              ready.sort((a, b) => a.number - b.number);
 
-              // Dispatch the LangGraph pipeline workflow
-              await github.rest.actions.createWorkflowDispatch({
-                owner, repo,
-                workflow_id: 'langgraph-agent.yml',
-                ref: 'main',
-                 inputs: {
-                   issue_number: String(issue.number),
-                   comment_body: `auto-assigned from merged PR #${context.payload.pull_request.number}`
-                 }
-              });
-              console.log(`LangGraph pipeline dispatched for issue #${issue.number}.`);
+              for (const issue of ready) {
+                const depMatch = issue.body?.match(/[Dd]epends?\s+on:?\s*#(\d+)/);
+                if (depMatch) {
+                  const dep = await github.rest.issues.get({
+                    owner, repo, issue_number: parseInt(depMatch[1])
+                  });
+                  if (dep.data.state !== 'closed') {
+                    console.log(`#${issue.number}: dependency #${depMatch[1]} not closed, skipping.`);
+                    continue;
+                  }
+                }
 
-              return; // Only assign one at a time
+                console.log(`Assigning #${issue.number} to LangGraph pipeline.`);
+                await github.rest.issues.removeLabel({
+                  owner, repo,
+                  issue_number: issue.number,
+                  name: 'ready'
+                }).catch(() => {});
+                await github.rest.issues.addLabels({
+                  owner, repo,
+                  issue_number: issue.number,
+                  labels: ['in-progress']
+                });
+
+                await github.rest.issues.createComment({
+                  owner, repo,
+                  issue_number: issue.number,
+                  body: `⚙️ Auto-assigned from merged PR #${context.payload.pull_request.number}`
+                });
+
+                await github.rest.actions.createWorkflowDispatch({
+                  owner, repo,
+                  workflow_id: 'langgraph-agent.yml',
+                  ref: 'main',
+                   inputs: {
+                     issue_number: String(issue.number),
+                     comment_body: `auto-assigned from merged PR #${context.payload.pull_request.number}`
+                   }
+                });
+                console.log(`LangGraph pipeline dispatched for issue #${issue.number}.`);
+
+                return;
+              }
+
+              console.log('No more ready issues. Pipeline idle.');
+            } else {
+              if (!autoAssignEnabled) {
+                console.log('Auto-assign is disabled (AGENTIC_AUTO_ASSIGN_ENABLED is not set to "true").');
+              }
+              if (!isBot) {
+                console.log(`PR author is ${context.payload.pull_request.user.type}, not Bot — skipping auto-assign.`);
+              }
             }
-
-            console.log('No more ready issues. Pipeline idle.');

--- a/.github/workflows/langgraph-agent.yml
+++ b/.github/workflows/langgraph-agent.yml
@@ -126,6 +126,7 @@ jobs:
 
           # ── GitHub ───────────────────────────────────────────────────────────
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AGENTIC_AUTO_MERGE_ENABLED: ${{ vars.AGENTIC_AUTO_MERGE_ENABLED }}
           GITHUB_WORKSPACE: ${{ github.workspace }}
           DEFAULT_REPO_OWNER: ${{ github.repository_owner }}
           DEFAULT_REPO_NAME: ${{ github.event.repository.name }}

--- a/.langgraph/nodes/open_pr.py
+++ b/.langgraph/nodes/open_pr.py
@@ -10,6 +10,7 @@ After creation:
 """
 
 from __future__ import annotations
+import os
 import sys
 from pathlib import Path
 
@@ -72,13 +73,19 @@ def open_pr(state: dict) -> dict:
                 {"role": "assistant", "content": f"warning: comment failed: {exc}"}
             ]
     else:
-        try:
-            auto_msg = enable_automerge(pr_num, merge_method="squash")
-            messages = messages + [{"role": "assistant", "content": auto_msg}]
-        except (RuntimeError, GithubException) as exc:
+        auto_merge_enabled = os.environ.get("AGENTIC_AUTO_MERGE_ENABLED", "true")
+        if auto_merge_enabled == "false":
             messages = messages + [
-                {"role": "assistant", "content": f"warning: auto-merge failed: {exc}"}
+                {"role": "assistant", "content": "auto-merge skipped: AGENTIC_AUTO_MERGE_ENABLED is false"}
             ]
+        else:
+            try:
+                auto_msg = enable_automerge(pr_num, merge_method="squash")
+                messages = messages + [{"role": "assistant", "content": auto_msg}]
+            except (RuntimeError, GithubException) as exc:
+                messages = messages + [
+                    {"role": "assistant", "content": f"warning: auto-merge failed: {exc}"}
+                ]
 
     try:
         remove_result = remove_label(issue_number, "in-progress")


### PR DESCRIPTION
… trigger

- Remove AGENTIC_AUTO_ASSIGN_ENABLED condition from agentic-trigger.yml (manual trigger should always proceed)
- Move condition from job-level to script-level in auto-assign-next.yml: cleanup (close issue, update backlog) always runs, auto-assign next issue is gated by variable + bot check
- Rename LANGGRAPH_AUTO_* vars to AGENTIC_AUTO_* for consistency
- Default AGENTIC_AUTO_ASSIGN_ENABLED to disabled (false) when unset