### PR TITLE
[5.15] Implement aggressive sleep: stationary for SLEEP_TICKS_REQUIRED ticks converts fragment to static

### DIFF
--- a/src/core/config/balance.ts
+++ b/src/core/config/balance.ts
@@ -178,6 +178,11 @@ export const MAX_PROJECTION_VELOCITY = 80;
 /** Velocity threshold (m/s) below which fragment is classified 'collapse'. */
 export const PROJECTION_VELOCITY_THRESHOLD = 2.0;
 
+/** Velocity threshold (m/s) below which a fragment is considered stationary for sleep detection. */
+export const SLEEP_VELOCITY_THRESHOLD = 0.1;
+/** Number of consecutive ticks a fragment must be below sleep velocity to become 'static'. */
+export const SLEEP_TICKS_REQUIRED = 15;
+
 // ─── Game Loop ──────────────────────────────────────────────────────────────────
 
 /** Duration of one game tick in real milliseconds at 1× speed. 1 tick = 1 game-hour. */

--- a/src/physics/FragmentSim.ts
+++ b/src/physics/FragmentSim.ts
@@ -44,7 +44,7 @@ export {
   assignFragmentVelocity,
 } from './FragmentSimVelocity.js';
 
-export { simulateProjectedFragments, simulateCollapseFragments } from './FragmentSimPhysics.js';
+export { simulateProjectedFragments, simulateCollapseFragments, updateFragmentSleepStates } from './FragmentSimPhysics.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────────
 
@@ -64,6 +64,7 @@ export interface RockFragment {
   velocity: Vec3;
   simulationTier: 'projected' | 'collapse';
   state: 'flying' | 'settling' | 'static';
+  sleepTicks: number;
 }
 
 // ─── Core Functions ─────────────────────────────────────────────────────────────
@@ -286,6 +287,7 @@ export function generateRockFragments(
       velocity: ZERO,
       simulationTier: 'collapse',
       state: 'settling',
+      sleepTicks: 0,
     };
     assignFragmentVelocity(fragment, _effectiveEnergy, _grid);
     fragments.push(fragment);

--- a/src/physics/FragmentSimPhysics.ts
+++ b/src/physics/FragmentSimPhysics.ts
@@ -202,28 +202,39 @@ export function simulateCollapseFragments(
 
 /**
  * Increment sleepTicks on stationary fragments and transition to 'static' state
- * when SLEEP_TICKS_REQUIRED consecutive ticks below SLEEP_VELOCITY_THRESHOLD.
+ * when sleepTicks reaches SLEEP_TICKS_REQUIRED.
  *
- * @param fragments - Array of fragments to evaluate.
- * @param tickCount - Number of ticks to advance (default 1).
+ * For each fragment that is not already 'static':
+ *   - If its speed is below SLEEP_VELOCITY_THRESHOLD, sleepTicks advances by tickCount.
+ *   - Otherwise, sleepTicks resets to 0.
+ * Transitions to 'static' when sleepTicks >= SLEEP_TICKS_REQUIRED.
+ *
+ * @param fragments - Array of fragments to evaluate (mutated in place).
+ * @param tickCount - Number of ticks to advance (must be a finite positive number;
+ *                    invalid values (NaN, Infinity, <=0) default to 1).
  * @returns The same array reference for chaining.
  */
 export function updateFragmentSleepStates(
   _fragments: RockFragment[],
   _tickCount: number = 1,
 ): RockFragment[] {
-  for (const frag of _fragments) {
-    if (frag.state === 'static') continue;
+  // Guard: ensure tickCount is a valid positive finite number
+  if (!Number.isFinite(_tickCount) || _tickCount <= 0) {
+    _tickCount = 1;
+  }
 
-    const speed = length(frag.velocity);
+  for (const fragment of _fragments) {
+    if (fragment.state === 'static') continue;
+
+    const speed = length(fragment.velocity);
 
     if (speed < SLEEP_VELOCITY_THRESHOLD) {
-      frag.sleepTicks += _tickCount;
-      if (frag.sleepTicks >= SLEEP_TICKS_REQUIRED) {
-        frag.state = 'static';
+      fragment.sleepTicks += _tickCount;
+      if (fragment.sleepTicks >= SLEEP_TICKS_REQUIRED) {
+        fragment.state = 'static';
       }
     } else {
-      frag.sleepTicks = 0;
+      fragment.sleepTicks = 0;
     }
   }
 

--- a/src/physics/FragmentSimPhysics.ts
+++ b/src/physics/FragmentSimPhysics.ts
@@ -2,6 +2,7 @@
 // Extracted from FragmentSim.ts to keep that file under 300 lines.
 // Part of Chapter 5 (Blast Full Pipeline)
 
+import { length } from '../core/math/Vec3.js';
 import { PhysicsWorld } from './PhysicsWorld.js';
 import { TerrainBody, findSurfaceY } from './TerrainBody.js';
 import { FragmentBody } from './FragmentBody.js';
@@ -13,6 +14,8 @@ import {
   PHYSICS_MAX_STEPS,
   PHYSICS_TERRAIN_CLEARANCE,
   GRAVITY,
+  SLEEP_VELOCITY_THRESHOLD,
+  SLEEP_TICKS_REQUIRED,
 } from '../core/config/balance.js';
 import { isFragmentValidForPhysics } from './FragmentSimUtils.js';
 
@@ -193,4 +196,21 @@ export function simulateCollapseFragments(
   }
 
   return _fragments;
+}
+
+// ─── Sleep Detection ─────────────────────────────────────────────────────────
+
+/**
+ * Increment sleepTicks on stationary fragments and transition to 'static' state
+ * when SLEEP_TICKS_REQUIRED consecutive ticks below SLEEP_VELOCITY_THRESHOLD.
+ *
+ * @param fragments - Array of fragments to evaluate.
+ * @returns The same array reference for chaining.
+ */
+export function updateFragmentSleepStates(fragments: RockFragment[]): RockFragment[] {
+  // TODO: implement sleep detection
+  void length;
+  void SLEEP_VELOCITY_THRESHOLD;
+  void SLEEP_TICKS_REQUIRED;
+  return fragments;
 }

--- a/src/physics/FragmentSimPhysics.ts
+++ b/src/physics/FragmentSimPhysics.ts
@@ -208,11 +208,24 @@ export function simulateCollapseFragments(
  * @param tickCount - Number of ticks to advance (default 1).
  * @returns The same array reference for chaining.
  */
-export function updateFragmentSleepStates(fragments: RockFragment[], tickCount: number = 1): RockFragment[] {
-  // TODO: implement sleep detection
-  void length;
-  void SLEEP_VELOCITY_THRESHOLD;
-  void SLEEP_TICKS_REQUIRED;
-  void tickCount;
-  return fragments;
+export function updateFragmentSleepStates(
+  _fragments: RockFragment[],
+  _tickCount: number = 1,
+): RockFragment[] {
+  for (const frag of _fragments) {
+    if (frag.state === 'static') continue;
+
+    const speed = length(frag.velocity);
+
+    if (speed < SLEEP_VELOCITY_THRESHOLD) {
+      frag.sleepTicks += _tickCount;
+      if (frag.sleepTicks >= SLEEP_TICKS_REQUIRED) {
+        frag.state = 'static';
+      }
+    } else {
+      frag.sleepTicks = 0;
+    }
+  }
+
+  return _fragments;
 }

--- a/src/physics/FragmentSimPhysics.ts
+++ b/src/physics/FragmentSimPhysics.ts
@@ -205,12 +205,14 @@ export function simulateCollapseFragments(
  * when SLEEP_TICKS_REQUIRED consecutive ticks below SLEEP_VELOCITY_THRESHOLD.
  *
  * @param fragments - Array of fragments to evaluate.
+ * @param tickCount - Number of ticks to advance (default 1).
  * @returns The same array reference for chaining.
  */
-export function updateFragmentSleepStates(fragments: RockFragment[]): RockFragment[] {
+export function updateFragmentSleepStates(fragments: RockFragment[], tickCount: number = 1): RockFragment[] {
   // TODO: implement sleep detection
   void length;
   void SLEEP_VELOCITY_THRESHOLD;
   void SLEEP_TICKS_REQUIRED;
+  void tickCount;
   return fragments;
 }

--- a/tests/unit/physics/FragmentSim.test.ts
+++ b/tests/unit/physics/FragmentSim.test.ts
@@ -20,6 +20,7 @@ import {
   type SeedVoxelInfo,
   simulateProjectedFragments,
   simulateCollapseFragments,
+  updateFragmentSleepStates,
 } from '../../../src/physics/FragmentSim.js';
 import { type VoronoiCell, type Tetrahedron } from '../../../src/physics/VoronoiFrag.js';
 import { vec3, ZERO } from '../../../src/core/math/Vec3.js';
@@ -36,7 +37,7 @@ import {
   assignFragmentVelocity,
 } from '../../../src/physics/FragmentSimVelocity.js';
 import { length } from '../../../src/core/math/Vec3.js';
-import { MAX_PROJECTION_VELOCITY, PHYSICS_FRAGMENT_CAP, PHYSICS_TERRAIN_CLEARANCE } from '../../../src/core/config/balance.js';
+import { MAX_PROJECTION_VELOCITY, PHYSICS_FRAGMENT_CAP, PHYSICS_TERRAIN_CLEARANCE, SLEEP_VELOCITY_THRESHOLD, SLEEP_TICKS_REQUIRED } from '../../../src/core/config/balance.js';
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Helpers
@@ -2320,6 +2321,128 @@ describe('FragmentSimPhysics — simulateCollapseFragments', () => {
     };
     const input = [frag];
     const result = simulateCollapseFragments(input, grid);
+    expect(result).toBe(input);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 19: FragmentSimPhysics — updateFragmentSleepStates
+// Aggressive sleep detection: stationary for SLEEP_TICKS_REQUIRED ticks → 'static'.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('FragmentSimPhysics — updateFragmentSleepStates', () => {
+  function makeFrag(overrides: Partial<RockFragment> = {}): RockFragment {
+    return {
+      id: 1, cx: 0, cy: 0, cz: 0,
+      graphicVertices: new Float32Array(),
+      collisionVertices: new Float32Array(),
+      composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
+      oreComposition: { ores: [] },
+      volumeM3: 1.0, massKg: 100,
+      overflowEnergy: 0,
+      velocity: ZERO,
+      simulationTier: 'projected',
+      state: 'flying',
+      sleepTicks: 0,
+      ...overrides,
+    };
+  }
+
+  it('handles empty fragment array', () => {
+    const result = updateFragmentSleepStates([]);
+    expect(result).toEqual([]);
+  });
+
+  it('does not change state on first call with zero velocity (sleepTicks < SLEEP_TICKS_REQUIRED)', () => {
+    const frag = makeFrag({ state: 'flying', velocity: ZERO, sleepTicks: 0 });
+    const result = updateFragmentSleepStates([frag]);
+    expect(result[0]!.state).toBe('flying');
+    expect(result[0]!.sleepTicks).toBe(1);
+  });
+
+  it('changes state to static after SLEEP_TICKS_REQUIRED calls when velocity is zero', () => {
+    const frag = makeFrag({ state: 'flying', velocity: ZERO, sleepTicks: SLEEP_TICKS_REQUIRED - 1 });
+    const result = updateFragmentSleepStates([frag]);
+    expect(result[0]!.state).toBe('static');
+    expect(result[0]!.sleepTicks).toBe(SLEEP_TICKS_REQUIRED);
+  });
+
+  it('changes state to static when velocity is below SLEEP_VELOCITY_THRESHOLD after enough ticks', () => {
+    const frag = makeFrag({
+      state: 'flying',
+      velocity: { x: 0.03, y: 0.04, z: 0 }, // magnitude = 0.05 < 0.1
+      sleepTicks: SLEEP_TICKS_REQUIRED - 1,
+    });
+    const result = updateFragmentSleepStates([frag]);
+    expect(result[0]!.state).toBe('static');
+  });
+
+  it('resets sleepTicks when velocity goes above threshold', () => {
+    const frag = makeFrag({
+      state: 'flying',
+      velocity: ZERO,
+      sleepTicks: 10,
+    });
+    // First call: accumulate to 11
+    const result1 = updateFragmentSleepStates([frag]);
+    expect(result1[0]!.sleepTicks).toBe(11);
+    // Now set velocity above threshold
+    result1[0]!.velocity = { x: 1, y: 0, z: 0 };
+    const result2 = updateFragmentSleepStates(result1);
+    expect(result2[0]!.sleepTicks).toBe(0);
+    expect(result2[0]!.state).toBe('flying');
+  });
+
+  it('does not affect fragments already static', () => {
+    const frag = makeFrag({ state: 'static', velocity: ZERO, sleepTicks: 99 });
+    const result = updateFragmentSleepStates([frag]);
+    expect(result[0]!.state).toBe('static');
+    expect(result[0]!.sleepTicks).toBe(99);
+  });
+
+  it('does not change state when velocity is above threshold', () => {
+    const frag = makeFrag({
+      state: 'flying',
+      velocity: { x: 1, y: 0, z: 0 }, // magnitude = 1 >= 0.1
+      sleepTicks: 0,
+    });
+    const result = updateFragmentSleepStates([frag]);
+    expect(result[0]!.state).toBe('flying');
+    expect(result[0]!.sleepTicks).toBe(0);
+  });
+
+  it('handles tickCount > 1', () => {
+    const frag = makeFrag({ state: 'flying', velocity: ZERO, sleepTicks: 0 });
+    const result = updateFragmentSleepStates([frag], 5);
+    // sleepTicks advances by 5 in one call
+    expect(result[0]!.sleepTicks).toBe(5);
+    expect(result[0]!.state).toBe('flying'); // still below SLEEP_TICKS_REQUIRED
+  });
+
+  it('tracks sleepTicks independently per fragment', () => {
+    const stationary = makeFrag({
+      id: 1,
+      state: 'flying',
+      velocity: ZERO,
+      sleepTicks: 0,
+    });
+    const moving = makeFrag({
+      id: 2,
+      state: 'flying',
+      velocity: { x: 1, y: 0, z: 0 },
+      sleepTicks: 0,
+    });
+    const result = updateFragmentSleepStates([stationary, moving]);
+    const stat = result.find(f => f.id === 1)!;
+    const mov = result.find(f => f.id === 2)!;
+    expect(stat.sleepTicks).toBeGreaterThan(0);
+    expect(mov.sleepTicks).toBe(0);
+  });
+
+  it('returns the same array reference (mutates in place)', () => {
+    const frag = makeFrag({ state: 'flying', velocity: ZERO, sleepTicks: 0 });
+    const input = [frag];
+    const result = updateFragmentSleepStates(input);
     expect(result).toBe(input);
   });
 });


### PR DESCRIPTION
Closes #211

## Summary
Implements aggressive sleep detection for rock fragments. Fragments with velocity magnitude below SLEEP_VELOCITY_THRESHOLD (0.1 m/s) for SLEEP_TICKS_REQUIRED (15) consecutive ticks transition to 'static' state.

## Changes
### New constants in `src/core/config/balance.ts`
- `SLEEP_VELOCITY_THRESHOLD = 0.1` — velocity threshold for sleep detection
- `SLEEP_TICKS_REQUIRED = 15` — consecutive ticks needed before sleep

### Modified `src/physics/FragmentSim.ts`
- Added `sleepTicks: number` field to `RockFragment` interface
- Initialized `sleepTicks: 0` in `generateRockFragments`
- Re-exported `updateFragmentSleepStates` from FragmentSimPhysics

### Modified `src/physics/FragmentSimPhysics.ts`
- Added `updateFragmentSleepStates()` function:
  - Skips already-static fragments
  - Accumulates `sleepTicks` while velocity < threshold
  - Transitions to `'static'` after SLEEP_TICKS_REQUIRED ticks
  - Resets counter if velocity exceeds threshold
  - Supports configurable tick count via `_tickCount` parameter
  - Validates tickCount (NaN/Infinity/<=0 default to 1)
  - Mutates in place, returns same array reference

### New tests in `tests/unit/physics/FragmentSim.test.ts`
- Group 19: 10 tests covering all sleep detection scenarios

## Validation
- ✅ All 1775 tests pass (109 files)
- ✅ TypeScript strict mode — zero type errors
- ✅ Build succeeds
- ✅ jscpd duplication check passed
- ✅ Security review: PASS
- ✅ Quality review: PASS
- ✅ i18n review: PASS
- ✅ Duplication review: PASS
- ✅ Semantic review: PASS

READY TO MERGE