### PR TITLE
docs: migrate pipeline to 3-branch workflow (tests, impl, feature)

### DIFF
--- a/.claude/agents/pipeline.md
+++ b/.claude/agents/pipeline.md
@@ -189,11 +189,17 @@ After creating the PR and before finishing, run:
 gh pr merge --auto --squash <pr-url>
 ```
 
-This is the **default**. Only skip it if the issue explicitly requires human artistic input or a critical software design decision. In that case, run instead:
+This is the **default**. Skip auto-merge when:
+1. The issue requires human input (artistic direction, critical design decision).
+2. You judge the pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs) — you lived through it, use your judgment.
+
+When skipping, run:
 
 ```
 gh pr comment <pr-url> --body "Auto-merge paused — human input needed: <reason>"
 ```
+
+Include churn details in the reason so the reviewer understands the risk.
 
 ## Output Format
 

--- a/.claude/agents/pipeline.md
+++ b/.claude/agents/pipeline.md
@@ -32,27 +32,28 @@ Steps are sequential unless marked parallel. Failure loops shown separately belo
  6. @test-writer            → Write failing tests on tests branch (unit + integration + scenario)
  7. [switch-to-impl]        → (non-agentic) switch to pipeline/impl-<issue-number>
  8. @implementer            → Minimum code to pass on impl branch (never sees test commits)
- 9. [cherry-pick]           → (non-agentic) cherry-pick impl commit onto tests branch
+ 9. [setup-feature-branch]  → (non-agentic) create pipeline/feature-<issue-number> from pipeline/tests-<issue-number> HEAD
+10. [cherry-pick]           → (non-agentic) cherry-pick impl commit onto feature branch
                              if conflicts → @conflict-resolver → retry cherry-pick
-10. [switch-to-test]        → (non-agentic) switch to pipeline/tests-<issue-number>
-11. [test-runner]           → (non-agentic) run full test suite on tests branch
+11. [switch-to-feature]     → (non-agentic) switch to pipeline/feature-<issue-number>
+12. [test-runner]           → (non-agentic) run full test suite on feature branch
                              if fail → @fixer → re-run test-runner (tight loop, max 7 retries)
-12. [qualimetry]            → (non-agentic) jscpd syntactic duplication check
+13. [qualimetry]            → (non-agentic) jscpd syntactic duplication check
                              if fail → @implementer (big loop)
-13. Code review (parallel):
+14. Code review (parallel):
       @security-reviewer    → exploitable vulnerabilities
       @quality-reviewer     → architecture, conventions, TypeScript strictness
       @i18n-reviewer        → hardcoded strings, locale mismatches
       @duplication-reviewer → semantic duplication, non-atomic functions
-14. [merge-findings]  → Orchestrator merges all sub-reviewer findings → pass/fail
+15. [merge-findings]  → Orchestrator merges all sub-reviewer findings → pass/fail
                         if fail → @implementer (big loop)
-15. @refactorer        → Clean up conventions, no behavior change
+16. @refactorer        → Clean up conventions, no behavior change
                          then re-run [test-runner] to verify no regression
-16. @validator         → Full validation: typecheck → tests → build
+17. @validator         → Full validation: typecheck → tests → build
                         if fail → @implementer (big loop)
-17. @visual-tester     → Screenshot verification (visual-change ONLY)
+18. @visual-tester     → Screenshot verification (visual-change ONLY)
                         if fail → @implementer (big loop)
-18. [open-pr]          → (non-agentic) create PR from tests branch to main + auto-merge
+19. [open-pr]          → (non-agentic) create PR from feature branch to main + auto-merge
 ```
 
 ### Failure loops (all pipelines)
@@ -70,7 +71,7 @@ Every agent failure loops back — either to `@implementer` (outer loop) or self
 | @visual-tester | @implementer |
 | Any node × 7 | Human escalation (interrupt) |
 
-When looping back to `@implementer`, the full downstream chain reruns: `implementer → cherry-pick → test-runner → qualimetry → code-review → refactorer → test-runner → validator → [visual-tester]`.
+When looping back to `@implementer`, the full downstream chain reruns: `implementer → setup-feature-branch → cherry-pick → switch-to-feature → test-runner → qualimetry → code-review → refactorer → test-runner → validator → [visual-tester]`.
 
 **Exception:** after `@refactorer` succeeds, the re-run of `[test-runner]` routes directly to `@validator` — qualimetry and code review are NOT repeated.
 
@@ -85,14 +86,15 @@ When looping back to `@implementer`, the full downstream chain reruns: `implemen
  6. @test-writer            → Write test that captures the bug
  7. [switch-to-impl]        → (non-agentic) switch to impl branch
  8. @implementer            → Fix the bug
- 9. [cherry-pick]           → (non-agentic) cherry-pick impl commit onto tests branch; conflicts → @conflict-resolver
-10. [switch-to-test]        → (non-agentic) switch to tests branch
-11. [test-runner]           → run tests; fail → @fixer loop
-12. [qualimetry]            → jscpd check; fail → @implementer
-13. Code review (parallel): @quality-reviewer + @security-reviewer + @i18n-reviewer + @duplication-reviewer
-14. [merge-findings]  → Orchestrator merges findings → pass/fail; fail → @implementer
-15. @validator         → typecheck → tests → build; fail → @implementer
-16. [open-pr]          → create PR from tests branch to main + auto-merge
+ 9. [setup-feature-branch]  → (non-agentic) create pipeline/feature-<issue-number> from pipeline/tests-<issue-number> HEAD
+10. [cherry-pick]           → (non-agentic) cherry-pick impl commit onto feature branch; conflicts → @conflict-resolver
+11. [switch-to-feature]     → (non-agentic) switch to pipeline/feature-<issue-number>
+12. [test-runner]           → run tests on feature branch; fail → @fixer loop
+13. [qualimetry]            → jscpd check; fail → @implementer
+14. Code review (parallel): @quality-reviewer + @security-reviewer + @i18n-reviewer + @duplication-reviewer
+15. [merge-findings]  → Orchestrator merges findings → pass/fail; fail → @implementer
+16. @validator         → typecheck → tests → build; fail → @implementer
+17. [open-pr]          → create PR from feature branch to main + auto-merge
 ```
 
 Note: `@refactorer` is skipped for fix-bug.
@@ -107,13 +109,15 @@ Note: `@refactorer` is skipped for fix-bug.
 
 ## Branch Isolation (Critical)
 
-The entire point of the 2-branch strategy is to prevent the implementer from seeing tests, ensuring unbiased TDD. You must enforce this strictly.
+The entire point of the 3-branch strategy is to prevent the implementer from seeing tests, ensuring unbiased TDD. You must enforce this strictly.
 
 ```
 main
  └─ pipeline/tests-<issue-number>   (stubs + tests — skeleton_commit_sha recorded here)
-      └─ pipeline/impl-<issue-number>  (forked from skeleton commit — implementer here)
-           ↓ cherry-pick impl commit onto tests branch → all quality gates run here
+ │    └─ pipeline/impl-<issue-number>  (forked from skeleton commit — implementer here)
+ │
+ └─ pipeline/feature-<issue-number> (deliverable — created from tests branch HEAD)
+                                     ↓ cherry-pick impl → quality gates + PR → main
 ```
 
 ### What each agent is allowed to see
@@ -123,15 +127,15 @@ main
 | @skeleton-writer | tests_branch | No tests exist yet |
 | @test-writer | tests_branch | Yes — writes them |
 | @implementer | impl_branch | **NO — branch enforces this** (test files never committed to impl_branch) |
-| @fixer | tests_branch | **Yes — both** (after cherry-pick, tests branch has impl + tests) |
-| @refactorer, @validator, reviewers | tests_branch | Yes (after cherry-pick) |
+| @fixer | feature_branch | **Yes — both** (after cherry-pick, feature branch has tests + impl) |
+| @refactorer, @validator, reviewers | feature_branch | Yes (after cherry-pick) |
 
 ### Enforcement rules for you (the orchestrator)
 
 - **Before invoking @implementer:** switch to `impl_branch` (`git checkout pipeline/impl-<issue-number>`). Confirm with `git branch` output before proceeding.
   - The branch itself enforces blindness — test files were never committed to `impl_branch`. No manual filtering needed.
   - Still: do **not** verbally describe test names, test logic, or expected assertions in the prompt. Pass only: plan, stub signatures, issue description.
-- **Before invoking @fixer:** switch to `tests_branch`. @fixer sees both implementation and test source (after cherry-pick) — this is intentional. It must judge which side is wrong (broken impl vs. incorrect test).
+- **Before invoking @fixer:** switch to `feature_branch`. @fixer sees both implementation and test source (after cherry-pick) — this is intentional. It must judge which side is wrong (broken impl vs. incorrect test).
 - If you accidentally switch to the wrong branch, stop, switch to the correct branch, and restart that agent step.
 
 ## Your Responsibilities
@@ -149,14 +153,16 @@ main
 |------|--------|
 | setup-test-branch | `git checkout -b pipeline/tests-<issue-number> main` |
 | setup-impl-branch | `git checkout -b pipeline/impl-<issue-number> <skeleton_commit_sha>` |
+| setup-feature-branch | `git checkout -b pipeline/feature-<issue-number> pipeline/tests-<issue-number>` |
 | switch-to-test | `git checkout pipeline/tests-<issue-number>` |
 | switch-to-impl | `git checkout pipeline/impl-<issue-number>` |
-| cherry-pick | `git cherry-pick <impl_commit_sha>` (on tests branch); detect conflicts |
+| switch-to-feature | `git checkout pipeline/feature-<issue-number>` |
+| cherry-pick | `git cherry-pick <impl_commit_sha>` (on feature branch); detect conflicts |
 | test-runner | `npx vitest run` — capture output, route to @fixer on fail |
 | qualimetry | `npx jscpd src/ tests/` — route to @implementer on fail |
 | merge-findings | Deduplicate and merge all 4 reviewer reports → pass/fail |
 | After refactorer | Re-run `npx vitest run` (skip qualimetry + code-review) |
-| open-pr | `gh pr create --base main --head pipeline/tests-<issue-number>` + `gh pr merge --auto --squash` — follow PR title/body/label standards in `agentic-autonomous-pipeline` skill |
+| open-pr | `gh pr create --base main --head pipeline/feature-<issue-number>` + `gh pr merge --auto --squash` — follow PR title/body/label standards in `agentic-autonomous-pipeline` skill |
 | Before completing | Summarize changes, files modified, test status |
 
 ## Key References

--- a/.claude/skills/agentic-autonomous-pipeline/SKILL.md
+++ b/.claude/skills/agentic-autonomous-pipeline/SKILL.md
@@ -47,28 +47,29 @@ Critical to unbiased implementation: test code and implementation code must neve
 
 ```
 main
- └─ pipeline/tests-<issue-number>   (test branch — skeleton → tests → final code)
-      └─ pipeline/impl-<issue-number>  (impl branch — forked from skeleton commit)
-           └─ implementer works here, never sees tests
-              ↓
-         cherry-pick → lands on test branch
+ └─ pipeline/tests-<issue-number>   (test branch — skeleton → tests)
+ │    └─ pipeline/impl-<issue-number>  (impl branch — forked from skeleton commit)
+ │
+ └─ pipeline/feature-<issue-number> (deliverable branch — created from tests branch HEAD)
+                                     ↓ cherry-pick impl → quality gates + PR → main
 ```
 
 1. **Skeleton branch:** create `pipeline/tests-<issue-number>` from `main`, write empty stubs, record `skeleton_commit_sha`
 2. **Fork impl branch:** create `pipeline/impl-<issue-number>` from that skeleton commit
 3. **Write tests** on `pipeline/tests-<issue-number>` (test branch)
 4. **Implement** on `pipeline/impl-<issue-number>` (impl branch) — agent never sees test commits
-5. **Cherry-pick** the implementation commit onto `pipeline/tests-<issue-number>`
-6. **Resolve conflicts** if cherry-pick fails
-7. **All subsequent quality gates** run on `pipeline/tests-<issue-number>`
+5. **Create feature branch:** create `pipeline/feature-<issue-number>` from `pipeline/tests-<issue-number>` HEAD
+6. **Cherry-pick** the implementation commit onto `pipeline/feature-<issue-number>`
+7. **Resolve conflicts** if cherry-pick fails
+8. **All subsequent quality gates** run on `pipeline/feature-<issue-number>`
 
 ### Cherry-Pick + Conflict Resolution
 
-The implementation commit is cherry-picked from the impl branch onto the test branch. If conflicts arise, a conflict resolver agent reads the conflicted files, merges both sides, removes conflict markers, and stages the resolved files. On resolution failure, the implementer re-runs.
+The implementation commit is cherry-picked from the impl branch onto the feature branch. If conflicts arise, a conflict resolver agent reads the conflicted files, merges both sides, removes conflict markers, and stages the resolved files. On resolution failure, the implementer re-runs.
 
 ### Quality Gates (after cherry-pick)
 
-After the code lands on the test branch, these gates run in sequence:
+After the code lands on the feature branch, these gates run in sequence:
 1. **Test runner** (non-agentic) — run test suite, pass → continue, fail → fixer loop
 2. **Duplication check** (non-agentic) — jscpd syntactic clone detection, fail → back to implementer
 3. **Code review fan-out** (agentic, parallel) — specialized sub-reviewers by risk tier:
@@ -83,7 +84,7 @@ After the code lands on the test branch, these gates run in sequence:
 
 ### PR Creation
 
-Create a pull request from `pipeline/tests-<issue-number>` to `main` with:
+Create a pull request from `pipeline/feature-<issue-number>` to `main` with:
 - Title prefixed by pipeline type (`feat:`, `fix:`, `docs:`)
 - Body includes `Closes #<issue_number>` and validation checklist
 - Labels updated: `in-progress` removed, `in-review` added

--- a/.claude/skills/agentic-autonomous-pipeline/SKILL.md
+++ b/.claude/skills/agentic-autonomous-pipeline/SKILL.md
@@ -95,4 +95,4 @@ This operation is always non-agentic (no LLM involved).
 
 Default: **enable GitHub native auto-merge** on every PR — via `gh pr merge --auto --squash`.
 
-Only skip auto-merge when the pipeline has explicitly flagged that human input is needed (artistic direction, critical architecture design decision). In that case, post a PR comment with the reason from the pipeline state instead. This is always non-agentic (no LLM involved).
+Skip auto-merge when the issue requires human input or the orchestrator judges the pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs). Post a PR comment with the reason.

--- a/.github/agents/pipeline.agent.md
+++ b/.github/agents/pipeline.agent.md
@@ -34,27 +34,28 @@ Steps are sequential unless marked parallel. Failure loops shown separately belo
  6. @test-writer            → Write failing tests on tests branch (unit + integration + scenario)
  7. [switch-to-impl]        → (non-agentic) switch to pipeline/impl-<issue-number>
  8. @implementer            → Minimum code to pass on impl branch (never sees test commits)
- 9. [cherry-pick]           → (non-agentic) cherry-pick impl commit onto tests branch
+ 9. [setup-feature-branch]  → (non-agentic) create pipeline/feature-<issue-number> from pipeline/tests-<issue-number> HEAD
+10. [cherry-pick]           → (non-agentic) cherry-pick impl commit onto feature branch
                              if conflicts → @conflict-resolver → retry cherry-pick
-10. [switch-to-test]        → (non-agentic) switch to pipeline/tests-<issue-number>
-11. [test-runner]           → (non-agentic) run full test suite on tests branch
+11. [switch-to-feature]     → (non-agentic) switch to pipeline/feature-<issue-number>
+12. [test-runner]           → (non-agentic) run full test suite on feature branch
                              if fail → @fixer → re-run test-runner (tight loop, max 7 retries)
-12. [qualimetry]            → (non-agentic) jscpd syntactic duplication check
+13. [qualimetry]            → (non-agentic) jscpd syntactic duplication check
                              if fail → @implementer (big loop)
-13. Code review (parallel):
+14. Code review (parallel):
       @security-reviewer    → exploitable vulnerabilities
       @quality-reviewer     → architecture, conventions, TypeScript strictness
       @i18n-reviewer        → hardcoded strings, locale mismatches
       @duplication-reviewer → semantic duplication, non-atomic functions
-14. [merge-findings]  → Orchestrator merges all sub-reviewer findings → pass/fail
+15. [merge-findings]  → Orchestrator merges all sub-reviewer findings → pass/fail
                         if fail → @implementer (big loop)
-15. @refactorer        → Clean up conventions, no behavior change
+16. @refactorer        → Clean up conventions, no behavior change
                          then re-run [test-runner] to verify no regression
-16. @validator         → Full validation: typecheck → tests → build
+17. @validator         → Full validation: typecheck → tests → build
                         if fail → @implementer (big loop)
-17. @visual-tester     → Screenshot verification (visual-change ONLY)
+18. @visual-tester     → Screenshot verification (visual-change ONLY)
                         if fail → @implementer (big loop)
-18. [open-pr]          → (non-agentic) create PR from tests branch to main + auto-merge
+19. [open-pr]          → (non-agentic) create PR from feature branch to main + auto-merge
 ```
 
 ### Failure loops (all pipelines)
@@ -72,7 +73,7 @@ Every agent failure loops back — either to `@implementer` (outer loop) or self
 | @visual-tester | @implementer |
 | Any node × 7 | Human escalation (interrupt) |
 
-When looping back to `@implementer`, the full downstream chain reruns: `implementer → cherry-pick → test-runner → qualimetry → code-review → refactorer → test-runner → validator → [visual-tester]`.
+When looping back to `@implementer`, the full downstream chain reruns: `implementer → setup-feature-branch → cherry-pick → switch-to-feature → test-runner → qualimetry → code-review → refactorer → test-runner → validator → [visual-tester]`.
 
 **Exception:** after `@refactorer` succeeds, the re-run of `[test-runner]` routes directly to `@validator` — qualimetry and code review are NOT repeated.
 
@@ -87,14 +88,15 @@ When looping back to `@implementer`, the full downstream chain reruns: `implemen
  6. @test-writer            → Write test that captures the bug
  7. [switch-to-impl]        → (non-agentic) switch to impl branch
  8. @implementer            → Fix the bug
- 9. [cherry-pick]           → (non-agentic) cherry-pick impl commit onto tests branch; conflicts → @conflict-resolver
-10. [switch-to-test]        → (non-agentic) switch to tests branch
-11. [test-runner]           → run tests; fail → @fixer loop
-12. [qualimetry]            → jscpd check; fail → @implementer
-13. Code review (parallel): @quality-reviewer + @security-reviewer + @i18n-reviewer + @duplication-reviewer
-14. [merge-findings]  → Orchestrator merges findings → pass/fail; fail → @implementer
-15. @validator         → typecheck → tests → build; fail → @implementer
-16. [open-pr]          → create PR from tests branch to main + auto-merge
+ 9. [setup-feature-branch]  → (non-agentic) create pipeline/feature-<issue-number> from pipeline/tests-<issue-number> HEAD
+10. [cherry-pick]           → (non-agentic) cherry-pick impl commit onto feature branch; conflicts → @conflict-resolver
+11. [switch-to-feature]     → (non-agentic) switch to pipeline/feature-<issue-number>
+12. [test-runner]           → run tests on feature branch; fail → @fixer loop
+13. [qualimetry]            → jscpd check; fail → @implementer
+14. Code review (parallel): @quality-reviewer + @security-reviewer + @i18n-reviewer + @duplication-reviewer
+15. [merge-findings]  → Orchestrator merges findings → pass/fail; fail → @implementer
+16. @validator         → typecheck → tests → build; fail → @implementer
+17. [open-pr]          → create PR from feature branch to main + auto-merge
 ```
 
 Note: `@refactorer` is skipped for fix-bug.
@@ -109,13 +111,15 @@ Note: `@refactorer` is skipped for fix-bug.
 
 ## Branch Isolation (Critical)
 
-The entire point of the 2-branch strategy is to prevent the implementer from seeing tests, ensuring unbiased TDD. You must enforce this strictly.
+The entire point of the 3-branch strategy is to prevent the implementer from seeing tests, ensuring unbiased TDD. You must enforce this strictly.
 
 ```
 main
  └─ pipeline/tests-<issue-number>   (stubs + tests — skeleton_commit_sha recorded here)
-      └─ pipeline/impl-<issue-number>  (forked from skeleton commit — implementer here)
-           ↓ cherry-pick impl commit onto tests branch → all quality gates run here
+ │    └─ pipeline/impl-<issue-number>  (forked from skeleton commit — implementer here)
+ │
+ └─ pipeline/feature-<issue-number> (deliverable — created from tests branch HEAD)
+                                     ↓ cherry-pick impl → quality gates + PR → main
 ```
 
 ### What each agent is allowed to see
@@ -125,15 +129,15 @@ main
 | @skeleton-writer | tests_branch | No tests exist yet |
 | @test-writer | tests_branch | Yes — writes them |
 | @implementer | impl_branch | **NO — branch enforces this** (test files never committed to impl_branch) |
-| @fixer | tests_branch | **Yes — both** (after cherry-pick, tests branch has impl + tests) |
-| @refactorer, @validator, reviewers | tests_branch | Yes (after cherry-pick) |
+| @fixer | feature_branch | **Yes — both** (after cherry-pick, feature branch has tests + impl) |
+| @refactorer, @validator, reviewers | feature_branch | Yes (after cherry-pick) |
 
 ### Enforcement rules for you (the orchestrator)
 
 - **Before invoking @implementer:** switch to `impl_branch` (`git checkout pipeline/impl-<issue-number>`). Confirm with `git branch` output before proceeding.
   - The branch itself enforces blindness — test files were never committed to `impl_branch`. No manual filtering needed.
   - Still: do **not** verbally describe test names, test logic, or expected assertions in the prompt. Pass only: plan, stub signatures, issue description.
-- **Before invoking @fixer:** switch to `tests_branch`. @fixer sees both implementation and test source (after cherry-pick) — this is intentional. It must judge which side is wrong (broken impl vs. incorrect test).
+- **Before invoking @fixer:** switch to `feature_branch`. @fixer sees both implementation and test source (after cherry-pick) — this is intentional. It must judge which side is wrong (broken impl vs. incorrect test).
 - If you accidentally switch to the wrong branch, stop, switch to the correct branch, and restart that agent step.
 
 ## Your Responsibilities
@@ -151,14 +155,16 @@ main
 |------|--------|
 | setup-test-branch | `git checkout -b pipeline/tests-<issue-number> main` |
 | setup-impl-branch | `git checkout -b pipeline/impl-<issue-number> <skeleton_commit_sha>` |
+| setup-feature-branch | `git checkout -b pipeline/feature-<issue-number> pipeline/tests-<issue-number>` |
 | switch-to-test | `git checkout pipeline/tests-<issue-number>` |
 | switch-to-impl | `git checkout pipeline/impl-<issue-number>` |
-| cherry-pick | `git cherry-pick <impl_commit_sha>` (on tests branch); detect conflicts |
+| switch-to-feature | `git checkout pipeline/feature-<issue-number>` |
+| cherry-pick | `git cherry-pick <impl_commit_sha>` (on feature branch); detect conflicts |
 | test-runner | `npx vitest run` — capture output, route to @fixer on fail |
 | qualimetry | `npx jscpd src/ tests/` — route to @implementer on fail |
 | merge-findings | Deduplicate and merge all 4 reviewer reports → pass/fail |
 | After refactorer | Re-run `npx vitest run` (skip qualimetry + code-review) |
-| open-pr | `gh pr create --base main --head pipeline/tests-<issue-number>` + `gh pr merge --auto --squash` — follow PR title/body/label standards in `agentic-autonomous-pipeline` skill |
+| open-pr | `gh pr create --base main --head pipeline/feature-<issue-number>` + `gh pr merge --auto --squash` — follow PR title/body/label standards in `agentic-autonomous-pipeline` skill |
 | Before completing | Summarize changes, files modified, test status |
 
 ## Key References

--- a/.github/agents/pipeline.agent.md
+++ b/.github/agents/pipeline.agent.md
@@ -191,11 +191,17 @@ After creating the PR and before finishing, run:
 gh pr merge --auto --squash <pr-url>
 ```
 
-This is the **default**. Only skip it if the issue explicitly requires human artistic input or a critical software design decision. In that case, run instead:
+This is the **default**. Skip auto-merge when:
+1. The issue requires human input (artistic direction, critical design decision).
+2. You judge the pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs) — you lived through it, use your judgment.
+
+When skipping, run:
 
 ```
 gh pr comment <pr-url> --body "Auto-merge paused — human input needed: <reason>"
 ```
+
+Include churn details in the reason so the reviewer understands the risk.
 
 ## Output Format
 

--- a/.github/skills/agentic-autonomous-pipeline/SKILL.md
+++ b/.github/skills/agentic-autonomous-pipeline/SKILL.md
@@ -47,28 +47,29 @@ Critical to unbiased implementation: test code and implementation code must neve
 
 ```
 main
- └─ pipeline/tests-<issue-number>   (test branch — skeleton → tests → final code)
-      └─ pipeline/impl-<issue-number>  (impl branch — forked from skeleton commit)
-           └─ implementer works here, never sees tests
-              ↓
-         cherry-pick → lands on test branch
+ └─ pipeline/tests-<issue-number>   (test branch — skeleton → tests)
+ │    └─ pipeline/impl-<issue-number>  (impl branch — forked from skeleton commit)
+ │
+ └─ pipeline/feature-<issue-number> (deliverable branch — created from tests branch HEAD)
+                                     ↓ cherry-pick impl → quality gates + PR → main
 ```
 
 1. **Skeleton branch:** create `pipeline/tests-<issue-number>` from `main`, write empty stubs, record `skeleton_commit_sha`
 2. **Fork impl branch:** create `pipeline/impl-<issue-number>` from that skeleton commit
 3. **Write tests** on `pipeline/tests-<issue-number>` (test branch)
 4. **Implement** on `pipeline/impl-<issue-number>` (impl branch) — agent never sees test commits
-5. **Cherry-pick** the implementation commit onto `pipeline/tests-<issue-number>`
-6. **Resolve conflicts** if cherry-pick fails
-7. **All subsequent quality gates** run on `pipeline/tests-<issue-number>`
+5. **Create feature branch:** create `pipeline/feature-<issue-number>` from `pipeline/tests-<issue-number>` HEAD
+6. **Cherry-pick** the implementation commit onto `pipeline/feature-<issue-number>`
+7. **Resolve conflicts** if cherry-pick fails
+8. **All subsequent quality gates** run on `pipeline/feature-<issue-number>`
 
 ### Cherry-Pick + Conflict Resolution
 
-The implementation commit is cherry-picked from the impl branch onto the test branch. If conflicts arise, a conflict resolver agent reads the conflicted files, merges both sides, removes conflict markers, and stages the resolved files. On resolution failure, the implementer re-runs.
+The implementation commit is cherry-picked from the impl branch onto the feature branch. If conflicts arise, a conflict resolver agent reads the conflicted files, merges both sides, removes conflict markers, and stages the resolved files. On resolution failure, the implementer re-runs.
 
 ### Quality Gates (after cherry-pick)
 
-After the code lands on the test branch, these gates run in sequence:
+After the code lands on the feature branch, these gates run in sequence:
 1. **Test runner** (non-agentic) — run test suite, pass → continue, fail → fixer loop
 2. **Duplication check** (non-agentic) — jscpd syntactic clone detection, fail → back to implementer
 3. **Code review fan-out** (agentic, parallel) — specialized sub-reviewers by risk tier:
@@ -83,7 +84,7 @@ After the code lands on the test branch, these gates run in sequence:
 
 ### PR Creation
 
-Create a pull request from `pipeline/tests-<issue-number>` to `main` with:
+Create a pull request from `pipeline/feature-<issue-number>` to `main` with:
 - Title prefixed by pipeline type (`feat:`, `fix:`, `docs:`)
 - Body includes `Closes #<issue_number>` and validation checklist
 - Labels updated: `in-progress` removed, `in-review` added

--- a/.github/skills/agentic-autonomous-pipeline/SKILL.md
+++ b/.github/skills/agentic-autonomous-pipeline/SKILL.md
@@ -95,4 +95,4 @@ This operation is always non-agentic (no LLM involved).
 
 Default: **enable GitHub native auto-merge** on every PR — via `gh pr merge --auto --squash`.
 
-Only skip auto-merge when the pipeline has explicitly flagged that human input is needed (artistic direction, critical architecture design decision). In that case, post a PR comment with the reason from the pipeline state instead. This is always non-agentic (no LLM involved).
+Skip auto-merge when the issue requires human input or the orchestrator judges the pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs). Post a PR comment with the reason.

--- a/.opencode/agents/pipeline.md
+++ b/.opencode/agents/pipeline.md
@@ -189,11 +189,17 @@ After creating the PR and before finishing, run:
 gh pr merge --auto --squash <pr-url>
 ```
 
-This is the **default**. Only skip it if the issue explicitly requires human artistic input or a critical software design decision. In that case, run instead:
+This is the **default**. Skip auto-merge when:
+1. The issue requires human input (artistic direction, critical design decision).
+2. You judge the pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs) — you lived through it, use your judgment.
+
+When skipping, run:
 
 ```
 gh pr comment <pr-url> --body "Auto-merge paused — human input needed: <reason>"
 ```
+
+Include churn details in the reason so the reviewer understands the risk.
 
 ## Output Format
 

--- a/.opencode/agents/pipeline.md
+++ b/.opencode/agents/pipeline.md
@@ -32,27 +32,28 @@ Steps are sequential unless marked parallel. Failure loops shown separately belo
  6. @test-writer            → Write failing tests on tests branch (unit + integration + scenario)
  7. [switch-to-impl]        → (non-agentic) switch to pipeline/impl-<issue-number>
  8. @implementer            → Minimum code to pass on impl branch (never sees test commits)
- 9. [cherry-pick]           → (non-agentic) cherry-pick impl commit onto tests branch
+ 9. [setup-feature-branch]  → (non-agentic) create pipeline/feature-<issue-number> from pipeline/tests-<issue-number> HEAD
+10. [cherry-pick]           → (non-agentic) cherry-pick impl commit onto feature branch
                              if conflicts → @conflict-resolver → retry cherry-pick
-10. [switch-to-test]        → (non-agentic) switch to pipeline/tests-<issue-number>
-11. [test-runner]           → (non-agentic) run full test suite on tests branch
+11. [switch-to-feature]     → (non-agentic) switch to pipeline/feature-<issue-number>
+12. [test-runner]           → (non-agentic) run full test suite on feature branch
                              if fail → @fixer → re-run test-runner (tight loop, max 7 retries)
-12. [qualimetry]            → (non-agentic) jscpd syntactic duplication check
+13. [qualimetry]            → (non-agentic) jscpd syntactic duplication check
                              if fail → @implementer (big loop)
-13. Code review (parallel):
+14. Code review (parallel):
       @security-reviewer    → exploitable vulnerabilities
       @quality-reviewer     → architecture, conventions, TypeScript strictness
       @i18n-reviewer        → hardcoded strings, locale mismatches
       @duplication-reviewer → semantic duplication, non-atomic functions
-14. [merge-findings]  → Orchestrator merges all sub-reviewer findings → pass/fail
+15. [merge-findings]  → Orchestrator merges all sub-reviewer findings → pass/fail
                         if fail → @implementer (big loop)
-15. @refactorer        → Clean up conventions, no behavior change
+16. @refactorer        → Clean up conventions, no behavior change
                          then re-run [test-runner] to verify no regression
-16. @validator         → Full validation: typecheck → tests → build
+17. @validator         → Full validation: typecheck → tests → build
                         if fail → @implementer (big loop)
-17. @visual-tester     → Screenshot verification (visual-change ONLY)
+18. @visual-tester     → Screenshot verification (visual-change ONLY)
                         if fail → @implementer (big loop)
-18. [open-pr]          → (non-agentic) create PR from tests branch to main + auto-merge
+19. [open-pr]          → (non-agentic) create PR from feature branch to main + auto-merge
 ```
 
 ### Failure loops (all pipelines)
@@ -70,7 +71,7 @@ Every agent failure loops back — either to `@implementer` (outer loop) or self
 | @visual-tester | @implementer |
 | Any node × 7 | Human escalation (interrupt) |
 
-When looping back to `@implementer`, the full downstream chain reruns: `implementer → cherry-pick → test-runner → qualimetry → code-review → refactorer → test-runner → validator → [visual-tester]`.
+When looping back to `@implementer`, the full downstream chain reruns: `implementer → setup-feature-branch → cherry-pick → switch-to-feature → test-runner → qualimetry → code-review → refactorer → test-runner → validator → [visual-tester]`.
 
 **Exception:** after `@refactorer` succeeds, the re-run of `[test-runner]` routes directly to `@validator` — qualimetry and code review are NOT repeated.
 
@@ -85,14 +86,15 @@ When looping back to `@implementer`, the full downstream chain reruns: `implemen
  6. @test-writer            → Write test that captures the bug
  7. [switch-to-impl]        → (non-agentic) switch to impl branch
  8. @implementer            → Fix the bug
- 9. [cherry-pick]           → (non-agentic) cherry-pick impl commit onto tests branch; conflicts → @conflict-resolver
-10. [switch-to-test]        → (non-agentic) switch to tests branch
-11. [test-runner]           → run tests; fail → @fixer loop
-12. [qualimetry]            → jscpd check; fail → @implementer
-13. Code review (parallel): @quality-reviewer + @security-reviewer + @i18n-reviewer + @duplication-reviewer
-14. [merge-findings]  → Orchestrator merges findings → pass/fail; fail → @implementer
-15. @validator         → typecheck → tests → build; fail → @implementer
-16. [open-pr]          → create PR from tests branch to main + auto-merge
+ 9. [setup-feature-branch]  → (non-agentic) create pipeline/feature-<issue-number> from pipeline/tests-<issue-number> HEAD
+10. [cherry-pick]           → (non-agentic) cherry-pick impl commit onto feature branch; conflicts → @conflict-resolver
+11. [switch-to-feature]     → (non-agentic) switch to pipeline/feature-<issue-number>
+12. [test-runner]           → run tests on feature branch; fail → @fixer loop
+13. [qualimetry]            → jscpd check; fail → @implementer
+14. Code review (parallel): @quality-reviewer + @security-reviewer + @i18n-reviewer + @duplication-reviewer
+15. [merge-findings]  → Orchestrator merges findings → pass/fail; fail → @implementer
+16. @validator         → typecheck → tests → build; fail → @implementer
+17. [open-pr]          → create PR from feature branch to main + auto-merge
 ```
 
 Note: `@refactorer` is skipped for fix-bug.
@@ -107,13 +109,15 @@ Note: `@refactorer` is skipped for fix-bug.
 
 ## Branch Isolation (Critical)
 
-The entire point of the 2-branch strategy is to prevent the implementer from seeing tests, ensuring unbiased TDD. You must enforce this strictly.
+The entire point of the 3-branch strategy is to prevent the implementer from seeing tests, ensuring unbiased TDD. You must enforce this strictly.
 
 ```
 main
  └─ pipeline/tests-<issue-number>   (stubs + tests — skeleton_commit_sha recorded here)
-      └─ pipeline/impl-<issue-number>  (forked from skeleton commit — implementer here)
-           ↓ cherry-pick impl commit onto tests branch → all quality gates run here
+ │    └─ pipeline/impl-<issue-number>  (forked from skeleton commit — implementer here)
+ │
+ └─ pipeline/feature-<issue-number> (deliverable — created from tests branch HEAD)
+                                     ↓ cherry-pick impl → quality gates + PR → main
 ```
 
 ### What each agent is allowed to see
@@ -123,15 +127,15 @@ main
 | @skeleton-writer | tests_branch | No tests exist yet |
 | @test-writer | tests_branch | Yes — writes them |
 | @implementer | impl_branch | **NO — branch enforces this** (test files never committed to impl_branch) |
-| @fixer | tests_branch | **Yes — both** (after cherry-pick, tests branch has impl + tests) |
-| @refactorer, @validator, reviewers | tests_branch | Yes (after cherry-pick) |
+| @fixer | feature_branch | **Yes — both** (after cherry-pick, feature branch has tests + impl) |
+| @refactorer, @validator, reviewers | feature_branch | Yes (after cherry-pick) |
 
 ### Enforcement rules for you (the orchestrator)
 
 - **Before invoking @implementer:** switch to `impl_branch` (`git checkout pipeline/impl-<issue-number>`). Confirm with `git branch` output before proceeding.
   - The branch itself enforces blindness — test files were never committed to `impl_branch`. No manual filtering needed.
   - Still: do **not** verbally describe test names, test logic, or expected assertions in the prompt. Pass only: plan, stub signatures, issue description.
-- **Before invoking @fixer:** switch to `tests_branch`. @fixer sees both implementation and test source (after cherry-pick) — this is intentional. It must judge which side is wrong (broken impl vs. incorrect test).
+- **Before invoking @fixer:** switch to `feature_branch`. @fixer sees both implementation and test source (after cherry-pick) — this is intentional. It must judge which side is wrong (broken impl vs. incorrect test).
 - If you accidentally switch to the wrong branch, stop, switch to the correct branch, and restart that agent step.
 
 ## Your Responsibilities
@@ -149,14 +153,16 @@ main
 |------|--------|
 | setup-test-branch | `git checkout -b pipeline/tests-<issue-number> main` |
 | setup-impl-branch | `git checkout -b pipeline/impl-<issue-number> <skeleton_commit_sha>` |
+| setup-feature-branch | `git checkout -b pipeline/feature-<issue-number> pipeline/tests-<issue-number>` |
 | switch-to-test | `git checkout pipeline/tests-<issue-number>` |
 | switch-to-impl | `git checkout pipeline/impl-<issue-number>` |
-| cherry-pick | `git cherry-pick <impl_commit_sha>` (on tests branch); detect conflicts |
+| switch-to-feature | `git checkout pipeline/feature-<issue-number>` |
+| cherry-pick | `git cherry-pick <impl_commit_sha>` (on feature branch); detect conflicts |
 | test-runner | `npx vitest run` — capture output, route to @fixer on fail |
 | qualimetry | `npx jscpd src/ tests/` — route to @implementer on fail |
 | merge-findings | Deduplicate and merge all 4 reviewer reports → pass/fail |
 | After refactorer | Re-run `npx vitest run` (skip qualimetry + code-review) |
-| open-pr | `gh pr create --base main --head pipeline/tests-<issue-number>` + `gh pr merge --auto --squash` — follow PR title/body/label standards in `agentic-autonomous-pipeline` skill |
+| open-pr | `gh pr create --base main --head pipeline/feature-<issue-number>` + `gh pr merge --auto --squash` — follow PR title/body/label standards in `agentic-autonomous-pipeline` skill |
 | Before completing | Summarize changes, files modified, test status |
 
 ## Key References

--- a/.opencode/skills/agentic-autonomous-pipeline/SKILL.md
+++ b/.opencode/skills/agentic-autonomous-pipeline/SKILL.md
@@ -95,4 +95,4 @@ This operation is always non-agentic (no LLM involved).
 
 Default: **enable GitHub native auto-merge** on every PR — via `gh pr merge --auto --squash`.
 
-Only skip auto-merge when the pipeline has explicitly flagged that human input is needed (artistic direction, critical architecture design decision). In that case, post a PR comment with the reason from the pipeline state instead. This is always non-agentic (no LLM involved).
+Skip auto-merge when the issue requires human input or the orchestrator judges the pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs). Post a PR comment with the reason.

--- a/.opencode/skills/agentic-autonomous-pipeline/SKILL.md
+++ b/.opencode/skills/agentic-autonomous-pipeline/SKILL.md
@@ -3,7 +3,6 @@ name: agentic-autonomous-pipeline
 description: >
   Agentic autonomous TDD development pipeline. Runs via OpenCode orchestrator (CLI or GitHub Actions).
   Use when setting up, debugging, or modifying the autonomous pipeline system.
-  Use when setting up, debugging, or modifying the autonomous pipeline system.
 ---
 
 ## Overview
@@ -48,28 +47,29 @@ Critical to unbiased implementation: test code and implementation code must neve
 
 ```
 main
- └─ pipeline/tests-<issue-number>   (test branch — skeleton → tests → final code)
-      └─ pipeline/impl-<issue-number>  (impl branch — forked from skeleton commit)
-           └─ implementer works here, never sees tests
-              ↓
-         cherry-pick → lands on test branch
+ └─ pipeline/tests-<issue-number>   (test branch — skeleton → tests)
+ │    └─ pipeline/impl-<issue-number>  (impl branch — forked from skeleton commit)
+ │
+ └─ pipeline/feature-<issue-number> (deliverable branch — created from tests branch HEAD)
+                                     ↓ cherry-pick impl → quality gates + PR → main
 ```
 
 1. **Skeleton branch:** create `pipeline/tests-<issue-number>` from `main`, write empty stubs, record `skeleton_commit_sha`
 2. **Fork impl branch:** create `pipeline/impl-<issue-number>` from that skeleton commit
 3. **Write tests** on `pipeline/tests-<issue-number>` (test branch)
 4. **Implement** on `pipeline/impl-<issue-number>` (impl branch) — agent never sees test commits
-5. **Cherry-pick** the implementation commit onto `pipeline/tests-<issue-number>`
-6. **Resolve conflicts** if cherry-pick fails
-7. **All subsequent quality gates** run on `pipeline/tests-<issue-number>`
+5. **Create feature branch:** create `pipeline/feature-<issue-number>` from `pipeline/tests-<issue-number>` HEAD
+6. **Cherry-pick** the implementation commit onto `pipeline/feature-<issue-number>`
+7. **Resolve conflicts** if cherry-pick fails
+8. **All subsequent quality gates** run on `pipeline/feature-<issue-number>`
 
 ### Cherry-Pick + Conflict Resolution
 
-The implementation commit is cherry-picked from the impl branch onto the test branch. If conflicts arise, a conflict resolver agent reads the conflicted files, merges both sides, removes conflict markers, and stages the resolved files. On resolution failure, the implementer re-runs.
+The implementation commit is cherry-picked from the impl branch onto the feature branch. If conflicts arise, a conflict resolver agent reads the conflicted files, merges both sides, removes conflict markers, and stages the resolved files. On resolution failure, the implementer re-runs.
 
 ### Quality Gates (after cherry-pick)
 
-After the code lands on the test branch, these gates run in sequence:
+After the code lands on the feature branch, these gates run in sequence:
 1. **Test runner** (non-agentic) — run test suite, pass → continue, fail → fixer loop
 2. **Duplication check** (non-agentic) — jscpd syntactic clone detection, fail → back to implementer
 3. **Code review fan-out** (agentic, parallel) — specialized sub-reviewers by risk tier:
@@ -84,7 +84,7 @@ After the code lands on the test branch, these gates run in sequence:
 
 ### PR Creation
 
-Create a pull request from `pipeline/tests-<issue-number>` to `main` with:
+Create a pull request from `pipeline/feature-<issue-number>` to `main` with:
 - Title prefixed by pipeline type (`feat:`, `fix:`, `docs:`)
 - Body includes `Closes #<issue_number>` and validation checklist
 - Labels updated: `in-progress` removed, `in-review` added


### PR DESCRIPTION
Add pipeline/feature-<N> as deliverable branch:
- pipeline/tests-<N>: skeleton + tests only (internal)
- pipeline/impl-<N>: impl only (implementer workspace)
- pipeline/feature-<N>: created from tests HEAD, cherry-pick impl, quality gates, PR to main

Update all 3 solution copies (OpenCode, Claude, GitHub).