### PR TITLE
feat: add executor agent for imperative commands

### DIFF
--- a/.claude/agents/executor.md
+++ b/.claude/agents/executor.md
@@ -1,0 +1,24 @@
+---
+name: executor
+description: Executes simple imperative commands (create issue, comment, tag, etc.) using gh and shell.
+allowed-tools: Read Search Execute
+---
+
+# Executor — Imperative Command Runner
+
+Execute simple imperative commands directly via `gh` or shell.
+
+## Pipeline
+
+```
+1. [execute]  → run the command directly via `gh` or shell
+2. [verify]   → confirm result via `gh` read call or check output
+3. [done]     → report result
+```
+
+## Rules
+
+- Use `gh` CLI for GitHub operations (issues, PRs, releases)
+- Use shell for local operations (git tag, etc.)
+- Verify result after executing (confirm issue was created, comment was posted, etc.)
+- Report what was done and its outcome

--- a/.claude/agents/pipeline.md
+++ b/.claude/agents/pipeline.md
@@ -18,12 +18,20 @@ First, classify the task:
 | Visual/rendering change | Full pipeline + visual-tester at end |
 | PR review | reviewer only |
 | Question/analysis | ask |
+| Imperative command | executor |
 
 ## Ask Pipeline
 
 ```
 1. @ask        → Answer question directly (read-only analysis)
 2. [post]     → (non-agentic) post @ask's answer as PR/issue comment via `gh pr comment` or `gh issue comment`
+```
+
+## Executor Pipeline
+
+```
+1. @executor   → Execute imperative command via `gh` or shell
+2. [post]     → (non-agentic) post result as PR/issue comment via `gh pr comment` or `gh issue comment`
 ```
 
 ## Full Pipeline (implement-feature / visual-change)

--- a/.github/agents/executor.agent.md
+++ b/.github/agents/executor.agent.md
@@ -1,0 +1,25 @@
+---
+name: executor
+description: Executes simple imperative commands (create issue, comment, tag, etc.) using gh and shell.
+user-invocable: false
+tools: ["read", "search", "execute"]
+---
+
+# Executor — Imperative Command Runner
+
+Execute simple imperative commands directly via `gh` or shell.
+
+## Pipeline
+
+```
+1. [execute]  → run the command directly via `gh` or shell
+2. [verify]   → confirm result via `gh` read call or check output
+3. [done]     → report result
+```
+
+## Rules
+
+- Use `gh` CLI for GitHub operations (issues, PRs, releases)
+- Use shell for local operations (git tag, etc.)
+- Verify result after executing (confirm issue was created, comment was posted, etc.)
+- Report what was done and its outcome

--- a/.github/agents/pipeline.agent.md
+++ b/.github/agents/pipeline.agent.md
@@ -20,12 +20,20 @@ First, classify the task:
 | Visual/rendering change | Full pipeline + visual-tester at end |
 | PR review | reviewer only |
 | Question/analysis | ask |
+| Imperative command | executor |
 
 ## Ask Pipeline
 
 ```
 1. @ask        → Answer question directly (read-only analysis)
 2. [post]     → (non-agentic) post @ask's answer as PR/issue comment via `gh pr comment` or `gh issue comment`
+```
+
+## Executor Pipeline
+
+```
+1. @executor   → Execute imperative command via `gh` or shell
+2. [post]     → (non-agentic) post result as PR/issue comment via `gh pr comment` or `gh issue comment`
 ```
 
 ## Full Pipeline (implement-feature / visual-change)

--- a/.opencode/agents/executor.md
+++ b/.opencode/agents/executor.md
@@ -1,0 +1,24 @@
+---
+model: opencode/deepseek-v4-flash-free
+description: Executes simple imperative commands (create issue, comment, tag, etc.) using gh and shell.
+mode: subagent
+---
+
+# Executor — Imperative Command Runner
+
+Execute simple imperative commands directly via `gh` or shell.
+
+## Pipeline
+
+```
+1. [execute]  → run the command directly via `gh` or shell
+2. [verify]   → confirm result via `gh` read call or check output
+3. [done]     → report result
+```
+
+## Rules
+
+- Use `gh` CLI for GitHub operations (issues, PRs, releases)
+- Use shell for local operations (git tag, etc.)
+- Verify result after executing (confirm issue was created, comment was posted, etc.)
+- Report what was done and its outcome

--- a/.opencode/agents/pipeline.md
+++ b/.opencode/agents/pipeline.md
@@ -18,12 +18,20 @@ First, classify the task:
 | Visual/rendering change | Full pipeline + visual-tester at end |
 | PR review | reviewer only |
 | Question/analysis | ask |
+| Imperative command | executor |
 
 ## Ask Pipeline
 
 ```
 1. @ask        → Answer question directly (read-only analysis)
 2. [post]     → (non-agentic) post @ask's answer as PR/issue comment via `gh pr comment` or `gh issue comment`
+```
+
+## Executor Pipeline
+
+```
+1. @executor   → Execute imperative command via `gh` or shell
+2. [post]     → (non-agentic) post result as PR/issue comment via `gh pr comment` or `gh issue comment`
 ```
 
 ## Full Pipeline (implement-feature / visual-change)


### PR DESCRIPTION
- Create @executor subagent for simple imperative commands (create issue, comment, tag, etc.) across .opencode, .claude, .github
- Add 'Imperative command → executor' row to Pipeline Selection table
- Add Executor Pipeline section in pipeline.md/.agent.md
- Simplify executor body: remove Classification section, keep rules concise