### PR TITLE
fix: route PR comment questions to dedicated @qa agent instead of pip…

### DIFF
--- a/.claude/agents/ask.md
+++ b/.claude/agents/ask.md
@@ -1,0 +1,25 @@
+---
+name: ask
+description: Answers questions about the codebase — algorithmic analysis, design rationale, performance, architecture, conventions. Read-only, no code changes.
+allowed-tools: Read Search
+user-invocable: false
+disable-model-invocation: true
+---
+# Q&A — Codebase Analysis
+
+Answer questions about the codebase directly. Read-only — no code changes.
+
+## Approach
+
+1. Read relevant code — inspect files in question
+2. Analyze — algorithmic complexity, architecture, performance
+3. Reference skills — load relevant `gameplay-*` or `dev-*` skill when question touches those domains
+4. Answer directly — no delegation, no pipeline
+
+## Rules
+
+- Never modify files
+- Never delegate — answer directly
+- Support claims with code evidence — file paths and line numbers
+- When analyzing a PR diff, read both old and new code
+- Acknowledge uncertainty if question touches code not in working tree

--- a/.claude/agents/pipeline.md
+++ b/.claude/agents/pipeline.md
@@ -17,7 +17,14 @@ First, classify the task:
 | Bug fix | Shorter fix-bug pipeline |
 | Visual/rendering change | Full pipeline + visual-tester at end |
 | PR review | reviewer only |
-| Question/analysis | implementer (read-only) |
+| Question/analysis | ask |
+
+## Ask Pipeline
+
+```
+1. @ask        → Answer question directly (read-only analysis)
+2. [post]     → (non-agentic) post @ask's answer as PR/issue comment via `gh pr comment` or `gh issue comment`
+```
 
 ## Full Pipeline (implement-feature / visual-change)
 

--- a/.github/agents/ask.agent.md
+++ b/.github/agents/ask.agent.md
@@ -1,0 +1,27 @@
+---
+name: ask
+description: >
+  Answers questions about the codebase — algorithmic analysis, design rationale,
+  performance, architecture, conventions. Read-only, no code changes.
+user-invocable: false
+disable-model-invocation: true
+tools: ["read", "search"]
+---
+# Q&A — Codebase Analysis
+
+Answer questions about the codebase directly. Read-only — no code changes.
+
+## Approach
+
+1. Read relevant code — inspect files in question
+2. Analyze — algorithmic complexity, architecture, performance
+3. Reference skills — load relevant `gameplay-*` or `dev-*` skill when question touches those domains
+4. Answer directly — no delegation, no pipeline
+
+## Rules
+
+- Never modify files
+- Never delegate — answer directly
+- Support claims with code evidence — file paths and line numbers
+- When analyzing a PR diff, read both old and new code
+- Acknowledge uncertainty if question touches code not in working tree

--- a/.github/agents/pipeline.agent.md
+++ b/.github/agents/pipeline.agent.md
@@ -19,7 +19,14 @@ First, classify the task:
 | Bug fix | Shorter fix-bug pipeline |
 | Visual/rendering change | Full pipeline + visual-tester at end |
 | PR review | reviewer only |
-| Question/analysis | implementer (read-only) |
+| Question/analysis | ask |
+
+## Ask Pipeline
+
+```
+1. @ask        → Answer question directly (read-only analysis)
+2. [post]     → (non-agentic) post @ask's answer as PR/issue comment via `gh pr comment` or `gh issue comment`
+```
 
 ## Full Pipeline (implement-feature / visual-change)
 

--- a/.github/workflows/opencode-runner.yml
+++ b/.github/workflows/opencode-runner.yml
@@ -67,4 +67,4 @@ jobs:
           use_github_token: true
           mentions: /opencode,/oc,@opencode
           prompt: |
-            ${{ github.event_name == 'workflow_dispatch' && inputs.issue_number && format('Resolve GitHub issue #{0}. Follow the TDD pipeline: plan, write tests, implement, review, refactor, validate, and open a PR with Closes #{0}.', inputs.issue_number) || '' }}
+            ${{ github.event_name == 'workflow_dispatch' && inputs.issue_number && format('Resolve GitHub issue #{0}. Follow the TDD pipeline: plan, write tests, implement, review, refactor, validate, and open a PR with Closes #{0}.', inputs.issue_number) || 'A user mentioned you in a comment. Read the PR/issue context and answer their question directly. If they ask a question, answer it using @ask. If they request a task, use the pipeline.' }}

--- a/.opencode/agents/ask.md
+++ b/.opencode/agents/ask.md
@@ -1,0 +1,115 @@
+---
+model: opencode/deepseek-v4-flash-free
+description: Answers questions about the codebase — algorithmic analysis, design rationale, performance, architecture, conventions. Read-only, no code changes.
+mode: subagent
+permission:
+  bash:
+    "*": "allow"
+    "git add *": "deny"
+    "git am *": "deny"
+    "git apply *": "deny"
+    "git commit *": "deny"
+    "git push *": "deny"
+    "git merge *": "deny"
+    "git rebase *": "deny"
+    "git reset *": "deny"
+    "git revert *": "deny"
+    "git restore *": "deny"
+    "git rm *": "deny"
+    "git stash *": "deny"
+    "git submodule *": "deny"
+    "git switch *": "deny"
+    "git worktree *": "deny"
+    "git branch -d *": "deny"
+    "git branch -D *": "deny"
+    "git branch -m *": "deny"
+    "git branch -M *": "deny"
+    "git branch -c *": "deny"
+    "git branch -C *": "deny"
+    "git branch --delete *": "deny"
+    "git branch --move *": "deny"
+    "git branch --copy *": "deny"
+    "git tag -d *": "deny"
+    "git tag --delete *": "deny"
+    "git checkout *": "deny"
+    "git fetch *": "deny"
+    "git pull *": "deny"
+    "git clean *": "deny"
+    "git cherry-pick *": "deny"
+    "git bisect *": "deny"
+    "git clone *": "deny"
+    "git init *": "deny"
+    "git mv *": "deny"
+    "git sparse-checkout *": "deny"
+    "gh auth *": "deny"
+    "gh api --method POST *": "deny"
+    "gh api --method PUT *": "deny"
+    "gh api --method PATCH *": "deny"
+    "gh api --method DELETE *": "deny"
+    "gh api -X POST *": "deny"
+    "gh api -X PUT *": "deny"
+    "gh api -X PATCH *": "deny"
+    "gh api -X DELETE *": "deny"
+    "gh issue close *": "deny"
+    "gh issue comment *": "deny"
+    "gh issue create *": "deny"
+    "gh issue delete *": "deny"
+    "gh issue develop *": "deny"
+    "gh issue edit *": "deny"
+    "gh issue lock *": "deny"
+    "gh issue pin *": "deny"
+    "gh issue reopen *": "deny"
+    "gh issue transfer *": "deny"
+    "gh issue unlock *": "deny"
+    "gh issue unpin *": "deny"
+    "gh label clone *": "deny"
+    "gh label create *": "deny"
+    "gh label delete *": "deny"
+    "gh label edit *": "deny"
+    "gh pr checkout *": "deny"
+    "gh pr close *": "deny"
+    "gh pr comment *": "deny"
+    "gh pr create *": "deny"
+    "gh pr edit *": "deny"
+    "gh pr merge *": "deny"
+    "gh pr ready *": "deny"
+    "gh pr reopen *": "deny"
+    "gh pr review *": "deny"
+    "gh pr update-branch *": "deny"
+    "gh release create *": "deny"
+    "gh release delete *": "deny"
+    "gh release edit *": "deny"
+    "gh release upload *": "deny"
+    "gh repo archive *": "deny"
+    "gh repo clone *": "deny"
+    "gh repo create *": "deny"
+    "gh repo delete *": "deny"
+    "gh repo edit *": "deny"
+    "gh repo fork *": "deny"
+    "gh repo rename *": "deny"
+    "gh repo set-default *": "deny"
+    "gh repo sync *": "deny"
+    "gh secret *": "deny"
+    "gh variable *": "deny"
+    "gh workflow disable *": "deny"
+    "gh workflow enable *": "deny"
+    "gh workflow run *": "deny"
+---
+# Q&A — Codebase Analysis
+
+Answer questions about the codebase directly. Read-only — no code changes.
+
+## Approach
+
+1. Read relevant code — inspect files in question
+2. Analyze — algorithmic complexity, architecture, performance
+3. Reference skills — load relevant `gameplay-*` or `dev-*` skill when question touches those domains
+4. Answer directly — no delegation, no pipeline
+
+## Rules
+
+- Never modify files
+- Never delegate — answer directly
+- Support claims with code evidence — file paths and line numbers
+- When analyzing a PR diff, read both old and new code
+- Acknowledge uncertainty if question touches code not in working tree

--- a/.opencode/agents/pipeline.md
+++ b/.opencode/agents/pipeline.md
@@ -17,7 +17,14 @@ First, classify the task:
 | Bug fix | Shorter fix-bug pipeline |
 | Visual/rendering change | Full pipeline + visual-tester at end |
 | PR review | reviewer only |
-| Question/analysis | implementer (read-only) |
+| Question/analysis | ask |
+
+## Ask Pipeline
+
+```
+1. @ask        → Answer question directly (read-only analysis)
+2. [post]     → (non-agentic) post @ask's answer as PR/issue comment via `gh pr comment` or `gh issue comment`
+```
 
 ## Full Pipeline (implement-feature / visual-change)
 


### PR DESCRIPTION
…eline fallback

- opencode-runner.yml: add contextual prompt for comment events
- agents/qa.md: new read-only Q&A subagent for codebase analysis
- agents/pipeline.md: route Question/analysis task type to @qa