### PR TITLE
chore: remove review-coordinator, orchestrator merges findings inline

### DIFF
--- a/.claude/agents/pipeline.md
+++ b/.claude/agents/pipeline.md
@@ -42,8 +42,8 @@ Steps are sequential unless marked parallel. Failure loops shown separately belo
       @quality-reviewer     → architecture, conventions, TypeScript strictness
       @i18n-reviewer        → hardcoded strings, locale mismatches
       @duplication-reviewer → semantic duplication, non-atomic functions
-12. @review-coordinator → Merge all sub-reviewer findings → pass/fail
-                          if fail → @implementer (big loop)
+12. [merge-findings]  → Orchestrator merges all sub-reviewer findings → pass/fail
+                        if fail → @implementer (big loop)
 13. @refactorer        → Clean up conventions, no behavior change
                          then re-run [test-runner] to verify no regression
 14. @validator         → Full validation: typecheck → tests → build
@@ -62,7 +62,7 @@ Every agent failure loops back — either to `@implementer` (outer loop) or self
 | @planner | @planner (self-retry) |
 | [test-runner] | @fixer → [test-runner] (tight loop) |
 | [qualimetry] | @implementer |
-| @review-coordinator | @implementer |
+| [merge-findings] | @implementer |
 | @refactorer | @implementer |
 | @validator | @implementer |
 | @visual-tester | @implementer |
@@ -86,7 +86,7 @@ When looping back to `@implementer`, the full downstream chain reruns: `implemen
  9. [test-runner]      → run tests; fail → @fixer loop
 10. [qualimetry]       → jscpd check; fail → @implementer
 11. Code review (parallel): @quality-reviewer + @security-reviewer + @i18n-reviewer + @duplication-reviewer
-12. @review-coordinator → pass/fail; fail → @implementer
+12. [merge-findings]  → Orchestrator merges findings → pass/fail; fail → @implementer
 13. @validator         → typecheck → tests → build; fail → @implementer
 14. [open-pr]          → create PR + auto-merge
 ```
@@ -97,7 +97,7 @@ Note: `@refactorer` is skipped for fix-bug.
 
 ```
 1. Code review (parallel): @quality-reviewer + @security-reviewer + @i18n-reviewer + @duplication-reviewer
-2. @review-coordinator → Merge sub-reviewer findings
+2. [merge-findings]  → Orchestrator merges sub-reviewer findings
 3. @reviewer           → Runtime validation: run tests, fix any critical items, post review outcome
 ```
 
@@ -136,8 +136,9 @@ main
 1. **Delegate to specialists** — Use `@agent-name` syntax to invoke sub-agents
 2. **Enforce branch isolation** — See above. Never let @implementer see tests.
 3. **Handle non-agentic steps** — Branch switches, test runs, jscpd, PR creation.
-4. **Enforce sequence** — Never skip phases. Tests before implementation.
-5. **Report status** — After each agent completes, summarize what was done and current branch.
+4. **Merge code review findings** — After parallel reviewers complete, merge their findings into a single pass/fail decision (deduplicate, re-categorize, drop false positives, check issue alignment). No separate coordinator agent needed.
+5. **Enforce sequence** — Never skip phases. Tests before implementation.
+6. **Report status** — After each agent completes, summarize what was done and current branch.
 
 ## Non-Agentic Steps You Must Handle
 
@@ -149,6 +150,7 @@ main
 | merge-branches | merge test + impl → `pipeline/full-<N>`; detect conflicts |
 | test-runner | `npx vitest run` — capture output, route to @fixer on fail |
 | qualimetry | `npx jscpd src/ tests/` — route to @implementer on fail |
+| merge-findings | Deduplicate and merge all 4 reviewer reports → pass/fail |
 | After refactorer | Re-run `npx vitest run` (skip qualimetry + code-review) |
 | open-pr | `gh pr create` + `gh pr merge --auto --squash` — follow PR title/body/label standards in `agentic-autonomous-pipeline` skill |
 | Before completing | Summarize changes, files modified, test status |

--- a/.claude/agents/review-coordinator.md
+++ b/.claude/agents/review-coordinator.md
@@ -1,80 +1,25 @@
 ---
 name: review-coordinator
-description: Merges findings from specialized sub-reviewers. Deduplicates, re-categorizes, drops false positives, makes final pass/fail decision. Read-only. 
+description: DEPRECATED — Orchestrator now handles merging reviewer findings directly. Kept for reference only. 
 allowed-tools: Read Search
 user-invocable: false
 disable-model-invocation: true
 ---
-# Review Coordinator
+# Review Coordinator (DEPRECATED)
 
-Position: after parallel sub-reviewers, before refactorer. Read-only.
+This role has been absorbed by the **pipeline orchestrator**. A dedicated coordinator agent is unnecessary because the orchestrator already holds all sub-reviewer outputs in context after fan-out. Merging them inline removes an extra LLM call and avoids re-transmitting findings.
 
-## Task
+## Previous Role (for reference)
 
-Merge findings from security, quality, i18n, and duplication sub-reviewers into one coherent review.
+Positioned after parallel sub-reviewers, before refactorer. Read-only.
 
-## Steps
+The coordinator merged findings from security, quality, i18n, and duplication reviewers into one coherent review. Steps were:
 
 1. **Deduplicate** — same issue flagged by multiple reviewers → keep once in best category
 2. **Re-categorize** — performance issue in quality section → move to correct category
-3. **Filter false positives** — speculative issues, nitpicks, convention-contradicted findings → drop. Also drop any [low] confidence findings unless they are [critical] severity.
-4. **Verify uncertain items** — if a finding is [medium] confidence, read the source file to confirm before keeping it
+3. **Filter false positives** — speculative issues, nitpicks, convention-contradicted findings → drop
+4. **Verify uncertain items** — if a finding is [medium] confidence, read source to confirm
 5. **Check issue alignment** — every acceptance criterion from the issue is implemented
 6. **Assess cross-file impact** — does this change break callers in other files?
 
-## Cross-File Impact Analysis
-
-When the risk tier is FULL, check:
-
-1. **API contract changes** — if a function signature, return type, or exported interface changed, search for all callers with `grep`. Verify each caller still works.
-2. **State shape changes** — if GameState or shared state types changed, find all consumers. Verify they handle the new shape.
-3. **Event payload changes** — if event types changed, find all listeners. Verify they handle the new payload.
-4. **Config key changes** — if balance/config keys changed, find all references. Verify they use the new keys.
-5. **Import path changes** — if a module was renamed/moved, find all imports. Verify none are broken.
-
-Use `grep` tool to search for callers/consumers. Do NOT guess — verify.
-
-## Decision Rubric (bias toward approval)
-
-| Condition | Decision |
-|-----------|----------|
-| All clean, or only [suggestion] items | ✅ PASSED |
-| Only [warning] items, no production risk | ✅ PASSED (with notes) |
-| Multiple [warning] suggesting risk pattern | ❌ FAILED |
-| Any [critical] item | ❌ FAILED |
-
-## Output Format
-
-```
-## Code Review — Coordinated
-
-### Critical
-(none, or list with file:line)
-
-### Warnings
-- src/core/foo/Bar.ts:100 — hardcoded balance value 1.5
-
-### Suggestions
-- src/ui/Baz.ts:15 — consider extracting constant
-
-### Issue Alignment
-- [x] Criterion 1 implemented
-- [x] Criterion 2 implemented
-- [ ] Criterion 3 — missing error handling for edge case
-
-### Cross-File Impact
-- No cross-file risks identified
-- OR: Bar.ts:42 changes API shape — callers in Baz.ts, Qux.ts may need updates
-
-### Decision
-✅ CODE REVIEW PASSED — ready for refactor
-```
-
-or:
-
-```
-### Decision
-❌ CODE REVIEW FAILED — 1 critical, 2 warnings
-```
-
-Read source files to verify uncertain findings. No guessing.
+The orchestrator now performs these steps directly after receiving all 4 reviewer outputs.

--- a/.github/agents/pipeline.agent.md
+++ b/.github/agents/pipeline.agent.md
@@ -44,8 +44,8 @@ Steps are sequential unless marked parallel. Failure loops shown separately belo
       @quality-reviewer     → architecture, conventions, TypeScript strictness
       @i18n-reviewer        → hardcoded strings, locale mismatches
       @duplication-reviewer → semantic duplication, non-atomic functions
-12. @review-coordinator → Merge all sub-reviewer findings → pass/fail
-                          if fail → @implementer (big loop)
+12. [merge-findings]  → Orchestrator merges all sub-reviewer findings → pass/fail
+                        if fail → @implementer (big loop)
 13. @refactorer        → Clean up conventions, no behavior change
                          then re-run [test-runner] to verify no regression
 14. @validator         → Full validation: typecheck → tests → build
@@ -64,7 +64,7 @@ Every agent failure loops back — either to `@implementer` (outer loop) or self
 | @planner | @planner (self-retry) |
 | [test-runner] | @fixer → [test-runner] (tight loop) |
 | [qualimetry] | @implementer |
-| @review-coordinator | @implementer |
+| [merge-findings] | @implementer |
 | @refactorer | @implementer |
 | @validator | @implementer |
 | @visual-tester | @implementer |
@@ -88,7 +88,7 @@ When looping back to `@implementer`, the full downstream chain reruns: `implemen
  9. [test-runner]      → run tests; fail → @fixer loop
 10. [qualimetry]       → jscpd check; fail → @implementer
 11. Code review (parallel): @quality-reviewer + @security-reviewer + @i18n-reviewer + @duplication-reviewer
-12. @review-coordinator → pass/fail; fail → @implementer
+12. [merge-findings]  → Orchestrator merges findings → pass/fail; fail → @implementer
 13. @validator         → typecheck → tests → build; fail → @implementer
 14. [open-pr]          → create PR + auto-merge
 ```
@@ -99,7 +99,7 @@ Note: `@refactorer` is skipped for fix-bug.
 
 ```
 1. Code review (parallel): @quality-reviewer + @security-reviewer + @i18n-reviewer + @duplication-reviewer
-2. @review-coordinator → Merge sub-reviewer findings
+2. [merge-findings]  → Orchestrator merges sub-reviewer findings
 3. @reviewer           → Runtime validation: run tests, fix any critical items, post review outcome
 ```
 
@@ -138,8 +138,9 @@ main
 1. **Delegate to specialists** — Use `@agent-name` syntax to invoke sub-agents
 2. **Enforce branch isolation** — See above. Never let @implementer see tests.
 3. **Handle non-agentic steps** — Branch switches, test runs, jscpd, PR creation.
-4. **Enforce sequence** — Never skip phases. Tests before implementation.
-5. **Report status** — After each agent completes, summarize what was done and current branch.
+4. **Merge code review findings** — After parallel reviewers complete, merge their findings into a single pass/fail decision (deduplicate, re-categorize, drop false positives, check issue alignment). No separate coordinator agent needed.
+5. **Enforce sequence** — Never skip phases. Tests before implementation.
+6. **Report status** — After each agent completes, summarize what was done and current branch.
 
 ## Non-Agentic Steps You Must Handle
 
@@ -151,6 +152,7 @@ main
 | merge-branches | merge test + impl → `pipeline/full-<N>`; detect conflicts |
 | test-runner | `npx vitest run` — capture output, route to @fixer on fail |
 | qualimetry | `npx jscpd src/ tests/` — route to @implementer on fail |
+| merge-findings | Deduplicate and merge all 4 reviewer reports → pass/fail |
 | After refactorer | Re-run `npx vitest run` (skip qualimetry + code-review) |
 | open-pr | `gh pr create` + `gh pr merge --auto --squash` — follow PR title/body/label standards in `agentic-autonomous-pipeline` skill |
 | Before completing | Summarize changes, files modified, test status |

--- a/.github/agents/review-coordinator.agent.md
+++ b/.github/agents/review-coordinator.agent.md
@@ -1,83 +1,28 @@
 ---
 name: review-coordinator
 description: >
-  Merges findings from specialized sub-reviewers. Deduplicates, re-categorizes,
-  drops false positives, makes final pass/fail decision. Read-only.
+  DEPRECATED — Orchestrator now handles merging reviewer findings directly.
+  This agent definition kept for reference only.
 user-invocable: false
 disable-model-invocation: true
 tools: ["read", "search"]
 ---
 
-# Review Coordinator
+# Review Coordinator (DEPRECATED)
 
-Position: after parallel sub-reviewers, before refactorer. Read-only.
+This role has been absorbed by the **pipeline orchestrator**. A dedicated coordinator agent is unnecessary because the orchestrator already holds all sub-reviewer outputs in context after fan-out. Merging them inline removes an extra LLM call and avoids re-transmitting findings.
 
-## Task
+## Previous Role (for reference)
 
-Merge findings from security, quality, i18n, and duplication sub-reviewers into one coherent review.
+Positioned after parallel sub-reviewers, before refactorer. Read-only.
 
-## Steps
+The coordinator merged findings from security, quality, i18n, and duplication reviewers into one coherent review. Steps were:
 
 1. **Deduplicate** — same issue flagged by multiple reviewers → keep once in best category
 2. **Re-categorize** — performance issue in quality section → move to correct category
-3. **Filter false positives** — speculative issues, nitpicks, convention-contradicted findings → drop. Also drop any [low] confidence findings unless they are [critical] severity.
-4. **Verify uncertain items** — if a finding is [medium] confidence, read the source file to confirm before keeping it
+3. **Filter false positives** — speculative issues, nitpicks, convention-contradicted findings → drop
+4. **Verify uncertain items** — if a finding is [medium] confidence, read source to confirm
 5. **Check issue alignment** — every acceptance criterion from the issue is implemented
 6. **Assess cross-file impact** — does this change break callers in other files?
 
-## Cross-File Impact Analysis
-
-When the risk tier is FULL, check:
-
-1. **API contract changes** — if a function signature, return type, or exported interface changed, search for all callers with `grep`. Verify each caller still works.
-2. **State shape changes** — if GameState or shared state types changed, find all consumers. Verify they handle the new shape.
-3. **Event payload changes** — if event types changed, find all listeners. Verify they handle the new payload.
-4. **Config key changes** — if balance/config keys changed, find all references. Verify they use the new keys.
-5. **Import path changes** — if a module was renamed/moved, find all imports. Verify none are broken.
-
-Use `grep` tool to search for callers/consumers. Do NOT guess — verify.
-
-## Decision Rubric (bias toward approval)
-
-| Condition | Decision |
-|-----------|----------|
-| All clean, or only [suggestion] items | ✅ PASSED |
-| Only [warning] items, no production risk | ✅ PASSED (with notes) |
-| Multiple [warning] suggesting risk pattern | ❌ FAILED |
-| Any [critical] item | ❌ FAILED |
-
-## Output Format
-
-```
-## Code Review — Coordinated
-
-### Critical
-(none, or list with file:line)
-
-### Warnings
-- src/core/foo/Bar.ts:100 — hardcoded balance value 1.5
-
-### Suggestions
-- src/ui/Baz.ts:15 — consider extracting constant
-
-### Issue Alignment
-- [x] Criterion 1 implemented
-- [x] Criterion 2 implemented
-- [ ] Criterion 3 — missing error handling for edge case
-
-### Cross-File Impact
-- No cross-file risks identified
-- OR: Bar.ts:42 changes API shape — callers in Baz.ts, Qux.ts may need updates
-
-### Decision
-✅ CODE REVIEW PASSED — ready for refactor
-```
-
-or:
-
-```
-### Decision
-❌ CODE REVIEW FAILED — 1 critical, 2 warnings
-```
-
-Read source files to verify uncertain findings. No guessing.
+The orchestrator now performs these steps directly after receiving all 4 reviewer outputs.

--- a/.opencode/agents/pipeline.md
+++ b/.opencode/agents/pipeline.md
@@ -42,8 +42,8 @@ Steps are sequential unless marked parallel. Failure loops shown separately belo
       @quality-reviewer     → architecture, conventions, TypeScript strictness
       @i18n-reviewer        → hardcoded strings, locale mismatches
       @duplication-reviewer → semantic duplication, non-atomic functions
-12. @review-coordinator → Merge all sub-reviewer findings → pass/fail
-                          if fail → @implementer (big loop)
+12. [merge-findings]  → Orchestrator merges all sub-reviewer findings → pass/fail
+                        if fail → @implementer (big loop)
 13. @refactorer        → Clean up conventions, no behavior change
                          then re-run [test-runner] to verify no regression
 14. @validator         → Full validation: typecheck → tests → build
@@ -62,7 +62,7 @@ Every agent failure loops back — either to `@implementer` (outer loop) or self
 | @planner | @planner (self-retry) |
 | [test-runner] | @fixer → [test-runner] (tight loop) |
 | [qualimetry] | @implementer |
-| @review-coordinator | @implementer |
+| [merge-findings] | @implementer |
 | @refactorer | @implementer |
 | @validator | @implementer |
 | @visual-tester | @implementer |
@@ -86,7 +86,7 @@ When looping back to `@implementer`, the full downstream chain reruns: `implemen
  9. [test-runner]      → run tests; fail → @fixer loop
 10. [qualimetry]       → jscpd check; fail → @implementer
 11. Code review (parallel): @quality-reviewer + @security-reviewer + @i18n-reviewer + @duplication-reviewer
-12. @review-coordinator → pass/fail; fail → @implementer
+12. [merge-findings]  → Orchestrator merges findings → pass/fail; fail → @implementer
 13. @validator         → typecheck → tests → build; fail → @implementer
 14. [open-pr]          → create PR + auto-merge
 ```
@@ -97,7 +97,7 @@ Note: `@refactorer` is skipped for fix-bug.
 
 ```
 1. Code review (parallel): @quality-reviewer + @security-reviewer + @i18n-reviewer + @duplication-reviewer
-2. @review-coordinator → Merge sub-reviewer findings
+2. [merge-findings]  → Orchestrator merges sub-reviewer findings
 3. @reviewer           → Runtime validation: run tests, fix any critical items, post review outcome
 ```
 
@@ -136,8 +136,9 @@ main
 1. **Delegate to specialists** — Use `@agent-name` syntax to invoke sub-agents
 2. **Enforce branch isolation** — See above. Never let @implementer see tests.
 3. **Handle non-agentic steps** — Branch switches, test runs, jscpd, PR creation.
-4. **Enforce sequence** — Never skip phases. Tests before implementation.
-5. **Report status** — After each agent completes, summarize what was done and current branch.
+4. **Merge code review findings** — After parallel reviewers complete, merge their findings into a single pass/fail decision (deduplicate, re-categorize, drop false positives, check issue alignment). No separate coordinator agent needed.
+5. **Enforce sequence** — Never skip phases. Tests before implementation.
+6. **Report status** — After each agent completes, summarize what was done and current branch.
 
 ## Non-Agentic Steps You Must Handle
 
@@ -149,6 +150,7 @@ main
 | merge-branches | merge test + impl → `pipeline/full-<N>`; detect conflicts |
 | test-runner | `npx vitest run` — capture output, route to @fixer on fail |
 | qualimetry | `npx jscpd src/ tests/` — route to @implementer on fail |
+| merge-findings | Deduplicate and merge all 4 reviewer reports → pass/fail |
 | After refactorer | Re-run `npx vitest run` (skip qualimetry + code-review) |
 | open-pr | `gh pr create` + `gh pr merge --auto --squash` — follow PR title/body/label standards in `agentic-autonomous-pipeline` skill |
 | Before completing | Summarize changes, files modified, test status |

--- a/.opencode/agents/review-coordinator.md
+++ b/.opencode/agents/review-coordinator.md
@@ -97,76 +97,21 @@ permission:
     "gh workflow enable *": "deny"
     "gh workflow run *": "deny"
 ---
-# Review Coordinator
+# Review Coordinator (DEPRECATED)
 
-Position: after parallel sub-reviewers, before refactorer. Read-only.
+This role has been absorbed by the **pipeline orchestrator**. A dedicated coordinator agent is unnecessary because the orchestrator already holds all sub-reviewer outputs in context after fan-out. Merging them inline removes an extra LLM call and avoids re-transmitting findings.
 
-## Task
+## Previous Role (for reference)
 
-Merge findings from security, quality, i18n, and duplication sub-reviewers into one coherent review.
+Positioned after parallel sub-reviewers, before refactorer. Read-only.
 
-## Steps
+The coordinator merged findings from security, quality, i18n, and duplication reviewers into one coherent review. Steps were:
 
 1. **Deduplicate** — same issue flagged by multiple reviewers → keep once in best category
 2. **Re-categorize** — performance issue in quality section → move to correct category
-3. **Filter false positives** — speculative issues, nitpicks, convention-contradicted findings → drop. Also drop any [low] confidence findings unless they are [critical] severity.
-4. **Verify uncertain items** — if a finding is [medium] confidence, read the source file to confirm before keeping it
+3. **Filter false positives** — speculative issues, nitpicks, convention-contradicted findings → drop
+4. **Verify uncertain items** — if a finding is [medium] confidence, read source to confirm
 5. **Check issue alignment** — every acceptance criterion from the issue is implemented
 6. **Assess cross-file impact** — does this change break callers in other files?
 
-## Cross-File Impact Analysis
-
-When the risk tier is FULL, check:
-
-1. **API contract changes** — if a function signature, return type, or exported interface changed, search for all callers with `grep`. Verify each caller still works.
-2. **State shape changes** — if GameState or shared state types changed, find all consumers. Verify they handle the new shape.
-3. **Event payload changes** — if event types changed, find all listeners. Verify they handle the new payload.
-4. **Config key changes** — if balance/config keys changed, find all references. Verify they use the new keys.
-5. **Import path changes** — if a module was renamed/moved, find all imports. Verify none are broken.
-
-Use `grep` tool to search for callers/consumers. Do NOT guess — verify.
-
-## Decision Rubric (bias toward approval)
-
-| Condition | Decision |
-|-----------|----------|
-| All clean, or only [suggestion] items | ✅ PASSED |
-| Only [warning] items, no production risk | ✅ PASSED (with notes) |
-| Multiple [warning] suggesting risk pattern | ❌ FAILED |
-| Any [critical] item | ❌ FAILED |
-
-## Output Format
-
-```
-## Code Review — Coordinated
-
-### Critical
-(none, or list with file:line)
-
-### Warnings
-- src/core/foo/Bar.ts:100 — hardcoded balance value 1.5
-
-### Suggestions
-- src/ui/Baz.ts:15 — consider extracting constant
-
-### Issue Alignment
-- [x] Criterion 1 implemented
-- [x] Criterion 2 implemented
-- [ ] Criterion 3 — missing error handling for edge case
-
-### Cross-File Impact
-- No cross-file risks identified
-- OR: Bar.ts:42 changes API shape — callers in Baz.ts, Qux.ts may need updates
-
-### Decision
-✅ CODE REVIEW PASSED — ready for refactor
-```
-
-or:
-
-```
-### Decision
-❌ CODE REVIEW FAILED — 1 critical, 2 warnings
-```
-
-Read source files to verify uncertain findings. No guessing.
+The orchestrator now performs these steps directly after receiving all 4 reviewer outputs.


### PR DESCRIPTION
## Summary

Removes the dedicated \@review-coordinator\ agent from the pipeline. The orchestrator now merges sub-reviewer findings directly after collecting them, eliminating an unnecessary LLM call and re-transmission of all findings as context.

### Rationale

The orchestrator already holds all 4 reviewer outputs in its context after fan-out. Spawning a 5th agent to deduplicate and summarize those findings is redundant — the orchestrator \**is\** the coordinator. This change:

1. Eliminates one LLM invocation per pipeline run
2. Avoids re-serializing all findings as a prompt to the coordinator
3. Produces the same outcome (merged pass/fail) at lower cost

### Changes

| File | Change |
|------|--------|
| \.github/agents/pipeline.agent.md\ | Replace @review-coordinator step 12 with [merge-findings] non-agentic step. Update all 3 pipeline diagrams (full, fix-bug, review PR), failure table, responsibilities. |
| \.claude/agents/pipeline.md\ | Same changes (Claude Code ecosystem) |
| \.opencode/agents/pipeline.md\ | Same changes (OpenCode ecosystem) |
| \.github/agents/review-coordinator.agent.md\ | Mark DEPRECATED, document that orchestrator now handles this |
| \.claude/agents/review-coordinator.md\ | Same (Claude Code ecosystem) |
| \.opencode/agents/review-coordinator.md\ | Same (OpenCode ecosystem) |

### Verification

No source code changed — only pipeline agent definitions. No test impact.