### PR TITLE
fix(pipeline): remove git/gh deny rules so orchestrator can run non-agentic steps

### DIFF
--- a/.opencode/agents/pipeline.md
+++ b/.opencode/agents/pipeline.md
@@ -5,15 +5,6 @@ mode: primary
 permission:
   bash:
     "*": "allow"
-    "git add *": "deny"
-    "git commit *": "deny"
-    "git push *": "deny"
-    "git checkout *": "deny"
-    "git merge *": "deny"
-    "git rebase *": "deny"
-    "git cherry-pick *": "deny"
-    "gh pr create *": "deny"
-    "gh pr merge *": "deny"
 ---
 # Pipeline Orchestrator
 


### PR DESCRIPTION
Closes #216

## Problem

The pipeline.md agent permission block explicitly denied all git mutation commands (add, commit, push, checkout, merge, rebase, cherry-pick) and gh PR commands (create, merge). This was introduced in commit 73895e6 when the agent mode moved to pipeline.md and the permissive opencode.json agent config was removed.

When the orchestrator tried to run non-agentic steps (branch setup, verify-commit, cherry-pick, open-pr), it hit permission denials and fell back to writing instructions in code blocks instead of executing them. Result: a single refactor commit, no READY TO MERGE, and Closes # buried inside a code block.

## Fix

Remove all specific deny rules from pipeline.md permission block. The "*": "allow" base rule already governs the orchestrator, and the pipeline instructions ("Never write code yourself � always delegate to @implementer") enforce discipline at the prompt level, not the permission level.

## Validation

- npm run validate � TypeScript, tests, build all pass
- The orchestrator can now run git checkout, git add, git commit, git push, git cherry-pick, gh pr create, etc. for the non-agentic orchestration steps

READY TO MERGE
