### PR TITLE
[6.4] Implement A* findPath() with 8-directional movement and octile heuristic

### DIFF
--- a/src/core/nav/Pathfinding.ts
+++ b/src/core/nav/Pathfinding.ts
@@ -191,6 +191,11 @@ function directLineWalk(
  * @returns A PathResult indicating whether a path was found and the resulting waypoints.
  */
 export function findPath(grid: NavGrid, request: PathRequest): PathResult {
+  // 0. Validate grid dimensions
+  if (grid.width <= 0 || grid.height <= 0) {
+    return { found: false, waypoints: [], totalCost: 0 };
+  }
+
   // 1. Clamp start and goal to grid bounds
   const sx = clampCoord(request.fromX, grid.width);
   const sz = clampCoord(request.fromZ, grid.height);
@@ -199,21 +204,21 @@ export function findPath(grid: NavGrid, request: PathRequest): PathResult {
 
   const { avoidVehicles, agentId } = request;
 
-  // 2. Trivial case: start == goal
-  if (sx === gx && sz === gz) {
-    return { found: true, waypoints: [{ x: sx, z: sz }], totalCost: 0 };
-  }
-
-  // 3. Start impassable check
+  // 2. Start impassable check (must precede start==goal check)
   const startCell = grid.cells[sz]![sx]!;
   if (isImpassable(startCell, avoidVehicles)) {
     return { found: false, waypoints: [], totalCost: 0 };
   }
 
-  // 4. Goal impassable check
+  // 3. Goal impassable check
   const goalCell = grid.cells[gz]![gx]!;
   if (isImpassable(goalCell, avoidVehicles)) {
     return { found: false, waypoints: [], totalCost: 0 };
+  }
+
+  // 4. Trivial case: start == goal (both passable)
+  if (sx === gx && sz === gz) {
+    return { found: true, waypoints: [{ x: sx, z: sz }], totalCost: 0 };
   }
 
   // 5. A* main loop

--- a/src/core/nav/Pathfinding.ts
+++ b/src/core/nav/Pathfinding.ts
@@ -1,0 +1,42 @@
+// BlastSimulator2026 — Pathfinding: A* route finding over the NavGrid
+// Part of the navmesh system.
+
+import { NavGrid } from './NavGrid.js';
+
+/**
+ * Describes a pathfinding request from one grid cell to another.
+ * Coordinates are in NavGrid cell space (x = column, z = row).
+ */
+export interface PathRequest {
+  agentId: number;
+  fromX: number;
+  fromZ: number;
+  toX: number;
+  toZ: number;
+  avoidVehicles: boolean;
+}
+
+/**
+ * The result of a pathfinding attempt.
+ * If `found` is false the `waypoints` array will be empty.
+ */
+export interface PathResult {
+  found: boolean;
+  waypoints: Array<{ x: number; z: number }>;
+  totalCost: number;
+}
+
+/**
+ * Find the shortest path from (fromX, fromZ) to (toX, toZ) on the given NavGrid.
+ * Uses A* with 8-directional movement and octile heuristic.
+ *
+ * @param grid   - The navigation grid to pathfind across.
+ * @param request - The pathfinding request parameters.
+ * @returns A PathResult indicating whether a path was found and the resulting waypoints.
+ */
+export function findPath(grid: NavGrid, request: PathRequest): PathResult {
+  // TODO: implement A* pathfinding
+  void grid;
+  void request;
+  return { found: false, waypoints: [], totalCost: 0 };
+}

--- a/src/core/nav/Pathfinding.ts
+++ b/src/core/nav/Pathfinding.ts
@@ -2,6 +2,7 @@
 // Part of the navmesh system.
 
 import { NavGrid } from './NavGrid.js';
+import type { NavCell } from './NavGrid.js';
 
 /**
  * Describes a pathfinding request from one grid cell to another.
@@ -26,6 +27,161 @@ export interface PathResult {
   totalCost: number;
 }
 
+/** Maximum number of nodes A* may explore before falling back to direct-line search. */
+const MAX_EXPLORED_NODES = 500;
+
+/** 8-directional neighbour offsets as [dx, dz] pairs. */
+const NEIGHBOUR_OFFSETS: readonly [number, number][] = [
+  [0, -1], [0, 1], [-1, 0], [1, 0],   // cardinal
+  [-1, -1], [1, -1], [-1, 1], [1, 1], // diagonal
+];
+
+// ---------------------------------------------------------------------------
+// Internal binary min-heap (generic)
+// ---------------------------------------------------------------------------
+
+/**
+ * A simple binary min-heap. Items are ordered by their `key` property.
+ */
+class MinHeap<T extends { key: number }> {
+  private _heap: T[] = [];
+
+  get size(): number {
+    return this._heap.length;
+  }
+
+  push(item: T): void {
+    this._heap.push(item);
+    this._siftUp(this._heap.length - 1);
+  }
+
+  pop(): T | undefined {
+    if (this._heap.length === 0) return undefined;
+    const top = this._heap[0]!;
+    const last = this._heap.pop()!;
+    if (this._heap.length > 0) {
+      this._heap[0] = last;
+      this._siftDown(0);
+    }
+    return top;
+  }
+
+  // --- private helpers ---
+
+  private _siftUp(idx: number): void {
+    while (idx > 0) {
+      const parent = (idx - 1) >> 1;
+      if (this._heap[idx]!.key >= this._heap[parent]!.key) break;
+      [this._heap[idx], this._heap[parent]] = [this._heap[parent]!, this._heap[idx]!];
+      idx = parent;
+    }
+  }
+
+  private _siftDown(idx: number): void {
+    const size = this._heap.length;
+    while (true) {
+      let smallest = idx;
+      const left = (idx << 1) + 1;
+      const right = left + 1;
+      if (left < size && this._heap[left]!.key < this._heap[smallest]!.key) smallest = left;
+      if (right < size && this._heap[right]!.key < this._heap[smallest]!.key) smallest = right;
+      if (smallest === idx) break;
+      [this._heap[idx], this._heap[smallest]] = [this._heap[smallest]!, this._heap[idx]!];
+      idx = smallest;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Check whether a cell blocks traversal. */
+function isImpassable(cell: NavCell, avoidVehicles: boolean): boolean {
+  if (cell.type === 'blocked' || cell.type === 'void') return true;
+  if (avoidVehicles && cell.vehicleOccupied) return true;
+  return false;
+}
+
+/** Octile distance heuristic. */
+function octileHeuristic(ax: number, az: number, bx: number, bz: number): number {
+  const dx = Math.abs(ax - bx);
+  const dz = Math.abs(az - bz);
+  return Math.max(dx, dz) + (Math.SQRT2 - 1) * Math.min(dx, dz);
+}
+
+/** Build the key string for a coordinate pair. */
+function cellKey(x: number, z: number): string {
+  return `${x},${z}`;
+}
+
+/** Clamp a coordinate to the grid bounds. */
+function clampCoord(value: number, max: number): number {
+  return Math.max(0, Math.min(max - 1, Math.floor(value)));
+}
+
+// ---------------------------------------------------------------------------
+// Direct-line fallback
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk a straight line from (x0,z0) to (x1,z1) using a simple DDA approach.
+ * Returns waypoints for every cell along the line (inclusive) if the entire
+ * line is passable, or null if any cell is impassable.
+ */
+function directLineWalk(
+  grid: NavGrid,
+  x0: number,
+  z0: number,
+  x1: number,
+  z1: number,
+  avoidVehicles: boolean,
+): PathResult | null {
+  const dx = x1 - x0;
+  const dz = z1 - z0;
+  const steps = Math.max(Math.abs(dx), Math.abs(dz));
+  if (steps === 0) {
+    // start == goal
+    return { found: true, waypoints: [{ x: x0, z: z0 }], totalCost: 0 };
+  }
+
+  const waypoints: { x: number; z: number }[] = [];
+  let totalCost = 0;
+  let prevX = x0;
+  let prevZ = z0;
+
+  for (let i = 0; i <= steps; i++) {
+    const t = steps > 0 ? i / steps : 0;
+    const cx = Math.round(x0 + dx * t);
+    const cz = Math.round(z0 + dz * t);
+
+    // Clamp to grid bounds
+    const clampedX = Math.max(0, Math.min(grid.width - 1, cx));
+    const clampedZ = Math.max(0, Math.min(grid.height - 1, cz));
+
+    const cell = grid.cells[clampedZ]![clampedX]!;
+    if (isImpassable(cell, avoidVehicles)) return null;
+
+    // Accumulate cost (use octile distance between consecutive steps for accuracy)
+    if (i > 0) {
+      const stepDx = clampedX - prevX;
+      const stepDz = clampedZ - prevZ;
+      const isDiagonal = stepDx !== 0 && stepDz !== 0;
+      totalCost += isDiagonal ? cell.moveCost * Math.SQRT2 : cell.moveCost;
+    }
+
+    waypoints.push({ x: clampedX, z: clampedZ });
+    prevX = clampedX;
+    prevZ = clampedZ;
+  }
+
+  return { found: true, waypoints, totalCost };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
 /**
  * Find the shortest path from (fromX, fromZ) to (toX, toZ) on the given NavGrid.
  * Uses A* with 8-directional movement and octile heuristic.
@@ -35,8 +191,132 @@ export interface PathResult {
  * @returns A PathResult indicating whether a path was found and the resulting waypoints.
  */
 export function findPath(grid: NavGrid, request: PathRequest): PathResult {
-  // TODO: implement A* pathfinding
-  void grid;
-  void request;
+  // 1. Clamp start and goal to grid bounds
+  const sx = clampCoord(request.fromX, grid.width);
+  const sz = clampCoord(request.fromZ, grid.height);
+  const gx = clampCoord(request.toX, grid.width);
+  const gz = clampCoord(request.toZ, grid.height);
+
+  const { avoidVehicles, agentId } = request;
+
+  // 2. Trivial case: start == goal
+  if (sx === gx && sz === gz) {
+    return { found: true, waypoints: [{ x: sx, z: sz }], totalCost: 0 };
+  }
+
+  // 3. Start impassable check
+  const startCell = grid.cells[sz]![sx]!;
+  if (isImpassable(startCell, avoidVehicles)) {
+    return { found: false, waypoints: [], totalCost: 0 };
+  }
+
+  // 4. Goal impassable check
+  const goalCell = grid.cells[gz]![gx]!;
+  if (isImpassable(goalCell, avoidVehicles)) {
+    return { found: false, waypoints: [], totalCost: 0 };
+  }
+
+  // 5. A* main loop
+
+  interface AStarNode {
+    key: number; // f = g + h, used by the min-heap
+    x: number;
+    z: number;
+  }
+
+  const openHeap = new MinHeap<AStarNode>();
+  const gScore = new Map<string, number>();
+  const cameFrom = new Map<string, { x: number; z: number }>();
+  let exploredCount = 0;
+
+  const startKey = cellKey(sx, sz);
+  gScore.set(startKey, 0);
+  const hStart = octileHeuristic(sx, sz, gx, gz);
+  openHeap.push({ key: hStart, x: sx, z: sz });
+
+  while (openHeap.size > 0 && exploredCount < MAX_EXPLORED_NODES) {
+    const current = openHeap.pop()!;
+    const { x: cx, z: cz } = current;
+    const currentKey = cellKey(cx, cz);
+
+    // Skip stale entries (we don't update keys in-place)
+    const currentG = gScore.get(currentKey);
+    if (currentG === undefined) continue;
+
+    exploredCount++;
+
+    // Goal reached?
+    if (cx === gx && cz === gz) {
+      return reconstructPath(cameFrom, cx, cz, gScore, gx, gz);
+    }
+
+    // Explore neighbours
+    for (const [dx, dz] of NEIGHBOUR_OFFSETS) {
+      const nx = cx + dx;
+      const nz = cz + dz;
+
+      // Bounds check
+      if (nx < 0 || nx >= grid.width || nz < 0 || nz >= grid.height) continue;
+
+      const neighborCell = grid.cells[nz]![nx]!;
+      if (isImpassable(neighborCell, avoidVehicles)) continue;
+
+      // Move cost
+      const isDiagonal = dx !== 0 && dz !== 0;
+      const stepCost = isDiagonal ? neighborCell.moveCost * Math.SQRT2 : neighborCell.moveCost;
+      const tentativeG = currentG + stepCost;
+
+      const neighborKey = cellKey(nx, nz);
+      const existingG = gScore.get(neighborKey);
+
+      if (existingG === undefined || tentativeG < existingG) {
+        gScore.set(neighborKey, tentativeG);
+        cameFrom.set(neighborKey, { x: cx, z: cz });
+        const h = octileHeuristic(nx, nz, gx, gz);
+        openHeap.push({ key: tentativeG + h, x: nx, z: nz });
+      }
+    }
+  }
+
+  // Budget exceeded or open set empty — try direct-line fallback
+  if (exploredCount >= MAX_EXPLORED_NODES) {
+    console.warn('pathfinding budget exceeded for agent', agentId);
+  }
+
+  const fallback = directLineWalk(grid, sx, sz, gx, gz, avoidVehicles);
+  if (fallback !== null) return fallback;
+
   return { found: false, waypoints: [], totalCost: 0 };
+}
+
+/**
+ * Reconstruct the path from the cameFrom map by walking backwards from goal to start.
+ */
+function reconstructPath(
+  cameFrom: Map<string, { x: number; z: number }>,
+  goalX: number,
+  goalZ: number,
+  gScore: Map<string, number>,
+  _startX: number,
+  _startZ: number,
+): PathResult {
+  const waypoints: { x: number; z: number }[] = [];
+  let cx = goalX;
+  let cz = goalZ;
+
+  // Walk backwards
+  while (true) {
+    waypoints.push({ x: cx, z: cz });
+    const key = cellKey(cx, cz);
+    const parent = cameFrom.get(key);
+    if (parent === undefined) break;
+    cx = parent.x;
+    cz = parent.z;
+  }
+
+  waypoints.reverse();
+
+  const totalCost = gScore.get(cellKey(goalX, goalZ)) ?? 0;
+
+  return { found: true, waypoints, totalCost };
 }

--- a/src/core/nav/Pathfinding.ts
+++ b/src/core/nav/Pathfinding.ts
@@ -28,7 +28,7 @@ export interface PathResult {
 }
 
 /** Maximum number of nodes A* may explore before falling back to direct-line search. */
-const MAX_EXPLORED_NODES = 500;
+const NODE_BUDGET_CAP = 500;
 
 /** 8-directional neighbour offsets as [dx, dz] pairs. */
 const NEIGHBOUR_OFFSETS: readonly [number, number][] = [
@@ -104,7 +104,7 @@ function isImpassable(cell: NavCell, avoidVehicles: boolean): boolean {
 }
 
 /** Octile distance heuristic. */
-function octileHeuristic(ax: number, az: number, bx: number, bz: number): number {
+export function octileHeuristic(ax: number, az: number, bx: number, bz: number): number {
   const dx = Math.abs(ax - bx);
   const dz = Math.abs(az - bz);
   return Math.max(dx, dz) + (Math.SQRT2 - 1) * Math.min(dx, dz);
@@ -125,9 +125,8 @@ function clampCoord(value: number, max: number): number {
 // ---------------------------------------------------------------------------
 
 /**
- * Walk a straight line from (x0,z0) to (x1,z1) using a simple DDA approach.
- * Returns waypoints for every cell along the line (inclusive) if the entire
- * line is passable, or null if any cell is impassable.
+ * Walk a straight line from (x0,z0) to (x1,z1) using a DDA approach.
+ * Returns waypoints for every cell along the line if all are passable, else null.
  */
 function directLineWalk(
   grid: NavGrid,
@@ -183,12 +182,7 @@ function directLineWalk(
 // ---------------------------------------------------------------------------
 
 /**
- * Find the shortest path from (fromX, fromZ) to (toX, toZ) on the given NavGrid.
- * Uses A* with 8-directional movement and octile heuristic.
- *
- * @param grid   - The navigation grid to pathfind across.
- * @param request - The pathfinding request parameters.
- * @returns A PathResult indicating whether a path was found and the resulting waypoints.
+ * Find the shortest path on a NavGrid using A* with 8-directional movement and octile heuristic.
  */
 export function findPath(grid: NavGrid, request: PathRequest): PathResult {
   // 0. Validate grid dimensions
@@ -239,7 +233,7 @@ export function findPath(grid: NavGrid, request: PathRequest): PathResult {
   const hStart = octileHeuristic(sx, sz, gx, gz);
   openHeap.push({ key: hStart, x: sx, z: sz });
 
-  while (openHeap.size > 0 && exploredCount < MAX_EXPLORED_NODES) {
+  while (openHeap.size > 0 && exploredCount < NODE_BUDGET_CAP) {
     const current = openHeap.pop()!;
     const { x: cx, z: cz } = current;
     const currentKey = cellKey(cx, cz);
@@ -252,7 +246,7 @@ export function findPath(grid: NavGrid, request: PathRequest): PathResult {
 
     // Goal reached?
     if (cx === gx && cz === gz) {
-      return reconstructPath(cameFrom, cx, cz, gScore, gx, gz);
+      return reconstructPath(cameFrom, cx, cz, gScore);
     }
 
     // Explore neighbours
@@ -284,7 +278,7 @@ export function findPath(grid: NavGrid, request: PathRequest): PathResult {
   }
 
   // Budget exceeded or open set empty — try direct-line fallback
-  if (exploredCount >= MAX_EXPLORED_NODES) {
+  if (exploredCount >= NODE_BUDGET_CAP) {
     console.warn('pathfinding budget exceeded for agent', agentId);
   }
 
@@ -294,16 +288,12 @@ export function findPath(grid: NavGrid, request: PathRequest): PathResult {
   return { found: false, waypoints: [], totalCost: 0 };
 }
 
-/**
- * Reconstruct the path from the cameFrom map by walking backwards from goal to start.
- */
+/** Reconstruct path by walking cameFrom map backwards from goal to start. */
 function reconstructPath(
   cameFrom: Map<string, { x: number; z: number }>,
   goalX: number,
   goalZ: number,
   gScore: Map<string, number>,
-  _startX: number,
-  _startZ: number,
 ): PathResult {
   const waypoints: { x: number; z: number }[] = [];
   let cx = goalX;

--- a/tests/unit/nav/Pathfinding.test.ts
+++ b/tests/unit/nav/Pathfinding.test.ts
@@ -13,7 +13,7 @@
 //   Group 9 — Waypoint validity: contiguous, includes goal, no dup start
 
 import { describe, it, expect } from 'vitest';
-import { findPath, type PathRequest } from '../../../src/core/nav/Pathfinding.js';
+import { findPath, octileHeuristic, type PathRequest } from '../../../src/core/nav/Pathfinding.js';
 import { NavGrid, type NavCell, type NavCellType } from '../../../src/core/nav/NavGrid.js';
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -57,13 +57,6 @@ function isValidStep(a: { x: number; z: number }, b: { x: number; z: number }): 
   const dx = Math.abs(b.x - a.x);
   const dz = Math.abs(b.z - a.z);
   return dx <= 1 && dz <= 1 && (dx + dz > 0);
-}
-
-/** Build the octile heuristic value between two cells. */
-function octileHeuristic(ax: number, az: number, bx: number, bz: number): number {
-  const dx = Math.abs(ax - bx);
-  const dz = Math.abs(az - bz);
-  return Math.max(dx, dz) + (Math.SQRT2 - 1) * Math.min(dx, dz);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -198,9 +191,8 @@ describe('findPath — cell type costs', () => {
     const grid = makeFlatGrid(10, 1, 'drill_hole');
     const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 9, toZ: 0, avoidVehicles: false });
     expect(result.found).toBe(true);
-    // Cost per step should be 5.0 (not 1.0)
-    expect(result.totalCost).toBeGreaterThan(20);
-    expect(result.totalCost).toBeLessThanOrEqual(9 * 5.0);
+    // Deterministic: 9 cardinal steps × 5.0 = 45.0
+    expect(result.totalCost).toBe(45.0);
   });
 
   it('computes totalCost correctly for a path through ramp cells (cost 1.8 per step)', () => {
@@ -209,8 +201,8 @@ describe('findPath — cell type costs', () => {
     const grid = makeFlatGrid(10, 1, 'ramp');
     const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 9, toZ: 0, avoidVehicles: false });
     expect(result.found).toBe(true);
-    expect(result.totalCost).toBeGreaterThan(9);
-    expect(result.totalCost).toBeLessThanOrEqual(9 * 1.8 + 0.01);
+    // Deterministic: 9 cardinal steps × 1.8 = 16.2
+    expect(result.totalCost).toBeCloseTo(16.2, 4);
   });
 
   it('prefers a walkable path over a drill_hole path when both exist (lower cost)', () => {
@@ -248,10 +240,6 @@ describe('findPath — vehicle avoidance', () => {
     expect(result.found).toBe(true);
     // Path should avoid the vehicleOccupied cell
     for (const wp of result.waypoints) {
-      if (wp.x === 5 && wp.z === 1) {
-        // If we're at (5,1), it must be a non-occupied cell pass-through
-        // But since we set it to occupied, this would be wrong
-      }
       expect(!(wp.x === 5 && wp.z === 1)).toBe(true); // Should not visit (5,1)
     }
   });
@@ -393,13 +381,12 @@ describe('findPath — budget fallback (500 node cap)', () => {
     expect(result.found).toBe(true);
   });
 
-  it('returns found:true when budget is exceeded but the direct line is clear', () => {
+  it('budget-exceeded path waypoints form a valid start-to-goal path', () => {
     // 600×1, all walkable. A* exceeds budget (600 cells > 500).
-    // Direct line is unobstructed → found: true
+    // Direct line is unobstructed → waypoints should span the full route.
     const grid = makeFlatGrid(600, 1, 'walkable');
     const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 599, toZ: 0, avoidVehicles: false });
     expect(result.found).toBe(true);
-    // Waypoints should still form a valid start-to-goal path
     expect(result.waypoints.length).toBeGreaterThanOrEqual(2);
     expect(result.waypoints[0]!.x).toBe(0);
     expect(result.waypoints[0]!.z).toBe(0);
@@ -424,7 +411,7 @@ describe('findPath — budget fallback (500 node cap)', () => {
     const grid = makeFlatGrid(600, 1, 'walkable');
     const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 599, toZ: 0, avoidVehicles: false });
     expect(result.found).toBe(true);
-    expect(result.totalCost).toBeGreaterThan(0);
+    expect(result.totalCost).toBe(599);
   });
 });
 

--- a/tests/unit/nav/Pathfinding.test.ts
+++ b/tests/unit/nav/Pathfinding.test.ts
@@ -149,15 +149,17 @@ describe('findPath — obstacle avoidance', () => {
     expect(result.found).toBe(false);
   });
 
-  it('returns found: false when no path exists (goal surrounded by blocked cells)', () => {
-    // 5×5 grid, goal at (4,4) surrounded by blocked cells
+  it('finds a diagonal path past blocked cells near the goal', () => {
+    // 5×5 grid, goal at (4,4), cells (3,4) and (4,3) are blocked.
+    // With 8-directional movement the goal is reachable diagonally from (3,3).
     const grid = makeFlatGrid(5, 5, 'walkable');
-    setCell(grid, 4, 4, 'walkable'); // goal is walkable but surrounded
+    setCell(grid, 4, 4, 'walkable'); // goal is walkable
     setCell(grid, 3, 4, 'blocked');
     setCell(grid, 4, 3, 'blocked');
-    // (5,4) and (4,5) are out of bounds, so goal is unreachable
     const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 4, toZ: 4, avoidVehicles: false });
-    expect(result.found).toBe(false);
+    expect(result.found).toBe(true);
+    // Optimal diagonal path: (0,0)→(1,1)→(2,2)→(3,3)→(4,4) = 4 diagonal steps × √2
+    expect(result.totalCost).toBeCloseTo(4 * Math.SQRT2, 4);
   });
 
   it('routes around a wall of blocked cells forming a corridor', () => {
@@ -570,8 +572,8 @@ describe('findPath — complex scenarios', () => {
     // Path must pass through (1,1) which is drill_hole
     const passesDrill = result.waypoints.some(wp => wp.x === 1 && wp.z === 1);
     expect(passesDrill).toBe(true);
-    // Cost reflects drill_hole: 2 cells × 5.0 = 10.0
-    expect(result.totalCost).toBeCloseTo(10.0, 4);
+    // Cost: entering drill_hole (5.0) + entering walkable goal (1.0) = 6.0
+    expect(result.totalCost).toBeCloseTo(6.0, 4);
   });
 
   it('handles a winding path through a maze-like grid', () => {

--- a/tests/unit/nav/Pathfinding.test.ts
+++ b/tests/unit/nav/Pathfinding.test.ts
@@ -1,0 +1,10 @@
+// BlastSimulator2026 — Unit tests: Pathfinding (A* over NavGrid)
+// Task 5.20: A* pathfinding with 8-directional movement and octile heuristic
+
+import { describe, it, expect } from 'vitest';
+
+describe('findPath', () => {
+  it('placeholder test', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/tests/unit/nav/Pathfinding.test.ts
+++ b/tests/unit/nav/Pathfinding.test.ts
@@ -1,10 +1,598 @@
-// BlastSimulator2026 — Unit tests: Pathfinding (A* over NavGrid)
+// BlastSimulator2026 — Unit tests: A* Pathfinding over NavGrid
 // Task 5.20: A* pathfinding with 8-directional movement and octile heuristic
+//
+// Test breakdown:
+//   Group 1 — Happy path: straight, vertical, diagonal paths found
+//   Group 2 — Obstacle avoidance: routing around blocked cells, start/goal blocked
+//   Group 3 — Cell type costs: drill_hole, ramp, walkable move costs
+//   Group 4 — Vehicle avoidance: avoidVehicles flag behaviour
+//   Group 5 — Diagonal movement: 8-directional preference and costs
+//   Group 6 — Edge cases: start==goal, OOB, zero-size, single cell
+//   Group 7 — Budget fallback: 500-node cap, directLineWalk
+//   Group 8 — Octile heuristic: correctness verification
+//   Group 9 — Waypoint validity: contiguous, includes goal, no dup start
 
 import { describe, it, expect } from 'vitest';
+import { findPath, type PathRequest } from '../../../src/core/nav/Pathfinding.js';
+import { NavGrid, type NavCell, type NavCellType } from '../../../src/core/nav/NavGrid.js';
 
-describe('findPath', () => {
-  it('placeholder test', () => {
-    expect(true).toBe(true);
+// ═══════════════════════════════════════════════════════════════════════════════
+// Helpers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function makeCell(type: NavCellType): NavCell {
+  let moveCost: number;
+  switch (type) {
+    case 'walkable':  moveCost = 1.0; break;
+    case 'ramp':      moveCost = 1.8; break;
+    case 'drill_hole': moveCost = 5.0; break;
+    case 'blocked':
+    case 'void':      moveCost = Infinity; break;
+  }
+  return { type, moveCost, benchLevel: 0, vehicleOccupied: false };
+}
+
+/** Create a flat NavGrid where every cell has the given type (default 'walkable'). */
+function makeFlatGrid(width: number, height: number, fillType: NavCellType = 'walkable'): NavGrid {
+  const cells: NavCell[][] = [];
+  for (let z = 0; z < height; z++) {
+    const row: NavCell[] = [];
+    for (let x = 0; x < width; x++) {
+      row.push(makeCell(fillType));
+    }
+    cells.push(row);
+  }
+  return new NavGrid(width, height, cells);
+}
+
+/** Mutate a single cell's type and move cost (and optionally other NavCell fields). */
+function setCell(grid: NavGrid, x: number, z: number, type: NavCellType, overrides?: Partial<NavCell>): void {
+  const cell = makeCell(type);
+  if (overrides) Object.assign(cell, overrides);
+  grid.cells[z]![x] = cell;
+}
+
+/** Check whether two waypoints form a valid cardinal or diagonal step. */
+function isValidStep(a: { x: number; z: number }, b: { x: number; z: number }): boolean {
+  const dx = Math.abs(b.x - a.x);
+  const dz = Math.abs(b.z - a.z);
+  return dx <= 1 && dz <= 1 && (dx + dz > 0);
+}
+
+/** Build the octile heuristic value between two cells. */
+function octileHeuristic(ax: number, az: number, bx: number, bz: number): number {
+  const dx = Math.abs(ax - bx);
+  const dz = Math.abs(az - bz);
+  return Math.max(dx, dz) + (Math.SQRT2 - 1) * Math.min(dx, dz);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 1: Happy path — basic reachability
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('findPath — happy path', () => {
+  it('finds a straight horizontal path from (0,0) to (9,0) on a 10×1 grid', () => {
+    const grid = makeFlatGrid(10, 1, 'walkable');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 9, toZ: 0, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    expect(result.waypoints.length).toBeGreaterThanOrEqual(2);
+    expect(result.totalCost).toBeGreaterThan(0);
+  });
+
+  it('finds a straight vertical path from (0,0) to (0,9) on a 1×10 grid', () => {
+    const grid = makeFlatGrid(1, 10, 'walkable');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 0, toZ: 9, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    expect(result.waypoints.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('finds a diagonal path from (0,0) to (9,9) on a 10×10 grid', () => {
+    const grid = makeFlatGrid(10, 10, 'walkable');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 9, toZ: 9, avoidVehicles: false });
+    expect(result.found).toBe(true);
+  });
+
+  it('returns waypoints that start at fromX/fromZ and end at toX/toZ', () => {
+    const grid = makeFlatGrid(10, 10, 'walkable');
+    const result = findPath(grid, { agentId: 1, fromX: 2, fromZ: 3, toX: 8, toZ: 7, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    expect(result.waypoints[0]!.x).toBe(2);
+    expect(result.waypoints[0]!.z).toBe(3);
+    expect(result.waypoints[result.waypoints.length - 1]!.x).toBe(8);
+    expect(result.waypoints[result.waypoints.length - 1]!.z).toBe(7);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 2: Obstacle avoidance
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('findPath — obstacle avoidance', () => {
+  it('routes around a single blocked cell on an otherwise clear path', () => {
+    // 10×3 grid, block the direct horizontal cell at (5,1)
+    // Start (0,1), Goal (9,1) — must go around the blocked cell
+    const grid = makeFlatGrid(10, 3, 'walkable');
+    setCell(grid, 5, 1, 'blocked');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 1, toX: 9, toZ: 1, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    // Path should not include the blocked cell
+    for (const wp of result.waypoints) {
+      expect(grid.cells[wp.z]![wp.x]!.type).not.toBe('blocked');
+    }
+  });
+
+  it('returns found: false when start cell is blocked', () => {
+    const grid = makeFlatGrid(5, 5, 'walkable');
+    setCell(grid, 0, 0, 'blocked');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 4, toZ: 4, avoidVehicles: false });
+    expect(result.found).toBe(false);
+  });
+
+  it('returns found: false when start cell is void', () => {
+    const grid = makeFlatGrid(5, 5, 'walkable');
+    setCell(grid, 0, 0, 'void');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 4, toZ: 4, avoidVehicles: false });
+    expect(result.found).toBe(false);
+  });
+
+  it('returns found: false when goal cell is blocked', () => {
+    const grid = makeFlatGrid(5, 5, 'walkable');
+    setCell(grid, 4, 4, 'blocked');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 4, toZ: 4, avoidVehicles: false });
+    expect(result.found).toBe(false);
+  });
+
+  it('returns found: false when goal cell is void', () => {
+    const grid = makeFlatGrid(5, 5, 'walkable');
+    setCell(grid, 4, 4, 'void');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 4, toZ: 4, avoidVehicles: false });
+    expect(result.found).toBe(false);
+  });
+
+  it('returns found: false when no path exists (goal surrounded by blocked cells)', () => {
+    // 5×5 grid, goal at (4,4) surrounded by blocked cells
+    const grid = makeFlatGrid(5, 5, 'walkable');
+    setCell(grid, 4, 4, 'walkable'); // goal is walkable but surrounded
+    setCell(grid, 3, 4, 'blocked');
+    setCell(grid, 4, 3, 'blocked');
+    // (5,4) and (4,5) are out of bounds, so goal is unreachable
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 4, toZ: 4, avoidVehicles: false });
+    expect(result.found).toBe(false);
+  });
+
+  it('routes around a wall of blocked cells forming a corridor', () => {
+    // 10×5 grid with a vertical wall of blocked cells from (5,0) to (5,4) except (5,2)
+    // Start (0,2), Goal (9,2) — must go through the gap at (5,2)
+    const grid = makeFlatGrid(10, 5, 'walkable');
+    // Build wall
+    for (let z = 0; z < 5; z++) {
+      if (z !== 2) setCell(grid, 5, z, 'blocked');
+    }
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 2, toX: 9, toZ: 2, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    // Path must go through the gap at (5,2)
+    const hasGap = result.waypoints.some(wp => wp.x === 5 && wp.z === 2);
+    expect(hasGap).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 3: Cell type costs
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('findPath — cell type costs', () => {
+  it('computes totalCost correctly for a path through walkable cells (cost 1.0 per step)', () => {
+    // 10×1 grid, walkable, from (0,0) to (9,0)
+    // Minimum cost: 9 cardinal steps × 1.0 = 9.0
+    const grid = makeFlatGrid(10, 1, 'walkable');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 9, toZ: 0, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    expect(result.totalCost).toBe(9.0);
+  });
+
+  it('computes totalCost correctly for a path through drill_hole cells (cost 5.0 per step)', () => {
+    // 10×1 grid, drill_hole cells, from (0,0) to (9,0)
+    // Minimum cost: 9 cardinal steps × 5.0 = 45.0
+    const grid = makeFlatGrid(10, 1, 'drill_hole');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 9, toZ: 0, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    // Cost per step should be 5.0 (not 1.0)
+    expect(result.totalCost).toBeGreaterThan(20);
+    expect(result.totalCost).toBeLessThanOrEqual(9 * 5.0);
+  });
+
+  it('computes totalCost correctly for a path through ramp cells (cost 1.8 per step)', () => {
+    // 10×1 grid, ramp cells, from (0,0) to (9,0)
+    // Minimum cost: 9 cardinal steps × 1.8 = 16.2
+    const grid = makeFlatGrid(10, 1, 'ramp');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 9, toZ: 0, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    expect(result.totalCost).toBeGreaterThan(9);
+    expect(result.totalCost).toBeLessThanOrEqual(9 * 1.8 + 0.01);
+  });
+
+  it('prefers a walkable path over a drill_hole path when both exist (lower cost)', () => {
+    // 10×3 grid, top and bottom rows walkable, middle row drill_hole
+    // Start (0,1), Goal (9,1)
+    // The pathfinder should route via row 0 or 2 (walkable) rather than go
+    // straight through drill_hole cells (cost 5.0 vs 1.0)
+    const grid = makeFlatGrid(10, 3, 'walkable');
+    // Set the entire middle row to drill_hole
+    for (let x = 0; x < 10; x++) {
+      setCell(grid, x, 1, 'drill_hole');
+    }
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 1, toX: 9, toZ: 1, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    // A path staying in the drill_hole row would cost 9 * 5.0 = 45.0
+    // A detour via walkable rows would cost much less
+    expect(result.totalCost).toBeLessThan(25);
+    // Path should NOT stay in the drill_hole row
+    const onlyDrillHole = result.waypoints.every(wp => wp.z === 1);
+    expect(onlyDrillHole).toBe(false);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 4: Vehicle avoidance
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('findPath — vehicle avoidance', () => {
+  it('routes around a vehicleOccupied cell when avoidVehicles=true', () => {
+    // 10×3 grid, cell (5,1) is vehicleOccupied
+    // Start (0,1), Goal (9,1)
+    const grid = makeFlatGrid(10, 3, 'walkable');
+    setCell(grid, 5, 1, 'walkable', { vehicleOccupied: true });
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 1, toX: 9, toZ: 1, avoidVehicles: true });
+    expect(result.found).toBe(true);
+    // Path should avoid the vehicleOccupied cell
+    for (const wp of result.waypoints) {
+      if (wp.x === 5 && wp.z === 1) {
+        // If we're at (5,1), it must be a non-occupied cell pass-through
+        // But since we set it to occupied, this would be wrong
+      }
+      expect(!(wp.x === 5 && wp.z === 1)).toBe(true); // Should not visit (5,1)
+    }
+  });
+
+  it('passes through vehicleOccupied cell at normal cost when avoidVehicles=false', () => {
+    // 10×1 grid, all cells walkable but some occupied
+    // avoidVehicles=false should ignore occupancy
+    const grid = makeFlatGrid(10, 1, 'walkable');
+    setCell(grid, 5, 0, 'walkable', { vehicleOccupied: true });
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 9, toZ: 0, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    // The path should go straight through, including the occupied cell
+    const passesThrough = result.waypoints.some(wp => wp.x === 5 && wp.z === 0);
+    expect(passesThrough).toBe(true);
+    expect(result.totalCost).toBe(9.0);
+  });
+
+  it('returns found: false when avoidVehicles=true and all viable paths are blocked by vehicleOccupied cells', () => {
+    // 10×1 grid, cell (5,0) is the only route and is vehicleOccupied
+    // avoidVehicles=true means the path cannot go through it
+    const grid = makeFlatGrid(10, 1, 'walkable');
+    setCell(grid, 5, 0, 'walkable', { vehicleOccupied: true });
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 9, toZ: 0, avoidVehicles: true });
+    expect(result.found).toBe(false);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 5: Diagonal movement
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('findPath — diagonal movement', () => {
+  it('prefers diagonal movement when it reduces path length', () => {
+    // 10×10 grid, start (0,0), goal (9,9)
+    // Pure diagonal path is 9 steps vs 18 cardinal steps
+    const grid = makeFlatGrid(10, 10, 'walkable');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 9, toZ: 9, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    // Optimal path length is 9 diagonal steps = 9 waypoints (including start)
+    // A cardinal-only path would have 19 waypoints
+    // A diagonal path should have ~10 waypoints (9 steps + start)
+    expect(result.waypoints.length).toBeLessThan(15);
+  });
+
+  it('applies Math.SQRT2 cost for diagonal steps', () => {
+    // 10×10 grid, start (0,0), goal (9,9), all walkable
+    // Optimal totalCost: 9 diagonal steps × 1.0 × √2 = 9 * √2 ≈ 12.7279
+    const grid = makeFlatGrid(10, 10, 'walkable');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 9, toZ: 9, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    const optimal = 9 * Math.SQRT2;
+    // Allow small floating point tolerance
+    expect(result.totalCost).toBeCloseTo(optimal, 4);
+  });
+
+  it('uses cell.moveCost directly for cardinal steps', () => {
+    // 10×1 grid, start (0,0), goal (9,0)
+    // 9 cardinal steps, each costing 1.0 = 9.0
+    const grid = makeFlatGrid(10, 1, 'walkable');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 9, toZ: 0, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    expect(result.totalCost).toBe(9.0);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 6: Edge cases
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('findPath — edge cases', () => {
+  it('returns found: true with single waypoint and totalCost 0 when start equals goal', () => {
+    const grid = makeFlatGrid(10, 10, 'walkable');
+    const result = findPath(grid, { agentId: 1, fromX: 5, fromZ: 5, toX: 5, toZ: 5, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    expect(result.waypoints.length).toBe(1);
+    expect(result.waypoints[0]!.x).toBe(5);
+    expect(result.waypoints[0]!.z).toBe(5);
+    expect(result.totalCost).toBe(0);
+  });
+
+  it('clamps out-of-bounds start coordinates to grid limits', () => {
+    // Start at (-5, -5) should be clamped to (0, 0)
+    const grid = makeFlatGrid(10, 10, 'walkable');
+    const result = findPath(grid, { agentId: 1, fromX: -5, fromZ: -5, toX: 5, toZ: 5, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    // Path should start at (0,0) after clamping
+    expect(result.waypoints[0]!.x).toBe(0);
+    expect(result.waypoints[0]!.z).toBe(0);
+  });
+
+  it('clamps out-of-bounds goal coordinates to grid limits', () => {
+    // Goal at (15, 15) should be clamped to (9, 9) on a 10×10 grid
+    const grid = makeFlatGrid(10, 10, 'walkable');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 15, toZ: 15, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    // Path should end at (9,9) after clamping
+    const last = result.waypoints[result.waypoints.length - 1]!;
+    expect(last.x).toBe(9);
+    expect(last.z).toBe(9);
+  });
+
+  it('returns found: false for a grid with 0 width', () => {
+    const grid = new NavGrid(0, 10, []);
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 0, toZ: 5, avoidVehicles: false });
+    expect(result.found).toBe(false);
+  });
+
+  it('returns found: false for a grid with 0 height', () => {
+    const grid = new NavGrid(10, 0, []);
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 5, toZ: 0, avoidVehicles: false });
+    expect(result.found).toBe(false);
+  });
+
+  it('works with a single cell (1×1) where start equals goal', () => {
+    const grid = makeFlatGrid(1, 1, 'walkable');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 0, toZ: 0, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    expect(result.waypoints.length).toBe(1);
+    expect(result.totalCost).toBe(0);
+  });
+
+  it('returns found: false for a single cell (1×1) when it is blocked', () => {
+    const grid = makeFlatGrid(1, 1, 'blocked');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 0, toZ: 0, avoidVehicles: false });
+    expect(result.found).toBe(false);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 7: Budget fallback (500 node cap)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('findPath — budget fallback (500 node cap)', () => {
+  it('falls back to directLineWalk when A* would explore more than 500 nodes', () => {
+    // 600×1 grid forces A* to expand 600 cells to reach the goal, exceeding the 500 budget.
+    // The direct line is all walkable, so the fallback should succeed.
+    const grid = makeFlatGrid(600, 1, 'walkable');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 599, toZ: 0, avoidVehicles: false });
+    expect(result.found).toBe(true);
+  });
+
+  it('returns found:true when budget is exceeded but the direct line is clear', () => {
+    // 600×1, all walkable. A* exceeds budget (600 cells > 500).
+    // Direct line is unobstructed → found: true
+    const grid = makeFlatGrid(600, 1, 'walkable');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 599, toZ: 0, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    // Waypoints should still form a valid start-to-goal path
+    expect(result.waypoints.length).toBeGreaterThanOrEqual(2);
+    expect(result.waypoints[0]!.x).toBe(0);
+    expect(result.waypoints[0]!.z).toBe(0);
+    expect(result.waypoints[result.waypoints.length - 1]!.x).toBe(599);
+    expect(result.waypoints[result.waypoints.length - 1]!.z).toBe(0);
+  });
+
+  it('returns found:false when budget is exceeded and the direct line is blocked', () => {
+    // 600×1 grid, cell (598,0) is blocked.
+    // A* would explore up to 600 cells (> 500 budget) before discovering
+    // the goal is unreachable. Fallback to directLineWalk: the line from
+    // (0,0) to (599,0) passes through (598,0) which is blocked → found: false.
+    const grid = makeFlatGrid(600, 1, 'walkable');
+    setCell(grid, 598, 0, 'blocked');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 599, toZ: 0, avoidVehicles: false });
+    expect(result.found).toBe(false);
+  });
+
+  it('budget-exceeded path has valid totalCost for the direct line', () => {
+    // 600×1, all walkable. Budget exceeded, direct line clear.
+    // Cost should reflect the direct line path (599 steps × 1.0 for walkable)
+    const grid = makeFlatGrid(600, 1, 'walkable');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 599, toZ: 0, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    expect(result.totalCost).toBeGreaterThan(0);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 8: Octile heuristic
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('findPath — octile heuristic', () => {
+  it('computes correct heuristic value: h = max(|dx|,|dz|) + (√2-1) * min(|dx|,|dz|)', () => {
+    // Direct test of the octile formula for several coordinate pairs
+    // (0,0) → (5,0): dx=5, dz=0, h = max(5,0) + (√2-1)*min(5,0) = 5
+    expect(octileHeuristic(0, 0, 5, 0)).toBe(5);
+    expect(octileHeuristic(0, 0, 0, 5)).toBe(5);
+    // (0,0) → (5,5): dx=5, dz=5, h = max(5,5) + (√2-1)*min(5,5) = 5 + (√2-1)*5 = 5√2
+    expect(octileHeuristic(0, 0, 5, 5)).toBeCloseTo(5 * Math.SQRT2, 6);
+    // (0,0) → (7,3): dx=7, dz=3, h = max(7,3) + (√2-1)*min(7,3) = 7 + (√2-1)*3
+    const expected = 7 + (Math.SQRT2 - 1) * 3;
+    expect(octileHeuristic(0, 0, 7, 3)).toBeCloseTo(expected, 6);
+    // (2,5) → (8,1): dx=6, dz=4, h = max(6,4) + (√2-1)*min(6,4) = 6 + (√2-1)*4
+    const expected2 = 6 + (Math.SQRT2 - 1) * 4;
+    expect(octileHeuristic(2, 5, 8, 1)).toBeCloseTo(expected2, 6);
+    // Same point: h = 0
+    expect(octileHeuristic(3, 3, 3, 3)).toBe(0);
+  });
+
+  it('uses octile heuristic to guide the search towards the goal', () => {
+    // Create a grid with two possible paths of different lengths.
+    // The heuristic should guide A* to find the shorter (diagonal) path.
+    // 10×10 grid, start (0,0), goal (9,9).
+    // Pure diagonal = 9 steps; pure cardinal = 18 steps.
+    const grid = makeFlatGrid(10, 10, 'walkable');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 9, toZ: 9, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    // Verify the heuristic gives admissible (non-overestimating) costs
+    // The path cost should be >= octile distance
+    const heuristicDistance = octileHeuristic(0, 0, 9, 9);
+    expect(result.totalCost).toBeGreaterThanOrEqual(heuristicDistance - 0.001);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 9: Waypoint validity
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('findPath — waypoint validity', () => {
+  it('waypoints array forms a valid contiguous path (each consecutive waypoint is a neighbor)', () => {
+    const grid = makeFlatGrid(10, 10, 'walkable');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 9, toZ: 9, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    for (let i = 0; i < result.waypoints.length - 1; i++) {
+      expect(isValidStep(result.waypoints[i]!, result.waypoints[i + 1]!)).toBe(true);
+    }
+  });
+
+  it('waypoints includes the goal cell', () => {
+    const grid = makeFlatGrid(10, 10, 'walkable');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 9, toZ: 9, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    const last = result.waypoints[result.waypoints.length - 1]!;
+    expect(last.x).toBe(9);
+    expect(last.z).toBe(9);
+  });
+
+  it('waypoints does not duplicate the start cell (unless start==goal)', () => {
+    const grid = makeFlatGrid(10, 10, 'walkable');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 9, toZ: 9, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    // Count occurrences of the start cell in waypoints
+    const startCount = result.waypoints.filter(wp => wp.x === 0 && wp.z === 0).length;
+    expect(startCount).toBe(1);
+  });
+
+  it('does not include unreachable (blocked/void) cells in the waypoints', () => {
+    // Create a grid with obstacles and verify no waypoint is on a blocked cell
+    const grid = makeFlatGrid(10, 5, 'walkable');
+    setCell(grid, 3, 1, 'blocked');
+    setCell(grid, 3, 2, 'blocked');
+    setCell(grid, 3, 3, 'blocked');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 2, toX: 9, toZ: 2, avoidVehicles: false });
+    if (result.found) {
+      for (const wp of result.waypoints) {
+        const cell = grid.cells[wp.z]![wp.x]!;
+        expect(cell.type).not.toBe('blocked');
+        expect(cell.type).not.toBe('void');
+      }
+    }
+  });
+
+  it('waypoints have monotonically non-decreasing distance to goal for a simple open grid', () => {
+    // On a simple open grid, A* should find a path where each step
+    // brings us closer (or stays same distance) to the goal
+    const grid = makeFlatGrid(10, 10, 'walkable');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 9, toZ: 9, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    for (let i = 0; i < result.waypoints.length - 1; i++) {
+      const curr = result.waypoints[i]!;
+      const next = result.waypoints[i + 1]!;
+      // Each step should not increase the octile distance to goal
+      const currDist = octileHeuristic(curr.x, curr.z, 9, 9);
+      const nextDist = octileHeuristic(next.x, next.z, 9, 9);
+      expect(nextDist).toBeLessThanOrEqual(currDist + 0.001);
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 10: Complex scenarios (additional coverage)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('findPath — complex scenarios', () => {
+  it('finds a path through a mixed grid of walkable and ramp cells', () => {
+    // 5×5 grid with a mix of walkable and ramp cells
+    const grid = makeFlatGrid(5, 5, 'walkable');
+    setCell(grid, 1, 1, 'ramp');
+    setCell(grid, 2, 1, 'ramp');
+    setCell(grid, 3, 1, 'ramp');
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 1, toX: 4, toZ: 1, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    // Cost should reflect ramp cells when they are used
+    expect(result.totalCost).toBeGreaterThan(4); // at least 4 cells
+  });
+
+  it('avoids vehicles when avoidVehicles=true even on a narrow corridor', () => {
+    // 5×1 grid (single row), all walkable, cell (2,0) occupied
+    // avoidVehicles=true but there's no alternate route — single row
+    // The only path goes through the occupied cell
+    const grid = makeFlatGrid(5, 1, 'walkable');
+    setCell(grid, 2, 0, 'walkable', { vehicleOccupied: true });
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 0, toX: 4, toZ: 0, avoidVehicles: true });
+    // Since there's no alternate route through a different row, the path should fail
+    expect(result.found).toBe(false);
+  });
+
+  it('uses drill_hole cells only when no walkable alternative exists', () => {
+    // 3×3 grid, start at (0,1), goal at (2,1)
+    // Middle cell (1,1) is drill_hole
+    // Top and bottom rows offer walkable alternatives
+    const grid = makeFlatGrid(3, 3, 'walkable');
+    setCell(grid, 1, 0, 'blocked'); // block the top detour
+    setCell(grid, 1, 2, 'blocked'); // block the bottom detour
+    setCell(grid, 1, 1, 'drill_hole'); // middle is drill_hole
+    // Now the only way from (0,1) to (2,1) is through (1,1) drill_hole
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 1, toX: 2, toZ: 1, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    // Path must pass through (1,1) which is drill_hole
+    const passesDrill = result.waypoints.some(wp => wp.x === 1 && wp.z === 1);
+    expect(passesDrill).toBe(true);
+    // Cost reflects drill_hole: 2 cells × 5.0 = 10.0
+    expect(result.totalCost).toBeCloseTo(10.0, 4);
+  });
+
+  it('handles a winding path through a maze-like grid', () => {
+    // Create a simple S-shaped corridor in a 10×10 grid
+    const grid = makeFlatGrid(10, 10, 'blocked');
+    // Clear a winding path: horizontal corridors at z=2 and z=6,
+    // connected by vertical corridors at x=3 and x=7
+    for (let x = 0; x < 10; x++) {
+      setCell(grid, x, 2, 'walkable'); // top horizontal
+      setCell(grid, x, 6, 'walkable'); // bottom horizontal
+    }
+    for (let z = 2; z <= 6; z++) {
+      setCell(grid, 3, z, 'walkable'); // left vertical connector
+      setCell(grid, 7, z, 'walkable'); // right vertical connector
+    }
+    // Start at (0,2), Goal at (9,6)
+    const result = findPath(grid, { agentId: 1, fromX: 0, fromZ: 2, toX: 9, toZ: 6, avoidVehicles: false });
+    expect(result.found).toBe(true);
+    // Path must exist and not use blocked cells
+    for (const wp of result.waypoints) {
+      expect(grid.cells[wp.z]![wp.x]!.type).not.toBe('blocked');
+    }
   });
 });


### PR DESCRIPTION
Closes #231

## Summary
Implements A* pathfinding over the NavGrid with 8-directional movement and octile heuristic. Part of the navigation mesh system (Chapter 6).

## Changes
- **New file:** `src/core/nav/Pathfinding.ts` — A* findPath() with 8-directional movement, octile heuristic, binary min-heap, 500-node budget cap with direct-line fallback
- **New file:** `tests/unit/nav/Pathfinding.test.ts` — 43 tests covering happy path, obstacle avoidance, cell type costs, vehicle avoidance, diagonal movement, edge cases, budget fallback, octile heuristic, waypoint validity

## Validation
- ✅ TypeScript strict mode: 0 errors
- ✅ Full test suite: 1964 tests passed (112 files)
- ✅ Build: 134 modules transformed
- ✅ All 43 Pathfinding tests passing

READY TO MERGE