### PR TITLE
[7.3] Implement tickNeedGauges() — drain gauges based on task state + morale modifier

### DIFF
--- a/src/core/config/balance.ts
+++ b/src/core/config/balance.ts
@@ -333,6 +333,19 @@ export const NEED_MORALE_PENALTIES = {
   breakNeed: -2,
 } as const;
 
+/** Morale thresholds for drain-rate adjustment in tickNeedGauges. */
+export const MORALE_THRESHOLDS = {
+  high: 70,
+  low: 30,
+} as const;
+
+/** Drain-rate multipliers applied by morale range in tickNeedGauges. */
+export const NEED_MORALE_DRAIN_MULTIPLIERS = {
+  high: 0.85,   // morale > MORALE_THRESHOLDS.high
+  normal: 1.0,  // morale between low and high (inclusive)
+  low: 1.20,    // morale < MORALE_THRESHOLDS.low
+} as const;
+
 /**
  * Warning thresholds that trigger proactive rest routing.
  * @deprecated Use {@link NEED_WARNING_THRESHOLDS} instead — this constant has identical values

--- a/src/core/entities/Employee.ts
+++ b/src/core/entities/Employee.ts
@@ -296,5 +296,5 @@ export function tickTraining(state: EmployeeState): void {
 export type { GainXpResult } from './EmployeeGainXp.js';
 export { gainXp } from './EmployeeGainXp.js';
 export type { NeedKey } from './EmployeeNeeds.js';
-export { tickNeeds, getNeedMultiplier, tickNeedMorale, replenishNeed } from './EmployeeNeeds.js';
+export { tickNeeds, tickNeedGauges, getNeedMultiplier, tickNeedMorale, replenishNeed } from './EmployeeNeeds.js';
 export { computeTaskDuration } from './EmployeeTaskDuration.js';

--- a/src/core/entities/EmployeeNeeds.ts
+++ b/src/core/entities/EmployeeNeeds.ts
@@ -73,11 +73,10 @@ export function replenishNeed(employee: Employee, need: NeedKey, amount: number)
  * - morale < 30: ×1.20 (faster drain — unhappy workers let themselves go)
  * - otherwise:   ×1.00 (standard drain)
  */
-function getMoraleDrainMultiplier(_morale: number): number {
-  // STUB — implement later
-  void MORALE_THRESHOLDS;
-  void NEED_MORALE_DRAIN_MULTIPLIERS;
-  throw new Error('Not implemented');
+function getMoraleDrainMultiplier(morale: number): number {
+  if (morale > MORALE_THRESHOLDS.high) return NEED_MORALE_DRAIN_MULTIPLIERS.high;
+  if (morale < MORALE_THRESHOLDS.low) return NEED_MORALE_DRAIN_MULTIPLIERS.low;
+  return NEED_MORALE_DRAIN_MULTIPLIERS.normal;
 }
 
 /**
@@ -87,8 +86,13 @@ function getMoraleDrainMultiplier(_morale: number): number {
  * Call this each tick for each employee.
  * All gauges are clamped to a minimum of 0.
  */
-export function tickNeedGauges(_employee: Employee, _isWorking: boolean): void {
-  // STUB — implement later
-  void getMoraleDrainMultiplier;
-  throw new Error('Not implemented');
+export function tickNeedGauges(employee: Employee, isWorking: boolean): void {
+  const multiplier = getMoraleDrainMultiplier(employee.morale);
+
+  const gauges: NeedKey[] = ['hunger', 'fatigue', 'breakNeed'];
+  for (const gauge of gauges) {
+    const baseRate = isWorking ? NEED_DRAIN_RATES[gauge].working : NEED_DRAIN_RATES[gauge].idle;
+    const actualDrain = baseRate * multiplier;
+    employee[gauge] = Math.max(0, employee[gauge] - actualDrain);
+  }
 }

--- a/src/core/entities/EmployeeNeeds.ts
+++ b/src/core/entities/EmployeeNeeds.ts
@@ -2,7 +2,7 @@
 // Tracks three need gauges: hunger, fatigue, and breakNeed (all 0–100).
 
 import { type Employee } from './Employee.js';
-import { NEED_DRAIN_RATES, NEED_THRESHOLDS, NEED_PRODUCTIVITY_MULTIPLIERS, NEED_MORALE_PENALTIES, NEED_WARNING_THRESHOLDS, NEED_COLLAPSE_THRESHOLDS } from '../config/balance.js';
+import { NEED_DRAIN_RATES, NEED_THRESHOLDS, NEED_PRODUCTIVITY_MULTIPLIERS, NEED_MORALE_PENALTIES, NEED_WARNING_THRESHOLDS, NEED_COLLAPSE_THRESHOLDS, MORALE_THRESHOLDS, NEED_MORALE_DRAIN_MULTIPLIERS } from '../config/balance.js';
 export { NEED_WARNING_THRESHOLDS, NEED_COLLAPSE_THRESHOLDS };
 
 /** The three need gauges tracked on every Employee. */
@@ -65,4 +65,30 @@ export function tickNeedMorale(employee: Employee): number {
  */
 export function replenishNeed(employee: Employee, need: NeedKey, amount: number): void {
   employee[need] = Math.max(0, Math.min(100, employee[need] + amount));
+}
+
+/**
+ * Internal helper. Returns a drain-rate multiplier based on employee morale.
+ * - morale > 70: ×0.85 (slower drain — happier workers take better care)
+ * - morale < 30: ×1.20 (faster drain — unhappy workers let themselves go)
+ * - otherwise:   ×1.00 (standard drain)
+ */
+function getMoraleDrainMultiplier(_morale: number): number {
+  // STUB — implement later
+  void MORALE_THRESHOLDS;
+  void NEED_MORALE_DRAIN_MULTIPLIERS;
+  throw new Error('Not implemented');
+}
+
+/**
+ * Drain all need gauges by one tick, adjusted by a morale-based multiplier.
+ *
+ * High morale (>70) slows drain (×0.85), low morale (<30) accelerates drain (×1.20).
+ * Call this each tick for each employee.
+ * All gauges are clamped to a minimum of 0.
+ */
+export function tickNeedGauges(_employee: Employee, _isWorking: boolean): void {
+  // STUB — implement later
+  void getMoraleDrainMultiplier;
+  throw new Error('Not implemented');
 }

--- a/src/core/entities/EmployeeNeeds.ts
+++ b/src/core/entities/EmployeeNeeds.ts
@@ -2,8 +2,7 @@
 // Tracks three need gauges: hunger, fatigue, and breakNeed (all 0–100).
 
 import { type Employee } from './Employee.js';
-import { NEED_DRAIN_RATES, NEED_THRESHOLDS, NEED_PRODUCTIVITY_MULTIPLIERS, NEED_MORALE_PENALTIES, NEED_WARNING_THRESHOLDS, NEED_COLLAPSE_THRESHOLDS, MORALE_THRESHOLDS, NEED_MORALE_DRAIN_MULTIPLIERS } from '../config/balance.js';
-export { NEED_WARNING_THRESHOLDS, NEED_COLLAPSE_THRESHOLDS };
+import { NEED_DRAIN_RATES, NEED_THRESHOLDS, NEED_PRODUCTIVITY_MULTIPLIERS, NEED_MORALE_PENALTIES, MORALE_THRESHOLDS, NEED_MORALE_DRAIN_MULTIPLIERS } from '../config/balance.js';
 
 /** The three need gauges tracked on every Employee. */
 export type NeedKey = 'hunger' | 'fatigue' | 'breakNeed';
@@ -16,6 +15,9 @@ export type NeedKey = 'hunger' | 'fatigue' | 'breakNeed';
  * recover breakNeed automatically when not working.
  *
  * All gauges are clamped to a minimum of 0.
+ *
+ * @deprecated Superseded by {@link tickNeedGauges} which applies a morale-based
+ *             drain multiplier. This function lacks the morale adjustment.
  */
 export function tickNeeds(employee: Employee, isWorking: boolean): void {
   employee.hunger    = Math.max(0, employee.hunger    - (isWorking ? NEED_DRAIN_RATES.hunger.working    : NEED_DRAIN_RATES.hunger.idle));

--- a/tests/unit/entities/Employee.test.ts
+++ b/tests/unit/entities/Employee.test.ts
@@ -16,6 +16,7 @@ import {
   HIRING_COSTS,
   // ── 3.10: need-meter functions ──
   tickNeeds,
+  tickNeedGauges,
   getNeedMultiplier,
   tickNeedMorale,
   replenishNeed,
@@ -29,10 +30,12 @@ import {
   XP_THRESHOLDS,
   QUALIFICATION_SALARY_BONUS,
   // ── 3.10: need-meter balance constants ──
+  MORALE_THRESHOLDS,
   NEED_DRAIN_RATES,
   NEED_THRESHOLDS,
   NEED_PRODUCTIVITY_MULTIPLIERS,
   NEED_MORALE_PENALTIES,
+  NEED_MORALE_DRAIN_MULTIPLIERS,
   // ── 3.13: proficiency multipliers ──
   PROFICIENCY_MULTIPLIERS,
 } from '../../../src/core/config/balance.js';
@@ -667,6 +670,172 @@ describe('Employee — need meters (7.1)', () => {
     replenishNeed(employee, 'hunger', 30);
 
     expect(employee.hunger).toBe(80);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 7.3 — tickNeedGauges: morale-adjusted drain rates
+//
+// Function under test:
+//   tickNeedGauges(employee, isWorking)
+// Drain rates are multiplied by a morale-dependent factor:
+//   morale > 70 → NEED_MORALE_DRAIN_MULTIPLIERS.high (0.85)
+//   morale < 30 → NEED_MORALE_DRAIN_MULTIPLIERS.low  (1.20)
+//   otherwise   → NEED_MORALE_DRAIN_MULTIPLIERS.normal (1.00)
+// All gauges clamped to minimum 0.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Employee — tickNeedGauges (7.3)', () => {
+
+  // ── Test 1 ──────────────────────────────────────────────────────────────────
+  it('high morale (>70) reduces drain rate when working', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.morale = 80; // > 70 → high morale
+    const hungerBefore = employee.hunger;
+    const fatigueBefore = employee.fatigue;
+    const breakNeedBefore = employee.breakNeed;
+
+    tickNeedGauges(employee, true);
+
+    const expectedHunger = hungerBefore - NEED_DRAIN_RATES.hunger.working * NEED_MORALE_DRAIN_MULTIPLIERS.high;
+    const expectedFatigue = fatigueBefore - NEED_DRAIN_RATES.fatigue.working * NEED_MORALE_DRAIN_MULTIPLIERS.high;
+    const expectedBreakNeed = breakNeedBefore - NEED_DRAIN_RATES.breakNeed.working * NEED_MORALE_DRAIN_MULTIPLIERS.high;
+    expect(employee.hunger).toBeCloseTo(expectedHunger, 5);
+    expect(employee.fatigue).toBeCloseTo(expectedFatigue, 5);
+    expect(employee.breakNeed).toBeCloseTo(expectedBreakNeed, 5);
+  });
+
+  // ── Test 2 ──────────────────────────────────────────────────────────────────
+  it('low morale (<30) increases drain rate when working', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.morale = 20; // < 30 → low morale
+
+    tickNeedGauges(employee, true);
+
+    expect(employee.hunger).toBeCloseTo(100 - NEED_DRAIN_RATES.hunger.working * NEED_MORALE_DRAIN_MULTIPLIERS.low, 5);
+    expect(employee.fatigue).toBeCloseTo(100 - NEED_DRAIN_RATES.fatigue.working * NEED_MORALE_DRAIN_MULTIPLIERS.low, 5);
+    expect(employee.breakNeed).toBeCloseTo(100 - NEED_DRAIN_RATES.breakNeed.working * NEED_MORALE_DRAIN_MULTIPLIERS.low, 5);
+  });
+
+  // ── Test 3 ──────────────────────────────────────────────────────────────────
+  it('normal morale (30-70) uses standard drain rate when working', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.morale = 50; // normal range
+
+    tickNeedGauges(employee, true);
+
+    expect(employee.hunger).toBeCloseTo(100 - NEED_DRAIN_RATES.hunger.working * NEED_MORALE_DRAIN_MULTIPLIERS.normal, 5);
+    expect(employee.fatigue).toBeCloseTo(100 - NEED_DRAIN_RATES.fatigue.working * NEED_MORALE_DRAIN_MULTIPLIERS.normal, 5);
+    expect(employee.breakNeed).toBeCloseTo(100 - NEED_DRAIN_RATES.breakNeed.working * NEED_MORALE_DRAIN_MULTIPLIERS.normal, 5);
+  });
+
+  // ── Test 4 ──────────────────────────────────────────────────────────────────
+  it('boundary: morale = 70 uses normal multiplier (not high)', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.morale = 70; // exactly at boundary — should be normal
+
+    tickNeedGauges(employee, true);
+
+    expect(employee.hunger).toBeCloseTo(100 - NEED_DRAIN_RATES.hunger.working * 1.0, 5);
+  });
+
+  // ── Test 5 ──────────────────────────────────────────────────────────────────
+  it('boundary: morale = 30 uses normal multiplier (not low)', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.morale = 30; // exactly at boundary — should be normal
+
+    tickNeedGauges(employee, true);
+
+    expect(employee.hunger).toBeCloseTo(100 - NEED_DRAIN_RATES.hunger.working * 1.0, 5);
+  });
+
+  // ── Test 6 ──────────────────────────────────────────────────────────────────
+  it('high morale reduces drain rate when idle', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.morale = 80;
+
+    tickNeedGauges(employee, false); // idle
+
+    expect(employee.hunger).toBeCloseTo(100 - NEED_DRAIN_RATES.hunger.idle * NEED_MORALE_DRAIN_MULTIPLIERS.high, 5);
+    expect(employee.fatigue).toBeCloseTo(100 - NEED_DRAIN_RATES.fatigue.idle * NEED_MORALE_DRAIN_MULTIPLIERS.high, 5);
+    // breakNeed idle rate is 0, so 0 * 0.85 = 0, stays at 100
+    expect(employee.breakNeed).toBe(100);
+  });
+
+  // ── Test 7 ──────────────────────────────────────────────────────────────────
+  it('low morale increases drain rate when idle', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.morale = 20;
+
+    tickNeedGauges(employee, false); // idle
+
+    expect(employee.hunger).toBeCloseTo(100 - NEED_DRAIN_RATES.hunger.idle * NEED_MORALE_DRAIN_MULTIPLIERS.low, 5);
+    expect(employee.fatigue).toBeCloseTo(100 - NEED_DRAIN_RATES.fatigue.idle * NEED_MORALE_DRAIN_MULTIPLIERS.low, 5);
+    expect(employee.breakNeed).toBe(100); // idle rate 0 × 1.20 = 0
+  });
+
+  // ── Test 8 ──────────────────────────────────────────────────────────────────
+  it('gauges are clamped to 0 and never go negative', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.hunger = 0;
+    employee.fatigue = 0;
+    employee.breakNeed = 0;
+    employee.morale = 20; // low morale — would drain faster
+
+    tickNeedGauges(employee, true);
+
+    expect(employee.hunger).toBe(0);
+    expect(employee.fatigue).toBe(0);
+    expect(employee.breakNeed).toBe(0);
+  });
+
+  // ── Test 9 ──────────────────────────────────────────────────────────────────
+  it('breakNeed does not drain when idle regardless of morale', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.morale = 20; // low morale
+    employee.breakNeed = 100;
+
+    tickNeedGauges(employee, false); // idle
+
+    expect(employee.breakNeed).toBe(100); // idle rate = 0
+  });
+
+  // ── Test 10 ─────────────────────────────────────────────────────────────────
+  it('extreme morale values: 0 (low) and 100 (high) both apply correct multipliers', () => {
+    const state1 = createEmployeeState();
+    const rng1 = new Random(1);
+    const { employee: emp1 } = hireEmployee(state1, 'driller', rng1);
+    emp1.morale = 0;
+
+    const state2 = createEmployeeState();
+    const rng2 = new Random(1);
+    const { employee: emp2 } = hireEmployee(state2, 'driller', rng2);
+    emp2.morale = 100;
+
+    tickNeedGauges(emp1, true);
+    tickNeedGauges(emp2, true);
+
+    // morale=0: ×1.20
+    expect(emp1.hunger).toBeCloseTo(100 - NEED_DRAIN_RATES.hunger.working * NEED_MORALE_DRAIN_MULTIPLIERS.low, 5);
+    // morale=100: ×0.85
+    expect(emp2.hunger).toBeCloseTo(100 - NEED_DRAIN_RATES.hunger.working * NEED_MORALE_DRAIN_MULTIPLIERS.high, 5);
   });
 });
 


### PR DESCRIPTION
Closes #242

## Summary

Implements `tickNeedGauges()` — drains employee need gauges (hunger, fatigue, breakNeed) each tick, adjusted by a morale-based drain multiplier.

### Changes

**`src/core/config/balance.ts`**
- Added `MORALE_THRESHOLDS` (high: 70, low: 30)
- Added `NEED_MORALE_DRAIN_MULTIPLIERS` (high: 0.85, normal: 1.0, low: 1.20)

**`src/core/entities/EmployeeNeeds.ts`**
- Added private `getMoraleDrainMultiplier(morale)` — returns ×0.85 for morale > 70, ×1.20 for morale < 30, ×1.0 otherwise
- Added `tickNeedGauges(employee, isWorking)` — drains all three gauges using base rates × morale multiplier, clamped to ≥0
- Removed dead re-exports of `NEED_WARNING_THRESHOLDS`/`NEED_COLLAPSE_THRESHOLDS`
- Deprecated `tickNeeds()` in favor of `tickNeedGauges()`

**`src/core/entities/Employee.ts`**
- Re-exports `tickNeedGauges` from EmployeeNeeds

**`tests/unit/entities/Employee.test.ts`**
- 10 new tests covering: high morale (>70), low morale (<30), normal (30-70), boundary values (exactly 30 and 70), working/idle modes, gauge clamping at 0, extreme morale values (0 and 100)

### Validation
- ✅ TypeScript compiles cleanly
- ✅ All 2148 tests pass (71 Employee tests + 2077 others)
- ✅ Vite build succeeds
- ✅ 10 new tests — all passing

### Drain Rates
| Condition | Morale | Hunger/tick | Fatigue/tick | breakNeed/tick |
|-----------|--------|------------|-------------|----------------|
| Working, high morale | >70 | 1 × 0.85 = 0.85 | 2 × 0.85 = 1.70 | 0.8 × 0.85 = 0.68 |
| Working, normal | 30–70 | 1 × 1.0 = 1.0 | 2 × 1.0 = 2.0 | 0.8 × 1.0 = 0.8 |
| Working, low morale | <30 | 1 × 1.20 = 1.20 | 2 × 1.20 = 2.40 | 0.8 × 1.20 = 0.96 |
| Idle, high morale | >70 | 0.5 × 0.85 = 0.425 | 0.5 × 0.85 = 0.425 | 0 × 0.85 = 0 |
| Idle, low morale | <30 | 0.5 × 1.20 = 0.60 | 0.5 × 1.20 = 0.60 | 0 × 1.20 = 0 |

READY TO MERGE