### PR TITLE
[7.4] Implement needsMoraleEffect() — compute tick-level morale delta from all gauges

### DIFF
--- a/src/core/config/balance.ts
+++ b/src/core/config/balance.ts
@@ -347,6 +347,34 @@ export const NEED_MORALE_DRAIN_MULTIPLIERS = {
 } as const;
 
 /**
+ * Thresholds (gauge values) for the per-gauge morale effect in needsMoraleEffect().
+ */
+export const NEED_MORALE_EFFECT_THRESHOLDS = {
+  comfortable: 50,
+  uncomfortable: 30,
+  suffering: 15,
+} as const;
+
+/**
+ * Per-tick morale penalties applied per gauge in needsMoraleEffect().
+ */
+export const NEED_MORALE_EFFECT_PENALTIES = {
+  comfortable: 0,
+  uncomfortable: -0.5,
+  suffering: -1.5,
+  critical: -3.0,
+} as const;
+
+/**
+ * If ALL three gauges (hunger, fatigue, breakNeed) are simultaneously above this
+ * threshold, the employee receives a well-rested morale bonus per tick.
+ */
+export const NEED_WELL_RESTED_THRESHOLD = 80;
+
+/** The well-rested morale bonus applied per tick when all gauges are above the threshold. */
+export const NEED_WELL_RESTED_BONUS = 1;
+
+/**
  * Warning thresholds that trigger proactive rest routing.
  * @deprecated Use {@link NEED_WARNING_THRESHOLDS} instead — this constant has identical values
  *             and is kept only for backward compatibility.

--- a/src/core/entities/Employee.ts
+++ b/src/core/entities/Employee.ts
@@ -296,5 +296,5 @@ export function tickTraining(state: EmployeeState): void {
 export type { GainXpResult } from './EmployeeGainXp.js';
 export { gainXp } from './EmployeeGainXp.js';
 export type { NeedKey } from './EmployeeNeeds.js';
-export { tickNeeds, tickNeedGauges, getNeedMultiplier, tickNeedMorale, replenishNeed } from './EmployeeNeeds.js';
+export { tickNeeds, tickNeedGauges, getNeedMultiplier, tickNeedMorale, replenishNeed, needsMoraleEffect } from './EmployeeNeeds.js';
 export { computeTaskDuration } from './EmployeeTaskDuration.js';

--- a/src/core/entities/EmployeeNeeds.ts
+++ b/src/core/entities/EmployeeNeeds.ts
@@ -2,7 +2,7 @@
 // Tracks three need gauges: hunger, fatigue, and breakNeed (all 0–100).
 
 import { type Employee } from './Employee.js';
-import { NEED_DRAIN_RATES, NEED_THRESHOLDS, NEED_PRODUCTIVITY_MULTIPLIERS, NEED_MORALE_PENALTIES, MORALE_THRESHOLDS, NEED_MORALE_DRAIN_MULTIPLIERS } from '../config/balance.js';
+import { NEED_DRAIN_RATES, NEED_THRESHOLDS, NEED_PRODUCTIVITY_MULTIPLIERS, NEED_MORALE_PENALTIES, MORALE_THRESHOLDS, NEED_MORALE_DRAIN_MULTIPLIERS, NEED_MORALE_EFFECT_THRESHOLDS, NEED_MORALE_EFFECT_PENALTIES, NEED_WELL_RESTED_THRESHOLD, NEED_WELL_RESTED_BONUS } from '../config/balance.js';
 
 /** The three need gauges tracked on every Employee. */
 export type NeedKey = 'hunger' | 'fatigue' | 'breakNeed';
@@ -59,6 +59,23 @@ export function tickNeedMorale(employee: Employee): number {
   let delta = 0;
   if (employee.breakNeed < NEED_THRESHOLDS.breakNeed.low) delta += NEED_MORALE_PENALTIES.breakNeed;
   return delta;
+}
+
+/**
+ * Pure function. Computes the tick-level morale delta from ALL need gauges
+ * (hunger, fatigue, breakNeed).
+ *
+ * This function does NOT mutate employee.morale — it returns a delta that the
+ * caller must apply each tick.
+ */
+export function needsMoraleEffect(employee: Employee): number {
+  void employee;
+  void NEED_MORALE_EFFECT_THRESHOLDS;
+  void NEED_MORALE_EFFECT_PENALTIES;
+  void NEED_WELL_RESTED_THRESHOLD;
+  void NEED_WELL_RESTED_BONUS;
+  // TODO: implement per-gauge penalties + well-rested bonus
+  return 0;
 }
 
 /**

--- a/src/core/entities/EmployeeNeeds.ts
+++ b/src/core/entities/EmployeeNeeds.ts
@@ -69,13 +69,29 @@ export function tickNeedMorale(employee: Employee): number {
  * caller must apply each tick.
  */
 export function needsMoraleEffect(employee: Employee): number {
-  void employee;
-  void NEED_MORALE_EFFECT_THRESHOLDS;
-  void NEED_MORALE_EFFECT_PENALTIES;
-  void NEED_WELL_RESTED_THRESHOLD;
-  void NEED_WELL_RESTED_BONUS;
-  // TODO: implement per-gauge penalties + well-rested bonus
-  return 0;
+  let delta = 0;
+
+  for (const gauge of ['hunger', 'fatigue', 'breakNeed'] as const) {
+    const value = employee[gauge];
+    if (value >= NEED_MORALE_EFFECT_THRESHOLDS.comfortable) {
+      delta += NEED_MORALE_EFFECT_PENALTIES.comfortable;
+    } else if (value >= NEED_MORALE_EFFECT_THRESHOLDS.uncomfortable) {
+      delta += NEED_MORALE_EFFECT_PENALTIES.uncomfortable;
+    } else if (value >= NEED_MORALE_EFFECT_THRESHOLDS.suffering) {
+      delta += NEED_MORALE_EFFECT_PENALTIES.suffering;
+    } else {
+      delta += NEED_MORALE_EFFECT_PENALTIES.critical;
+    }
+  }
+
+  // Well-rested bonus: all three gauges strictly above threshold
+  if (employee.hunger > NEED_WELL_RESTED_THRESHOLD
+      && employee.fatigue > NEED_WELL_RESTED_THRESHOLD
+      && employee.breakNeed > NEED_WELL_RESTED_THRESHOLD) {
+    delta += NEED_WELL_RESTED_BONUS;
+  }
+
+  return delta;
 }
 
 /**

--- a/src/core/entities/EmployeeNeeds.ts
+++ b/src/core/entities/EmployeeNeeds.ts
@@ -54,6 +54,9 @@ export function getNeedMultiplier(employee: Employee): number {
  *
  * Example:
  *   employee.morale = Math.max(0, employee.morale + tickNeedMorale(employee));
+ *
+ * @deprecated Superseded by {@link needsMoraleEffect} which accounts for ALL
+ *             three need gauges (hunger, fatigue, breakNeed) instead of only breakNeed.
  */
 export function tickNeedMorale(employee: Employee): number {
   let delta = 0;
@@ -65,13 +68,23 @@ export function tickNeedMorale(employee: Employee): number {
  * Pure function. Computes the tick-level morale delta from ALL need gauges
  * (hunger, fatigue, breakNeed).
  *
+ * Each gauge contributes 0 (≥50), −0.5 (30–49), −1.5 (15–29), or −3.0 (<15),
+ * yielding a per-tick range of −9.0 to +0.0 from penalties alone.
+ *
+ * If ALL three gauges are simultaneously above {@link NEED_WELL_RESTED_THRESHOLD}
+ * (currently 80), a well-rested bonus of +1 (NEED_WELL_RESTED_BONUS) is applied,
+ * bringing the total return range to **−9.0 to +1.0**.
+ *
  * This function does NOT mutate employee.morale — it returns a delta that the
  * caller must apply each tick.
+ *
+ * @returns The morale delta for this tick, ranging from −9.0 to +1.0.
  */
 export function needsMoraleEffect(employee: Employee): number {
   let delta = 0;
 
-  for (const gauge of ['hunger', 'fatigue', 'breakNeed'] as const) {
+  const gauges: NeedKey[] = ['hunger', 'fatigue', 'breakNeed'];
+  for (const gauge of gauges) {
     const value = employee[gauge];
     if (value >= NEED_MORALE_EFFECT_THRESHOLDS.comfortable) {
       delta += NEED_MORALE_EFFECT_PENALTIES.comfortable;

--- a/tests/unit/entities/Employee.test.ts
+++ b/tests/unit/entities/Employee.test.ts
@@ -20,6 +20,7 @@ import {
   getNeedMultiplier,
   tickNeedMorale,
   replenishNeed,
+  needsMoraleEffect,
   // ── 3.13: task-duration function ──
   computeTaskDuration,
   type SkillQualification,
@@ -36,6 +37,11 @@ import {
   NEED_PRODUCTIVITY_MULTIPLIERS,
   NEED_MORALE_PENALTIES,
   NEED_MORALE_DRAIN_MULTIPLIERS,
+  // ── 7.4: needsMoraleEffect balance constants ──
+  NEED_MORALE_EFFECT_THRESHOLDS,
+  NEED_MORALE_EFFECT_PENALTIES,
+  NEED_WELL_RESTED_THRESHOLD,
+  NEED_WELL_RESTED_BONUS,
   // ── 3.13: proficiency multipliers ──
   PROFICIENCY_MULTIPLIERS,
 } from '../../../src/core/config/balance.js';
@@ -836,6 +842,277 @@ describe('Employee — tickNeedGauges (7.3)', () => {
     expect(emp1.hunger).toBeCloseTo(100 - NEED_DRAIN_RATES.hunger.working * NEED_MORALE_DRAIN_MULTIPLIERS.low, 5);
     // morale=100: ×0.85
     expect(emp2.hunger).toBeCloseTo(100 - NEED_DRAIN_RATES.hunger.working * NEED_MORALE_DRAIN_MULTIPLIERS.high, 5);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 7.4 — needsMoraleEffect: morale delta from all three need gauges
+//
+// Function under test:
+//   needsMoraleEffect(employee) → number
+// Pure function returning the tick-level morale delta from hunger, fatigue,
+// and breakNeed gauges. Each gauge applies a tiered penalty:
+//   gauge >= 50:  0        (comfortable)
+//   gauge >= 30: -0.5      (uncomfortable)
+//   gauge >= 15: -1.5      (suffering)
+//   gauge <  15: -3.0      (critical)
+//
+// If all three gauges are > NEED_WELL_RESTED_THRESHOLD (80), a +1 bonus is
+// applied (well-rested bonus).
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Employee — needsMoraleEffect (7.4)', () => {
+
+  // ── Test 1 ──────────────────────────────────────────────────────────────────
+  it('all gauges at 100 → returns +1 (well-rested bonus)', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    // All gauges default to 100
+    const result = needsMoraleEffect(employee);
+    // comfortable (0) + comfortable (0) + comfortable (0) + well-rested (+1) = +1
+    expect(result).toBe(1);
+  });
+
+  // ── Test 2 ──────────────────────────────────────────────────────────────────
+  it('all gauges at 100, well-rested bonus equals NEED_WELL_RESTED_BONUS', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    const result = needsMoraleEffect(employee);
+    expect(result).toBe(NEED_WELL_RESTED_BONUS);
+  });
+
+  // ── Test 3 ──────────────────────────────────────────────────────────────────
+  it('single gauge critical (hunger=10, others 100) → returns -3.0', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.hunger = 10;
+    // hunger: critical (-3.0), fatigue: comfortable (0), breakNeed: comfortable (0)
+    const result = needsMoraleEffect(employee);
+    expect(result).toBeCloseTo(-3.0, 5);
+  });
+
+  // ── Test 4 ──────────────────────────────────────────────────────────────────
+  it('two critical gauges (fatigue=5, breakNeed=10, hunger=100) → returns -6.0', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.fatigue = 5;
+    employee.breakNeed = 10;
+    // fatigue: critical (-3.0), breakNeed: critical (-3.0), hunger: comfortable (0)
+    const result = needsMoraleEffect(employee);
+    expect(result).toBeCloseTo(-6.0, 5);
+  });
+
+  // ── Test 5 ──────────────────────────────────────────────────────────────────
+  it('all three gauges critical (0, 0, 0) → returns -9.0', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.hunger = 0;
+    employee.fatigue = 0;
+    employee.breakNeed = 0;
+    // critical (-3.0) × 3 = -9.0
+    const result = needsMoraleEffect(employee);
+    expect(result).toBeCloseTo(-9.0, 5);
+  });
+
+  // ── Test 6 ──────────────────────────────────────────────────────────────────
+  it('mixed gauges (hunger=40, fatigue=100, breakNeed=20) → returns -2.0', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.hunger = 40;    // 40 >= 30 → uncomfortable (-0.5)
+    employee.fatigue = 100;  // 100 >= 50 → comfortable (0)
+    employee.breakNeed = 20; // 20 >= 15 → suffering (-1.5)
+    // -0.5 + 0 + -1.5 = -2.0
+    const result = needsMoraleEffect(employee);
+    expect(result).toBeCloseTo(-2.0, 5);
+  });
+
+  // ── Test 7 ──────────────────────────────────────────────────────────────────
+  it('borderline comfortable (50, 50, 50) → returns 0', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.hunger = 50;
+    employee.fatigue = 50;
+    employee.breakNeed = 50;
+    // All comfortable (0) — no well-rested bonus (50 is not > 80)
+    const result = needsMoraleEffect(employee);
+    expect(result).toBe(0);
+  });
+
+  // ── Test 8 ──────────────────────────────────────────────────────────────────
+  it('borderline well-rested threshold (80, 80, 80) → returns 0', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.hunger = 80;
+    employee.fatigue = 80;
+    employee.breakNeed = 80;
+    // All comfortable (0) — no well-rested bonus (80 is not > 80)
+    const result = needsMoraleEffect(employee);
+    expect(result).toBe(0);
+  });
+
+  // ── Test 9 ──────────────────────────────────────────────────────────────────
+  it('well-rested threshold crossed (81, 81, 81) → returns +1', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.hunger = 81;
+    employee.fatigue = 81;
+    employee.breakNeed = 81;
+    // All comfortable (0) + well-rested (+1) = +1
+    const result = needsMoraleEffect(employee);
+    expect(result).toBe(1);
+  });
+
+  // ── Test 10 ─────────────────────────────────────────────────────────────────
+  it('one gauge just below well-rested (79, 100, 100) → returns 0', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.hunger = 79;
+    employee.fatigue = 100;
+    employee.breakNeed = 100;
+    // All comfortable (0) — no bonus because 79 is not > 80
+    const result = needsMoraleEffect(employee);
+    expect(result).toBe(0);
+  });
+
+  // ── Test 11 ─────────────────────────────────────────────────────────────────
+  it('suffering threshold edge (15, 15, 15) → returns -4.5', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.hunger = 15;
+    employee.fatigue = 15;
+    employee.breakNeed = 15;
+    // All suffering (-1.5 × 3) = -4.5
+    const result = needsMoraleEffect(employee);
+    expect(result).toBeCloseTo(-4.5, 5);
+  });
+
+  // ── Test 12 ─────────────────────────────────────────────────────────────────
+  it('below suffering / critical (14, 14, 14) → returns -9.0', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.hunger = 14;
+    employee.fatigue = 14;
+    employee.breakNeed = 14;
+    // All critical (-3.0 × 3) = -9.0
+    const result = needsMoraleEffect(employee);
+    expect(result).toBeCloseTo(-9.0, 5);
+  });
+
+  // ── Test 13 ─────────────────────────────────────────────────────────────────
+  it('uncomfortable threshold edge (30, 30, 30) → returns -1.5', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.hunger = 30;
+    employee.fatigue = 30;
+    employee.breakNeed = 30;
+    // All uncomfortable (-0.5 × 3) = -1.5
+    const result = needsMoraleEffect(employee);
+    expect(result).toBeCloseTo(-1.5, 5);
+  });
+
+  // ── Test 14 ─────────────────────────────────────────────────────────────────
+  it('below uncomfortable (29, 29, 29) → returns -4.5', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.hunger = 29;
+    employee.fatigue = 29;
+    employee.breakNeed = 29;
+    // All suffering (-1.5 × 3) = -4.5
+    const result = needsMoraleEffect(employee);
+    expect(result).toBeCloseTo(-4.5, 5);
+  });
+
+  // ── Test 15 ─────────────────────────────────────────────────────────────────
+  it('pure function — does not mutate employee', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.hunger = 10;
+    employee.fatigue = 20;
+    employee.breakNeed = 30;
+    employee.morale = 60;
+
+    const oldMorale = employee.morale;
+    const oldHunger = employee.hunger;
+    const oldFatigue = employee.fatigue;
+    const oldBreakNeed = employee.breakNeed;
+
+    needsMoraleEffect(employee); // call the pure function
+
+    // Verify nothing was mutated
+    expect(employee.morale).toBe(oldMorale);
+    expect(employee.hunger).toBe(oldHunger);
+    expect(employee.fatigue).toBe(oldFatigue);
+    expect(employee.breakNeed).toBe(oldBreakNeed);
+  });
+
+  // ── Test 16 ─────────────────────────────────────────────────────────────────
+  it('well-rested bonus does not mask critical gauge', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.hunger = 85;    // comfortable (0)
+    employee.fatigue = 85;   // comfortable (0)
+    employee.breakNeed = 10; // critical (-3.0)
+    // Sum = -3.0, no bonus because breakNeed (10) is not > 80
+    const result = needsMoraleEffect(employee);
+    expect(result).toBeCloseTo(-3.0, 5);
+  });
+
+  // ── Test 17 ─────────────────────────────────────────────────────────────────
+  it('exactly at comfortable threshold (50, 50, 50) with no bonus → return exactly 0', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.hunger = NEED_MORALE_EFFECT_THRESHOLDS.comfortable;
+    employee.fatigue = NEED_MORALE_EFFECT_THRESHOLDS.comfortable;
+    employee.breakNeed = NEED_MORALE_EFFECT_THRESHOLDS.comfortable;
+    // gauge=50 is the comfortable threshold; 50 >= 50 → comfortable (0)
+    const result = needsMoraleEffect(employee);
+    expect(NEED_MORALE_EFFECT_THRESHOLDS.comfortable).toBe(50);
+    expect(result).toBe(0);
+  });
+
+  // ── Test 18 ─────────────────────────────────────────────────────────────────
+  it('all three above well-rested threshold (82, 82, 82) → bonus positive', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.hunger = 82;
+    employee.fatigue = 82;
+    employee.breakNeed = 82;
+    // All comfortable (0) + well-rested (+1) = +1
+    const result = needsMoraleEffect(employee);
+    expect(result).toBe(1);
+  });
+
+  // ── Test 19 ─────────────────────────────────────────────────────────────────
+  it('uses the correct constant values from balance.ts', () => {
+    // Verify penalty constants
+    expect(NEED_MORALE_EFFECT_PENALTIES.comfortable).toBe(0);
+    expect(NEED_MORALE_EFFECT_PENALTIES.uncomfortable).toBe(-0.5);
+    expect(NEED_MORALE_EFFECT_PENALTIES.suffering).toBe(-1.5);
+    expect(NEED_MORALE_EFFECT_PENALTIES.critical).toBe(-3.0);
+    // Verify well-rested bonus constant
+    expect(NEED_WELL_RESTED_BONUS).toBe(1);
+    // Verify threshold constants
+    expect(NEED_MORALE_EFFECT_THRESHOLDS.comfortable).toBe(50);
+    expect(NEED_MORALE_EFFECT_THRESHOLDS.uncomfortable).toBe(30);
+    expect(NEED_MORALE_EFFECT_THRESHOLDS.suffering).toBe(15);
+    expect(NEED_WELL_RESTED_THRESHOLD).toBe(80);
   });
 });
 


### PR DESCRIPTION
## Summary

Implements `needsMoraleEffect(employee)` — pure function that computes the tick-level morale delta from all three need gauges (hunger, fatigue, breakNeed).

### Specification
- Per-gauge penalty: gauge ≥ 50 → 0, ≥ 30 → -0.5, ≥ 15 → -1.5, < 15 → -3.0
- Summed across all three gauges
- Well-rested bonus: +1 when all three gauges > 80
- Returns number (-9.0 to +1.0)

### Files Changed
- `src/core/config/balance.ts` — Added `NEED_MORALE_EFFECT_THRESHOLDS`, `NEED_MORALE_EFFECT_PENALTIES`, `NEED_WELL_RESTED_THRESHOLD`, `NEED_WELL_RESTED_BONUS`
- `src/core/entities/EmployeeNeeds.ts` — Added `needsMoraleEffect()`, deprecated `tickNeedMorale()`
- `src/core/entities/Employee.ts` — Re-exported `needsMoraleEffect`
- `tests/unit/entities/Employee.test.ts` — 19 new tests covering all boundary conditions

### Validation
- TypeScript: ✅ 0 errors
- Tests: ✅ 2167 passed (115 files) — all 19 new tests pass
- Build: ✅ Success

Closes #243

READY TO MERGE