### PR TITLE
fix(pipeline): polling safety net + PAT token to fix auto-close/chain after PR merge

### DIFF
--- a/.github/workflows/auto-assign-next.yml
+++ b/.github/workflows/auto-assign-next.yml
@@ -3,6 +3,16 @@ name: "Pipeline: assign next issue to OpenCode"
 on:
   pull_request:
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number to close and chain from'
+        required: true
+        type: string
+      pr_number:
+        description: 'PR number that was merged (defaults to issue_number context)'
+        required: false
+        type: string
 
 permissions:
   issues: write
@@ -11,7 +21,9 @@ permissions:
 
 jobs:
   chain-next-task:
-    if: github.event.pull_request.merged == true
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Close done issue + assign next ready issue to OpenCode
@@ -19,26 +31,54 @@ jobs:
         env:
           AGENTIC_AUTO_ASSIGN_ENABLED: ${{ vars.AGENTIC_AUTO_ASSIGN_ENABLED }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION || secrets.GITHUB_TOKEN }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const prBody = context.payload.pull_request.body || '';
 
-            // --- 1. Find and close the completed issue ---
-            const closesMatch = prBody.match(/[Cc]loses?\s+#(\d+)/);
-            const issueNum = closesMatch?.[1];
+            // --- 0. Determine the issue number from the best available source ---
+            let n = null;
+            let issueSource = 'none';
 
-            if (!issueNum) {
-              console.log('No explicit close directive found in PR body. Skipping issue close.');
+            // Source A: workflow_dispatch input (most reliable)
+            if (context.eventName === 'workflow_dispatch') {
+              const inputIssue = context.payload.inputs?.issue_number;
+              if (inputIssue) {
+                n = parseInt(inputIssue);
+                issueSource = 'workflow_dispatch input';
+              }
             }
 
-            const n = issueNum ? parseInt(issueNum) : null;
+            // Source B: "Closes #N" or "closes #N" in PR body
+            if (!n && context.payload.pull_request) {
+              const prBody = context.payload.pull_request.body || '';
+              const closesMatch = prBody.match(/[Cc]loses?\s+#(\d+)/);
+              if (closesMatch) {
+                n = parseInt(closesMatch[1]);
+                issueSource = 'PR body "Closes #N"';
+              }
+            }
+
+            // Source C: branch name pipeline/tests-<issue_number> or pipeline/impl-<issue_number>
+            if (!n && context.payload.pull_request) {
+              const headRef = context.payload.pull_request.head.ref || '';
+              const branchMatch = headRef.match(/pipeline\/(?:tests|impl)-(\d+)/);
+              if (branchMatch) {
+                n = parseInt(branchMatch[1]);
+                issueSource = `branch name (${headRef})`;
+              }
+            }
+
+            console.log(`Issue number: ${n} (source: ${issueSource})`);
+
+            // --- 1. Find and close the completed issue ---
             if (n) {
-              console.log(`Closing issue #${n} (referenced in merged PR body).`);
+              console.log(`Closing issue #${n}.`);
               await github.rest.issues.update({ owner, repo, issue_number: n, state: 'closed' });
               await github.rest.issues.addLabels({ owner, repo, issue_number: n, labels: ['done'] }).catch(() => {});
               await github.rest.issues.removeLabel({ owner, repo, issue_number: n, name: 'in-progress' }).catch(() => {});
+            } else {
+              console.log('Could not determine issue number from any source. Skipping issue close.');
             }
 
             // --- 2. Update backlog.json to mark the closed task as done ---
@@ -48,10 +88,10 @@ jobs:
             const backlogIdMatch = closedIssueBody?.match(/^backlog-id:\s*(\S+)/m);
             if (backlogIdMatch) {
               const backlogId = backlogIdMatch[1];
-              const prNumber = context.payload.pull_request.number;
+              const prNumber = context.payload.pull_request?.number ?? context.payload.inputs?.pr_number ?? n;
               try {
                 const { data: fileData } = await github.rest.repos.getContent({
-                  owner, repo, path: '.github/skills/backlog/backlog.json'
+                  owner, repo, path: '.github/skills/agentic-backlog/backlog.json'
                 });
                 const raw = Buffer.from(fileData.content, 'base64').toString('utf8');
                 const tasks = JSON.parse(raw);
@@ -62,7 +102,7 @@ jobs:
                   const updated = JSON.stringify(tasks, null, 2) + '\n';
                   await github.rest.repos.createOrUpdateFileContents({
                     owner, repo,
-                    path: '.github/skills/backlog/backlog.json',
+                    path: '.github/skills/agentic-backlog/backlog.json',
                     message: `chore: mark backlog task ${backlogId} as done [skip ci]`,
                     content: Buffer.from(updated).toString('base64'),
                     sha: fileData.sha,
@@ -82,8 +122,11 @@ jobs:
             }
 
             // --- Auto-assign next issue (only when enabled + bot PR) ---
+            const rawEnv = process.env.AGENTIC_AUTO_ASSIGN_ENABLED ?? '(unset)';
             const autoAssignEnabled = (process.env.AGENTIC_AUTO_ASSIGN_ENABLED || 'false') === 'true';
-            const isBot = context.payload.pull_request.user.type === 'Bot';
+            const isBot = context.payload.pull_request?.user?.type === 'Bot';
+
+            console.log(`Auto-assign config: rawEnv="${rawEnv}", enabled=${autoAssignEnabled}, isBot=${isBot}`);
 
             if (autoAssignEnabled && isBot) {
               // --- 2.5 Check for stalled in-progress issues ---
@@ -154,16 +197,16 @@ jobs:
                 await github.rest.issues.createComment({
                   owner, repo,
                   issue_number: issue.number,
-                  body: `⚙️ Auto-assigned from merged PR #${context.payload.pull_request.number}`
+                  body: `⚙️ Auto-assigned from merged PR #${context.payload.pull_request?.number ?? '?'}`
                 });
 
                 await github.rest.actions.createWorkflowDispatch({
                   owner, repo,
                   workflow_id: 'opencode-runner.yml',
                   ref: 'main',
-                   inputs: {
-                     issue_number: String(issue.number)
-                   }
+                  inputs: {
+                    issue_number: String(issue.number)
+                  }
                 });
                 console.log(`OpenCode pipeline dispatched for issue #${issue.number}.`);
 
@@ -176,6 +219,7 @@ jobs:
                 console.log('Auto-assign is disabled (AGENTIC_AUTO_ASSIGN_ENABLED is not set to "true").');
               }
               if (!isBot) {
-                console.log(`PR author is ${context.payload.pull_request.user.type}, not Bot — skipping auto-assign.`);
+                const userType = context.payload.pull_request?.user?.type ?? 'unknown';
+                console.log(`PR author is ${userType}, not Bot — skipping auto-assign.`);
               }
             }

--- a/.github/workflows/opencode-runner.yml
+++ b/.github/workflows/opencode-runner.yml
@@ -68,3 +68,106 @@ jobs:
           mentions: /opencode,/oc,@opencode
           prompt: |
             ${{ github.event_name == 'workflow_dispatch' && inputs.issue_number && format('Resolve GitHub issue #{0}. Follow the TDD pipeline: plan, write tests, implement, review, refactor, validate, and open a PR with Closes #{0}.', inputs.issue_number) || 'A user mentioned you in a comment. Read the PR/issue context and answer their question directly. If they ask a question, answer it using @ask. If they request a task, use the pipeline.' }}
+
+      - name: Wait for PR merge, close issue, and chain next (safety net)
+        if: github.event_name == 'workflow_dispatch' && inputs.issue_number
+        uses: actions/github-script@v7
+        env:
+          AGENTIC_AUTO_ASSIGN_ENABLED: ${{ vars.AGENTIC_AUTO_ASSIGN_ENABLED }}
+        with:
+          github-token: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION || secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNumber = parseInt(context.payload.inputs.issue_number);
+
+
+            // --- Poll for PR merge (up to 30 min) ---
+            let prNumber = null;
+            for (let attempt = 0; attempt < 30; attempt++) {
+              const { data: events } = await github.rest.issues.listEventsForTimeline({
+                owner, repo, issue_number: issueNumber, per_page: 100
+              });
+              const prEvent = events.find(e =>
+                e.event === 'cross-referenced' && e.source?.issue?.pull_request
+              );
+              if (prEvent) {
+                prNumber = prEvent.source.issue.number;
+                const { data: pr } = await github.rest.pulls.get({
+                  owner, repo, pull_number: prNumber
+                });
+                if (pr.merged) {
+                  console.log(`PR #${prNumber} merged!`);
+                  break;
+                }
+              }
+              console.log(`Waiting for PR merge (attempt ${attempt + 1}/30)...`);
+              await new Promise(r => setTimeout(r, 60000));
+            }
+
+            if (!prNumber) {
+              console.log('No PR found for this issue — skipping chain.');
+              return;
+            }
+
+            // --- Close the originating issue ---
+            console.log(`Closing issue #${issueNumber}.`);
+            await github.rest.issues.update({ owner, repo, issue_number: issueNumber, state: 'closed' });
+            await github.rest.issues.addLabels({ owner, repo, issue_number: issueNumber, labels: ['done'] }).catch(() => {});
+            await github.rest.issues.removeLabel({ owner, repo, issue_number: issueNumber, name: 'in-progress' }).catch(() => {});
+
+            // --- Auto-assign next issue ---
+            const autoAssignEnabled = (process.env.AGENTIC_AUTO_ASSIGN_ENABLED || 'false') === 'true';
+            if (!autoAssignEnabled) {
+              console.log('Auto-assign disabled (AGENTIC_AUTO_ASSIGN_ENABLED not "true").');
+              return;
+            }
+
+            // Check for stalled in-progress issues
+            const { data: inProgress } = await github.rest.issues.listForRepo({
+              owner, repo, labels: 'in-progress', state: 'open', per_page: 10
+            });
+            for (const stuck of inProgress) {
+              if (stuck.number === issueNumber) continue;
+              const { data: events } = await github.rest.issues.listEventsForTimeline({
+                owner, repo, issue_number: stuck.number, per_page: 100
+              });
+              const hasPR = events.some(e => e.event === 'cross-referenced' && e.source?.issue?.pull_request);
+              if (!hasPR) {
+                console.log(`Issue #${stuck.number} in-progress but no linked PR. Halting chain.`);
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: stuck.number,
+                  body: '⏸️ Pipeline halted — this issue was marked **in-progress** but no linked PR was created.'
+                });
+                return;
+              }
+            }
+
+            // Find next ready issue
+            const { data: ready } = await github.rest.issues.listForRepo({
+              owner, repo, labels: 'ready', state: 'open',
+              sort: 'created', direction: 'asc', per_page: 10
+            });
+            ready.sort((a, b) => a.number - b.number);
+
+            for (const issue of ready) {
+              const depMatch = issue.body?.match(/[Dd]epends?\s+on:?\s*#(\d+)/);
+              if (depMatch) {
+                const dep = await github.rest.issues.get({ owner, repo, issue_number: parseInt(depMatch[1]) });
+                if (dep.data.state !== 'closed') {
+                  console.log(`#${issue.number}: dependency #${depMatch[1]} not closed, skipping.`);
+                  continue;
+                }
+              }
+              console.log(`Assigning #${issue.number} to OpenCode pipeline.`);
+              await github.rest.issues.removeLabel({ owner, repo, issue_number: issue.number, name: 'ready' }).catch(() => {});
+              await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels: ['in-progress'] });
+              await github.rest.issues.createComment({ owner, repo, issue_number: issue.number, body: `⚙️ Auto-assigned from merged PR #${prNumber}` });
+              await github.rest.actions.createWorkflowDispatch({
+                owner, repo, workflow_id: 'opencode-runner.yml', ref: 'main',
+                inputs: { issue_number: String(issue.number) }
+              });
+              console.log(`OpenCode pipeline dispatched for issue #${issue.number}.`);
+              return;
+            }
+            console.log('No more ready issues. Pipeline idle.');


### PR DESCRIPTION
## Problem

After PR #204 was auto-merged, the originating issue wasn't closed and the next issue wasn't dispatched, despite the PR body having `Closes #N`.

**Root cause:** The `auto-assign-next.yml` workflow relies on `pull_request: [closed]` events to trigger. But when auto-merge is enabled by `GITHUB_TOKEN`, GitHub Actions **blocks** the resulting `pull_request: [closed]` event from starting new workflows. The workflow never ran.

## Changes

### 1. `opencode-runner.yml` — New polling safety net step (primary fix)

After the OpenCode action creates the PR, a new step runs that:
- Polls every 60s (up to 30 min) waiting for the PR to merge
- Once merged, closes the originating issue
- Finds the next ready issue and dispatches `opencode-runner.yml` for it
- Uses `PAT_TOKEN_COPILOT_AUTOMATION` so the `workflow_dispatch` **will** trigger new workflows (bypasses GITHUB_TOKEN recursion limit)

### 2. `auto-assign-next.yml` — PAT token + branch name fallback

- Changed `github-token` to `PAT_TOKEN_COPILOT_AUTOMATION` so its own `createWorkflowDispatch` calls also bypass the limit
- Added branch name parsing (`pipeline/tests-<N>` / `pipeline/impl-<N>`) as fallback if "Closes #N" is missing
- Added `workflow_dispatch` trigger for manual retry from GitHub UI
- Added diagnostic logging

### 3. Other fixes

- Corrected the backlog path from `.github/skills/backlog/` (404) to `.github/skills/agentic-backlog/`
- Added diagnostic logging for `AGENTIC_AUTO_ASSIGN_ENABLED` raw value and `isBot` status

## Testing

Deploy and trigger the pipeline — the new safety net step will run after the OpenCode action completes. Confirm the issue is closed and the next one is dispatched after the PR merges.
