### PR TITLE
fix(pipeline): agent signals READY TO MERGE via PR body, PAT-based auto-merge in workflow

### DIFF
--- a/.claude/agents/pipeline.md
+++ b/.claude/agents/pipeline.md
@@ -68,7 +68,8 @@ Steps are sequential unless marked parallel. Failure loops shown separately belo
                         if fail → @implementer (big loop)
 18. @visual-tester     → Screenshot verification (visual-change ONLY)
                         if fail → @implementer (big loop)
-19. [open-pr]          → (non-agentic) create PR from feature branch to main + auto-merge
+19. [open-pr]          → (non-agentic) create PR from feature branch to main + READY TO MERGE
+
 ```
 
 ### Failure loops (all pipelines)
@@ -109,7 +110,7 @@ When looping back to `@implementer`, the full downstream chain reruns: `implemen
 14. Code review (parallel): @quality-reviewer + @security-reviewer + @i18n-reviewer + @duplication-reviewer
 15. [merge-findings]  → Orchestrator merges findings → pass/fail; fail → @implementer
 16. @validator         → typecheck → tests → build; fail → @implementer
-17. [open-pr]          → create PR from feature branch to main + auto-merge
+17. [open-pr]          → create PR from feature branch to main + READY TO MERGE
 ```
 
 Note: `@refactorer` is skipped for fix-bug.
@@ -177,7 +178,7 @@ main
 | qualimetry | `npx jscpd src/ tests/` — route to @implementer on fail |
 | merge-findings | Deduplicate and merge all 4 reviewer reports → pass/fail |
 | After refactorer | Re-run `npx vitest run` (skip qualimetry + code-review) |
-| open-pr | `gh pr create --base main --head pipeline/feature-<issue-number>` + `gh pr merge --auto --squash` — follow PR title/body/label standards in `agentic-autonomous-pipeline` skill |
+| open-pr | `gh pr create --base main --head pipeline/feature-<issue-number> --body "Closes #<issue-number>\n\nREADY TO MERGE"` — include validation checklist per `agentic-autonomous-pipeline` skill |
 | Before completing | Summarize changes, files modified, test status |
 
 ## Key References
@@ -196,22 +197,18 @@ main
   - **@implementer specifically:** do not verbally describe tests — only plan + stub signatures + expected behavior. Branch isolation handles the rest.
   - **@fixer specifically:** pass both the test runner error output AND full context (it needs both sides to decide what to fix)
 
-## Auto-Merge
+## READY TO MERGE
 
-After creating the PR and before finishing, run:
+After creating the PR, the body must include `READY TO MERGE` on its own line. The `auto-assign-next.yml` workflow detects this and enables GitHub native auto-merge via a PAT token, ensuring downstream CI events trigger correctly.
 
-```
-gh pr merge --auto --squash <pr-url>
-```
-
-This is the **default**. Skip auto-merge when:
+This is the **default**. Skip `READY TO MERGE` when:
 1. The issue requires human input (artistic direction, critical design decision).
 2. You judge the pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs) — you lived through it, use your judgment.
 
-When skipping, run:
+When skipping, post a comment explaining why:
 
 ```
-gh pr comment <pr-url> --body "Auto-merge paused — human input needed: <reason>"
+gh pr comment <pr-url> --body "READY TO MERGE skipped — human input needed: <reason>"
 ```
 
 Include churn details in the reason so the reviewer understands the risk.

--- a/.claude/skills/agentic-autonomous-pipeline/SKILL.md
+++ b/.claude/skills/agentic-autonomous-pipeline/SKILL.md
@@ -86,13 +86,13 @@ After the code lands on the feature branch, these gates run in sequence:
 
 Create a pull request from `pipeline/feature-<issue-number>` to `main` with:
 - Title prefixed by pipeline type (`feat:`, `fix:`, `docs:`)
-- Body includes `Closes #<issue_number>` and validation checklist
+- Body includes `Closes #<issue_number>`, validation checklist, and `READY TO MERGE` on its own line
 - Labels updated: `in-progress` removed, `in-review` added
 
 This operation is always non-agentic (no LLM involved).
 
 ### Auto-Merge
 
-Default: **enable GitHub native auto-merge** on every PR — via `gh pr merge --auto --squash`.
+The agent does **not** call `gh pr merge --auto` directly. Instead, the PR body includes `READY TO MERGE`. The `auto-assign-next.yml` workflow (triggered on `pull_request: [opened, synchronize]`) detects this and enables GitHub native auto-merge via a PAT token. This ensures the merge is attributed to the PAT, so the downstream `pull_request: [closed]` event triggers `auto-assign-next.yml` to close the issue and dispatch the next task.
 
-Skip auto-merge when the issue requires human input or the orchestrator judges the pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs). Post a PR comment with the reason.
+Skip `READY TO MERGE` when the issue requires human input or the orchestrator judges the pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs). Post a PR comment with the reason.

--- a/.claude/skills/agentic-autonomous-pipeline/SKILL.md
+++ b/.claude/skills/agentic-autonomous-pipeline/SKILL.md
@@ -93,6 +93,6 @@ This operation is always non-agentic (no LLM involved).
 
 ### Auto-Merge
 
-The agent does **not** call `gh pr merge --auto` directly. Instead, the PR body includes `READY TO MERGE`. The `auto-assign-next.yml` workflow (triggered on `pull_request: [opened, synchronize]`) detects this and enables GitHub native auto-merge via a PAT token. This ensures the merge is attributed to the PAT, so the downstream `pull_request: [closed]` event triggers `auto-assign-next.yml` to close the issue and dispatch the next task.
+The agent includes `READY TO MERGE` in the PR body. The `auto-assign-next.yml` workflow (triggered on `pull_request: [opened, synchronize]`) detects this and enables GitHub native auto-merge via a PAT token. The merge is attributed to the PAT, so the downstream `pull_request: [closed]` event triggers `auto-assign-next.yml` to close the issue and dispatch the next task.
 
 Skip `READY TO MERGE` when the issue requires human input or the orchestrator judges the pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs). Post a PR comment with the reason.

--- a/.claude/skills/agentic-skill-edition/SKILL.md
+++ b/.claude/skills/agentic-skill-edition/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-skill-edition
 description: >
   Create and edit agentic context files (SKILL.md, agent definitions, slash command prompts)
   across all agent standards (Copilot, Claude Code, OpenCode). Enforces same-wording
-  duplication rule: body content must be identical across solutions, only frontmatter differs.
+  duplication rule and affirmative phrasing (state what agent does, not what it avoids).
   Use when writing or editing skills, agents, or prompts in any solution directory.
 ---
 

--- a/.claude/skills/agentic-skill-edition/SKILL.md
+++ b/.claude/skills/agentic-skill-edition/SKILL.md
@@ -65,6 +65,9 @@ Check existing skills before writing. If new skill overlaps, extend existing ski
 ### DRY
 Information lives in one place. Reference other files instead of copying. Keep SKILL.md under 500 lines. Split content into separate files (progressive disclosure).
 
+### Affirmative Instructions
+State what the agent does, not what it does not do. Write "The agent includes `READY TO MERGE` in the PR body." not "The agent does not call `gh pr merge --auto`." Positive phrasing reduces cognitive load and clarifies expected behavior.
+
 ## Structure
 
 ### YAML Frontmatter

--- a/.claude/skills/agentic-skill-edition/SKILL.md
+++ b/.claude/skills/agentic-skill-edition/SKILL.md
@@ -66,7 +66,7 @@ Check existing skills before writing. If new skill overlaps, extend existing ski
 Information lives in one place. Reference other files instead of copying. Keep SKILL.md under 500 lines. Split content into separate files (progressive disclosure).
 
 ### Affirmative Instructions
-State what the agent does, not what it does not do. Write "The agent includes `READY TO MERGE` in the PR body." not "The agent does not call `gh pr merge --auto`." Positive phrasing reduces cognitive load and clarifies expected behavior.
+State what the agent does, not what it does not do. Positive phrasing reduces cognitive load and clarifies expected behavior.
 
 ## Structure
 
@@ -141,6 +141,7 @@ Provide input/output pairs for quality-sensitive skills.
 - Vague skill names (`helper`, `utils`, `tools`)
 - Offering too many approaches
 - Deeply nested references (beyond one level)
+- Negative phrasing: state what to do, not what not to do
 
 ## Checklist
 
@@ -153,3 +154,4 @@ Provide input/output pairs for quality-sensitive skills.
 - [ ] Under 500 lines
 - [ ] Forward slashes only
 - [ ] Concise: every token earns its place
+- [ ] Affirmative phrasing: describes what agent does, not what it avoids

--- a/.claude/skills/agentic-skill-edition/SKILL.md
+++ b/.claude/skills/agentic-skill-edition/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-skill-edition
 description: >
   Create and edit agentic context files (SKILL.md, agent definitions, slash command prompts)
   across all agent standards (Copilot, Claude Code, OpenCode). Enforces same-wording
-  duplication rule and affirmative phrasing (state what agent does, not what it avoids).
+  duplication rule: body content must be identical across solutions, only frontmatter differs.
   Use when writing or editing skills, agents, or prompts in any solution directory.
 ---
 
@@ -67,6 +67,9 @@ Information lives in one place. Reference other files instead of copying. Keep S
 
 ### Affirmative Instructions
 State what the agent does, not what it does not do. Positive phrasing reduces cognitive load and clarifies expected behavior.
+
+### Examples
+Use only when the instruction is not self-sufficient. Keep examples generic — domain-specific references become meaningless outside the original context.
 
 ## Structure
 

--- a/.github/agents/pipeline.agent.md
+++ b/.github/agents/pipeline.agent.md
@@ -70,7 +70,8 @@ Steps are sequential unless marked parallel. Failure loops shown separately belo
                         if fail → @implementer (big loop)
 18. @visual-tester     → Screenshot verification (visual-change ONLY)
                         if fail → @implementer (big loop)
-19. [open-pr]          → (non-agentic) create PR from feature branch to main + auto-merge
+19. [open-pr]          → (non-agentic) create PR from feature branch to main + READY TO MERGE
+
 ```
 
 ### Failure loops (all pipelines)
@@ -111,7 +112,7 @@ When looping back to `@implementer`, the full downstream chain reruns: `implemen
 14. Code review (parallel): @quality-reviewer + @security-reviewer + @i18n-reviewer + @duplication-reviewer
 15. [merge-findings]  → Orchestrator merges findings → pass/fail; fail → @implementer
 16. @validator         → typecheck → tests → build; fail → @implementer
-17. [open-pr]          → create PR from feature branch to main + auto-merge
+17. [open-pr]          → create PR from feature branch to main + READY TO MERGE
 ```
 
 Note: `@refactorer` is skipped for fix-bug.
@@ -179,7 +180,7 @@ main
 | qualimetry | `npx jscpd src/ tests/` — route to @implementer on fail |
 | merge-findings | Deduplicate and merge all 4 reviewer reports → pass/fail |
 | After refactorer | Re-run `npx vitest run` (skip qualimetry + code-review) |
-| open-pr | `gh pr create --base main --head pipeline/feature-<issue-number>` + `gh pr merge --auto --squash` — follow PR title/body/label standards in `agentic-autonomous-pipeline` skill |
+| open-pr | `gh pr create --base main --head pipeline/feature-<issue-number> --body "Closes #<issue-number>\n\nREADY TO MERGE"` — include validation checklist per `agentic-autonomous-pipeline` skill |
 | Before completing | Summarize changes, files modified, test status |
 
 ## Key References
@@ -198,22 +199,18 @@ main
   - **@implementer specifically:** do not verbally describe tests — only plan + stub signatures + expected behavior. Branch isolation handles the rest.
   - **@fixer specifically:** pass both the test runner error output AND full context (it needs both sides to decide what to fix)
 
-## Auto-Merge
+## READY TO MERGE
 
-After creating the PR and before finishing, run:
+After creating the PR, the body must include `READY TO MERGE` on its own line. The `auto-assign-next.yml` workflow detects this and enables GitHub native auto-merge via a PAT token, ensuring downstream CI events trigger correctly.
 
-```
-gh pr merge --auto --squash <pr-url>
-```
-
-This is the **default**. Skip auto-merge when:
+This is the **default**. Skip `READY TO MERGE` when:
 1. The issue requires human input (artistic direction, critical design decision).
 2. You judge the pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs) — you lived through it, use your judgment.
 
-When skipping, run:
+When skipping, post a comment explaining why:
 
 ```
-gh pr comment <pr-url> --body "Auto-merge paused — human input needed: <reason>"
+gh pr comment <pr-url> --body "READY TO MERGE skipped — human input needed: <reason>"
 ```
 
 Include churn details in the reason so the reviewer understands the risk.

--- a/.github/skills/agentic-autonomous-pipeline/SKILL.md
+++ b/.github/skills/agentic-autonomous-pipeline/SKILL.md
@@ -86,13 +86,13 @@ After the code lands on the feature branch, these gates run in sequence:
 
 Create a pull request from `pipeline/feature-<issue-number>` to `main` with:
 - Title prefixed by pipeline type (`feat:`, `fix:`, `docs:`)
-- Body includes `Closes #<issue_number>` and validation checklist
+- Body includes `Closes #<issue_number>`, validation checklist, and `READY TO MERGE` on its own line
 - Labels updated: `in-progress` removed, `in-review` added
 
 This operation is always non-agentic (no LLM involved).
 
 ### Auto-Merge
 
-Default: **enable GitHub native auto-merge** on every PR — via `gh pr merge --auto --squash`.
+The agent does **not** call `gh pr merge --auto` directly. Instead, the PR body includes `READY TO MERGE`. The `auto-assign-next.yml` workflow (triggered on `pull_request: [opened, synchronize]`) detects this and enables GitHub native auto-merge via a PAT token. This ensures the merge is attributed to the PAT, so the downstream `pull_request: [closed]` event triggers `auto-assign-next.yml` to close the issue and dispatch the next task.
 
-Skip auto-merge when the issue requires human input or the orchestrator judges the pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs). Post a PR comment with the reason.
+Skip `READY TO MERGE` when the issue requires human input or the orchestrator judges the pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs). Post a PR comment with the reason.

--- a/.github/skills/agentic-autonomous-pipeline/SKILL.md
+++ b/.github/skills/agentic-autonomous-pipeline/SKILL.md
@@ -93,6 +93,6 @@ This operation is always non-agentic (no LLM involved).
 
 ### Auto-Merge
 
-The agent does **not** call `gh pr merge --auto` directly. Instead, the PR body includes `READY TO MERGE`. The `auto-assign-next.yml` workflow (triggered on `pull_request: [opened, synchronize]`) detects this and enables GitHub native auto-merge via a PAT token. This ensures the merge is attributed to the PAT, so the downstream `pull_request: [closed]` event triggers `auto-assign-next.yml` to close the issue and dispatch the next task.
+The agent includes `READY TO MERGE` in the PR body. The `auto-assign-next.yml` workflow (triggered on `pull_request: [opened, synchronize]`) detects this and enables GitHub native auto-merge via a PAT token. The merge is attributed to the PAT, so the downstream `pull_request: [closed]` event triggers `auto-assign-next.yml` to close the issue and dispatch the next task.
 
 Skip `READY TO MERGE` when the issue requires human input or the orchestrator judges the pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs). Post a PR comment with the reason.

--- a/.github/skills/agentic-skill-edition/SKILL.md
+++ b/.github/skills/agentic-skill-edition/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-skill-edition
 description: >
   Create and edit agentic context files (SKILL.md, agent definitions, slash command prompts)
   across all agent standards (Copilot, Claude Code, OpenCode). Enforces same-wording
-  duplication rule: body content must be identical across solutions, only frontmatter differs.
+  duplication rule and affirmative phrasing (state what agent does, not what it avoids).
   Use when writing or editing skills, agents, or prompts in any solution directory.
 ---
 

--- a/.github/skills/agentic-skill-edition/SKILL.md
+++ b/.github/skills/agentic-skill-edition/SKILL.md
@@ -65,6 +65,9 @@ Check existing skills before writing. If new skill overlaps, extend existing ski
 ### DRY
 Information lives in one place. Reference other files instead of copying. Keep SKILL.md under 500 lines. Split content into separate files (progressive disclosure).
 
+### Affirmative Instructions
+State what the agent does, not what it does not do. Write "The agent includes `READY TO MERGE` in the PR body." not "The agent does not call `gh pr merge --auto`." Positive phrasing reduces cognitive load and clarifies expected behavior.
+
 ## Structure
 
 ### YAML Frontmatter

--- a/.github/skills/agentic-skill-edition/SKILL.md
+++ b/.github/skills/agentic-skill-edition/SKILL.md
@@ -66,7 +66,7 @@ Check existing skills before writing. If new skill overlaps, extend existing ski
 Information lives in one place. Reference other files instead of copying. Keep SKILL.md under 500 lines. Split content into separate files (progressive disclosure).
 
 ### Affirmative Instructions
-State what the agent does, not what it does not do. Write "The agent includes `READY TO MERGE` in the PR body." not "The agent does not call `gh pr merge --auto`." Positive phrasing reduces cognitive load and clarifies expected behavior.
+State what the agent does, not what it does not do. Positive phrasing reduces cognitive load and clarifies expected behavior.
 
 ## Structure
 
@@ -141,6 +141,7 @@ Provide input/output pairs for quality-sensitive skills.
 - Vague skill names (`helper`, `utils`, `tools`)
 - Offering too many approaches
 - Deeply nested references (beyond one level)
+- Negative phrasing: state what to do, not what not to do
 
 ## Checklist
 
@@ -153,3 +154,4 @@ Provide input/output pairs for quality-sensitive skills.
 - [ ] Under 500 lines
 - [ ] Forward slashes only
 - [ ] Concise: every token earns its place
+- [ ] Affirmative phrasing: describes what agent does, not what it avoids

--- a/.github/skills/agentic-skill-edition/SKILL.md
+++ b/.github/skills/agentic-skill-edition/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-skill-edition
 description: >
   Create and edit agentic context files (SKILL.md, agent definitions, slash command prompts)
   across all agent standards (Copilot, Claude Code, OpenCode). Enforces same-wording
-  duplication rule and affirmative phrasing (state what agent does, not what it avoids).
+  duplication rule: body content must be identical across solutions, only frontmatter differs.
   Use when writing or editing skills, agents, or prompts in any solution directory.
 ---
 
@@ -67,6 +67,9 @@ Information lives in one place. Reference other files instead of copying. Keep S
 
 ### Affirmative Instructions
 State what the agent does, not what it does not do. Positive phrasing reduces cognitive load and clarifies expected behavior.
+
+### Examples
+Use only when the instruction is not self-sufficient. Keep examples generic — domain-specific references become meaningless outside the original context.
 
 ## Structure
 

--- a/.github/workflows/auto-assign-next.yml
+++ b/.github/workflows/auto-assign-next.yml
@@ -2,24 +2,35 @@ name: "Pipeline: assign next issue to OpenCode"
 
 on:
   pull_request:
-    types: [closed]
+    types: [opened, synchronize, closed]
 
 permissions:
   issues: write
   contents: write
+  pull-requests: write
   actions: write
 
 jobs:
   chain-next-task:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - name: Enable auto-merge for bot PRs with READY TO MERGE
+        if: >
+          github.event.action != 'closed' &&
+          contains(github.event.pull_request.body, 'READY TO MERGE') &&
+          github.event.pull_request.user.type == 'Bot'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
+        run: |
+          gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+
       - name: Close done issue + assign next ready issue to OpenCode
+        if: github.event.pull_request.merged == true
         uses: actions/github-script@v7
         env:
           AGENTIC_AUTO_ASSIGN_ENABLED: ${{ vars.AGENTIC_AUTO_ASSIGN_ENABLED }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -51,7 +62,7 @@ jobs:
               const prNumber = context.payload.pull_request.number;
               try {
                 const { data: fileData } = await github.rest.repos.getContent({
-                  owner, repo, path: '.github/skills/backlog/backlog.json'
+                  owner, repo, path: '.github/skills/agentic-backlog/backlog.json'
                 });
                 const raw = Buffer.from(fileData.content, 'base64').toString('utf8');
                 const tasks = JSON.parse(raw);
@@ -62,7 +73,7 @@ jobs:
                   const updated = JSON.stringify(tasks, null, 2) + '\n';
                   await github.rest.repos.createOrUpdateFileContents({
                     owner, repo,
-                    path: '.github/skills/backlog/backlog.json',
+                    path: '.github/skills/agentic-backlog/backlog.json',
                     message: `chore: mark backlog task ${backlogId} as done [skip ci]`,
                     content: Buffer.from(updated).toString('base64'),
                     sha: fileData.sha,

--- a/.opencode/agents/pipeline.md
+++ b/.opencode/agents/pipeline.md
@@ -68,7 +68,7 @@ Steps are sequential unless marked parallel. Failure loops shown separately belo
                         if fail → @implementer (big loop)
 18. @visual-tester     → Screenshot verification (visual-change ONLY)
                         if fail → @implementer (big loop)
-19. [open-pr]          → (non-agentic) create PR from feature branch to main + auto-merge
+19. [open-pr]          → (non-agentic) create PR from feature branch to main + READY TO MERGE
 ```
 
 ### Failure loops (all pipelines)
@@ -109,7 +109,7 @@ When looping back to `@implementer`, the full downstream chain reruns: `implemen
 14. Code review (parallel): @quality-reviewer + @security-reviewer + @i18n-reviewer + @duplication-reviewer
 15. [merge-findings]  → Orchestrator merges findings → pass/fail; fail → @implementer
 16. @validator         → typecheck → tests → build; fail → @implementer
-17. [open-pr]          → create PR from feature branch to main + auto-merge
+17. [open-pr]          → create PR from feature branch to main + READY TO MERGE
 ```
 
 Note: `@refactorer` is skipped for fix-bug.
@@ -177,7 +177,7 @@ main
 | qualimetry | `npx jscpd src/ tests/` — route to @implementer on fail |
 | merge-findings | Deduplicate and merge all 4 reviewer reports → pass/fail |
 | After refactorer | Re-run `npx vitest run` (skip qualimetry + code-review) |
-| open-pr | `gh pr create --base main --head pipeline/feature-<issue-number>` + `gh pr merge --auto --squash` — follow PR title/body/label standards in `agentic-autonomous-pipeline` skill |
+| open-pr | `gh pr create --base main --head pipeline/feature-<issue-number> --body "Closes #<issue-number>\n\nREADY TO MERGE"` — include validation checklist per `agentic-autonomous-pipeline` skill |
 | Before completing | Summarize changes, files modified, test status |
 
 ## Key References
@@ -196,22 +196,18 @@ main
   - **@implementer specifically:** do not verbally describe tests — only plan + stub signatures + expected behavior. Branch isolation handles the rest.
   - **@fixer specifically:** pass both the test runner error output AND full context (it needs both sides to decide what to fix)
 
-## Auto-Merge
+## READY TO MERGE
 
-After creating the PR and before finishing, run:
+After creating the PR, the body must include `READY TO MERGE` on its own line. The `auto-assign-next.yml` workflow detects this and enables GitHub native auto-merge via a PAT token, ensuring downstream CI events trigger correctly.
 
-```
-gh pr merge --auto --squash <pr-url>
-```
-
-This is the **default**. Skip auto-merge when:
+This is the **default**. Skip `READY TO MERGE` when:
 1. The issue requires human input (artistic direction, critical design decision).
 2. You judge the pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs) — you lived through it, use your judgment.
 
-When skipping, run:
+When skipping, post a comment explaining why:
 
 ```
-gh pr comment <pr-url> --body "Auto-merge paused — human input needed: <reason>"
+gh pr comment <pr-url> --body "READY TO MERGE skipped — human input needed: <reason>"
 ```
 
 Include churn details in the reason so the reviewer understands the risk.

--- a/.opencode/skills/agentic-autonomous-pipeline/SKILL.md
+++ b/.opencode/skills/agentic-autonomous-pipeline/SKILL.md
@@ -86,13 +86,13 @@ After the code lands on the feature branch, these gates run in sequence:
 
 Create a pull request from `pipeline/feature-<issue-number>` to `main` with:
 - Title prefixed by pipeline type (`feat:`, `fix:`, `docs:`)
-- Body includes `Closes #<issue_number>` and validation checklist
+- Body includes `Closes #<issue_number>`, validation checklist, and `READY TO MERGE` on its own line
 - Labels updated: `in-progress` removed, `in-review` added
 
 This operation is always non-agentic (no LLM involved).
 
 ### Auto-Merge
 
-Default: **enable GitHub native auto-merge** on every PR — via `gh pr merge --auto --squash`.
+The agent does **not** call `gh pr merge --auto` directly. Instead, the PR body includes `READY TO MERGE`. The `auto-assign-next.yml` workflow (triggered on `pull_request: [opened, synchronize]`) detects this and enables GitHub native auto-merge via a PAT token. This ensures the merge is attributed to the PAT, so the downstream `pull_request: [closed]` event triggers `auto-assign-next.yml` to close the issue and dispatch the next task.
 
-Skip auto-merge when the issue requires human input or the orchestrator judges the pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs). Post a PR comment with the reason.
+Skip `READY TO MERGE` when the issue requires human input or the orchestrator judges the pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs). Post a PR comment with the reason.

--- a/.opencode/skills/agentic-autonomous-pipeline/SKILL.md
+++ b/.opencode/skills/agentic-autonomous-pipeline/SKILL.md
@@ -93,6 +93,6 @@ This operation is always non-agentic (no LLM involved).
 
 ### Auto-Merge
 
-The agent does **not** call `gh pr merge --auto` directly. Instead, the PR body includes `READY TO MERGE`. The `auto-assign-next.yml` workflow (triggered on `pull_request: [opened, synchronize]`) detects this and enables GitHub native auto-merge via a PAT token. This ensures the merge is attributed to the PAT, so the downstream `pull_request: [closed]` event triggers `auto-assign-next.yml` to close the issue and dispatch the next task.
+The agent includes `READY TO MERGE` in the PR body. The `auto-assign-next.yml` workflow (triggered on `pull_request: [opened, synchronize]`) detects this and enables GitHub native auto-merge via a PAT token. The merge is attributed to the PAT, so the downstream `pull_request: [closed]` event triggers `auto-assign-next.yml` to close the issue and dispatch the next task.
 
 Skip `READY TO MERGE` when the issue requires human input or the orchestrator judges the pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs). Post a PR comment with the reason.

--- a/.opencode/skills/agentic-skill-edition/SKILL.md
+++ b/.opencode/skills/agentic-skill-edition/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-skill-edition
 description: >
   Create and edit agentic context files (SKILL.md, agent definitions, slash command prompts)
   across all agent standards (Copilot, Claude Code, OpenCode). Enforces same-wording
-  duplication rule: body content must be identical across solutions, only frontmatter differs.
+  duplication rule and affirmative phrasing (state what agent does, not what it avoids).
   Use when writing or editing skills, agents, or prompts in any solution directory.
 ---
 

--- a/.opencode/skills/agentic-skill-edition/SKILL.md
+++ b/.opencode/skills/agentic-skill-edition/SKILL.md
@@ -65,6 +65,9 @@ Check existing skills before writing. If new skill overlaps, extend existing ski
 ### DRY
 Information lives in one place. Reference other files instead of copying. Keep SKILL.md under 500 lines. Split content into separate files (progressive disclosure).
 
+### Affirmative Instructions
+State what the agent does, not what it does not do. Write "The agent includes `READY TO MERGE` in the PR body." not "The agent does not call `gh pr merge --auto`." Positive phrasing reduces cognitive load and clarifies expected behavior.
+
 ## Structure
 
 ### YAML Frontmatter

--- a/.opencode/skills/agentic-skill-edition/SKILL.md
+++ b/.opencode/skills/agentic-skill-edition/SKILL.md
@@ -66,7 +66,7 @@ Check existing skills before writing. If new skill overlaps, extend existing ski
 Information lives in one place. Reference other files instead of copying. Keep SKILL.md under 500 lines. Split content into separate files (progressive disclosure).
 
 ### Affirmative Instructions
-State what the agent does, not what it does not do. Write "The agent includes `READY TO MERGE` in the PR body." not "The agent does not call `gh pr merge --auto`." Positive phrasing reduces cognitive load and clarifies expected behavior.
+State what the agent does, not what it does not do. Positive phrasing reduces cognitive load and clarifies expected behavior.
 
 ## Structure
 
@@ -141,6 +141,7 @@ Provide input/output pairs for quality-sensitive skills.
 - Vague skill names (`helper`, `utils`, `tools`)
 - Offering too many approaches
 - Deeply nested references (beyond one level)
+- Negative phrasing: state what to do, not what not to do
 
 ## Checklist
 
@@ -153,3 +154,4 @@ Provide input/output pairs for quality-sensitive skills.
 - [ ] Under 500 lines
 - [ ] Forward slashes only
 - [ ] Concise: every token earns its place
+- [ ] Affirmative phrasing: describes what agent does, not what it avoids

--- a/.opencode/skills/agentic-skill-edition/SKILL.md
+++ b/.opencode/skills/agentic-skill-edition/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-skill-edition
 description: >
   Create and edit agentic context files (SKILL.md, agent definitions, slash command prompts)
   across all agent standards (Copilot, Claude Code, OpenCode). Enforces same-wording
-  duplication rule and affirmative phrasing (state what agent does, not what it avoids).
+  duplication rule: body content must be identical across solutions, only frontmatter differs.
   Use when writing or editing skills, agents, or prompts in any solution directory.
 ---
 
@@ -67,6 +67,9 @@ Information lives in one place. Reference other files instead of copying. Keep S
 
 ### Affirmative Instructions
 State what the agent does, not what it does not do. Positive phrasing reduces cognitive load and clarifies expected behavior.
+
+### Examples
+Use only when the instruction is not self-sufficient. Keep examples generic — domain-specific references become meaningless outside the original context.
 
 ## Structure
 


### PR DESCRIPTION
## Problem

PR #204 was auto-merged but `auto-assign-next.yml` never ran, so the originating issue wasn't closed and the next issue wasn't dispatched.

**Root cause:** The agent enabled auto-merge via `gh pr merge --auto --squash` using `GITHUB_TOKEN`. When auto-merge completed, GitHub attributed the merge to `app/github-actions` and **blocked** the downstream `pull_request: [closed]` event from triggering new workflows.

> Replaces PR #205 (which used a polling approach with a 30-min wait in `opencode-runner.yml`).

## Solution (event-driven, zero polling)

Instead of having the agent call `gh pr merge --auto` directly (which uses `GITHUB_TOKEN` and blocks downstream events), the agent writes `READY TO MERGE` in the PR body. The `auto-assign-next.yml` workflow handles everything via PAT:

```
Agent creates PR with "READY TO MERGE" + "Closes #N"
  → auto-assign-next triggers on [opened]
  → sees "READY TO MERGE" + bot author
  → enables auto-merge via PAT_TOKEN_COPILOT_AUTOMATION
  → workflow ends immediately (no waiting)

  → CI passes → auto-merge completes
  → merge attributed to PAT → [closed] event FIRES

  → auto-assign-next triggers on [closed] + merged
  → closes issue, dispatches next session
```

### Changes

**`auto-assign-next.yml`:**
- Trigger changed from `[closed]` to `[opened, synchronize, closed]`
- New step: enables auto-merge via PAT when `READY TO MERGE` + bot author detected
- Chain logic unchanged, still runs only on `[closed] + merged`
- Changed `github-token` to `PAT_TOKEN_COPILOT_AUTOMATION` so `createWorkflowDispatch` bypasses recursion limit
- Fixed backlog path (`backlog/` → `agentic-backlog/`)
- Added `pull-requests: write` permission

**3x pipeline agent files (`.opencode`, `.github`, `.claude`):**
- Step 19/17: `+ auto-merge` → `+ READY TO MERGE`
- PR body includes `READY TO MERGE` alongside `Closes #N`
- Auto-Merge section replaced with READY TO MERGE section

**3x skill files (`.opencode`, `.github`, `.claude`):**
- PR Creation: `READY TO MERGE` added to body requirements
- Auto-Merge section describes the delegated PAT-based approach

## Why not polling

PR #205 added a 30-min polling loop in `opencode-runner.yml` that keeps the runner alive waiting for merge. This is wasteful (actions minutes), fragile (runner interruptions), and adds complexity. The new approach is purely event-driven — no background task, no polling.
