### PR TITLE
feat: implement advanceAgent() — move agent 1 step along waypoints per tick

### DIFF
--- a/src/core/config/balance.ts
+++ b/src/core/config/balance.ts
@@ -210,6 +210,9 @@ export const BLAST_REMESH_RADIUS_CHUNKS = 2;
 /** Maximum nodes A* may explore before falling back to direct-line search. */
 export const PATHFINDING_NODE_BUDGET_CAP = 500;
 
+/** Employee agent walking speed in grid cells per tick (1 tick = 1 game-hour). */
+export const AGENT_WALK_SPEED = 2;
+
 /** Height of one bench level in voxels. Affects benchLevel computation in NavGrid. */
 export const NAV_BENCH_HEIGHT = 5;
 

--- a/src/core/nav/AgentMovement.ts
+++ b/src/core/nav/AgentMovement.ts
@@ -29,7 +29,7 @@ export interface AdvanceResult {
   /** Updated waypoint index (may have advanced past one or more waypoints). */
   waypointIndex: number;
   /** Whether the agent has reached the final waypoint this tick. */
-  pathComplete: boolean;
+  isPathComplete: boolean;
 }
 
 /**
@@ -39,22 +39,27 @@ export interface AdvanceResult {
  * @returns The updated position and path-progress information.
  */
 export function advanceAgent(state: AgentState): AdvanceResult {
+  // Guard: NaN/infinite coordinates → bail out as path complete (defense-in-depth)
+  if (!Number.isFinite(state.x) || !Number.isFinite(state.z)) {
+    return { x: state.x, z: state.z, waypointIndex: state.waypointIndex, isPathComplete: true };
+  }
+
   // Guard: no waypoints or already past the end → path complete
   if (state.waypoints.length === 0 || state.waypointIndex >= state.waypoints.length) {
-    return { x: state.x, z: state.z, waypointIndex: state.waypointIndex, pathComplete: true };
+    return { x: state.x, z: state.z, waypointIndex: state.waypointIndex, isPathComplete: true };
   }
 
   // Clamp walk speed to non-negative
   const speed = Math.max(0, state.walkSpeed);
   let remaining = speed;
 
-  // If speed is zero, return current position with appropriate pathComplete
+  // If speed is zero, return current position with appropriate isPathComplete
   if (remaining === 0) {
     return {
       x: state.x,
       z: state.z,
       waypointIndex: state.waypointIndex,
-      pathComplete: state.waypointIndex >= state.waypoints.length,
+      isPathComplete: state.waypointIndex >= state.waypoints.length,
     };
   }
 
@@ -87,6 +92,6 @@ export function advanceAgent(state: AgentState): AdvanceResult {
     x,
     z,
     waypointIndex,
-    pathComplete: waypointIndex >= state.waypoints.length,
+    isPathComplete: waypointIndex >= state.waypoints.length,
   };
 }

--- a/src/core/nav/AgentMovement.ts
+++ b/src/core/nav/AgentMovement.ts
@@ -1,0 +1,44 @@
+// BlastSimulator2026 — AgentMovement: per-tick agent position advancement along a path
+// Part of the navmesh system.
+
+/**
+ * The current navigation state of an agent walking along a path.
+ * Tracks position, waypoint list, progress index, and base walk speed.
+ */
+export interface AgentState {
+  /** Current world x-coordinate (grid cells). */
+  x: number;
+  /** Current world z-coordinate (grid cells). */
+  z: number;
+  /** Ordered list of waypoints the agent must traverse. */
+  waypoints: Array<{ x: number; z: number }>;
+  /** Index into `waypoints` pointing to the next target waypoint. */
+  waypointIndex: number;
+  /** Agent walking speed in grid cells per tick. */
+  walkSpeed: number;
+}
+
+/**
+ * The result of advancing an agent along its path for one tick.
+ */
+export interface AdvanceResult {
+  /** New x-coordinate after movement. */
+  x: number;
+  /** New z-coordinate after movement. */
+  z: number;
+  /** Updated waypoint index (may have advanced past one or more waypoints). */
+  waypointIndex: number;
+  /** Whether the agent has reached the final waypoint this tick. */
+  pathComplete: boolean;
+}
+
+/**
+ * Advance an agent toward the next waypoint for a single tick.
+ *
+ * @param state - The agent's current navigation state.
+ * @returns The updated position and path-progress information.
+ */
+export function advanceAgent(state: AgentState): AdvanceResult {
+  // TODO: implement
+  return { x: state.x, z: state.z, waypointIndex: state.waypointIndex, pathComplete: true };
+}

--- a/src/core/nav/AgentMovement.ts
+++ b/src/core/nav/AgentMovement.ts
@@ -39,6 +39,54 @@ export interface AdvanceResult {
  * @returns The updated position and path-progress information.
  */
 export function advanceAgent(state: AgentState): AdvanceResult {
-  // TODO: implement
-  return { x: state.x, z: state.z, waypointIndex: state.waypointIndex, pathComplete: true };
+  // Guard: no waypoints or already past the end → path complete
+  if (state.waypoints.length === 0 || state.waypointIndex >= state.waypoints.length) {
+    return { x: state.x, z: state.z, waypointIndex: state.waypointIndex, pathComplete: true };
+  }
+
+  // Clamp walk speed to non-negative
+  const speed = Math.max(0, state.walkSpeed);
+  let remaining = speed;
+
+  // If speed is zero, return current position with appropriate pathComplete
+  if (remaining === 0) {
+    return {
+      x: state.x,
+      z: state.z,
+      waypointIndex: state.waypointIndex,
+      pathComplete: state.waypointIndex >= state.waypoints.length,
+    };
+  }
+
+  // Work with local copies to avoid mutating the input
+  let x = state.x;
+  let z = state.z;
+  let waypointIndex = state.waypointIndex;
+
+  while (remaining > 0 && waypointIndex < state.waypoints.length) {
+    const target = state.waypoints[waypointIndex]!;
+    const dx = target.x - x;
+    const dz = target.z - z;
+    const dist = Math.sqrt(dx * dx + dz * dz);
+
+    if (dist <= remaining) {
+      // Snap to target
+      x = target.x;
+      z = target.z;
+      remaining -= dist;
+      waypointIndex++;
+    } else {
+      // Move fractionally toward target
+      x += (dx / dist) * remaining;
+      z += (dz / dist) * remaining;
+      remaining = 0;
+    }
+  }
+
+  return {
+    x,
+    z,
+    waypointIndex,
+    pathComplete: waypointIndex >= state.waypoints.length,
+  };
 }

--- a/tests/unit/nav/AgentMovement.test.ts
+++ b/tests/unit/nav/AgentMovement.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { advanceAgent } from '../../../src/core/nav/AgentMovement.js';
-import type { AgentState } from '../../../src/core/nav/AgentMovement.js';
+import type { AdvanceResult, AgentState } from '../../../src/core/nav/AgentMovement.js';
 import { AGENT_WALK_SPEED } from '../../../src/core/config/balance.js';
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -30,6 +30,20 @@ function makeState(overrides?: Partial<AgentState>): AgentState {
   };
 }
 
+/**
+ * Assert that an AdvanceResult matches expected values.
+ * Uses toBeCloseTo for coordinates to handle floating-point comparisons.
+ */
+function expectResult(
+  result: AdvanceResult,
+  expected: { x?: number; z?: number; waypointIndex?: number; isPathComplete?: boolean },
+): void {
+  if (expected.x !== undefined) expect(result.x).toBeCloseTo(expected.x, 6);
+  if (expected.z !== undefined) expect(result.z).toBeCloseTo(expected.z, 6);
+  if (expected.waypointIndex !== undefined) expect(result.waypointIndex).toBe(expected.waypointIndex);
+  if (expected.isPathComplete !== undefined) expect(result.isPathComplete).toBe(expected.isPathComplete);
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // Group 1: Basic single-waypoint advancement
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -38,19 +52,13 @@ describe('advanceAgent — single waypoint', () => {
   it('reaches the target when walkSpeed >= distance', () => {
     const state = makeState({ x: 0, z: 0, waypoints: [{ x: 2, z: 0 }], waypointIndex: 0, walkSpeed: 2 });
     const result = advanceAgent(state);
-    expect(result.x).toBe(2);
-    expect(result.z).toBe(0);
-    expect(result.waypointIndex).toBe(1);
-    expect(result.pathComplete).toBe(true);
+    expectResult(result, { x: 2, z: 0, waypointIndex: 1, isPathComplete: true });
   });
 
   it('moves partially toward target when walkSpeed < distance', () => {
     const state = makeState({ x: 0, z: 0, waypoints: [{ x: 3, z: 0 }], waypointIndex: 0, walkSpeed: 1 });
     const result = advanceAgent(state);
-    expect(result.x).toBe(1);
-    expect(result.z).toBe(0);
-    expect(result.waypointIndex).toBe(0);
-    expect(result.pathComplete).toBe(false);
+    expectResult(result, { x: 1, z: 0, waypointIndex: 0, isPathComplete: false });
   });
 });
 
@@ -63,10 +71,7 @@ describe('advanceAgent — fractional walkSpeed', () => {
     const state = makeState({ x: 0, z: 0, waypoints: [{ x: 2, z: 0 }], waypointIndex: 0, walkSpeed: 0.5 });
     const result = advanceAgent(state);
     // Moves 0.5 units toward (2,0) from (0,0)
-    expect(result.x).toBeCloseTo(0.5, 6);
-    expect(result.z).toBe(0);
-    expect(result.waypointIndex).toBe(0);
-    expect(result.pathComplete).toBe(false);
+    expectResult(result, { x: 0.5, z: 0, waypointIndex: 0, isPathComplete: false });
   });
 });
 
@@ -85,11 +90,8 @@ describe('advanceAgent — multiple waypoints consumed in one tick', () => {
       walkSpeed: 3,
     });
     const result = advanceAgent(state);
-    expect(result.x).toBe(3);
-    expect(result.z).toBe(0);
-    expect(result.waypointIndex).toBe(3);
     // Still one waypoint remaining (at index 3, there are 4 waypoints total)
-    expect(result.pathComplete).toBe(false);
+    expectResult(result, { x: 3, z: 0, waypointIndex: 3, isPathComplete: false });
   });
 
   it('consumes all waypoints when walkSpeed is sufficient for the entire path', () => {
@@ -101,10 +103,7 @@ describe('advanceAgent — multiple waypoints consumed in one tick', () => {
       walkSpeed: 4,
     });
     const result = advanceAgent(state);
-    expect(result.x).toBe(4);
-    expect(result.z).toBe(0);
-    expect(result.waypointIndex).toBe(4);
-    expect(result.pathComplete).toBe(true);
+    expectResult(result, { x: 4, z: 0, waypointIndex: 4, isPathComplete: true });
   });
 });
 
@@ -122,10 +121,7 @@ describe('advanceAgent — path completion', () => {
       walkSpeed: 2,
     });
     const result = advanceAgent(state);
-    expect(result.x).toBe(2);
-    expect(result.z).toBe(0);
-    expect(result.waypointIndex).toBe(2);
-    expect(result.pathComplete).toBe(true);
+    expectResult(result, { x: 2, z: 0, waypointIndex: 2, isPathComplete: true });
   });
 
   it('completes immediately when already at the final waypoint', () => {
@@ -137,10 +133,7 @@ describe('advanceAgent — path completion', () => {
       walkSpeed: 1,
     });
     const result = advanceAgent(state);
-    expect(result.x).toBe(2);
-    expect(result.z).toBe(0);
-    expect(result.waypointIndex).toBe(1);
-    expect(result.pathComplete).toBe(true);
+    expectResult(result, { x: 2, z: 0, waypointIndex: 1, isPathComplete: true });
   });
 });
 
@@ -159,10 +152,7 @@ describe('advanceAgent — diagonal movement', () => {
       walkSpeed: 3,
     });
     const result = advanceAgent(state);
-    expect(result.x).toBe(2);
-    expect(result.z).toBe(2);
-    expect(result.waypointIndex).toBe(1);
-    expect(result.pathComplete).toBe(true);
+    expectResult(result, { x: 2, z: 2, waypointIndex: 1, isPathComplete: true });
   });
 });
 
@@ -171,16 +161,13 @@ describe('advanceAgent — diagonal movement', () => {
 // ═══════════════════════════════════════════════════════════════════════════════
 
 describe('advanceAgent — edge cases', () => {
-  it('returns pathComplete=true when waypoints array is empty', () => {
+  it('returns isPathComplete=true when waypoints array is empty', () => {
     const state = makeState({ x: 5, z: 3, waypoints: [], waypointIndex: 0, walkSpeed: 2 });
     const result = advanceAgent(state);
-    expect(result.x).toBe(5);
-    expect(result.z).toBe(3);
-    expect(result.waypointIndex).toBe(0);
-    expect(result.pathComplete).toBe(true);
+    expectResult(result, { x: 5, z: 3, waypointIndex: 0, isPathComplete: true });
   });
 
-  it('returns pathComplete=true when waypointIndex is past the array length', () => {
+  it('returns isPathComplete=true when waypointIndex is past the array length', () => {
     const state = makeState({
       x: 5, z: 3,
       waypoints: [{ x: 1, z: 0 }, { x: 2, z: 0 }],
@@ -188,13 +175,10 @@ describe('advanceAgent — edge cases', () => {
       walkSpeed: 2,
     });
     const result = advanceAgent(state);
-    expect(result.x).toBe(5);
-    expect(result.z).toBe(3);
-    expect(result.waypointIndex).toBe(5);
-    expect(result.pathComplete).toBe(true);
+    expectResult(result, { x: 5, z: 3, waypointIndex: 5, isPathComplete: true });
   });
 
-  it('does not move and pathComplete is false when walkSpeed is 0 and waypoints exist', () => {
+  it('does not move and isPathComplete is false when walkSpeed is 0 and waypoints exist', () => {
     // walkSpeed=0 means no movement budget; waypoints remain unconsumed
     const state = makeState({
       x: 0, z: 0,
@@ -203,11 +187,8 @@ describe('advanceAgent — edge cases', () => {
       walkSpeed: 0,
     });
     const result = advanceAgent(state);
-    expect(result.x).toBe(0);
-    expect(result.z).toBe(0);
-    expect(result.waypointIndex).toBe(0);
-    // pathComplete should be false because we haven't reached the end
-    expect(result.pathComplete).toBe(false);
+    // isPathComplete should be false because we haven't reached the end
+    expectResult(result, { x: 0, z: 0, waypointIndex: 0, isPathComplete: false });
   });
 
   it('treats negative walkSpeed as 0 (no movement, no progress)', () => {
@@ -218,10 +199,7 @@ describe('advanceAgent — edge cases', () => {
       walkSpeed: -5,
     });
     const result = advanceAgent(state);
-    expect(result.x).toBe(0);
-    expect(result.z).toBe(0);
-    expect(result.waypointIndex).toBe(0);
-    expect(result.pathComplete).toBe(false);
+    expectResult(result, { x: 0, z: 0, waypointIndex: 0, isPathComplete: false });
   });
 });
 

--- a/tests/unit/nav/AgentMovement.test.ts
+++ b/tests/unit/nav/AgentMovement.test.ts
@@ -1,0 +1,263 @@
+// BlastSimulator2026 — Unit tests: Agent per-tick path advancement
+// Task 6.7: advanceAgent() movement along waypoint path
+//
+// Test breakdown:
+//   Group 1 — Basic single-waypoint advancement (reach target, partial move)
+//   Group 2 — Fractional walkSpeed (< 1)
+//   Group 3 — Multiple waypoints consumed in one tick
+//   Group 4 — Path completion
+//   Group 5 — Diagonal movement
+//   Group 6 — Edge cases (empty, past length, zero/negative speed)
+//   Group 7 — Immutability (original AgentState not mutated)
+
+import { describe, it, expect } from 'vitest';
+import { advanceAgent } from '../../../src/core/nav/AgentMovement.js';
+import type { AgentState } from '../../../src/core/nav/AgentMovement.js';
+import { AGENT_WALK_SPEED } from '../../../src/core/config/balance.js';
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Helper
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function makeState(overrides?: Partial<AgentState>): AgentState {
+  return {
+    x: 0,
+    z: 0,
+    waypoints: [],
+    waypointIndex: 0,
+    walkSpeed: AGENT_WALK_SPEED,
+    ...overrides,
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 1: Basic single-waypoint advancement
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('advanceAgent — single waypoint', () => {
+  it('reaches the target when walkSpeed >= distance', () => {
+    const state = makeState({ x: 0, z: 0, waypoints: [{ x: 2, z: 0 }], waypointIndex: 0, walkSpeed: 2 });
+    const result = advanceAgent(state);
+    expect(result.x).toBe(2);
+    expect(result.z).toBe(0);
+    expect(result.waypointIndex).toBe(1);
+    expect(result.pathComplete).toBe(true);
+  });
+
+  it('moves partially toward target when walkSpeed < distance', () => {
+    const state = makeState({ x: 0, z: 0, waypoints: [{ x: 3, z: 0 }], waypointIndex: 0, walkSpeed: 1 });
+    const result = advanceAgent(state);
+    expect(result.x).toBe(1);
+    expect(result.z).toBe(0);
+    expect(result.waypointIndex).toBe(0);
+    expect(result.pathComplete).toBe(false);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 2: Fractional walkSpeed (< 1)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('advanceAgent — fractional walkSpeed', () => {
+  it('moves fractionally toward target with walkSpeed 0.5', () => {
+    const state = makeState({ x: 0, z: 0, waypoints: [{ x: 2, z: 0 }], waypointIndex: 0, walkSpeed: 0.5 });
+    const result = advanceAgent(state);
+    // Moves 0.5 units toward (2,0) from (0,0)
+    expect(result.x).toBeCloseTo(0.5, 6);
+    expect(result.z).toBe(0);
+    expect(result.waypointIndex).toBe(0);
+    expect(result.pathComplete).toBe(false);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 3: Multiple waypoints consumed in one tick
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('advanceAgent — multiple waypoints consumed in one tick', () => {
+  it('consumes waypoints until walkSpeed runs out, ending mid-path', () => {
+    // walkSpeed=3 on a path of 4 waypoints spaced 1 unit apart
+    // Should consume first 3 waypoints and stop at (3,0), index=3
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [{ x: 1, z: 0 }, { x: 2, z: 0 }, { x: 3, z: 0 }, { x: 4, z: 0 }],
+      waypointIndex: 0,
+      walkSpeed: 3,
+    });
+    const result = advanceAgent(state);
+    expect(result.x).toBe(3);
+    expect(result.z).toBe(0);
+    expect(result.waypointIndex).toBe(3);
+    // Still one waypoint remaining (at index 3, there are 4 waypoints total)
+    expect(result.pathComplete).toBe(false);
+  });
+
+  it('consumes all waypoints when walkSpeed is sufficient for the entire path', () => {
+    // walkSpeed=4 on a path of 4 waypoints spaced 1 unit apart
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [{ x: 1, z: 0 }, { x: 2, z: 0 }, { x: 3, z: 0 }, { x: 4, z: 0 }],
+      waypointIndex: 0,
+      walkSpeed: 4,
+    });
+    const result = advanceAgent(state);
+    expect(result.x).toBe(4);
+    expect(result.z).toBe(0);
+    expect(result.waypointIndex).toBe(4);
+    expect(result.pathComplete).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 4: Path completion
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('advanceAgent — path completion', () => {
+  it('completes a multi-waypoint path exactly when walkSpeed matches total distance', () => {
+    // Two waypoints, each 1 unit apart, total distance = 2, walkSpeed = 2
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [{ x: 1, z: 0 }, { x: 2, z: 0 }],
+      waypointIndex: 0,
+      walkSpeed: 2,
+    });
+    const result = advanceAgent(state);
+    expect(result.x).toBe(2);
+    expect(result.z).toBe(0);
+    expect(result.waypointIndex).toBe(2);
+    expect(result.pathComplete).toBe(true);
+  });
+
+  it('completes immediately when already at the final waypoint', () => {
+    // Agent is already at the target waypoint
+    const state = makeState({
+      x: 2, z: 0,
+      waypoints: [{ x: 2, z: 0 }],
+      waypointIndex: 0,
+      walkSpeed: 1,
+    });
+    const result = advanceAgent(state);
+    expect(result.x).toBe(2);
+    expect(result.z).toBe(0);
+    expect(result.waypointIndex).toBe(1);
+    expect(result.pathComplete).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 5: Diagonal movement
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('advanceAgent — diagonal movement', () => {
+  it('reaches a diagonal waypoint when walkSpeed >= distance', () => {
+    // Distance from (0,0) to (2,2) = sqrt(8) ≈ 2.828
+    // walkSpeed=3 >= 2.828 → reaches the target
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [{ x: 2, z: 2 }],
+      waypointIndex: 0,
+      walkSpeed: 3,
+    });
+    const result = advanceAgent(state);
+    expect(result.x).toBe(2);
+    expect(result.z).toBe(2);
+    expect(result.waypointIndex).toBe(1);
+    expect(result.pathComplete).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 6: Edge cases
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('advanceAgent — edge cases', () => {
+  it('returns pathComplete=true when waypoints array is empty', () => {
+    const state = makeState({ x: 5, z: 3, waypoints: [], waypointIndex: 0, walkSpeed: 2 });
+    const result = advanceAgent(state);
+    expect(result.x).toBe(5);
+    expect(result.z).toBe(3);
+    expect(result.waypointIndex).toBe(0);
+    expect(result.pathComplete).toBe(true);
+  });
+
+  it('returns pathComplete=true when waypointIndex is past the array length', () => {
+    const state = makeState({
+      x: 5, z: 3,
+      waypoints: [{ x: 1, z: 0 }, { x: 2, z: 0 }],
+      waypointIndex: 5,
+      walkSpeed: 2,
+    });
+    const result = advanceAgent(state);
+    expect(result.x).toBe(5);
+    expect(result.z).toBe(3);
+    expect(result.waypointIndex).toBe(5);
+    expect(result.pathComplete).toBe(true);
+  });
+
+  it('does not move and pathComplete is false when walkSpeed is 0 and waypoints exist', () => {
+    // walkSpeed=0 means no movement budget; waypoints remain unconsumed
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [{ x: 1, z: 0 }],
+      waypointIndex: 0,
+      walkSpeed: 0,
+    });
+    const result = advanceAgent(state);
+    expect(result.x).toBe(0);
+    expect(result.z).toBe(0);
+    expect(result.waypointIndex).toBe(0);
+    // pathComplete should be false because we haven't reached the end
+    expect(result.pathComplete).toBe(false);
+  });
+
+  it('treats negative walkSpeed as 0 (no movement, no progress)', () => {
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [{ x: 1, z: 0 }],
+      waypointIndex: 0,
+      walkSpeed: -5,
+    });
+    const result = advanceAgent(state);
+    expect(result.x).toBe(0);
+    expect(result.z).toBe(0);
+    expect(result.waypointIndex).toBe(0);
+    expect(result.pathComplete).toBe(false);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 7: Immutability
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('advanceAgent — immutability', () => {
+  it('does not mutate the original AgentState object', () => {
+    const original: AgentState = {
+      x: 0,
+      z: 0,
+      waypoints: [{ x: 3, z: 0 }, { x: 6, z: 0 }],
+      waypointIndex: 0,
+      walkSpeed: 2,
+    };
+    // Snapshot original values
+    const origX = original.x;
+    const origZ = original.z;
+    const origIndex = original.waypointIndex;
+    const origWaypointsLength = original.waypoints.length;
+    const origWaypoints = [...original.waypoints];
+
+    const result = advanceAgent(original);
+
+    // Verify original state fields are unchanged
+    expect(original.x).toBe(origX);
+    expect(original.z).toBe(origZ);
+    expect(original.waypointIndex).toBe(origIndex);
+    expect(original.waypoints.length).toBe(origWaypointsLength);
+    expect(original.waypoints[0]!.x).toBe(origWaypoints[0]!.x);
+    expect(original.waypoints[0]!.z).toBe(origWaypoints[0]!.z);
+    expect(original.waypoints[1]!.x).toBe(origWaypoints[1]!.x);
+    expect(original.waypoints[1]!.z).toBe(origWaypoints[1]!.z);
+
+    // Returned object should be a different reference
+    expect(result).not.toBe(original);
+  });
+});


### PR DESCRIPTION
Closes #234

## Summary
Implements `advanceAgent()` — moves an agent one step along its waypoints per tick, consuming waypoints as they are reached. Part of the navmesh system (backlog task 6.7).

## Changes
- **src/core/nav/AgentMovement.ts** (NEW — 97 lines) — `AgentState`, `AdvanceResult` interfaces and `advanceAgent()` pure function
- **src/core/config/balance.ts** (+3 lines) — Added `AGENT_WALK_SPEED` constant (2 cells/tick)
- **tests/unit/nav/AgentMovement.test.ts** (NEW — 241 lines) — 13 tests across 7 groups

## Acceptance Criteria
- [x] AC1: walkSpeed >= distance → agent snaps to target waypoint
- [x] AC2: walkSpeed < distance → agent moves partially toward target
- [x] AC3: Fractional walkSpeed (< 1) moves fractionally
- [x] AC4: Reaches final waypoint → path complete
- [x] AC5: Already at final waypoint → path complete immediately
- [x] AC6: Empty waypoints list → path complete
- [x] AC7: Single waypoint (start == goal) → snap + path complete
- [x] AC8: walkSpeed=0 → no movement
- [x] AC9: Multiple waypoints consumed in one tick with remaining budget carryover
- [x] AC10: No mutation of input AgentState (pure function)

## Validation Checklist
- ✅ TypeScript (`tsc --noEmit`): 0 errors
- ✅ Tests (`vitest run`): 1987 passed (113 files) — no regressions
- ✅ Build (`vite build`): Successful

## Pipeline Summary
| Step | Status |
|------|--------|
| @planner | ✅ |
| @skeleton-writer | ✅ |
| @test-writer (13 tests) | ✅ |
| @implementer | ✅ |
| Test runner (13/13) | ✅ |
| Qualimetry (jscpd) | ✅ (no clones in source) |
| @security-reviewer | ✅ |
| @quality-reviewer | ✅ (pathComplete→isPathComplete fixed) |
| @i18n-reviewer | ✅ |
| @duplication-reviewer | ✅ |
| @semantic-reviewer | ✅ |
| @refactorer | ✅ |
| @validator (tsc+tests+build) | ✅ |

READY TO MERGE