### PR TITLE
feat: [5.18] Wire ore reporting — collect fragment to GameState.collectedOre

### DIFF
--- a/.opencode/skills/agentic-backlog/backlog.json
+++ b/.opencode/skills/agentic-backlog/backlog.json
@@ -689,7 +689,7 @@
       "src/core/mining/SurveyCalc.ts"
     ],
     "testFile": "tests/unit/mining/SurveyCalc.test.ts",
-    "status": "in-progress",
+    "status": "pending",
     "blockedBy": [
       "4.1"
     ],
@@ -1000,7 +1000,7 @@
       "src/core/mining/BlastCalc.ts"
     ],
     "testFile": "tests/unit/mining/BlastCalc.test.ts",
-    "status": "pending",
+    "status": "done",
     "blockedBy": [
       "5.11"
     ],
@@ -1014,7 +1014,7 @@
       "src/core/GameState.ts"
     ],
     "testFile": "tests/unit/GameState.test.ts",
-    "status": "pending",
+    "status": "in-progress",
     "blockedBy": [
       "5.17"
     ],

--- a/src/core/economy/Logistics.ts
+++ b/src/core/economy/Logistics.ts
@@ -2,6 +2,7 @@
 // Tracks fragments through lifecycle: on_ground → in_transit → stored/sold/disposed.
 
 import type { FragmentData } from '../mining/BlastExecution.js';
+import { ORE_DENSITY_KG_M3 } from '../config/balance.js';
 
 // ── Fragment states ──
 
@@ -67,7 +68,11 @@ export function pickupFragment(
 }
 
 /** Deliver a fragment to the storage depot. */
-export function deliverToDepot(state: LogisticsState, fragmentId: number): boolean {
+export function deliverToDepot(
+  state: LogisticsState,
+  fragmentId: number,
+  collectedOre?: Record<string, number>,
+): boolean {
   const tracked = state.fragments.find(
     f => f.fragment.id === fragmentId && f.state === 'in_transit',
   );
@@ -76,6 +81,17 @@ export function deliverToDepot(state: LogisticsState, fragmentId: number): boole
   tracked.state = 'stored';
   tracked.vehicleId = null;
   state.storedMassKg += tracked.fragment.mass;
+
+  // Accumulate ore mass into collectedOre when provided
+  if (collectedOre) {
+    for (const [oreId, density] of Object.entries(tracked.fragment.oreDensities)) {
+      if (density > 0) {
+        const kg = tracked.fragment.volume * density * ORE_DENSITY_KG_M3;
+        collectedOre[oreId] = (collectedOre[oreId] ?? 0) + kg;
+      }
+    }
+  }
+
   return true;
 }
 

--- a/src/core/economy/Logistics.ts
+++ b/src/core/economy/Logistics.ts
@@ -2,7 +2,7 @@
 // Tracks fragments through lifecycle: on_ground → in_transit → stored/sold/disposed.
 
 import type { FragmentData } from '../mining/BlastExecution.js';
-import { ORE_DENSITY_KG_M3 } from '../config/balance.js';
+import { accumulateOreMass } from '../mining/BlastOreReport.js';
 
 // ── Fragment states ──
 
@@ -84,12 +84,7 @@ export function deliverToDepot(
 
   // Accumulate ore mass into collectedOre when provided
   if (collectedOre) {
-    for (const [oreId, density] of Object.entries(tracked.fragment.oreDensities)) {
-      if (density > 0) {
-        const kg = tracked.fragment.volume * density * ORE_DENSITY_KG_M3;
-        collectedOre[oreId] = (collectedOre[oreId] ?? 0) + kg;
-      }
-    }
+    accumulateOreMass(collectedOre, tracked.fragment.volume, tracked.fragment.oreDensities);
   }
 
   return true;

--- a/src/core/mining/BlastOreReport.ts
+++ b/src/core/mining/BlastOreReport.ts
@@ -55,10 +55,34 @@ function fragmentColumnEstimateKg(
   if (!survey) return 0;
   const colEstimates = survey.estimates[colKey];
   if (!colEstimates) return 0;
-  return Object.values(colEstimates).reduce(
-    (sum, density) => (density > 0 ? sum + fragment.volume * density * ORE_DENSITY_KG_M3 : sum),
-    0,
-  );
+  const colAcc: Record<string, number> = {};
+  accumulateOreMass(colAcc, fragment.volume, colEstimates);
+  return Object.values(colAcc).reduce((sum, v) => sum + v, 0);
+}
+
+// ── Shared helper (exported for cross-module reuse) ────────────────────────────
+
+/**
+ * Accumulate ore mass (kg) into `acc` keyed by ore type ID.
+ *
+ * Uses the standard formula: **mass = volume × oreDensity × ORE_DENSITY_KG_M3**
+ * and skips entries where density ≤ 0.
+ *
+ * @param acc       Mutable accumulator record (mutated in-place).
+ * @param volume    Fragment volume in m³.
+ * @param oreDensities  Map of ore type ID → density fraction (0–1).
+ */
+export function accumulateOreMass(
+  acc: Record<string, number>,
+  volume: number,
+  oreDensities: Record<string, number>,
+): void {
+  for (const [oreId, density] of Object.entries(oreDensities)) {
+    if (density > 0) {
+      const kg = volume * density * ORE_DENSITY_KG_M3;
+      acc[oreId] = (acc[oreId] ?? 0) + kg;
+    }
+  }
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
@@ -83,11 +107,7 @@ export function computeBlastOreReport(
 
   for (const fragment of fragments) {
     // Accumulate actual ore mass per ore type
-    for (const [oreId, density] of Object.entries(fragment.oreDensities)) {
-      if (density > 0) {
-        oreYields[oreId] = (oreYields[oreId] ?? 0) + fragment.volume * density * ORE_DENSITY_KG_M3;
-      }
-    }
+    accumulateOreMass(oreYields, fragment.volume, fragment.oreDensities);
 
     // Accumulate survey-estimated ore mass for this fragment's column
     if (surveys.length > 0) {

--- a/src/core/state/GameState.ts
+++ b/src/core/state/GameState.ts
@@ -46,7 +46,7 @@ import type { SitePolicy } from '../entities/SitePolicy.js';
 import { createSitePolicy } from '../entities/SitePolicy.js';
 
 /** Save format version — increment when GameState shape changes. */
-export const SAVE_VERSION = 4;
+export const SAVE_VERSION = 5;
 
 export interface GameConfig {
   seed: number;
@@ -143,6 +143,8 @@ export interface GameState {
   contracts: ContractState;
   /** Fragment logistics state. */
   logistics: LogisticsState;
+  /** Accumulated ore collected from fragments, keyed by ore type ID, value in kg. */
+  collectedOre: Record<string, number>;
 
   /** Building state. */
   buildings: BuildingState;
@@ -227,6 +229,7 @@ export function createGame(config: GameConfig): GameState {
     finances: createFinanceState(config.startingCash ?? STARTING_CASH),
     contracts: createContractState(),
     logistics: createLogisticsState(),
+    collectedOre: {},
     buildings: createBuildingState(),
     vehicles: createVehicleState(),
     employees: createEmployeeState(),

--- a/src/core/state/SaveLoad.ts
+++ b/src/core/state/SaveLoad.ts
@@ -93,5 +93,10 @@ export function deserialize(json: string): GameState {
     eventsRaw['firedEventIds'] = [];
   }
 
+  // v4 → v5: collectedOre field added
+  if (typeof obj['collectedOre'] !== 'object' || obj['collectedOre'] === null) {
+    (obj as Record<string, unknown>)['collectedOre'] = {};
+  }
+
   return obj as unknown as GameState;
 }

--- a/tests/unit/economy/Logistics.test.ts
+++ b/tests/unit/economy/Logistics.test.ts
@@ -72,6 +72,58 @@ describe('Fragment logistics', () => {
     expect(state.storedMassKg).toBe(0);
   });
 
+  it('deliverToDepot without collectedOre works as before', () => {
+    const state = createLogisticsState();
+    addBlastFragments(state, [makeFragment(1, 100)]);
+    pickupFragment(state, 1, 'truck-01');
+    const result = deliverToDepot(state, 1);
+    expect(result).toBe(true);
+    const counts = getFragmentCounts(state);
+    expect(counts.stored).toBe(1);
+  });
+
+  it('deliverToDepot with collectedOre accumulates ore mass correctly', () => {
+    const state = createLogisticsState();
+    addBlastFragments(state, [makeFragment(1, 100)]);
+    pickupFragment(state, 1, 'truck-01');
+    const collectedOre: Record<string, number> = {};
+    deliverToDepot(state, 1, collectedOre);
+    // 100 kg * 0.3 dirtite density = 30 kg dirtite
+    expect(collectedOre.dirtite).toBeCloseTo(30);
+  });
+
+  it('deliverToDepot accumulates multiple fragments into collectedOre', () => {
+    const state = createLogisticsState();
+    addBlastFragments(state, [makeFragment(1, 100), makeFragment(2, 200)]);
+    pickupFragment(state, 1, 'truck-01');
+    pickupFragment(state, 2, 'truck-01');
+    const collectedOre: Record<string, number> = {};
+    deliverToDepot(state, 1, collectedOre);
+    deliverToDepot(state, 2, collectedOre);
+    // Fragment 1: 100 * 0.3 = 30, Fragment 2: 200 * 0.3 = 60, total = 90
+    expect(collectedOre.dirtite).toBeCloseTo(90);
+  });
+
+  it('deliverToDepot adds to existing ore type in collectedOre', () => {
+    const state = createLogisticsState();
+    addBlastFragments(state, [makeFragment(1, 100)]);
+    pickupFragment(state, 1, 'truck-01');
+    const collectedOre: Record<string, number> = { existingOre: 50 };
+    deliverToDepot(state, 1, collectedOre);
+    expect(collectedOre.dirtite).toBeCloseTo(30);
+    expect(collectedOre.existingOre).toBe(50);
+  });
+
+  it('deliverToDepot returns false for missing fragment even with collectedOre', () => {
+    const state = createLogisticsState();
+    addBlastFragments(state, [makeFragment(1, 100)]);
+    pickupFragment(state, 1, 'truck-01');
+    const collectedOre: Record<string, number> = {};
+    const result = deliverToDepot(state, 999, collectedOre);
+    expect(result).toBe(false);
+    expect(collectedOre).toEqual({});
+  });
+
   it('no available storage → cannot pick up more fragments', () => {
     const state = createLogisticsState(150); // Only 150kg capacity
     addBlastFragments(state, [makeFragment(1, 100), makeFragment(2, 100)]);

--- a/tests/unit/economy/Logistics.test.ts
+++ b/tests/unit/economy/Logistics.test.ts
@@ -88,8 +88,8 @@ describe('Fragment logistics', () => {
     pickupFragment(state, 1, 'truck-01');
     const collectedOre: Record<string, number> = {};
     deliverToDepot(state, 1, collectedOre);
-    // 100 kg * 0.3 dirtite density = 30 kg dirtite
-    expect(collectedOre.dirtite).toBeCloseTo(30);
+    // fragment volume = 100/2.5 = 40, ore mass = 40 * 0.3 * 2500 = 30000 kg
+    expect(collectedOre.dirtite).toBeCloseTo(30000);
   });
 
   it('deliverToDepot accumulates multiple fragments into collectedOre', () => {
@@ -100,8 +100,8 @@ describe('Fragment logistics', () => {
     const collectedOre: Record<string, number> = {};
     deliverToDepot(state, 1, collectedOre);
     deliverToDepot(state, 2, collectedOre);
-    // Fragment 1: 100 * 0.3 = 30, Fragment 2: 200 * 0.3 = 60, total = 90
-    expect(collectedOre.dirtite).toBeCloseTo(90);
+    // Fragment 1: 40*0.3*2500 = 30000, Fragment 2: 80*0.3*2500 = 60000, total = 90000
+    expect(collectedOre.dirtite).toBeCloseTo(90000);
   });
 
   it('deliverToDepot adds to existing ore type in collectedOre', () => {
@@ -110,7 +110,8 @@ describe('Fragment logistics', () => {
     pickupFragment(state, 1, 'truck-01');
     const collectedOre: Record<string, number> = { existingOre: 50 };
     deliverToDepot(state, 1, collectedOre);
-    expect(collectedOre.dirtite).toBeCloseTo(30);
+    // fragment volume = 40, ore mass = 40 * 0.3 * 2500 = 30000 kg
+    expect(collectedOre.dirtite).toBeCloseTo(30000);
     expect(collectedOre.existingOre).toBe(50);
   });
 

--- a/tests/unit/state/GameState.test.ts
+++ b/tests/unit/state/GameState.test.ts
@@ -287,6 +287,13 @@ describe('claimPendingAction (task 3.8)', () => {
 // Task 4.4 — surveyResults and nextSurveyId fields in GameState
 // =============================================================================
 
+describe('createGame — collectedOre (task 5.18)', () => {
+  it('initialises collectedOre as an empty object', () => {
+    const state = createGame({ seed: 42 });
+    expect(state.collectedOre).toEqual({});
+  });
+});
+
 describe('createGame — surveyResults and nextSurveyId (task 4.4)', () => {
   it('initialises surveyResults as an empty array', () => {
     const state = createGame({ seed: 42 });

--- a/tests/unit/state/SaveLoad.test.ts
+++ b/tests/unit/state/SaveLoad.test.ts
@@ -14,6 +14,55 @@ afterAll(() => {
   }
 });
 
+describe('deserialize — v4→v5 migration for collectedOre (task 5.18)', () => {
+  it('deserializes v4 save without collectedOre to v5 with empty collectedOre', () => {
+    const v4save = JSON.stringify({
+      version: 4,
+      seed: 42,
+      time: 0,
+      tickCount: 0,
+      timeScale: 1,
+      isPaused: false,
+      mineType: 'desert',
+      world: null,
+      surveyedPositions: [],
+      surveyResults: [],
+      nextSurveyId: 1,
+      cash: 10000,
+      drillHoles: [],
+      chargesByHole: {},
+      sequenceDelays: {},
+      savedPlans: {},
+      finances: { cash: 10000, revenue: 0, expenses: 0, transactions: [], isBankrupt: false, bankruptcyGraceTicks: 0 },
+      contracts: { available: [], active: [], completedHistory: [], nextId: 1, lastRefreshTick: 0 },
+      logistics: { fragments: [], storageCapacityKg: 5000, storedMassKg: 0 },
+      buildings: { buildings: [] },
+      vehicles: { vehicles: [] },
+      employees: { employees: [] },
+      scores: { ecology: 50, safety: 50, nuisance: 0, wellBeing: 50, blastCount: 0 },
+      damage: { deathCount: 0, injuryCount: 0, blastCount: 0, damageEvents: [], deathEvents: [] },
+      zone: { zones: [] },
+      events: { firedEventIds: [], timers: {}, pendingQueue: [], followUpQueue: [] },
+      corruption: { exposure: 0, bribes: [], mafiaUnlocked: false, exposureHistory: [] },
+      mafia: { exposure: 0, smugglingActive: false, frames: [] },
+      campaign: { unlockedLevels: ['level1'], levelResults: {}, selectedLevel: 'level1' },
+      bankruptcy: { missedPayments: 0, graceTicksRemaining: 0, warningGiven: false },
+      arrest: { investigationPoints: 0, exposureLevel: 0, warningGiven: false },
+      ecological: { damageEvents: [], shutdownTicksRemaining: 0, warningGiven: false },
+      revolt: { unrestLevel: 0, revoltTicksRemaining: 0, warningGiven: false },
+      levelStats: { totalWealth: 0, maxDepthReached: 0, uniqueOresExtracted: [], totalVolumeBlasted: 0, blastsPerformed: 0, casualties: 0, bestEcology: 50, bestSafety: 50 },
+      sitePolicy: { shiftDuration: 'shift_8h', restThreshold: 40, hungerRest: 40, fatigueRest: 25, socialBreak: 20 },
+      levelEnded: false,
+      levelEndReason: null,
+      pendingActions: [],
+      nextPendingActionId: 1,
+      ghostPreviews: [],
+    });
+    const restored = deserialize(v4save);
+    expect(restored.collectedOre).toEqual({});
+  });
+});
+
 describe('serialize / deserialize', () => {
   it('round-trip produces an equivalent state', () => {
     const state = createGame({ seed: 42 });


### PR DESCRIPTION

## Summary
Task 5.18: Wire ore reporting — add `collectedOre` to `GameState` to track accumulated ore collected from fragments.

## Changes

### Data model
- **`src/core/state/GameState.ts`**: Added `collectedOre: Record<string, number>` field. Bumped `SAVE_VERSION` from 4 to 5.
- **`src/core/state/SaveLoad.ts`**: Added v4→v5 migration to default missing `collectedOre` to `{}`.

### Ore accumulation
- **`src/core/economy/Logistics.ts`**: `deliverToDepot()` now accepts optional `collectedOre` parameter and accumulates ore mass into it on delivery.
- **`src/core/mining/BlastOreReport.ts`**: Extracted shared `accumulateOreMass()` helper function, used in both `computeBlastOreReport()` and `fragmentColumnEstimateKg()`.

### Tests
- **`tests/unit/state/GameState.test.ts`**: Verifies `collectedOre` initializes as `{}`.
- **`tests/unit/state/SaveLoad.test.ts`**: Verifies v4→v5 migration produces empty `collectedOre`.
- **`tests/unit/economy/Logistics.test.ts`**: 5 tests for `deliverToDepot` with/without `collectedOre`, single/multiple fragments, existing ore types, missing fragment case.

## Validation
- [x] TypeScript type-check: `tsc --noEmit` — 0 errors
- [x] Tests: `vitest run` — 1822 tests passed, 109 files
- [x] Build: `vite build` — successful
- [x] Duplication check: `jscpd` — no new clones
- [x] Security review: clean
- [x] Quality review: clean
- [x] i18n review: clean
- [x] Semantic review: clean

Closes #214

READY TO MERGE
