### PR TITLE
feat: add blast_preview console command (#226)

### DIFF
--- a/src/console/commands/mining.ts
+++ b/src/console/commands/mining.ts
@@ -348,8 +348,11 @@ export function previewCommand(
   return { success: false, output: 'Usage: preview energy|fragments|projections|vibrations' };
 }
 
-// ── Blast preview command ──
-
+/**
+ * Show a comprehensive blast preview covering energy, fragmentation,
+ * projections, and vibrations — each unlocked by the corresponding
+ * software tier.  Sections with insufficient tier display a lock message.
+ */
 export function blastPreviewCommand(
   ctx: MiningContext,
   _args: string[],
@@ -375,7 +378,6 @@ export function blastPreviewCommand(
 
   const lines: string[] = ['=== BLAST PREVIEW ==='];
 
-  // ── Energy Map section ──
   lines.push('');
   if (energyPreview) {
     lines.push('--- Energy Map ---');
@@ -386,7 +388,6 @@ export function blastPreviewCommand(
     lines.push('--- Energy Map --- [Requires software tier 1]');
   }
 
-  // ── Fragmentation section ──
   lines.push('');
   if (fragmentPreview) {
     lines.push('--- Fragmentation ---');
@@ -398,11 +399,11 @@ export function blastPreviewCommand(
     lines.push('--- Fragmentation --- [Requires software tier 2]');
   }
 
-  // ── Projections section ──
   lines.push('');
   if (projectionPreview) {
     const fractured = fragmentPreview?.fracturedCount ?? 0;
     const cracked = fragmentPreview?.crackedCount ?? 0;
+    // Fragments that are fractured/cracked but NOT projected outward collapse in place
     const collapseCount = (fractured + cracked) - projectionPreview.projectionZoneCount;
     lines.push('--- Projections ---');
     lines.push(`  Projection zone voxels: ${projectionPreview.projectionZoneCount}`);
@@ -412,7 +413,6 @@ export function blastPreviewCommand(
     lines.push('--- Projections --- [Requires software tier 3]');
   }
 
-  // ── Vibrations section ──
   lines.push('');
   if (vibrationPreview) {
     lines.push('--- Vibrations ---');

--- a/src/console/commands/mining.ts
+++ b/src/console/commands/mining.ts
@@ -351,12 +351,78 @@ export function previewCommand(
 // ── Blast preview command ──
 
 export function blastPreviewCommand(
-  _ctx: MiningContext,
+  ctx: MiningContext,
   _args: string[],
   _named: Record<string, string>,
 ): CommandResult {
-  // TODO: implement blast preview
-  return { success: true, output: '' };
+  const err = requireGame(ctx);
+  if (err) return { success: false, output: err };
+
+  if (ctx.state!.drillHoles.length === 0) {
+    return { success: false, output: 'No drill plan. Create one with drill_plan grid or drill_plan add.' };
+  }
+
+  const plan = assembleBlastPlan(ctx.state!.drillHoles, ctx.state!.chargesByHole, ctx.state!.sequenceDelays);
+  const errors = validateBlastPlan(plan);
+  if (errors.length > 0) {
+    return { success: false, output: `Invalid plan:\n${errors.map(e => `  ${e.holeId}: ${e.issue}`).join('\n')}` };
+  }
+
+  const energyPreview = previewEnergy(plan, ctx.grid!, ctx.softwareTier);
+  const fragmentPreview = previewFragments(plan, ctx.grid!, ctx.softwareTier);
+  const projectionPreview = previewProjections(plan, ctx.grid!, ctx.softwareTier);
+  const vibrationPreview = previewVibrations(plan, [], ctx.softwareTier);
+
+  const lines: string[] = ['=== BLAST PREVIEW ==='];
+
+  // ── Energy Map section ──
+  lines.push('');
+  if (energyPreview) {
+    lines.push('--- Energy Map ---');
+    lines.push(`  Affected voxels: ${energyPreview.energyMap.size}`);
+    lines.push(`  Min energy: ${energyPreview.minEnergy.toFixed(1)}`);
+    lines.push(`  Max energy: ${energyPreview.maxEnergy.toFixed(1)}`);
+  } else {
+    lines.push('--- Energy Map --- [Requires software tier 1]');
+  }
+
+  // ── Fragmentation section ──
+  lines.push('');
+  if (fragmentPreview) {
+    lines.push('--- Fragmentation ---');
+    lines.push(`  Fractured: ${fragmentPreview.fracturedCount}`);
+    lines.push(`  Cracked: ${fragmentPreview.crackedCount}`);
+    lines.push(`  Unaffected: ${fragmentPreview.unaffectedCount}`);
+    lines.push(`  Average fragment size: ${fragmentPreview.avgFragmentSize.toFixed(3)} m³`);
+  } else {
+    lines.push('--- Fragmentation --- [Requires software tier 2]');
+  }
+
+  // ── Projections section ──
+  lines.push('');
+  if (projectionPreview) {
+    const fractured = fragmentPreview?.fracturedCount ?? 0;
+    const cracked = fragmentPreview?.crackedCount ?? 0;
+    const collapseCount = (fractured + cracked) - projectionPreview.projectionZoneCount;
+    lines.push('--- Projections ---');
+    lines.push(`  Projection zone voxels: ${projectionPreview.projectionZoneCount}`);
+    lines.push(`  Projected fragments: ${projectionPreview.projectionZoneCount}`);
+    lines.push(`  Collapse fragments: ${collapseCount}`);
+  } else {
+    lines.push('--- Projections --- [Requires software tier 3]');
+  }
+
+  // ── Vibrations section ──
+  lines.push('');
+  if (vibrationPreview) {
+    lines.push('--- Vibrations ---');
+    lines.push(`  Max vibration: ${vibrationPreview.maxVibration.toFixed(4)}`);
+    lines.push(`  Affected villages: ${vibrationPreview.villages.length}`);
+  } else {
+    lines.push('--- Vibrations --- [Requires software tier 4]');
+  }
+
+  return { success: true, output: lines.join('\n') };
 }
 
 // ── Buy software ──

--- a/src/console/commands/mining.ts
+++ b/src/console/commands/mining.ts
@@ -348,6 +348,17 @@ export function previewCommand(
   return { success: false, output: 'Usage: preview energy|fragments|projections|vibrations' };
 }
 
+// ── Blast preview command ──
+
+export function blastPreviewCommand(
+  _ctx: MiningContext,
+  _args: string[],
+  _named: Record<string, string>,
+): CommandResult {
+  // TODO: implement blast preview
+  return { success: true, output: '' };
+}
+
 // ── Buy software ──
 
 export function buySoftwareCommand(

--- a/src/console/createRunner.ts
+++ b/src/console/createRunner.ts
@@ -16,6 +16,7 @@ import {
   blastCommand,
   blastPlanCommand,
   previewCommand,
+  blastPreviewCommand,
   buySoftwareCommand,
   buildRampCommand,
   weatherCommand,
@@ -104,6 +105,9 @@ export function createRunner(): RunnerWithContext {
   );
   runner.register('preview', 'Preview blast (energy|fragments|projections|vibrations)', (args, named) =>
     previewCommand(ctx, args, named),
+  );
+  runner.register('blast_preview', 'Comprehensive blast preview (energy, fragments, projections, vibrations)', (args, named) =>
+    blastPreviewCommand(ctx, args, named),
   );
   runner.register('buy_software', 'Buy software upgrade', (args, named) =>
     buySoftwareCommand(ctx, args, named),

--- a/tests/unit/console/mining-commands.test.ts
+++ b/tests/unit/console/mining-commands.test.ts
@@ -5,6 +5,7 @@ import type { MiningContext } from '../../../src/console/commands/mining.js';
 import {
   blastCommand,
   blastPlanCommand,
+  blastPreviewCommand,
   buySoftwareCommand,
   chargeCommand,
   drillPlanCommand,
@@ -128,6 +129,144 @@ describe('buy_software tier validation', () => {
     const result = buySoftwareCommand(ctx, [], { tier: '0' });
     expect(result.success).toBe(false);
     expect(result.output).toContain('Already at tier');
+  });
+});
+
+// ── blast_preview ─────────────────────────────────────────────────────────────
+
+describe('blast_preview', () => {
+  // ── guard: no game loaded ───────────────────────────────────────────────────
+
+  it('returns success:false with "No game loaded" when ctx.state is null', () => {
+    const ctx: MiningContext = {
+      state: null,
+      grid: null,
+      softwareTier: 0,
+      tubingState: createTubingState(),
+      emitter: new EventEmitter(),
+    };
+    const result = blastPreviewCommand(ctx, [], {});
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('No game loaded');
+  });
+
+  // ── guard: no drill plan ────────────────────────────────────────────────────
+
+  it('returns success:false with "No drill plan" when drillHoles is empty', () => {
+    const ctx = makeMiningContext();
+    const result = blastPreviewCommand(ctx, [], {});
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('No drill plan');
+  });
+
+  // ── guard: incomplete plan ──────────────────────────────────────────────────
+
+  it('returns success:false with validation error when holes exist but charges are missing', () => {
+    const ctx = makeMiningContext();
+    drillPlanCommand(ctx, ['grid'], { rows: '1', cols: '1', spacing: '3', depth: '8' });
+    const result = blastPreviewCommand(ctx, [], {});
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('Missing charge');
+  });
+
+  // ── software tier 0 — all locked ────────────────────────────────────────────
+
+  it('tier 0 — complete plan, all sections require higher software tier', () => {
+    const ctx = makeMiningContext();
+    drillPlanCommand(ctx, ['grid'], { rows: '1', cols: '1', spacing: '3', depth: '8' });
+    chargeCommand(ctx, [], { hole: 'H1', explosive: 'boomite', amount: '5kg', stemming: '2m' });
+    sequenceCommand(ctx, ['set'], { hole: 'H1', delay: '0ms' });
+
+    const result = blastPreviewCommand(ctx, [], {});
+    expect(result.success).toBe(true);
+    const matches = result.output.match(/Requires software tier/g);
+    expect(matches).toHaveLength(4);
+  });
+
+  // ── software tier 1 — energy unlocked ───────────────────────────────────────
+
+  it('tier 1 — energy section shows data, fragmentation+projections+vibrations require higher tier', () => {
+    const ctx = makeMiningContext();
+    ctx.softwareTier = 1;
+    drillPlanCommand(ctx, ['grid'], { rows: '1', cols: '1', spacing: '3', depth: '8' });
+    chargeCommand(ctx, [], { hole: 'H1', explosive: 'boomite', amount: '5kg', stemming: '2m' });
+    sequenceCommand(ctx, ['set'], { hole: 'H1', delay: '0ms' });
+
+    const result = blastPreviewCommand(ctx, [], {});
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('Affected voxels');
+    expect(result.output).toContain('Min energy');
+    expect(result.output).toContain('Max energy');
+    // Remaining 3 sections still locked
+    const matches = result.output.match(/Requires software tier/g);
+    expect(matches).toHaveLength(3);
+  });
+
+  // ── software tier 2 — energy + frag unlocked ────────────────────────────────
+
+  it('tier 2 — energy + fragmentation show data, projections+vibrations require higher tier', () => {
+    const ctx = makeMiningContext();
+    ctx.softwareTier = 2;
+    drillPlanCommand(ctx, ['grid'], { rows: '1', cols: '1', spacing: '3', depth: '8' });
+    chargeCommand(ctx, [], { hole: 'H1', explosive: 'boomite', amount: '5kg', stemming: '2m' });
+    sequenceCommand(ctx, ['set'], { hole: 'H1', delay: '0ms' });
+
+    const result = blastPreviewCommand(ctx, [], {});
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('Affected voxels');
+    expect(result.output).toContain('Min energy');
+    expect(result.output).toContain('Max energy');
+    expect(result.output).toContain('Fractured');
+    expect(result.output).toContain('Cracked');
+    expect(result.output).toContain('Average fragment size');
+    // Remaining 2 sections still locked
+    const matches = result.output.match(/Requires software tier/g);
+    expect(matches).toHaveLength(2);
+  });
+
+  // ── software tier 3 — energy + frag + projections unlocked ─────────────────
+
+  it('tier 3 — energy + fragmentation + projections show data, vibrations require higher tier', () => {
+    const ctx = makeMiningContext();
+    ctx.softwareTier = 3;
+    drillPlanCommand(ctx, ['grid'], { rows: '1', cols: '1', spacing: '3', depth: '8' });
+    chargeCommand(ctx, [], { hole: 'H1', explosive: 'boomite', amount: '5kg', stemming: '2m' });
+    sequenceCommand(ctx, ['set'], { hole: 'H1', delay: '0ms' });
+
+    const result = blastPreviewCommand(ctx, [], {});
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('Affected voxels');
+    expect(result.output).toContain('Fractured');
+    expect(result.output).toContain('Projection zone voxels');
+    expect(result.output).toContain('Projected fragments');
+    expect(result.output).toContain('Collapse fragments');
+    // Remaining 1 section still locked
+    const matches = result.output.match(/Requires software tier/g);
+    expect(matches).toHaveLength(1);
+  });
+
+  // ── software tier 4 — all unlocked ─────────────────────────────────────────
+
+  it('tier 4 — all sections show data', () => {
+    const ctx = makeMiningContext();
+    ctx.softwareTier = 4;
+    drillPlanCommand(ctx, ['grid'], { rows: '1', cols: '1', spacing: '3', depth: '8' });
+    chargeCommand(ctx, [], { hole: 'H1', explosive: 'boomite', amount: '5kg', stemming: '2m' });
+    sequenceCommand(ctx, ['set'], { hole: 'H1', delay: '0ms' });
+
+    const result = blastPreviewCommand(ctx, [], {});
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('Energy Map');
+    expect(result.output).toContain('Fragmentation');
+    expect(result.output).toContain('Projections');
+    expect(result.output).toContain('Vibrations');
+    expect(result.output).toContain('Affected voxels');
+    expect(result.output).toContain('Fractured');
+    expect(result.output).toContain('Projection zone voxels');
+    expect(result.output).toContain('Max vibration');
+    expect(result.output).toContain('Affected villages');
+    // All unlocked — no "Requires software tier" messages
+    expect(result.output).not.toMatch(/Requires software tier/);
   });
 });
 

--- a/tests/unit/console/mining-commands.test.ts
+++ b/tests/unit/console/mining-commands.test.ts
@@ -135,6 +135,17 @@ describe('buy_software tier validation', () => {
 // ── blast_preview ─────────────────────────────────────────────────────────────
 
 describe('blast_preview', () => {
+  /**
+   * Helper: create a mining context with a single-hole plan already set up
+   * (1 hole, 1 charge, 1 sequence delay). Optionally sets software tier.
+   */
+  function makePlan(ctx: MiningContext, tier?: number): void {
+    if (tier !== undefined) ctx.softwareTier = tier;
+    drillPlanCommand(ctx, ['grid'], { rows: '1', cols: '1', spacing: '3', depth: '8' });
+    chargeCommand(ctx, [], { hole: 'H1', explosive: 'boomite', amount: '5kg', stemming: '2m' });
+    sequenceCommand(ctx, ['set'], { hole: 'H1', delay: '0ms' });
+  }
+
   // ── guard: no game loaded ───────────────────────────────────────────────────
 
   it('returns success:false with "No game loaded" when ctx.state is null', () => {
@@ -173,9 +184,7 @@ describe('blast_preview', () => {
 
   it('tier 0 — complete plan, all sections require higher software tier', () => {
     const ctx = makeMiningContext();
-    drillPlanCommand(ctx, ['grid'], { rows: '1', cols: '1', spacing: '3', depth: '8' });
-    chargeCommand(ctx, [], { hole: 'H1', explosive: 'boomite', amount: '5kg', stemming: '2m' });
-    sequenceCommand(ctx, ['set'], { hole: 'H1', delay: '0ms' });
+    makePlan(ctx);
 
     const result = blastPreviewCommand(ctx, [], {});
     expect(result.success).toBe(true);
@@ -187,10 +196,7 @@ describe('blast_preview', () => {
 
   it('tier 1 — energy section shows data, fragmentation+projections+vibrations require higher tier', () => {
     const ctx = makeMiningContext();
-    ctx.softwareTier = 1;
-    drillPlanCommand(ctx, ['grid'], { rows: '1', cols: '1', spacing: '3', depth: '8' });
-    chargeCommand(ctx, [], { hole: 'H1', explosive: 'boomite', amount: '5kg', stemming: '2m' });
-    sequenceCommand(ctx, ['set'], { hole: 'H1', delay: '0ms' });
+    makePlan(ctx, 1);
 
     const result = blastPreviewCommand(ctx, [], {});
     expect(result.success).toBe(true);
@@ -206,10 +212,7 @@ describe('blast_preview', () => {
 
   it('tier 2 — energy + fragmentation show data, projections+vibrations require higher tier', () => {
     const ctx = makeMiningContext();
-    ctx.softwareTier = 2;
-    drillPlanCommand(ctx, ['grid'], { rows: '1', cols: '1', spacing: '3', depth: '8' });
-    chargeCommand(ctx, [], { hole: 'H1', explosive: 'boomite', amount: '5kg', stemming: '2m' });
-    sequenceCommand(ctx, ['set'], { hole: 'H1', delay: '0ms' });
+    makePlan(ctx, 2);
 
     const result = blastPreviewCommand(ctx, [], {});
     expect(result.success).toBe(true);
@@ -228,10 +231,7 @@ describe('blast_preview', () => {
 
   it('tier 3 — energy + fragmentation + projections show data, vibrations require higher tier', () => {
     const ctx = makeMiningContext();
-    ctx.softwareTier = 3;
-    drillPlanCommand(ctx, ['grid'], { rows: '1', cols: '1', spacing: '3', depth: '8' });
-    chargeCommand(ctx, [], { hole: 'H1', explosive: 'boomite', amount: '5kg', stemming: '2m' });
-    sequenceCommand(ctx, ['set'], { hole: 'H1', delay: '0ms' });
+    makePlan(ctx, 3);
 
     const result = blastPreviewCommand(ctx, [], {});
     expect(result.success).toBe(true);
@@ -249,10 +249,7 @@ describe('blast_preview', () => {
 
   it('tier 4 — all sections show data', () => {
     const ctx = makeMiningContext();
-    ctx.softwareTier = 4;
-    drillPlanCommand(ctx, ['grid'], { rows: '1', cols: '1', spacing: '3', depth: '8' });
-    chargeCommand(ctx, [], { hole: 'H1', explosive: 'boomite', amount: '5kg', stemming: '2m' });
-    sequenceCommand(ctx, ['set'], { hole: 'H1', delay: '0ms' });
+    makePlan(ctx, 4);
 
     const result = blastPreviewCommand(ctx, [], {});
     expect(result.success).toBe(true);


### PR DESCRIPTION
Closes #226

## Summary
Add `blast_preview` console command — prints comprehensive blast preview with energy map statistics, predicted fragment count, projected/collapse split, and vibration data.

## Changes
- **src/console/commands/mining.ts** — New `blastPreviewCommand` function (77 lines)
- **src/console/createRunner.ts** — Register `blast_preview` command
- **tests/unit/console/mining-commands.test.ts** — 8 new test cases (guard, tier 0-4)

## Validation
- TypeScript: 0 errors
- Tests: 1901 passed, 0 failed (111 files, including 8 new blast_preview tests)
- Build: dist/ produced (992 KB, no regressions)

## Pipeline
Followed full TDD pipeline:
1. Plan → 2. Skeleton → 3. Tests (Red) → 4. Implement (Green) → 5. Review (5 parallel reviewers) → 6. Refactor → 7. Validate → 8. PR

## Verification
| Guard | Pass |
|-------|------|
| No game loaded | ✅ |
| No drill plan | ✅ |
| Missing charges validation | ✅ |
| Tier 0 — all sections locked | ✅ |
| Tier 1 — energy preview | ✅ |
| Tier 2 — fragment preview | ✅ |
| Tier 3 — projection preview | ✅ |
| Tier 4 — full preview | ✅ |

READY TO MERGE