### PR TITLE
fix(pipeline): detect interrupt, relabel + comment on max-retries hit

### DIFF
--- a/.claude/agents/fixer.md
+++ b/.claude/agents/fixer.md
@@ -17,7 +17,6 @@ Fix implementation code to make test suite pass.
 2. Identify failing source files from stack traces + error messages.
 3. Write targeted fix — change only what error indicates.
 4. Do NOT commit — graph commits after you finish.
-5. Do NOT run test suite — graph re-runs after you finish.
 
 ## Process
 
@@ -26,7 +25,8 @@ Fix implementation code to make test suite pass.
 3. Read those source files with `read_file`.
 4. Apply minimal fix.
 5. Verify with `npx tsc --noEmit` (type check only).
-6. Report what you changed.
+6. Run `npx vitest run <failing-test-file>` on the specific file from the stack trace. If tests still fail, read the new output and iterate. Only stop when the targeted file passes or you are genuinely stuck with no path forward.
+7. Report what you changed.
 
 ## Key References
 

--- a/.github/agents/fixer.agent.md
+++ b/.github/agents/fixer.agent.md
@@ -20,7 +20,6 @@ Fix implementation code to make test suite pass.
 2. Identify failing source files from stack traces + error messages.
 3. Write targeted fix — change only what error indicates.
 4. Do NOT commit — graph commits after you finish.
-5. Do NOT run test suite — graph re-runs after you finish.
 
 ## Process
 
@@ -29,7 +28,8 @@ Fix implementation code to make test suite pass.
 3. Read those source files with `read_file`.
 4. Apply minimal fix.
 5. Verify with `npx tsc --noEmit` (type check only).
-6. Report what you changed.
+6. Run `npx vitest run <failing-test-file>` on the specific file from the stack trace. If tests still fail, read the new output and iterate. Only stop when the targeted file passes or you are genuinely stuck with no path forward.
+7. Report what you changed.
 
 ## Key References
 

--- a/.langgraph/nodes/fixer.py
+++ b/.langgraph/nodes/fixer.py
@@ -76,6 +76,8 @@ def _build_context(state: dict, _tool_names: list | None = None) -> str:
         "- Only modify implementation files in src/ (not test files).",
         "- Fix only what the errors indicate — do not rewrite working code.",
         "- Do NOT call git yourself — the graph auto-commits your changes after you finish.",
+        "- After each fix attempt, run `npx vitest run <failing-test-file>` (extract file path from stack trace).",
+        "  If the test still fails, read the new output and iterate until it passes or you are genuinely stuck.",
         "",
         "## Test Failure Output",
         state.get("test_output", "(no output captured)"),

--- a/.langgraph/pipeline_logger.py
+++ b/.langgraph/pipeline_logger.py
@@ -116,9 +116,15 @@ def _log_end_status(node: str, output: dict) -> None:
 # Main stream processor
 # ---------------------------------------------------------------------------
 
-async def stream_pipeline(graph: Any, initial_state: dict, config: dict) -> None:
-    """Process astream_events and emit per-node structured logs."""
+async def stream_pipeline(graph: Any, initial_state: dict, config: dict) -> bool:
+    """Process astream_events and emit per-node structured logs.
+
+    Returns:
+        True if the pipeline was paused by an interrupt (handle_interrupt node
+        fired or LangGraph emitted an __interrupt__ event); False otherwise.
+    """
     current_node: str = ""
+    interrupted: bool = False
 
     async for event in graph.astream_events(initial_state, config=config, version="v2"):
         kind: str = event.get("event", "")
@@ -126,6 +132,11 @@ async def stream_pipeline(graph: Any, initial_state: dict, config: dict) -> None
         metadata: dict = event.get("metadata", {})
         data: dict = event.get("data", {})
         node: str = metadata.get("langgraph_node", "")
+
+        # Detect interrupt — either the handle_interrupt node started, or
+        # LangGraph emitted its own __interrupt__ event.
+        if node == "handle_interrupt" or (kind == "on_chain_start" and name == "__interrupt__"):
+            interrupted = True
 
         # Open a new collapsible group when the active node changes.
         if node and node != current_node and node not in ("LangGraph", ""):
@@ -172,3 +183,5 @@ async def stream_pipeline(graph: Any, initial_state: dict, config: dict) -> None
     # Close the final open group.
     if current_node:
         _gha_endgroup()
+
+    return interrupted

--- a/.langgraph/runner.py
+++ b/.langgraph/runner.py
@@ -140,17 +140,27 @@ async def run(issue_number: int, comment_body: str) -> None:
         from routing import MAX_RETRIES
         from tools.github_write import github_post_comment, github_add_label, github_remove_label
         log.warning(
-            "Pipeline paused: max retries (%d) reached. Posting failure comment and updating labels.",
+            "Pipeline paused: max retries (%d) reached during pipeline execution. Posting pause comment and updating labels.",
             MAX_RETRIES,
         )
-        github_post_comment(
-            issue_number,
-            f"⚠️ **Pipeline paused** — max retries ({MAX_RETRIES}) reached without passing tests.\n\n"
-            "The autonomous agent was unable to fix the failing tests after the maximum number of attempts. "
-            "Review the CI log output above, add clarification or guidance to this issue, then re-trigger the pipeline.",
-        )
-        github_remove_label(issue_number, "in-progress")
-        github_add_label(issue_number, "blocked")
+        results = [
+            (
+                "post comment",
+                github_post_comment(
+                    issue_number,
+                    f"⚠️ **Pipeline paused** — max retries ({MAX_RETRIES}) reached during pipeline execution.\n\n"
+                    "The autonomous agent reached the retry limit before completing the workflow. "
+                    "Review the CI log output above, add clarification or guidance to this issue, then re-trigger the pipeline.",
+                ),
+            ),
+            ("remove label", github_remove_label(issue_number, "in-progress")),
+            ("add label", github_add_label(issue_number, "blocked")),
+        ]
+        for action, result in results:
+            if result.startswith("error:"):
+                log.warning("GitHub %s warning: %s", action, result)
+            else:
+                log.info("GitHub %s: %s", action, result)
         sys.exit(1)
 
     log.info("Pipeline complete.")

--- a/.langgraph/runner.py
+++ b/.langgraph/runner.py
@@ -134,7 +134,24 @@ async def run(issue_number: int, comment_body: str) -> None:
     log.info("Starting pipeline for issue #%d", issue_number)
     log.info("Comment: %r", comment_body)
 
-    await stream_pipeline(graph, initial_state, config)
+    interrupted = await stream_pipeline(graph, initial_state, config)
+
+    if interrupted:
+        from routing import MAX_RETRIES
+        from tools.github_write import github_post_comment, github_add_label, github_remove_label
+        log.warning(
+            "Pipeline paused: max retries (%d) reached. Posting failure comment and updating labels.",
+            MAX_RETRIES,
+        )
+        github_post_comment(
+            issue_number,
+            f"⚠️ **Pipeline paused** — max retries ({MAX_RETRIES}) reached without passing tests.\n\n"
+            "The autonomous agent was unable to fix the failing tests after the maximum number of attempts. "
+            "Review the CI log output above, add clarification or guidance to this issue, then re-trigger the pipeline.",
+        )
+        github_remove_label(issue_number, "in-progress")
+        github_add_label(issue_number, "blocked")
+        sys.exit(1)
 
     log.info("Pipeline complete.")
 

--- a/.opencode/agents/fixer.md
+++ b/.opencode/agents/fixer.md
@@ -14,7 +14,6 @@ Fix implementation code to make test suite pass.
 2. Identify failing source files from stack traces + error messages.
 3. Write targeted fix — change only what error indicates.
 4. Do NOT commit — graph commits after you finish.
-5. Do NOT run test suite — graph re-runs after you finish.
 
 ## Process
 
@@ -23,7 +22,8 @@ Fix implementation code to make test suite pass.
 3. Read those source files with `read_file`.
 4. Apply minimal fix.
 5. Verify with `npx tsc --noEmit` (type check only).
-6. Report what you changed.
+6. Run `npx vitest run <failing-test-file>` on the specific file from the stack trace. If tests still fail, read the new output and iterate. Only stop when the targeted file passes or you are genuinely stuck with no path forward.
+7. Report what you changed.
 
 ## Key References
 


### PR DESCRIPTION
Root cause of run #11 silent-success bug:
- LangGraph `interrupt()` pauses graph cleanly, `astream_events` ends normally, and the runner exited 0 with no PR and no issue feedback.

Changes:
- `pipeline_logger`: track `handle_interrupt` node + `__interrupt__` events; `stream_pipeline()` now returns `bool` (`True` = interrupted)
- `runner`: on `interrupted=True`, post a generic pipeline pause comment to the issue, swap `in-progress` for `blocked`, log GitHub comment/label helper results (warning on `error:` responses), then `sys.exit(1)`
- fixer agent (all 3 copies + `_build_context`): remove the instruction to avoid running tests, and instead require targeted `vitest` runs for the failing file after each fix attempt