### PR TITLE
fix: explicitly close issue on PR merge instead of relying on GitHub …

### DIFF
--- a/.github/workflows/auto-assign-next.yml
+++ b/.github/workflows/auto-assign-next.yml
@@ -35,7 +35,8 @@ jobs:
 
             const n = issueNum ? parseInt(issueNum) : null;
             if (n) {
-              console.log(`Updating labels for issue #${n} (closed by native GitHub auto-close).`);
+              console.log(`Closing issue #${n} (referenced in merged PR body).`);
+              await github.rest.issues.update({ owner, repo, issue_number: n, state: 'closed' });
               await github.rest.issues.addLabels({ owner, repo, issue_number: n, labels: ['done'] }).catch(() => {});
               await github.rest.issues.removeLabel({ owner, repo, issue_number: n, name: 'in-progress' }).catch(() => {});
             }


### PR DESCRIPTION
…auto-close

GitHub's native auto-close (Closes #N in PR body) does not reliably trigger when the PR is merged by github-actions[bot] using GITHUB_TOKEN. This adds an explicit issues.update({ state: 'closed' }) call as a fallback.