### PR TITLE
[6.8] Implement stale-path detection and re-request on obstacle change

### DIFF
--- a/src/core/nav/AgentMovement.ts
+++ b/src/core/nav/AgentMovement.ts
@@ -59,6 +59,11 @@ export function advanceAgent(state: AgentState): AdvanceResult {
     return { x: state.x, z: state.z, waypointIndex: state.waypointIndex, isPathComplete: true };
   }
 
+  // Guard: NaN walkSpeed → treat as 0 (no movement)
+  if (!Number.isFinite(state.walkSpeed)) {
+    return { x: state.x, z: state.z, waypointIndex: state.waypointIndex, isPathComplete: false };
+  }
+
   // Guard: no waypoints or already past the end → path complete
   if (state.waypoints.length === 0 || state.waypointIndex >= state.waypoints.length) {
     return { x: state.x, z: state.z, waypointIndex: state.waypointIndex, isPathComplete: true };
@@ -112,6 +117,24 @@ export function advanceAgent(state: AgentState): AdvanceResult {
 }
 
 /**
+ * Iterate over remaining waypoints and return true if any satisfy the predicate.
+ * Returns false if no waypoints remain or the path is already complete.
+ */
+function someRemainingWaypoint(
+  state: AgentState,
+  predicate: (wp: { x: number; z: number }) => boolean,
+): boolean {
+  if (state.waypoints.length === 0 || state.waypointIndex >= state.waypoints.length) {
+    return false;
+  }
+  for (let i = state.waypointIndex; i < state.waypoints.length; i++) {
+    const wp = state.waypoints[i]!;
+    if (predicate(wp)) return true;
+  }
+  return false;
+}
+
+/**
  * Check whether the next waypoint or any subsequent waypoint is blocked
  * by an obstacle (vehicle or terrain change) on the NavGrid.
  *
@@ -121,12 +144,7 @@ export function advanceAgent(state: AgentState): AdvanceResult {
  * @returns `true` if any remaining waypoint is blocked.
  */
 export function isPathBlocked(state: AgentState, grid: NavGrid, avoidVehicles: boolean): boolean {
-  if (state.waypoints.length === 0 || state.waypointIndex >= state.waypoints.length) {
-    return false;
-  }
-
-  for (let i = state.waypointIndex; i < state.waypoints.length; i++) {
-    const wp = state.waypoints[i]!;
+  return someRemainingWaypoint(state, (wp) => {
     const clampedX = Math.max(0, Math.min(grid.width - 1, Math.floor(wp.x)));
     const clampedZ = Math.max(0, Math.min(grid.height - 1, Math.floor(wp.z)));
     const cell = grid.cells[clampedZ]![clampedX]!;
@@ -137,39 +155,40 @@ export function isPathBlocked(state: AgentState, grid: NavGrid, avoidVehicles: b
     if (avoidVehicles && cell.vehicleOccupied) {
       return true;
     }
-  }
-
-  return false;
+    return false;
+  });
 }
 
 /**
- * Check whether any segment of the agent's remaining path crosses
- * a specified axis-aligned region (e.g., a recently updated blast area).
+ * Check whether any remaining waypoint in the agent's path falls within
+ * the specified axis-aligned region (point-in-AABB test).
+ *
+ * If waypoints are dense (adjacent cells), this approximates segment
+ * intersection. For sparse waypoints, a segment may cross the region
+ * without any waypoint inside it — callers should ensure waypoint density
+ * or use a separate segment-intersection test if needed.
  *
  * @param state  - The agent's current navigation state.
  * @param region - The axis-aligned bounding box to test against.
- * @returns `true` if the remaining path intersects the region.
+ * @returns `true` if any remaining waypoint lies inside the region.
  */
 export function doesPathCrossRegion(
   state: AgentState,
   region: { minX: number; maxX: number; minZ: number; maxZ: number },
 ): boolean {
+  // Guard: NaN/infinite region bounds → conservative (assume crossing)
+  if (!Number.isFinite(region.minX) || !Number.isFinite(region.maxX) ||
+      !Number.isFinite(region.minZ) || !Number.isFinite(region.maxZ)) {
+    return true;
+  }
+
   if (region.minX > region.maxX || region.minZ > region.maxZ) {
     return false;
   }
 
-  if (state.waypoints.length === 0 || state.waypointIndex >= state.waypoints.length) {
-    return false;
-  }
-
-  for (let i = state.waypointIndex; i < state.waypoints.length; i++) {
-    const wp = state.waypoints[i]!;
-    if (wp.x >= region.minX && wp.x <= region.maxX && wp.z >= region.minZ && wp.z <= region.maxZ) {
-      return true;
-    }
-  }
-
-  return false;
+  return someRemainingWaypoint(state, (wp) =>
+    wp.x >= region.minX && wp.x <= region.maxX && wp.z >= region.minZ && wp.z <= region.maxZ,
+  );
 }
 
 /**

--- a/src/core/nav/AgentMovement.ts
+++ b/src/core/nav/AgentMovement.ts
@@ -121,7 +121,24 @@ export function advanceAgent(state: AgentState): AdvanceResult {
  * @returns `true` if any remaining waypoint is blocked.
  */
 export function isPathBlocked(state: AgentState, grid: NavGrid, avoidVehicles: boolean): boolean {
-  // TODO: implement
+  if (state.waypoints.length === 0 || state.waypointIndex >= state.waypoints.length) {
+    return false;
+  }
+
+  for (let i = state.waypointIndex; i < state.waypoints.length; i++) {
+    const wp = state.waypoints[i]!;
+    const clampedX = Math.max(0, Math.min(grid.width - 1, Math.floor(wp.x)));
+    const clampedZ = Math.max(0, Math.min(grid.height - 1, Math.floor(wp.z)));
+    const cell = grid.cells[clampedZ]![clampedX]!;
+
+    if (cell.type === 'blocked' || cell.type === 'void') {
+      return true;
+    }
+    if (avoidVehicles && cell.vehicleOccupied) {
+      return true;
+    }
+  }
+
   return false;
 }
 
@@ -137,7 +154,21 @@ export function doesPathCrossRegion(
   state: AgentState,
   region: { minX: number; maxX: number; minZ: number; maxZ: number },
 ): boolean {
-  // TODO: implement
+  if (region.minX > region.maxX || region.minZ > region.maxZ) {
+    return false;
+  }
+
+  if (state.waypoints.length === 0 || state.waypointIndex >= state.waypoints.length) {
+    return false;
+  }
+
+  for (let i = state.waypointIndex; i < state.waypoints.length; i++) {
+    const wp = state.waypoints[i]!;
+    if (wp.x >= region.minX && wp.x <= region.maxX && wp.z >= region.minZ && wp.z <= region.maxZ) {
+      return true;
+    }
+  }
+
   return false;
 }
 
@@ -149,6 +180,13 @@ export function doesPathCrossRegion(
  * @returns A new `AgentState` with cleared waypoints ready for re-routing.
  */
 export function requestReRoute(state: AgentState): AgentState {
-  // TODO: implement
-  return state;
+  return {
+    x: state.x,
+    z: state.z,
+    waypoints: [],
+    waypointIndex: 0,
+    walkSpeed: state.walkSpeed,
+    destinationX: state.destinationX,
+    destinationZ: state.destinationZ,
+  };
 }

--- a/src/core/nav/AgentMovement.ts
+++ b/src/core/nav/AgentMovement.ts
@@ -1,6 +1,8 @@
 // BlastSimulator2026 — AgentMovement: per-tick agent position advancement along a path
 // Part of the navmesh system.
 
+import type { NavGrid } from './NavGrid.js';
+
 /**
  * The current navigation state of an agent walking along a path.
  * Tracks position, waypoint list, progress index, and base walk speed.
@@ -16,6 +18,10 @@ export interface AgentState {
   waypointIndex: number;
   /** Agent walking speed in grid cells per tick. */
   walkSpeed: number;
+  /** The ultimate destination x-coordinate. */
+  destinationX: number;
+  /** The ultimate destination z-coordinate. */
+  destinationZ: number;
 }
 
 /**
@@ -30,6 +36,15 @@ export interface AdvanceResult {
   waypointIndex: number;
   /** Whether the agent has reached the final waypoint this tick. */
   isPathComplete: boolean;
+}
+
+/**
+ * The result of checking whether an agent's current path is stale
+ * due to obstacles or changed regions.
+ */
+export interface StaleCheckResult {
+  isStale: boolean;
+  reason?: 'BLOCKED_WAYPOINT' | 'CROSSES_UPDATED_REGION';
 }
 
 /**
@@ -94,4 +109,46 @@ export function advanceAgent(state: AgentState): AdvanceResult {
     waypointIndex,
     isPathComplete: waypointIndex >= state.waypoints.length,
   };
+}
+
+/**
+ * Check whether the next waypoint or any subsequent waypoint is blocked
+ * by an obstacle (vehicle or terrain change) on the NavGrid.
+ *
+ * @param state - The agent's current navigation state.
+ * @param grid  - The navigation grid to check against.
+ * @param avoidVehicles - Whether to treat vehicle-occupied cells as blocked.
+ * @returns `true` if any remaining waypoint is blocked.
+ */
+export function isPathBlocked(state: AgentState, grid: NavGrid, avoidVehicles: boolean): boolean {
+  // TODO: implement
+  return false;
+}
+
+/**
+ * Check whether any segment of the agent's remaining path crosses
+ * a specified axis-aligned region (e.g., a recently updated blast area).
+ *
+ * @param state  - The agent's current navigation state.
+ * @param region - The axis-aligned bounding box to test against.
+ * @returns `true` if the remaining path intersects the region.
+ */
+export function doesPathCrossRegion(
+  state: AgentState,
+  region: { minX: number; maxX: number; minZ: number; maxZ: number },
+): boolean {
+  // TODO: implement
+  return false;
+}
+
+/**
+ * Request a re-route by clearing the current waypoint list and resetting
+ * the agent's state so a new path can be computed.
+ *
+ * @param state - The agent's current navigation state.
+ * @returns A new `AgentState` with cleared waypoints ready for re-routing.
+ */
+export function requestReRoute(state: AgentState): AgentState {
+  // TODO: implement
+  return state;
 }

--- a/tests/unit/nav/AgentMovement.test.ts
+++ b/tests/unit/nav/AgentMovement.test.ts
@@ -11,9 +11,11 @@
 //   Group 7 — Immutability (original AgentState not mutated)
 
 import { describe, it, expect } from 'vitest';
-import { advanceAgent } from '../../../src/core/nav/AgentMovement.js';
-import type { AdvanceResult, AgentState } from '../../../src/core/nav/AgentMovement.js';
+import { advanceAgent, isPathBlocked, doesPathCrossRegion, requestReRoute } from '../../../src/core/nav/AgentMovement.js';
+import type { AdvanceResult, AgentState, StaleCheckResult } from '../../../src/core/nav/AgentMovement.js';
 import { AGENT_WALK_SPEED } from '../../../src/core/config/balance.js';
+import { NavGrid } from '../../../src/core/nav/NavGrid.js';
+import type { NavCell } from '../../../src/core/nav/NavGrid.js';
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Helper
@@ -26,8 +28,28 @@ function makeState(overrides?: Partial<AgentState>): AgentState {
     waypoints: [],
     waypointIndex: 0,
     walkSpeed: AGENT_WALK_SPEED,
+    destinationX: 0,
+    destinationZ: 0,
     ...overrides,
   };
+}
+
+/**
+ * Create a small NavGrid with known cell types for deterministic tests.
+ * Default is a 5×5 all-walkable grid unless overridden.
+ */
+function makeNavGrid(cells?: NavCell[][]): NavGrid {
+  if (cells) return new NavGrid(cells[0]!.length, cells.length, cells);
+  // Default: 5×5 walkable grid
+  const defaultCells: NavCell[][] = [];
+  for (let z = 0; z < 5; z++) {
+    const row: NavCell[] = [];
+    for (let x = 0; x < 5; x++) {
+      row.push({ type: 'walkable', moveCost: 1, benchLevel: 0, vehicleOccupied: false });
+    }
+    defaultCells.push(row);
+  }
+  return new NavGrid(5, 5, defaultCells);
 }
 
 /**
@@ -237,5 +259,360 @@ describe('advanceAgent — immutability', () => {
 
     // Returned object should be a different reference
     expect(result).not.toBe(original);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 8: isPathBlocked — stale-path detection via blocked waypoints
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('isPathBlocked — blocked waypoint detection', () => {
+  it('returns true when the next remaining waypoint is blocked', () => {
+    const grid = makeNavGrid([
+      [{ type: 'walkable', moveCost: 1, benchLevel: 0, vehicleOccupied: false }, { type: 'blocked', moveCost: Infinity, benchLevel: 0, vehicleOccupied: false }],
+      [{ type: 'walkable', moveCost: 1, benchLevel: 0, vehicleOccupied: false }, { type: 'walkable', moveCost: 1, benchLevel: 0, vehicleOccupied: false }],
+    ]);
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [{ x: 1, z: 0 }],
+      waypointIndex: 0,
+      walkSpeed: 1,
+      destinationX: 1, destinationZ: 0,
+    });
+    expect(isPathBlocked(state, grid, false)).toBe(true);
+  });
+
+  it('returns true when a later remaining waypoint is blocked (not just the next one)', () => {
+    // Create a 3×1 grid: row 0 = [walkable, walkable, blocked]
+    const cells: NavCell[][] = [
+      [
+        { type: 'walkable', moveCost: 1, benchLevel: 0, vehicleOccupied: false },
+        { type: 'walkable', moveCost: 1, benchLevel: 0, vehicleOccupied: false },
+        { type: 'blocked', moveCost: Infinity, benchLevel: 0, vehicleOccupied: false },
+      ],
+    ];
+    const grid = makeNavGrid(cells);
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [{ x: 0, z: 0 }, { x: 1, z: 0 }, { x: 2, z: 0 }],
+      waypointIndex: 0,
+      walkSpeed: 1,
+      destinationX: 2, destinationZ: 0,
+    });
+    expect(isPathBlocked(state, grid, false)).toBe(true);
+  });
+
+  it('returns true when avoidVehicles is true and a waypoint is vehicleOccupied', () => {
+    const grid = makeNavGrid([
+      [
+        { type: 'walkable', moveCost: 1, benchLevel: 0, vehicleOccupied: true },
+        { type: 'walkable', moveCost: 1, benchLevel: 0, vehicleOccupied: false },
+      ],
+      [
+        { type: 'walkable', moveCost: 1, benchLevel: 0, vehicleOccupied: false },
+        { type: 'walkable', moveCost: 1, benchLevel: 0, vehicleOccupied: false },
+      ],
+    ]);
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [{ x: 0, z: 0 }],
+      waypointIndex: 0,
+      walkSpeed: 1,
+      destinationX: 0, destinationZ: 0,
+    });
+    expect(isPathBlocked(state, grid, true)).toBe(true);
+  });
+
+  it('returns false when avoidVehicles is false and a waypoint is vehicleOccupied', () => {
+    const grid = makeNavGrid([
+      [
+        { type: 'walkable', moveCost: 1, benchLevel: 0, vehicleOccupied: true },
+        { type: 'walkable', moveCost: 1, benchLevel: 0, vehicleOccupied: false },
+      ],
+      [
+        { type: 'walkable', moveCost: 1, benchLevel: 0, vehicleOccupied: false },
+        { type: 'walkable', moveCost: 1, benchLevel: 0, vehicleOccupied: false },
+      ],
+    ]);
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [{ x: 0, z: 0 }],
+      waypointIndex: 0,
+      walkSpeed: 1,
+      destinationX: 0, destinationZ: 0,
+    });
+    expect(isPathBlocked(state, grid, false)).toBe(false);
+  });
+
+  it('returns false when all remaining waypoints are walkable', () => {
+    const grid = makeNavGrid(); // Default 5×5 all-walkable
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [{ x: 2, z: 2 }, { x: 4, z: 4 }],
+      waypointIndex: 0,
+      walkSpeed: 1,
+      destinationX: 4, destinationZ: 4,
+    });
+    expect(isPathBlocked(state, grid, false)).toBe(false);
+  });
+
+  it('returns false when waypoints array is empty', () => {
+    const grid = makeNavGrid();
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [],
+      waypointIndex: 0,
+      walkSpeed: 1,
+      destinationX: 0, destinationZ: 0,
+    });
+    expect(isPathBlocked(state, grid, false)).toBe(false);
+  });
+
+  it('returns false when waypointIndex is past the end of waypoints', () => {
+    const grid = makeNavGrid();
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [{ x: 2, z: 0 }],
+      waypointIndex: 5,
+      walkSpeed: 1,
+      destinationX: 2, destinationZ: 0,
+    });
+    expect(isPathBlocked(state, grid, false)).toBe(false);
+  });
+
+  it('does not mutate the input AgentState', () => {
+    const grid = makeNavGrid([
+      [{ type: 'blocked', moveCost: Infinity, benchLevel: 0, vehicleOccupied: false }, { type: 'walkable', moveCost: 1, benchLevel: 0, vehicleOccupied: false }],
+      [{ type: 'walkable', moveCost: 1, benchLevel: 0, vehicleOccupied: false }, { type: 'walkable', moveCost: 1, benchLevel: 0, vehicleOccupied: false }],
+    ]);
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [{ x: 0, z: 0 }],
+      waypointIndex: 0,
+      walkSpeed: 1,
+      destinationX: 0, destinationZ: 0,
+    });
+    const snapshot = { ...state, waypoints: [...state.waypoints] };
+
+    isPathBlocked(state, grid, false);
+
+    expect(state.x).toBe(snapshot.x);
+    expect(state.z).toBe(snapshot.z);
+    expect(state.waypointIndex).toBe(snapshot.waypointIndex);
+    expect(state.walkSpeed).toBe(snapshot.walkSpeed);
+    expect(state.destinationX).toBe(snapshot.destinationX);
+    expect(state.destinationZ).toBe(snapshot.destinationZ);
+    expect(state.waypoints.length).toBe(snapshot.waypoints.length);
+    expect(state.waypoints[0]!.x).toBe(snapshot.waypoints[0]!.x);
+    expect(state.waypoints[0]!.z).toBe(snapshot.waypoints[0]!.z);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 9: doesPathCrossRegion — stale-path detection via updated regions
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('doesPathCrossRegion — region intersection', () => {
+  const region = { minX: 1, maxX: 3, minZ: 1, maxZ: 3 };
+
+  it('returns true when a waypoint falls inside the region', () => {
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [{ x: 2, z: 2 }],
+      waypointIndex: 0,
+      walkSpeed: 1,
+      destinationX: 2, destinationZ: 2,
+    });
+    expect(doesPathCrossRegion(state, region)).toBe(true);
+  });
+
+  it('returns true when a waypoint is exactly on a region boundary (inclusive)', () => {
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [{ x: 1, z: 1 }],
+      waypointIndex: 0,
+      walkSpeed: 1,
+      destinationX: 1, destinationZ: 1,
+    });
+    expect(doesPathCrossRegion(state, region)).toBe(true);
+  });
+
+  it('returns false when no waypoint is inside the region', () => {
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [{ x: 4, z: 4 }],
+      waypointIndex: 0,
+      walkSpeed: 1,
+      destinationX: 4, destinationZ: 4,
+    });
+    expect(doesPathCrossRegion(state, region)).toBe(false);
+  });
+
+  it('returns false when the region is empty (minX > maxX)', () => {
+    const emptyRegion = { minX: 5, maxX: 3, minZ: 1, maxZ: 3 };
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [{ x: 2, z: 2 }],
+      waypointIndex: 0,
+      walkSpeed: 1,
+      destinationX: 2, destinationZ: 2,
+    });
+    expect(doesPathCrossRegion(state, emptyRegion)).toBe(false);
+  });
+
+  it('returns false when the region is empty (minZ > maxZ)', () => {
+    const emptyRegion = { minX: 1, maxX: 3, minZ: 5, maxZ: 3 };
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [{ x: 2, z: 2 }],
+      waypointIndex: 0,
+      walkSpeed: 1,
+      destinationX: 2, destinationZ: 2,
+    });
+    expect(doesPathCrossRegion(state, emptyRegion)).toBe(false);
+  });
+
+  it('returns false when waypoints array is empty', () => {
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [],
+      waypointIndex: 0,
+      walkSpeed: 1,
+      destinationX: 0, destinationZ: 0,
+    });
+    expect(doesPathCrossRegion(state, region)).toBe(false);
+  });
+
+  it('returns false when waypointIndex is past the end', () => {
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [{ x: 2, z: 2 }],
+      waypointIndex: 5,
+      walkSpeed: 1,
+      destinationX: 2, destinationZ: 2,
+    });
+    expect(doesPathCrossRegion(state, region)).toBe(false);
+  });
+
+  it('does not mutate the input AgentState', () => {
+    const state = makeState({
+      x: 0, z: 0,
+      waypoints: [{ x: 2, z: 2 }],
+      waypointIndex: 0,
+      walkSpeed: 1,
+      destinationX: 2, destinationZ: 2,
+    });
+    const snapshot = { ...state, waypoints: [...state.waypoints] };
+
+    doesPathCrossRegion(state, region);
+
+    expect(state.x).toBe(snapshot.x);
+    expect(state.z).toBe(snapshot.z);
+    expect(state.waypointIndex).toBe(snapshot.waypointIndex);
+    expect(state.walkSpeed).toBe(snapshot.walkSpeed);
+    expect(state.destinationX).toBe(snapshot.destinationX);
+    expect(state.destinationZ).toBe(snapshot.destinationZ);
+    expect(state.waypoints.length).toBe(snapshot.waypoints.length);
+    expect(state.waypoints[0]!.x).toBe(snapshot.waypoints[0]!.x);
+    expect(state.waypoints[0]!.z).toBe(snapshot.waypoints[0]!.z);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 10: requestReRoute — clearing waypoints for re-routing
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('requestReRoute — clear waypoints for re-routing', () => {
+  it('returns a new AgentState with empty waypoints and waypointIndex 0', () => {
+    const state = makeState({
+      x: 10, z: 20,
+      waypoints: [{ x: 15, z: 25 }, { x: 30, z: 40 }],
+      waypointIndex: 1,
+      walkSpeed: 2,
+      destinationX: 30, destinationZ: 40,
+    });
+    const result = requestReRoute(state);
+    expect(result.waypoints).toEqual([]);
+    expect(result.waypointIndex).toBe(0);
+  });
+
+  it('preserves x, z, walkSpeed, destinationX, destinationZ', () => {
+    const state = makeState({
+      x: 10, z: 20,
+      waypoints: [{ x: 15, z: 25 }],
+      waypointIndex: 0,
+      walkSpeed: 3,
+      destinationX: 15, destinationZ: 25,
+    });
+    const result = requestReRoute(state);
+    expect(result.x).toBe(10);
+    expect(result.z).toBe(20);
+    expect(result.walkSpeed).toBe(3);
+    expect(result.destinationX).toBe(15);
+    expect(result.destinationZ).toBe(25);
+  });
+
+  it('does not mutate the input AgentState', () => {
+    const state = makeState({
+      x: 10, z: 20,
+      waypoints: [{ x: 15, z: 25 }],
+      waypointIndex: 0,
+      walkSpeed: 3,
+      destinationX: 15, destinationZ: 25,
+    });
+    const snapshot = { ...state, waypoints: [...state.waypoints] };
+
+    requestReRoute(state);
+
+    expect(state.x).toBe(snapshot.x);
+    expect(state.z).toBe(snapshot.z);
+    expect(state.waypointIndex).toBe(snapshot.waypointIndex);
+    expect(state.walkSpeed).toBe(snapshot.walkSpeed);
+    expect(state.destinationX).toBe(snapshot.destinationX);
+    expect(state.destinationZ).toBe(snapshot.destinationZ);
+    expect(state.waypoints.length).toBe(snapshot.waypoints.length);
+    expect(state.waypoints[0]!.x).toBe(snapshot.waypoints[0]!.x);
+    expect(state.waypoints[0]!.z).toBe(snapshot.waypoints[0]!.z);
+  });
+
+  it('works when destination equals current position', () => {
+    const state = makeState({
+      x: 5, z: 5,
+      waypoints: [{ x: 5, z: 5 }],
+      waypointIndex: 0,
+      walkSpeed: 1,
+      destinationX: 5, destinationZ: 5,
+    });
+    const result = requestReRoute(state);
+    expect(result.waypoints).toEqual([]);
+    expect(result.waypointIndex).toBe(0);
+    expect(result.x).toBe(5);
+    expect(result.z).toBe(5);
+    expect(result.destinationX).toBe(5);
+    expect(result.destinationZ).toBe(5);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 11: StaleCheckResult — type shape validation
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('StaleCheckResult — type shape', () => {
+  it('creates a stale result with BLOCKED_WAYPOINT reason', () => {
+    const result: StaleCheckResult = { isStale: true, reason: 'BLOCKED_WAYPOINT' };
+    expect(result.isStale).toBe(true);
+    expect(result.reason).toBe('BLOCKED_WAYPOINT');
+  });
+
+  it('creates a stale result with CROSSES_UPDATED_REGION reason', () => {
+    const result: StaleCheckResult = { isStale: true, reason: 'CROSSES_UPDATED_REGION' };
+    expect(result.isStale).toBe(true);
+    expect(result.reason).toBe('CROSSES_UPDATED_REGION');
+  });
+
+  it('creates a non-stale result with no reason', () => {
+    const result: StaleCheckResult = { isStale: false };
+    expect(result.isStale).toBe(false);
+    expect(result.reason).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #235

## Summary

Implements stale-path detection and re-request on obstacle change for the NavMesh system (task 6.8).

### Changes to `src/core/nav/AgentMovement.ts` (+114 lines)

- **AgentState** extended with `destinationX` and `destinationZ` fields (tracks original destination for re-routing)
- **StaleCheckResult** interface added (type-safe stale reason: `BLOCKED_WAYPOINT` | `CROSSES_UPDATED_REGION`)
- **isPathBlocked()** — checks if any remaining waypoint is now on a blocked/void/vehicleOccupied NavGrid cell
- **doesPathCrossRegion()** — checks if any remaining waypoint falls within a rectangular region (e.g. blast-affected zone)
- **requestReRoute()** — returns new AgentState with cleared waypoints, preserving position and destination
- **advanceAgent()** — added NaN walkSpeed guard (defense-in-depth)
- Extracted private `someRemainingWaypoint()` helper to reduce duplication

### Changes to `tests/unit/nav/AgentMovement.test.ts` (+381 lines)

- Updated `makeState()` helper with `destinationX`/`destinationZ` defaults
- Added `makeNavGrid()` test helper for deterministic cell grids
- 4 new test groups (23 test cases) covering:
  - `isPathBlocked`: blocked cells, vehicle occupancy, edge cases, immutability
  - `doesPathCrossRegion`: point-in-region, boundary, empty region, edge cases, immutability
  - `requestReRoute`: empty waypoints, preserved fields, immutability, same-position
  - `StaleCheckResult`: type shape validation

### Validation

- TypeScript: `tsc --noEmit` — 0 errors
- Tests: 2010/2010 passed (all existing + new stale-path tests)
- Build: `npm run build` — success (134 modules, 997.7 kB total)
- Duplication: jscpd — 1.46% (no new clones)
- Code reviews: security, quality, i18n, duplication, semantic — all PASS

### Quality Gates
- [x] TypeScript strict — no `any` types
- [x] Pure functional style — no mutation of inputs
- [x] File size ≤ 300 lines (211 lines)
- [x] JSDoc on all exported symbols
- [x] Bounds-checked grid access
- [x] NaN/infinity defense-in-depth guards
- [x] Immutability contract verified in tests
- [x] No hardcoded user-facing strings (i18n clean)

READY TO MERGE