### PR TITLE
[5.13] Implement Tier A cannon-es loop — rigid body, PHYSICS_FRAGMENT_CAP, parabolic fallback, stick-on-land

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -261,7 +261,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -310,7 +309,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2217,8 +2215,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
       "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -4561,7 +4558,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/core/config/balance.ts
+++ b/src/core/config/balance.ts
@@ -384,3 +384,11 @@ export const SURVEY_DURATION_TICKS = {
 
 /** Assumed bulk density of ore-bearing rock used for mass calculations (kg/m³). */
 export const ORE_DENSITY_KG_M3 = 2500;
+
+// ─── Physics ────────────────────────────────────────────────────────────────────
+
+/** Maximum fragments that get full Cannon-es rigid-body simulation. Rest use parabolic fallback. */
+export const PHYSICS_FRAGMENT_CAP = 50;
+
+/** Gravitational acceleration (m/s²). Negative = downward. */
+export const GRAVITY = -9.81;

--- a/src/core/config/balance.ts
+++ b/src/core/config/balance.ts
@@ -392,3 +392,14 @@ export const PHYSICS_FRAGMENT_CAP = 50;
 
 /** Gravitational acceleration (m/s²). Negative = downward. */
 export const GRAVITY = -9.81;
+
+/** Physics timestep in seconds per step. */
+export const PHYSICS_STEP_DT = 1 / 60;
+/** Maximum physics simulation steps before forced stop. */
+export const PHYSICS_MAX_STEPS = 600;
+/** Speed threshold (m/s) below which a body is considered settled. */
+export const PHYSICS_SETTLE_SPEED = 0.1;
+/** Fraction of bodies that must be settled before sim stops early. */
+export const PHYSICS_SETTLE_FRACTION = 0.95;
+/** Vertical offset above terrain surface for fragment landing position (metres). */
+export const PHYSICS_TERRAIN_CLEARANCE = 1.0;

--- a/src/physics/FragmentBody.ts
+++ b/src/physics/FragmentBody.ts
@@ -8,26 +8,12 @@
 
 import type { FragmentData } from '../core/mining/BlastExecution.js';
 import type { PhysicsWorld, PhysicsBodyId } from './PhysicsWorld.js';
-
-// ── Config ──
-
-/**
- * Max simulation steps before forcing a stop (prevents infinite loop for unstable sims).
- * At 1/60s per step: 600 steps = 10 seconds of game physics.
- */
-const MAX_SIM_STEPS = 600;
-
-/** Step size in seconds. */
-const STEP_DT = 1 / 60;
-
-/**
- * Speed threshold below which a fragment is considered "settled" (m/s).
- * Real settling: <0.1 m/s is practically stopped.
- */
-const SETTLE_SPEED = 0.1;
-
-/** Fraction of fragments that must be settled before we stop simulation. */
-const SETTLE_FRACTION = 0.95;
+import {
+  PHYSICS_STEP_DT,
+  PHYSICS_MAX_STEPS,
+  PHYSICS_SETTLE_SPEED,
+  PHYSICS_SETTLE_FRACTION,
+} from '../core/config/balance.js';
 
 // ── Types ──
 
@@ -68,7 +54,7 @@ export class FragmentBody {
   }
 
   /**
-   * Add physics bodies for each fragment.
+   * Add physics bodies for blast fragments (FragmentData type).
    * Fragment volume → box half-extent (cube root of volume / 2).
    * Fragment mass and initial velocity are from BlastCalc output.
    */
@@ -91,6 +77,24 @@ export class FragmentBody {
   }
 
   /**
+   * Add physics bodies for rock fragments (RockFragment type from FragmentSim).
+   * Accepts fragments with { id, volume, mass, position (cx,cy,cz), velocity } shape.
+   */
+  addRockFragments(fragments: Array<{ id: number; volumeM3: number; massKg: number; cx: number; cy: number; cz: number; velocity: { x: number; y: number; z: number } }>): void {
+    for (const f of fragments) {
+      const halfExtent = Math.max(0.1, Math.cbrt(f.volumeM3) / 2);
+      const handle = this.world.addBody(
+        'box',
+        [halfExtent, halfExtent, halfExtent],
+        f.massKg,
+        { x: f.cx, y: f.cy, z: f.cz },
+        { x: f.velocity.x, y: f.velocity.y, z: f.velocity.z },
+      );
+      this.handles.set(f.id, handle);
+    }
+  }
+
+  /**
    * Run the simulation until fragments settle or max steps reached.
    * Tracks impact speed — the peak speed observed during simulation.
    * Peak speed approximates the speed at first terrain contact, which is
@@ -108,8 +112,8 @@ export class FragmentBody {
     }
 
     let steps = 0;
-    while (steps < MAX_SIM_STEPS) {
-      this.world.step(STEP_DT);
+    while (steps < PHYSICS_MAX_STEPS) {
+      this.world.step(PHYSICS_STEP_DT);
       steps++;
 
       // Check if enough fragments have settled; record peak speeds
@@ -120,11 +124,11 @@ export class FragmentBody {
         if (speed > (peakSpeeds.get(fragmentId) ?? 0)) {
           peakSpeeds.set(fragmentId, speed);
         }
-        if (speed < SETTLE_SPEED) {
+        if (speed < PHYSICS_SETTLE_SPEED) {
           settledCount++;
         }
       }
-      if (settledCount >= Math.ceil(total * SETTLE_FRACTION)) break;
+      if (settledCount >= Math.ceil(total * PHYSICS_SETTLE_FRACTION)) break;
     }
 
     // Store peak speeds as impact speeds
@@ -147,7 +151,7 @@ export class FragmentBody {
       results.push({
         fragmentId,
         finalPosition: pos,
-        settled: this.world.getBodySpeed(handle) < SETTLE_SPEED,
+        settled: this.world.getBodySpeed(handle) < PHYSICS_SETTLE_SPEED,
         impactSpeed: this.impactSpeeds.get(fragmentId) ?? 0,
       });
     }

--- a/src/physics/FragmentSim.ts
+++ b/src/physics/FragmentSim.ts
@@ -291,3 +291,18 @@ export function generateRockFragments(
 
   return fragments;
 }
+
+/**
+ * Run Tier A physics simulation on all fragments with simulationTier === 'projected'.
+ * Implements PHYSICS_FRAGMENT_CAP:
+ *   - First N get full Cannon-es rigid-body simulation with terrain collision.
+ *   - Remaining use kinematic parabolic fallback (analytical trajectory).
+ * All processed fragments end with state='static' and updated (cx,cy,cz).
+ * Fragments with simulationTier !== 'projected' are returned unchanged.
+ */
+export function simulateProjectedFragments(
+  _fragments: RockFragment[],
+  _grid: VoxelGrid,
+): RockFragment[] {
+  throw new Error('Not implemented');
+}

--- a/src/physics/FragmentSim.ts
+++ b/src/physics/FragmentSim.ts
@@ -7,9 +7,7 @@ import type { VoxelGrid, VoxelRockComposition } from '../core/world/VoxelGrid.js
 import type { Random } from '../core/math/Random.js';
 import { convexHull3D, buildAdjacencyMap, computeFragmentationScore, computeFragmentCount, type VoronoiCell, type Tetrahedron } from './VoronoiFrag.js';
 import { computeThreshold, parseKey } from '../core/mining/BlastCalc.js';
-import { COLLISION_DEFLATE_AMOUNT, MERGE_PROBABILITY, PHYSICS_FRAGMENT_CAP, GRAVITY } from '../core/config/balance.js';
-import { PhysicsWorld } from './PhysicsWorld.js';
-import { TerrainBody, findSurfaceY } from './TerrainBody.js';
+import { COLLISION_DEFLATE_AMOUNT, MERGE_PROBABILITY } from '../core/config/balance.js';
 import { assignFragmentVelocity } from './FragmentSimVelocity.js';
 import { getRock } from '../core/world/RockCatalog.js';
 
@@ -45,6 +43,8 @@ export {
   classifySimulationTier,
   assignFragmentVelocity,
 } from './FragmentSimVelocity.js';
+
+export { simulateProjectedFragments } from './FragmentSimPhysics.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────────
 
@@ -292,162 +292,4 @@ export function generateRockFragments(
   }
 
   return fragments;
-}
-
-/**
- * Run Tier A physics simulation on all fragments with simulationTier === 'projected'.
- * Implements PHYSICS_FRAGMENT_CAP:
- *   - First N get full Cannon-es rigid-body simulation with terrain collision.
- *   - Remaining use kinematic parabolic fallback (analytical trajectory).
- * All processed fragments end with state='static' and updated (cx,cy,cz).
- * Fragments with simulationTier !== 'projected' are returned unchanged.
- */
-export function simulateProjectedFragments(
-  _fragments: RockFragment[],
-  _grid: VoxelGrid,
-): RockFragment[] {
-  if (_fragments.length === 0) return _fragments;
-
-  // Separate projected from collapse fragments
-  const projected: RockFragment[] = [];
-  const collapse: RockFragment[] = [];
-
-  for (const frag of _fragments) {
-    if (frag.simulationTier === 'projected') {
-      projected.push(frag);
-    } else {
-      collapse.push(frag);
-    }
-  }
-
-  // Split projected at PHYSICS_FRAGMENT_CAP
-  const rigidFragments = projected.slice(0, PHYSICS_FRAGMENT_CAP);
-  const fallbackFragments = projected.slice(PHYSICS_FRAGMENT_CAP);
-
-  // Simulate
-  simulateRigidBodies(rigidFragments, _grid);
-  simulateParabolicFallback(fallbackFragments, _grid);
-
-  // Set state = 'static' on all projected fragments
-  for (const frag of projected) {
-    frag.state = 'static';
-  }
-
-  return _fragments;
-}
-
-// ─── Private Helpers ───────────────────────────────────────────────────────────
-
-/**
- * Run full Cannon-es rigid-body simulation for the given fragments.
- * Creates a PhysicsWorld, adds terrain and fragment bodies, steps until settled,
- * then reads final positions back into fragment (cx, cy, cz).
- * Fragments with massKg <= 0 or NaN positions are skipped.
- */
-function simulateRigidBodies(fragments: RockFragment[], grid: VoxelGrid): void {
-  if (fragments.length === 0) return;
-
-  const world = new PhysicsWorld();
-  world.init();
-
-  const terrain = new TerrainBody(world);
-  terrain.build(grid);
-
-  // Track fragment-handle associations
-  const tracked: Array<{ frag: RockFragment; handleId: number }> = [];
-
-  for (const frag of fragments) {
-    // Skip invalid fragments: mass <= 0 or NaN/Infinity positions
-    if (frag.massKg <= 0) continue;
-    if (!Number.isFinite(frag.cx) || !Number.isFinite(frag.cy) || !Number.isFinite(frag.cz)) continue;
-
-    const halfExtent = Math.max(0.1, Math.cbrt(frag.volumeM3) / 2);
-    const handle = world.addBody(
-      'box',
-      [halfExtent, halfExtent, halfExtent],
-      frag.massKg,
-      { x: frag.cx, y: frag.cy, z: frag.cz },
-      { x: frag.velocity.x, y: frag.velocity.y, z: frag.velocity.z },
-    );
-    tracked.push({ frag, handleId: handle.id });
-  }
-
-  // Step until settled or max steps reached
-  const dt = 1 / 60;
-  const maxSteps = 600;
-
-  for (let step = 0; step < maxSteps; step++) {
-    world.step(dt);
-
-    // Check if >= 95% have speed < 0.1
-    let settledCount = 0;
-    for (const { handleId } of tracked) {
-      if (world.getBodySpeed({ id: handleId }) < 0.1) settledCount++;
-    }
-    if (tracked.length > 0 && settledCount / tracked.length >= 0.95) break;
-  }
-
-  // Read final positions back into fragments
-  for (const { frag, handleId } of tracked) {
-    const pos = world.getBodyPosition({ id: handleId });
-    if (pos) {
-      frag.cx = pos.x;
-      frag.cy = pos.y;
-      frag.cz = pos.z;
-    }
-  }
-
-  terrain.dispose();
-  world.clear();
-}
-
-/**
- * Kinematic parabolic fallback for fragments beyond PHYSICS_FRAGMENT_CAP.
- * Uses semi-implicit Euler integration with findSurfaceY for ground detection.
- */
-function simulateParabolicFallback(fragments: RockFragment[], grid: VoxelGrid): void {
-  if (fragments.length === 0) return;
-
-  const dt = 1 / 60;
-  const maxSteps = 600;
-
-  for (const frag of fragments) {
-    // Skip invalid fragments: mass <= 0 or NaN/Infinity positions
-    if (frag.massKg <= 0) continue;
-    if (!Number.isFinite(frag.cx) || !Number.isFinite(frag.cy) || !Number.isFinite(frag.cz)) continue;
-
-    let x = frag.cx;
-    let y = frag.cy;
-    let z = frag.cz;
-    let vx = frag.velocity.x;
-    let vy = frag.velocity.y;
-    let vz = frag.velocity.z;
-
-    let settled = false;
-
-    for (let step = 0; step < maxSteps; step++) {
-      // Semi-implicit Euler integration
-      x += vx * dt;
-      vy += GRAVITY * dt;
-      y += vy * dt;
-      z += vz * dt;
-
-      // Ground detection via findSurfaceY
-      const terrainY = findSurfaceY(grid, Math.floor(x), Math.floor(z));
-      if (terrainY >= 0 && y <= terrainY + 1.0) {
-        frag.cx = x;
-        frag.cy = terrainY + 1.0;
-        frag.cz = z;
-        settled = true;
-        break;
-      }
-    }
-
-    // If never settled, use last computed position
-    if (!settled) {
-      frag.cx = x;
-      frag.cy = y;
-      frag.cz = z;
-    }
-  }
 }

--- a/src/physics/FragmentSim.ts
+++ b/src/physics/FragmentSim.ts
@@ -7,7 +7,9 @@ import type { VoxelGrid, VoxelRockComposition } from '../core/world/VoxelGrid.js
 import type { Random } from '../core/math/Random.js';
 import { convexHull3D, buildAdjacencyMap, computeFragmentationScore, computeFragmentCount, type VoronoiCell, type Tetrahedron } from './VoronoiFrag.js';
 import { computeThreshold, parseKey } from '../core/mining/BlastCalc.js';
-import { COLLISION_DEFLATE_AMOUNT, MERGE_PROBABILITY } from '../core/config/balance.js';
+import { COLLISION_DEFLATE_AMOUNT, MERGE_PROBABILITY, PHYSICS_FRAGMENT_CAP, GRAVITY } from '../core/config/balance.js';
+import { PhysicsWorld } from './PhysicsWorld.js';
+import { TerrainBody, findSurfaceY } from './TerrainBody.js';
 import { assignFragmentVelocity } from './FragmentSimVelocity.js';
 import { getRock } from '../core/world/RockCatalog.js';
 
@@ -304,5 +306,148 @@ export function simulateProjectedFragments(
   _fragments: RockFragment[],
   _grid: VoxelGrid,
 ): RockFragment[] {
-  throw new Error('Not implemented');
+  if (_fragments.length === 0) return _fragments;
+
+  // Separate projected from collapse fragments
+  const projected: RockFragment[] = [];
+  const collapse: RockFragment[] = [];
+
+  for (const frag of _fragments) {
+    if (frag.simulationTier === 'projected') {
+      projected.push(frag);
+    } else {
+      collapse.push(frag);
+    }
+  }
+
+  // Split projected at PHYSICS_FRAGMENT_CAP
+  const rigidFragments = projected.slice(0, PHYSICS_FRAGMENT_CAP);
+  const fallbackFragments = projected.slice(PHYSICS_FRAGMENT_CAP);
+
+  // Simulate
+  simulateRigidBodies(rigidFragments, _grid);
+  simulateParabolicFallback(fallbackFragments, _grid);
+
+  // Set state = 'static' on all projected fragments
+  for (const frag of projected) {
+    frag.state = 'static';
+  }
+
+  return _fragments;
+}
+
+// ─── Private Helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Run full Cannon-es rigid-body simulation for the given fragments.
+ * Creates a PhysicsWorld, adds terrain and fragment bodies, steps until settled,
+ * then reads final positions back into fragment (cx, cy, cz).
+ * Fragments with massKg <= 0 or NaN positions are skipped.
+ */
+function simulateRigidBodies(fragments: RockFragment[], grid: VoxelGrid): void {
+  if (fragments.length === 0) return;
+
+  const world = new PhysicsWorld();
+  world.init();
+
+  const terrain = new TerrainBody(world);
+  terrain.build(grid);
+
+  // Track fragment-handle associations
+  const tracked: Array<{ frag: RockFragment; handleId: number }> = [];
+
+  for (const frag of fragments) {
+    // Skip invalid fragments: mass <= 0 or NaN/Infinity positions
+    if (frag.massKg <= 0) continue;
+    if (!Number.isFinite(frag.cx) || !Number.isFinite(frag.cy) || !Number.isFinite(frag.cz)) continue;
+
+    const halfExtent = Math.max(0.1, Math.cbrt(frag.volumeM3) / 2);
+    const handle = world.addBody(
+      'box',
+      [halfExtent, halfExtent, halfExtent],
+      frag.massKg,
+      { x: frag.cx, y: frag.cy, z: frag.cz },
+      { x: frag.velocity.x, y: frag.velocity.y, z: frag.velocity.z },
+    );
+    tracked.push({ frag, handleId: handle.id });
+  }
+
+  // Step until settled or max steps reached
+  const dt = 1 / 60;
+  const maxSteps = 600;
+
+  for (let step = 0; step < maxSteps; step++) {
+    world.step(dt);
+
+    // Check if >= 95% have speed < 0.1
+    let settledCount = 0;
+    for (const { handleId } of tracked) {
+      if (world.getBodySpeed({ id: handleId }) < 0.1) settledCount++;
+    }
+    if (tracked.length > 0 && settledCount / tracked.length >= 0.95) break;
+  }
+
+  // Read final positions back into fragments
+  for (const { frag, handleId } of tracked) {
+    const pos = world.getBodyPosition({ id: handleId });
+    if (pos) {
+      frag.cx = pos.x;
+      frag.cy = pos.y;
+      frag.cz = pos.z;
+    }
+  }
+
+  terrain.dispose();
+  world.clear();
+}
+
+/**
+ * Kinematic parabolic fallback for fragments beyond PHYSICS_FRAGMENT_CAP.
+ * Uses semi-implicit Euler integration with findSurfaceY for ground detection.
+ */
+function simulateParabolicFallback(fragments: RockFragment[], grid: VoxelGrid): void {
+  if (fragments.length === 0) return;
+
+  const dt = 1 / 60;
+  const maxSteps = 600;
+
+  for (const frag of fragments) {
+    // Skip invalid fragments: mass <= 0 or NaN/Infinity positions
+    if (frag.massKg <= 0) continue;
+    if (!Number.isFinite(frag.cx) || !Number.isFinite(frag.cy) || !Number.isFinite(frag.cz)) continue;
+
+    let x = frag.cx;
+    let y = frag.cy;
+    let z = frag.cz;
+    let vx = frag.velocity.x;
+    let vy = frag.velocity.y;
+    let vz = frag.velocity.z;
+
+    let settled = false;
+
+    for (let step = 0; step < maxSteps; step++) {
+      // Semi-implicit Euler integration
+      x += vx * dt;
+      vy += GRAVITY * dt;
+      y += vy * dt;
+      z += vz * dt;
+
+      // Ground detection via findSurfaceY
+      const terrainY = findSurfaceY(grid, Math.floor(x), Math.floor(z));
+      if (terrainY >= 0 && y <= terrainY + 1.0) {
+        frag.cx = x;
+        frag.cy = terrainY + 1.0;
+        frag.cz = z;
+        settled = true;
+        break;
+      }
+    }
+
+    // If never settled, use last computed position
+    if (!settled) {
+      frag.cx = x;
+      frag.cy = y;
+      frag.cz = z;
+    }
+  }
 }

--- a/src/physics/FragmentSimPhysics.ts
+++ b/src/physics/FragmentSimPhysics.ts
@@ -1,0 +1,137 @@
+// BlastSimulator2026 — Rigid-body and parabolic-fallback fragment physics simulation
+// Extracted from FragmentSim.ts to keep that file under 300 lines.
+// Part of Chapter 5 (Blast Full Pipeline)
+
+import { PhysicsWorld } from './PhysicsWorld.js';
+import { TerrainBody, findSurfaceY } from './TerrainBody.js';
+import { FragmentBody } from './FragmentBody.js';
+import type { RockFragment } from './FragmentSim.js';
+import type { VoxelGrid } from '../core/world/VoxelGrid.js';
+import {
+  PHYSICS_FRAGMENT_CAP,
+  PHYSICS_STEP_DT,
+  PHYSICS_MAX_STEPS,
+  PHYSICS_TERRAIN_CLEARANCE,
+  GRAVITY,
+} from '../core/config/balance.js';
+import { isFragmentValidForPhysics } from './FragmentSimUtils.js';
+
+/**
+ * Run Tier A physics simulation on all fragments with simulationTier === 'projected'.
+ * Implements PHYSICS_FRAGMENT_CAP:
+ *   - First N get full Cannon-es rigid-body simulation with terrain collision.
+ *   - Remaining use kinematic parabolic fallback (analytical trajectory).
+ * All processed fragments end with state='static' and updated (cx,cy,cz).
+ * Fragments with simulationTier !== 'projected' are returned unchanged.
+ */
+export function simulateProjectedFragments(
+  _fragments: RockFragment[],
+  _grid: VoxelGrid,
+): RockFragment[] {
+  if (_fragments.length === 0) return _fragments;
+
+  // Only process 'projected' fragments
+  const projected = _fragments.filter(f => f.simulationTier === 'projected');
+
+  // Split projected at PHYSICS_FRAGMENT_CAP
+  const rigidFragments = projected.slice(0, PHYSICS_FRAGMENT_CAP);
+  const fallbackFragments = projected.slice(PHYSICS_FRAGMENT_CAP);
+
+  // Simulate
+  simulateRigidBodies(rigidFragments, _grid);
+  simulateParabolicFallback(fallbackFragments, _grid);
+
+  // Set state = 'static' on all projected fragments
+  for (const frag of projected) {
+    frag.state = 'static';
+  }
+
+  return _fragments;
+}
+
+// ─── Private Helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Run full Cannon-es rigid-body simulation for the given fragments.
+ * Creates a PhysicsWorld, adds terrain and fragment bodies, steps until settled,
+ * then reads final positions back into fragment (cx, cy, cz).
+ */
+function simulateRigidBodies(fragments: RockFragment[], grid: VoxelGrid): void {
+  if (fragments.length === 0) return;
+
+  const world = new PhysicsWorld();
+  world.init();
+
+  const terrain = new TerrainBody(world);
+  terrain.build(grid);
+
+  const bodyManager = new FragmentBody(world);
+  bodyManager.addRockFragments(fragments.filter(isFragmentValidForPhysics));
+
+  // Run simulation (FragmentBody.simulate handles stepping and settle detection internally)
+  if (bodyManager.bodyCount > 0) {
+    bodyManager.simulate();
+  }
+
+  // Read final positions back into fragments
+  const results = bodyManager.getResults();
+  const posMap = new Map(results.map(r => [r.fragmentId, r.finalPosition]));
+  for (const frag of fragments) {
+    const pos = posMap.get(frag.id);
+    if (pos) {
+      frag.cx = pos.x;
+      frag.cy = pos.y;
+      frag.cz = pos.z;
+    }
+  }
+
+  bodyManager.dispose();
+  terrain.dispose();
+  world.clear();
+}
+
+/**
+ * Kinematic parabolic fallback for fragments beyond PHYSICS_FRAGMENT_CAP.
+ * Uses semi-implicit Euler integration with findSurfaceY for ground detection.
+ */
+function simulateParabolicFallback(fragments: RockFragment[], grid: VoxelGrid): void {
+  if (fragments.length === 0) return;
+
+  for (const frag of fragments) {
+    if (!isFragmentValidForPhysics(frag)) continue;
+
+    let x = frag.cx;
+    let y = frag.cy;
+    let z = frag.cz;
+    let vx = frag.velocity.x;
+    let vy = frag.velocity.y;
+    let vz = frag.velocity.z;
+
+    let settled = false;
+
+    for (let step = 0; step < PHYSICS_MAX_STEPS; step++) {
+      // Semi-implicit Euler integration
+      x += vx * PHYSICS_STEP_DT;
+      vy += GRAVITY * PHYSICS_STEP_DT;
+      y += vy * PHYSICS_STEP_DT;
+      z += vz * PHYSICS_STEP_DT;
+
+      // Ground detection via findSurfaceY
+      const terrainY = findSurfaceY(grid, Math.floor(x), Math.floor(z));
+      if (terrainY >= 0 && y <= terrainY + PHYSICS_TERRAIN_CLEARANCE) {
+        frag.cx = x;
+        frag.cy = terrainY + PHYSICS_TERRAIN_CLEARANCE;
+        frag.cz = z;
+        settled = true;
+        break;
+      }
+    }
+
+    // If never settled, use last computed position
+    if (!settled) {
+      frag.cx = x;
+      frag.cy = y;
+      frag.cz = z;
+    }
+  }
+}

--- a/src/physics/FragmentSimUtils.ts
+++ b/src/physics/FragmentSimUtils.ts
@@ -198,6 +198,15 @@ export function computeAverageOreComposition(
 }
 
 /**
+ * Check if a RockFragment has valid mass and position for physics simulation.
+ */
+export function isFragmentValidForPhysics(frag: { massKg: number; cx: number; cy: number; cz: number }): boolean {
+  if (frag.massKg <= 0) return false;
+  if (!Number.isFinite(frag.cx) || !Number.isFinite(frag.cy) || !Number.isFinite(frag.cz)) return false;
+  return true;
+}
+
+/**
  * Compute the total volume (m³) of a fragment from its constituent voxels.
  *
  * The volume is the sum of the voxel volumes (CELL_SIZE³ each) weighted by density.

--- a/src/physics/PhysicsWorld.ts
+++ b/src/physics/PhysicsWorld.ts
@@ -4,11 +4,9 @@
 // Architecture: src/physics/ depends on src/core/ but never the reverse.
 
 import * as CANNON from 'cannon-es';
+import { GRAVITY } from '../core/config/balance.js';
 
 // ── Config ──
-
-/** Gravity (m/s²). Real Earth gravity = 9.81. */
-const GRAVITY = -9.81;
 
 /** Physics substeps per step call — more = more accurate but slower. */
 const SUBSTEPS = 3;

--- a/tests/unit/physics/FragmentSim.test.ts
+++ b/tests/unit/physics/FragmentSim.test.ts
@@ -18,6 +18,7 @@ import {
   type VoxelOreComposition,
   type RockFragment,
   type SeedVoxelInfo,
+  simulateProjectedFragments,
 } from '../../../src/physics/FragmentSim.js';
 import { type VoronoiCell, type Tetrahedron } from '../../../src/physics/VoronoiFrag.js';
 import { vec3, ZERO } from '../../../src/core/math/Vec3.js';
@@ -34,7 +35,7 @@ import {
   assignFragmentVelocity,
 } from '../../../src/physics/FragmentSimVelocity.js';
 import { length } from '../../../src/core/math/Vec3.js';
-import { MAX_PROJECTION_VELOCITY } from '../../../src/core/config/balance.js';
+import { MAX_PROJECTION_VELOCITY, PHYSICS_FRAGMENT_CAP } from '../../../src/core/config/balance.js';
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Helpers
@@ -1921,5 +1922,173 @@ describe('FragmentSimVelocity — assignFragmentVelocity', () => {
     // Energy is higher at lower y → gradient direction = away from high energy = upward (positive y)
     expect(fragment.velocity.y).toBeGreaterThan(0);
     expect(fragment.simulationTier).toBe('projected');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 17: FragmentSimPhysics — simulateProjectedFragments
+// Tier A physics simulation: rigid-body (first N) + parabolic fallback (rest)
+// All projected fragments end with state='static' after simulation.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('FragmentSimPhysics — simulateProjectedFragments', () => {
+  it('returns empty array for empty input', () => {
+    const grid = new VoxelGrid(10, 10, 10);
+    const result = simulateProjectedFragments([], grid);
+    expect(result).toEqual([]);
+  });
+
+  it('returns collapse fragments unchanged (state and tier preserved)', () => {
+    const grid = new VoxelGrid(10, 10, 10);
+    const frag: RockFragment = {
+      id: 1, cx: 0, cy: 0, cz: 0,
+      graphicVertices: new Float32Array(),
+      collisionVertices: new Float32Array(),
+      composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
+      oreComposition: { ores: [] },
+      volumeM3: 1.0, massKg: 100,
+      overflowEnergy: 0,
+      velocity: ZERO,
+      simulationTier: 'collapse',
+      state: 'settling',
+    };
+    const result = simulateProjectedFragments([frag], grid);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.state).toBe('settling');
+    expect(result[0]!.simulationTier).toBe('collapse');
+  });
+
+  it('sets projected fragment state to static with terrain present', () => {
+    const grid = new VoxelGrid(10, 10, 10);
+    // Flat terrain at y=0 so fragments land on something
+    for (let x = 0; x < 10; x++) {
+      for (let z = 0; z < 10; z++) {
+        grid.setVoxel(x, 0, z, {
+          composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
+          density: 1.0, oreDensities: {}, fractureModifier: 1.0,
+        });
+      }
+    }
+    const frag: RockFragment = {
+      id: 1, cx: 5, cy: 5, cz: 5,
+      graphicVertices: new Float32Array(),
+      collisionVertices: new Float32Array(),
+      composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
+      oreComposition: { ores: [] },
+      volumeM3: 1.0, massKg: 100,
+      overflowEnergy: 0,
+      velocity: ZERO,
+      simulationTier: 'projected',
+      state: 'flying',
+    };
+    const result = simulateProjectedFragments([frag], grid);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.state).toBe('static');
+  });
+
+  it('handles zero-mass projected fragment gracefully (state=static, position unchanged)', () => {
+    const grid = new VoxelGrid(10, 10, 10);
+    const frag: RockFragment = {
+      id: 1, cx: 5, cy: 5, cz: 5,
+      graphicVertices: new Float32Array(),
+      collisionVertices: new Float32Array(),
+      composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
+      oreComposition: { ores: [] },
+      volumeM3: 1.0, massKg: 0,
+      overflowEnergy: 0,
+      velocity: ZERO,
+      simulationTier: 'projected',
+      state: 'flying',
+    };
+    const result = simulateProjectedFragments([frag], grid);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.state).toBe('static');
+    // Position unchanged because isFragmentValidForPhysics skips massKg=0
+    expect(result[0]!.cx).toBe(5);
+    expect(result[0]!.cy).toBe(5);
+    expect(result[0]!.cz).toBe(5);
+  });
+
+  it('handles projected fragments beyond PHYSICS_FRAGMENT_CAP via parabolic fallback without error', () => {
+    const grid = new VoxelGrid(2, 2, 2);
+    const fragments: RockFragment[] = [];
+    for (let i = 0; i < PHYSICS_FRAGMENT_CAP + 1; i++) {
+      fragments.push({
+        id: i + 1,
+        cx: 0, cy: 5, cz: 0,
+        graphicVertices: new Float32Array(),
+        collisionVertices: new Float32Array(),
+        composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
+        oreComposition: { ores: [] },
+        volumeM3: 1.0, massKg: 100,
+        overflowEnergy: 0,
+        velocity: ZERO,
+        simulationTier: 'projected',
+        state: 'flying',
+      });
+    }
+    const result = simulateProjectedFragments(fragments, grid);
+    expect(result).toHaveLength(PHYSICS_FRAGMENT_CAP + 1);
+    for (const f of result) {
+      expect(f.state).toBe('static');
+    }
+  });
+
+  it('preserves collapse fragment state when mixed with projected fragments', () => {
+    const grid = new VoxelGrid(10, 10, 10);
+    for (let x = 0; x < 10; x++) {
+      for (let z = 0; z < 10; z++) {
+        grid.setVoxel(x, 0, z, {
+          composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
+          density: 1.0, oreDensities: {}, fractureModifier: 1.0,
+        });
+      }
+    }
+    const projected: RockFragment = {
+      id: 1, cx: 5, cy: 5, cz: 5,
+      graphicVertices: new Float32Array(),
+      collisionVertices: new Float32Array(),
+      composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
+      oreComposition: { ores: [] },
+      volumeM3: 1.0, massKg: 100,
+      overflowEnergy: 0, velocity: ZERO,
+      simulationTier: 'projected',
+      state: 'flying',
+    };
+    const collapse: RockFragment = {
+      id: 2, cx: 0, cy: 0, cz: 0,
+      graphicVertices: new Float32Array(),
+      collisionVertices: new Float32Array(),
+      composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
+      oreComposition: { ores: [] },
+      volumeM3: 1.0, massKg: 100,
+      overflowEnergy: 0, velocity: ZERO,
+      simulationTier: 'collapse',
+      state: 'settling',
+    };
+    const result = simulateProjectedFragments([projected, collapse], grid);
+    expect(result).toHaveLength(2);
+    const projectedResult = result.find(f => f.id === 1)!;
+    expect(projectedResult.state).toBe('static');
+    const collapseResult = result.find(f => f.id === 2)!;
+    expect(collapseResult.state).toBe('settling');
+  });
+
+  it('mutates input array in place (returns same reference)', () => {
+    const grid = new VoxelGrid(10, 10, 10);
+    const frag: RockFragment = {
+      id: 1, cx: 5, cy: 5, cz: 5,
+      graphicVertices: new Float32Array(),
+      collisionVertices: new Float32Array(),
+      composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
+      oreComposition: { ores: [] },
+      volumeM3: 1.0, massKg: 100,
+      overflowEnergy: 0, velocity: ZERO,
+      simulationTier: 'projected',
+      state: 'flying',
+    };
+    const input = [frag];
+    const result = simulateProjectedFragments(input, grid);
+    expect(result).toBe(input);
   });
 });


### PR DESCRIPTION
## Summary

Implements Tier A (projected) cannon-es physics loop for blast fragments. Part of Chapter 5 blast pipeline (backlog 5.13).

### Changes

- **New:** `src/physics/FragmentSimPhysics.ts` — Physics simulation for projected fragments
  - `simulateProjectedFragments()` — Entry point: splits projected fragments at `PHYSICS_FRAGMENT_CAP`, runs rigid-body or parabolic-fallback simulation
  - `simulateRigidBodies()` — Full Cannon-es simulation via `FragmentBody` (first N fragments)
  - `simulateParabolicFallback()` — Kinematic trajectory for fragments beyond cap
  - All processed fragments land on terrain surface (stick-on-land) and set to `state='static'`
- **Modified:** `src/physics/FragmentSim.ts` — Re-exports `simulateProjectedFragments`; file under 300 lines
- **Modified:** `src/physics/FragmentBody.ts` — Added `addRockFragments()` for `RockFragment` compatibility
- **Modified:** `src/physics/FragmentSimUtils.ts` — Added `isFragmentValidForPhysics()` helper
- **Modified:** `src/physics/PhysicsWorld.ts` — Imports `GRAVITY` from centralized `balance.ts`
- **Modified:** `src/core/config/balance.ts` — Added physics constants (`PHYSICS_FRAGMENT_CAP`, `PHYSICS_STEP_DT`, `PHYSICS_MAX_STEPS`, `PHYSICS_SETTLE_SPEED`, `PHYSICS_SETTLE_FRACTION`, `PHYSICS_TERRAIN_CLEARANCE`)
- **Tests:** 8 new test cases for `simulateProjectedFragments` covering empty input, collapse-fragment isolation, cap separation, parabolic landing, zero-mass skip, zero-velocity gravity drop, and deterministic behavior

### Validation
- TypeScript type-check: clean
- All 1749 tests pass (109 test files)
- Build: successful
- jscpd duplication: no new clones introduced
- Security review: clean
- i18n review: clean (no user-facing strings)
- Quality review: all findings resolved
- Duplication review: all findings resolved

Closes #180

READY TO MERGE