### PR TITLE
[5.17] Implement fragment size check and oversized flag

### DIFF
--- a/src/core/mining/BlastCalc.ts
+++ b/src/core/mining/BlastCalc.ts
@@ -399,4 +399,4 @@ export function parseKey(key: string): [number, number, number] | null {
 }
 
 export { PROJECTION_SPEED_THRESHOLD };
-export { isOversized, fragmentBoulder, resetBoulderFragIds, OVERSIZED_FRAGMENT_THRESHOLD, type Boulder, type FragmentBoulderResult } from './BoulderFragmentation.js';
+export { isOversized, isFragmentOversized, fragmentBoulder, resetBoulderFragIds, OVERSIZED_FRAGMENT_THRESHOLD, type Boulder, type FragmentBoulderResult } from './BoulderFragmentation.js';

--- a/src/core/mining/BoulderFragmentation.ts
+++ b/src/core/mining/BoulderFragmentation.ts
@@ -37,6 +37,11 @@ export function isOversized(volume: number): boolean {
   return volume > OVERSIZED_FRAGMENT_THRESHOLD;
 }
 
+/** Stub: checks whether a fragment's volume exceeds the oversized threshold. */
+export function isFragmentOversized(_volumeM3: number): boolean {
+  return false;
+}
+
 /**
  * Split an oversized boulder into N equal sub-fragments where every piece
  * has volume < OVERSIZED_FRAGMENT_THRESHOLD.

--- a/src/core/mining/BoulderFragmentation.ts
+++ b/src/core/mining/BoulderFragmentation.ts
@@ -37,9 +37,9 @@ export function isOversized(volume: number): boolean {
   return volume > OVERSIZED_FRAGMENT_THRESHOLD;
 }
 
-/** Checks whether a fragment's volume exceeds the oversized threshold. */
+/** Checks whether a fragment's volume exceeds the oversized threshold. Delegates to {@link isOversized}. */
 export function isFragmentOversized(volumeM3: number): boolean {
-  return volumeM3 > OVERSIZED_FRAGMENT_THRESHOLD;
+  return isOversized(volumeM3);
 }
 
 /**

--- a/src/core/mining/BoulderFragmentation.ts
+++ b/src/core/mining/BoulderFragmentation.ts
@@ -37,9 +37,9 @@ export function isOversized(volume: number): boolean {
   return volume > OVERSIZED_FRAGMENT_THRESHOLD;
 }
 
-/** Stub: checks whether a fragment's volume exceeds the oversized threshold. */
-export function isFragmentOversized(_volumeM3: number): boolean {
-  return false;
+/** Checks whether a fragment's volume exceeds the oversized threshold. */
+export function isFragmentOversized(volumeM3: number): boolean {
+  return volumeM3 > OVERSIZED_FRAGMENT_THRESHOLD;
 }
 
 /**

--- a/src/physics/FragmentSim.ts
+++ b/src/physics/FragmentSim.ts
@@ -70,6 +70,7 @@ export interface RockFragment {
   composition: VoxelRockComposition;
   oreComposition: VoxelOreComposition;
   volumeM3: number;
+  oversized: boolean;
   massKg: number;
   overflowEnergy: number;
   velocity: Vec3;
@@ -293,6 +294,7 @@ export function generateRockFragments(
       composition,
       oreComposition,
       volumeM3,
+      oversized: false,
       massKg,
       overflowEnergy,
       velocity: ZERO,

--- a/src/physics/FragmentSim.ts
+++ b/src/physics/FragmentSim.ts
@@ -6,7 +6,7 @@ import { vec3, ZERO, type Vec3 } from '../core/math/Vec3.js';
 import type { VoxelGrid, VoxelRockComposition } from '../core/world/VoxelGrid.js';
 import type { Random } from '../core/math/Random.js';
 import { convexHull3D, buildAdjacencyMap, computeFragmentationScore, computeFragmentCount, type VoronoiCell, type Tetrahedron } from './VoronoiFrag.js';
-import { computeThreshold, parseKey } from '../core/mining/BlastCalc.js';
+import { computeThreshold, isFragmentOversized, parseKey } from '../core/mining/BlastCalc.js';
 import { COLLISION_DEFLATE_AMOUNT, MERGE_PROBABILITY } from '../core/config/balance.js';
 import { assignFragmentVelocity } from './FragmentSimVelocity.js';
 import { getRock } from '../core/world/RockCatalog.js';
@@ -294,7 +294,7 @@ export function generateRockFragments(
       composition,
       oreComposition,
       volumeM3,
-      oversized: false,
+      oversized: isFragmentOversized(volumeM3),
       massKg,
       overflowEnergy,
       velocity: ZERO,

--- a/tests/unit/mining/BlastCalc.test.ts
+++ b/tests/unit/mining/BlastCalc.test.ts
@@ -15,6 +15,7 @@ import {
   PROJECTION_SPEED_THRESHOLD,
   fragmentBoulder,
   isOversized,
+  isFragmentOversized,
   OVERSIZED_FRAGMENT_THRESHOLD,
   resetBoulderFragIds,
   computeThreshold,
@@ -1194,5 +1195,31 @@ describe('BlastCalc — identifyFragmentedVoxels', () => {
 
     expect(identifyFragmentedVoxels(gridBelow, resultBelow).has('0,0,0')).toBe(false);
     expect(identifyFragmentedVoxels(gridAt, resultAt).has('0,0,0')).toBe(true);
+  });
+});
+
+// ── 5.17: isFragmentOversized ──
+
+describe('BlastCalc — isFragmentOversized', () => {
+  it('returns true for volume strictly above the threshold', () => {
+    expect(isFragmentOversized(OVERSIZED_FRAGMENT_THRESHOLD + 0.001)).toBe(true);
+    expect(isFragmentOversized(1.0)).toBe(true);
+    expect(isFragmentOversized(10.0)).toBe(true);
+  });
+
+  it('returns false for volume at or below the threshold', () => {
+    expect(isFragmentOversized(OVERSIZED_FRAGMENT_THRESHOLD)).toBe(false);
+    expect(isFragmentOversized(OVERSIZED_FRAGMENT_THRESHOLD - 0.001)).toBe(false);
+    expect(isFragmentOversized(0.0)).toBe(false);
+  });
+
+  it('returns false for negative volume (graceful handling)', () => {
+    expect(isFragmentOversized(-1)).toBe(false);
+  });
+
+  it('is consistent with isOversized behavior for same volume values', () => {
+    expect(isFragmentOversized(0.3)).toBe(isOversized(0.3));
+    expect(isFragmentOversized(0.5)).toBe(isOversized(0.5));
+    expect(isFragmentOversized(0.7)).toBe(isOversized(0.7));
   });
 });

--- a/tests/unit/physics/FragmentSim.test.ts
+++ b/tests/unit/physics/FragmentSim.test.ts
@@ -1541,6 +1541,69 @@ describe('FragmentSim — generateRockFragments', () => {
     // overflowEnergy should reflect all seeds contributing
     expect(frag.overflowEnergy).toBeGreaterThan(0);
   });
+
+  // ── 5.17: Oversized flag ──
+
+  it('sets oversized=true when volumeM3 > 0.5', () => {
+    const grid = baseGrid();
+    const cells: VoronoiCell[] = [
+      { seedIndex: 0, vertices: cellVertices1, isValid: true },
+    ];
+    // Two seeds with fragmentCount=2 → volume = 2/2 = 1.0 > 0.5
+    const seedToVoxelMap = new Map<number, SeedVoxelInfo>([
+      [0, { x: 0, y: 0, z: 0, fragmentCount: 2, effectiveEnergy: 200, generatedOverflow: 0 }],
+      [1, { x: 0, y: 0, z: 0, fragmentCount: 2, effectiveEnergy: 200, generatedOverflow: 0 }],
+    ]);
+    const seedGroupings = [[0, 1]];
+    const generatedOverflow = new Map<string, number>();
+    const rng = new Random(42);
+
+    const result = generateRockFragments(cells, seedToVoxelMap, seedGroupings, grid, new Map<string, number>(), generatedOverflow, rng);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.volumeM3).toBeGreaterThan(0.5);
+    expect(result[0]!.oversized).toBe(true);
+  });
+
+  it('sets oversized=false when volumeM3 <= 0.5', () => {
+    const grid = baseGrid();
+    const cells: VoronoiCell[] = [
+      { seedIndex: 0, vertices: cellVertices1, isValid: true },
+    ];
+    // One seed with fragmentCount=3 → volume = 1/3 ≈ 0.333 < 0.5
+    const seedToVoxelMap = new Map<number, SeedVoxelInfo>([
+      [0, { x: 0, y: 0, z: 0, fragmentCount: 3, effectiveEnergy: 200, generatedOverflow: 0 }],
+    ]);
+    const seedGroupings = [[0]];
+    const generatedOverflow = new Map<string, number>();
+    const rng = new Random(42);
+
+    const result = generateRockFragments(cells, seedToVoxelMap, seedGroupings, grid, new Map<string, number>(), generatedOverflow, rng);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.volumeM3).toBeLessThanOrEqual(0.5);
+    expect(result[0]!.oversized).toBe(false);
+  });
+
+  it('sets oversized=false at the boundary (volumeM3 === 0.5)', () => {
+    const grid = baseGrid();
+    const cells: VoronoiCell[] = [
+      { seedIndex: 0, vertices: cellVertices1, isValid: true },
+    ];
+    // One seed with fragmentCount=2 → volume = 1/2 = 0.5
+    const seedToVoxelMap = new Map<number, SeedVoxelInfo>([
+      [0, { x: 0, y: 0, z: 0, fragmentCount: 2, effectiveEnergy: 200, generatedOverflow: 0 }],
+    ]);
+    const seedGroupings = [[0]];
+    const generatedOverflow = new Map<string, number>();
+    const rng = new Random(42);
+
+    const result = generateRockFragments(cells, seedToVoxelMap, seedGroupings, grid, new Map<string, number>(), generatedOverflow, rng);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.volumeM3).toBeCloseTo(0.5);
+    expect(result[0]!.oversized).toBe(false);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -1822,6 +1885,7 @@ describe('FragmentSimVelocity — assignFragmentVelocity', () => {
       composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
       oreComposition: { ores: [] },
       volumeM3: 1.0,
+      oversized: true,
       massKg: 100,
       overflowEnergy: 100000,
       velocity: ZERO,
@@ -1858,6 +1922,7 @@ describe('FragmentSimVelocity — assignFragmentVelocity', () => {
       composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
       oreComposition: { ores: [] },
       volumeM3: 1.0,
+      oversized: true,
       massKg: 100,
       overflowEnergy: 0,
       velocity: ZERO,
@@ -1896,6 +1961,7 @@ describe('FragmentSimVelocity — assignFragmentVelocity', () => {
       composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
       oreComposition: { ores: [] },
       volumeM3: 1.0,
+      oversized: true,
       massKg: 100,
       overflowEnergy: 5000,
       velocity: ZERO,
@@ -1926,6 +1992,7 @@ describe('FragmentSimVelocity — assignFragmentVelocity', () => {
       composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
       oreComposition: { ores: [] },
       volumeM3: 1.0,
+      oversized: true,
       massKg: 100,
       overflowEnergy: 50000,
       velocity: ZERO,
@@ -1969,7 +2036,7 @@ describe('FragmentSimPhysics — simulateProjectedFragments', () => {
       collisionVertices: new Float32Array(),
       composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
       oreComposition: { ores: [] },
-      volumeM3: 1.0, massKg: 100,
+      volumeM3: 1.0, oversized: true, massKg: 100,
       overflowEnergy: 0,
       velocity: ZERO,
       simulationTier: 'collapse',
@@ -1998,7 +2065,7 @@ describe('FragmentSimPhysics — simulateProjectedFragments', () => {
       collisionVertices: new Float32Array(),
       composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
       oreComposition: { ores: [] },
-      volumeM3: 1.0, massKg: 100,
+      volumeM3: 1.0, oversized: true, massKg: 100,
       overflowEnergy: 0,
       velocity: ZERO,
       simulationTier: 'projected',
@@ -2017,7 +2084,7 @@ describe('FragmentSimPhysics — simulateProjectedFragments', () => {
       collisionVertices: new Float32Array(),
       composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
       oreComposition: { ores: [] },
-      volumeM3: 1.0, massKg: 0,
+      volumeM3: 1.0, oversized: true, massKg: 0,
       overflowEnergy: 0,
       velocity: ZERO,
       simulationTier: 'projected',
@@ -2043,7 +2110,7 @@ describe('FragmentSimPhysics — simulateProjectedFragments', () => {
         collisionVertices: new Float32Array(),
         composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
         oreComposition: { ores: [] },
-        volumeM3: 1.0, massKg: 100,
+        volumeM3: 1.0, oversized: true, massKg: 100,
         overflowEnergy: 0,
         velocity: ZERO,
         simulationTier: 'projected',
@@ -2073,7 +2140,7 @@ describe('FragmentSimPhysics — simulateProjectedFragments', () => {
       collisionVertices: new Float32Array(),
       composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
       oreComposition: { ores: [] },
-      volumeM3: 1.0, massKg: 100,
+      volumeM3: 1.0, oversized: true, massKg: 100,
       overflowEnergy: 0, velocity: ZERO,
       simulationTier: 'projected',
       state: 'flying',
@@ -2084,7 +2151,7 @@ describe('FragmentSimPhysics — simulateProjectedFragments', () => {
       collisionVertices: new Float32Array(),
       composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
       oreComposition: { ores: [] },
-      volumeM3: 1.0, massKg: 100,
+      volumeM3: 1.0, oversized: true, massKg: 100,
       overflowEnergy: 0, velocity: ZERO,
       simulationTier: 'collapse',
       state: 'settling',
@@ -2105,7 +2172,7 @@ describe('FragmentSimPhysics — simulateProjectedFragments', () => {
       collisionVertices: new Float32Array(),
       composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
       oreComposition: { ores: [] },
-      volumeM3: 1.0, massKg: 100,
+      volumeM3: 1.0, oversized: true, massKg: 100,
       overflowEnergy: 0, velocity: ZERO,
       simulationTier: 'projected',
       state: 'flying',
@@ -2136,7 +2203,7 @@ describe('FragmentSimPhysics — simulateCollapseFragments', () => {
       collisionVertices: new Float32Array(),
       composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
       oreComposition: { ores: [] },
-      volumeM3: 1.0, massKg: 100,
+      volumeM3: 1.0, oversized: true, massKg: 100,
       overflowEnergy: 0,
       velocity: ZERO,
       simulationTier: 'projected',
@@ -2165,7 +2232,7 @@ describe('FragmentSimPhysics — simulateCollapseFragments', () => {
       collisionVertices: new Float32Array(),
       composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
       oreComposition: { ores: [] },
-      volumeM3: 1.0, massKg: 100,
+      volumeM3: 1.0, oversized: true, massKg: 100,
       overflowEnergy: 0,
       velocity: ZERO,
       simulationTier: 'collapse',
@@ -2194,7 +2261,7 @@ describe('FragmentSimPhysics — simulateCollapseFragments', () => {
       collisionVertices: new Float32Array(),
       composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
       oreComposition: { ores: [] },
-      volumeM3: 1.0, massKg: 100,
+      volumeM3: 1.0, oversized: true, massKg: 100,
       overflowEnergy: 0,
       velocity: ZERO,
       simulationTier: 'collapse',
@@ -2217,7 +2284,7 @@ describe('FragmentSimPhysics — simulateCollapseFragments', () => {
       collisionVertices: new Float32Array(),
       composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
       oreComposition: { ores: [] },
-      volumeM3: 1.0, massKg: 0,
+      volumeM3: 1.0, oversized: true, massKg: 0,
       overflowEnergy: 0,
       velocity: ZERO,
       simulationTier: 'collapse',
@@ -2249,7 +2316,7 @@ describe('FragmentSimPhysics — simulateCollapseFragments', () => {
       collisionVertices: new Float32Array(),
       composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
       oreComposition: { ores: [] },
-      volumeM3: 1.0, massKg: 100,
+      volumeM3: 1.0, oversized: true, massKg: 100,
       overflowEnergy: 0,
       velocity: ZERO,
       simulationTier: 'collapse',
@@ -2271,7 +2338,7 @@ describe('FragmentSimPhysics — simulateCollapseFragments', () => {
       collisionVertices: new Float32Array(),
       composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
       oreComposition: { ores: [] },
-      volumeM3: 1.0, massKg: 100,
+      volumeM3: 1.0, oversized: true, massKg: 100,
       overflowEnergy: 0,
       velocity: ZERO,
       simulationTier: 'collapse',
@@ -2301,7 +2368,7 @@ describe('FragmentSimPhysics — simulateCollapseFragments', () => {
       collisionVertices: new Float32Array(),
       composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
       oreComposition: { ores: [] },
-      volumeM3: 1.0, massKg: 100,
+      volumeM3: 1.0, oversized: true, massKg: 100,
       overflowEnergy: 0, velocity: ZERO,
       simulationTier: 'projected',
       state: 'flying',
@@ -2312,7 +2379,7 @@ describe('FragmentSimPhysics — simulateCollapseFragments', () => {
       collisionVertices: new Float32Array(),
       composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
       oreComposition: { ores: [] },
-      volumeM3: 1.0, massKg: 100,
+      volumeM3: 1.0, oversized: true, massKg: 100,
       overflowEnergy: 0, velocity: ZERO,
       simulationTier: 'collapse',
       state: 'settling',
@@ -2335,7 +2402,7 @@ describe('FragmentSimPhysics — simulateCollapseFragments', () => {
       collisionVertices: new Float32Array(),
       composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
       oreComposition: { ores: [] },
-      volumeM3: 1.0, massKg: 100,
+      volumeM3: 1.0, oversized: true, massKg: 100,
       overflowEnergy: 0, velocity: ZERO,
       simulationTier: 'collapse',
       state: 'settling',
@@ -2359,7 +2426,7 @@ describe('FragmentSimPhysics — updateFragmentSleepStates', () => {
       collisionVertices: new Float32Array(),
       composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
       oreComposition: { ores: [] },
-      volumeM3: 1.0, massKg: 100,
+      volumeM3: 1.0, oversized: true, massKg: 100,
       overflowEnergy: 0,
       velocity: ZERO,
       simulationTier: 'projected',
@@ -2487,6 +2554,7 @@ function makeFragment(overrides: Partial<RockFragment> = {}): RockFragment {
     composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
     oreComposition: { ores: [] },
     volumeM3: 1.0,
+    oversized: true,
     massKg: 100,
     overflowEnergy: 0,
     velocity: ZERO,
@@ -2773,6 +2841,7 @@ function makeStackFragment(id: number, cy: number, aabb: AABB, overrides: Partia
     composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
     oreComposition: { ores: [] },
     volumeM3: 1.0,
+    oversized: true,
     massKg: 100,
     overflowEnergy: 0,
     velocity: ZERO,


### PR DESCRIPTION
## Summary
Implements task 5.17: fragment size check and oversized flag.

## Changes
### Source files
- **`src/core/mining/BoulderFragmentation.ts`**: Added `isFragmentOversized(volumeM3: number): boolean` — checks if a fragment's volume exceeds the oversized threshold (delegates to `isOversized` to avoid duplication).
- **`src/core/mining/BlastCalc.ts`**: Updated re-export to include `isFragmentOversized`.
- **`src/physics/FragmentSim.ts`**: Added `oversized: boolean` field to `RockFragment` interface; set during `generateRockFragments()` based on `isFragmentOversized(volumeM3)`.

### Test files
- **`tests/unit/mining/BlastCalc.test.ts`**: Added 4 tests covering >threshold, ≤threshold, negative, and consistency with `isOversized`.
- **`tests/unit/physics/FragmentSim.test.ts`**: Added 3 tests for oversized flag in fragment generation (true when >0.5, false when <0.5, false at boundary 0.5). Updated all 23 manual `RockFragment` constructions with `oversized` field.

## Validation
- ✅ TypeScript type-check: clean
- ✅ 1815 tests pass (109 test files)
- ✅ Build succeeds
- ✅ jscpd duplication: 1.43% (all pre-existing)
- ✅ Security review: clean
- ✅ Quality review: clean (minor duplication fixed via delegation)
- ✅ i18n review: no user-facing strings
- ✅ Semantic review: all tests match behavior

Closes #213

READY TO MERGE