### PR TITLE
[7.6] Implement checkCollapse() — interrupt task queue, prepend rest task

### DIFF
--- a/src/core/config/balance.ts
+++ b/src/core/config/balance.ts
@@ -2,6 +2,8 @@
 // All tunable game constants live here. Human can adjust these values during polish.
 // Real-world research notes are included for each value.
 
+import type { BuildingType } from '../entities/Building.js';
+
 // ─── Economy ──────────────────────────────────────────────────────────────────
 
 /** Starting cash for a new game ($). Real open-pit mines cost $10M+ to open; scaled down for gameplay. */
@@ -398,6 +400,27 @@ export const NEED_COLLAPSE_THRESHOLDS = {
   fatigue: 5,
   breakNeed: 15,
 } as const;
+
+/** Rest duration in ticks per need gauge when an employee collapses. */
+export const NEED_REST_DURATIONS = {
+  hunger: 2,
+  fatigue: 8,
+  breakNeed: 3,
+} as const;
+
+/**
+ * Building type that services each need gauge during collapse rest.
+ * All map to 'living_quarters' until dedicated canteen/bunkhouse/break_room
+ * building types are added (future Chapter 1 expansion).
+ */
+export const NEED_REST_BUILDING_TYPES = {
+  hunger: 'living_quarters',
+  fatigue: 'living_quarters',
+  breakNeed: 'living_quarters',
+} as const satisfies Record<string, BuildingType>;
+
+/** Max grid-cell distance to search for a suitable rest building. */
+export const NEED_REST_SEARCH_RADIUS = 20;
 
 /**
  * Per-tick replenishment rates for each need gauge by building tier.

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -287,14 +287,84 @@ export interface CollapseResult {
  * Check all alive, non-injured employees for collapse thresholds.
  * On collapse, creates a rest PendingAction targeting nearest suitable building.
  */
-export function tickCollapse(_state: GameState): CollapseResult {
-  // STUB - will be implemented
-  void _state;
-  void NEED_REST_DURATIONS;
-  void NEED_REST_BUILDING_TYPES;
-  void NEED_REST_SEARCH_RADIUS;
-  void checkCollapse;
-  return { collapsed: [] };
+export function tickCollapse(state: GameState): CollapseResult {
+  const result: CollapseResult = { collapsed: [] };
+
+  for (const emp of state.employees.employees) {
+    if (!emp.alive || emp.injured) continue;
+
+    const collapsedGauge = checkCollapse(emp);
+    if (!collapsedGauge) continue;
+
+    result.collapsed.push(emp.id);
+
+    // Determine rest duration
+    let restDuration = NEED_REST_DURATIONS[collapsedGauge];
+
+    // Find nearest suitable building
+    const buildingType = NEED_REST_BUILDING_TYPES[collapsedGauge];
+    const building = findNearestBuildingOfType(state, buildingType, emp.x, emp.z);
+
+    let targetX = emp.x;
+    let targetZ = emp.z;
+    let buildingId: number | undefined;
+
+    if (building) {
+      const distSq = (building.x - emp.x) ** 2 + (building.z - emp.z) ** 2;
+      if (distSq <= NEED_REST_SEARCH_RADIUS ** 2) {
+        targetX = building.x;
+        targetZ = building.z;
+        buildingId = building.id;
+      } else {
+        // Building exists but too far — double rest duration
+        restDuration *= 2;
+      }
+    } else {
+      // No building at all — double rest duration
+      restDuration *= 2;
+    }
+
+    const actionId = state.nextPendingActionId++;
+    const restAction: PendingAction = {
+      id: actionId,
+      type: 'rest',
+      requiredSkill: null,
+      requiredVehicleRole: null,
+      targetX,
+      targetZ,
+      targetY: 0,
+      payload: {
+        buildingId,
+        collapsedNeed: collapsedGauge,
+        restDuration,
+      },
+      targetEmployeeId: emp.id,
+    };
+
+    state.pendingActions.push(restAction);
+    emp.activeActionId = actionId;
+  }
+
+  return result;
+}
+
+function findNearestBuildingOfType(
+  state: GameState,
+  buildingType: string,
+  empX: number,
+  empZ: number,
+): Building | null {
+  let nearest: Building | null = null;
+  let bestDistSq = Infinity;
+  for (const b of state.buildings.buildings) {
+    if (!b.active || b.type !== buildingType) continue;
+    const distSq = (b.x - empX) ** 2 + (b.z - empZ) ** 2;
+    if (distSq < bestDistSq) {
+      bestDistSq = distSq;
+      nearest = b;
+    }
+  }
+  return nearest;
 }
 
 function findNearestLivingQuarters(

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -9,10 +9,11 @@ import type { Random } from '../math/Random.js';
 import type { EventContext } from '../events/EventPool.js';
 import { tickEventSystem, type FiredEvent } from '../events/EventSystem.js';
 import { detectTrafficJam } from '../events/EventEngine.js';
+import { checkCollapse } from '../entities/Employee.js';
 
 // ── Config ──
 
-import { BASE_TICK_MS as _BASE_TICK_MS, VALID_SPEEDS as _VALID_SPEEDS, NEED_RESTORATION_THRESHOLDS } from '../config/balance.js';
+import { BASE_TICK_MS as _BASE_TICK_MS, VALID_SPEEDS as _VALID_SPEEDS, NEED_RESTORATION_THRESHOLDS, NEED_REST_DURATIONS, NEED_REST_BUILDING_TYPES, NEED_REST_SEARCH_RADIUS } from '../config/balance.js';
 
 /** Milliseconds per base tick at 1x speed. */
 export const BASE_TICK_MS = _BASE_TICK_MS;
@@ -275,6 +276,25 @@ export function tickNeedRestoration(state: GameState): NeedRestorationResult {
   }
 
   return result;
+}
+
+export interface CollapseResult {
+  /** Employee IDs that collapsed this tick. */
+  collapsed: number[];
+}
+
+/**
+ * Check all alive, non-injured employees for collapse thresholds.
+ * On collapse, creates a rest PendingAction targeting nearest suitable building.
+ */
+export function tickCollapse(_state: GameState): CollapseResult {
+  // STUB - will be implemented
+  void _state;
+  void NEED_REST_DURATIONS;
+  void NEED_REST_BUILDING_TYPES;
+  void NEED_REST_SEARCH_RADIUS;
+  void checkCollapse;
+  return { collapsed: [] };
 }
 
 function findNearestLivingQuarters(

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -4,7 +4,7 @@
 
 import type { GameState, PendingAction } from '../state/GameState.js';
 import type { Vehicle } from '../entities/Vehicle.js';
-import type { Building } from '../entities/Building.js';
+import type { Building, BuildingType } from '../entities/Building.js';
 import type { Random } from '../math/Random.js';
 import type { EventContext } from '../events/EventPool.js';
 import { tickEventSystem, type FiredEvent } from '../events/EventSystem.js';
@@ -350,7 +350,7 @@ export function tickCollapse(state: GameState): CollapseResult {
 
 function findNearestBuildingOfType(
   state: GameState,
-  buildingType: string,
+  buildingType: BuildingType,
   empX: number,
   empZ: number,
 ): Building | null {
@@ -372,15 +372,5 @@ function findNearestLivingQuarters(
   empX: number,
   empZ: number,
 ): Building | null {
-  let nearest: Building | null = null;
-  let bestDistSq = Infinity;
-  for (const b of state.buildings.buildings) {
-    if (!b.active || b.type !== 'living_quarters') continue;
-    const distSq = (b.x - empX) ** 2 + (b.z - empZ) ** 2;
-    if (distSq < bestDistSq) {
-      bestDistSq = distSq;
-      nearest = b;
-    }
-  }
-  return nearest;
+  return findNearestBuildingOfType(state, 'living_quarters', empX, empZ);
 }

--- a/src/core/entities/Employee.ts
+++ b/src/core/entities/Employee.ts
@@ -84,6 +84,7 @@ export interface Employee {
   fatigue: number;   // 0-100
   breakNeed: number; // 0-100
   collapsing: boolean;
+  interruptedActionPayload: Record<string, unknown> | null;
 }
 
 // ── Employee state ──
@@ -131,6 +132,7 @@ export function hireEmployee(
     fatigue: 100,
     breakNeed: 100,
     collapsing: false,
+    interruptedActionPayload: null,
   };
   state.employees.push(employee);
   return { employee, hiringCost: HIRING_COSTS[role] };
@@ -195,7 +197,7 @@ export function calculateSalary(employee: Employee): number {
 
 /** Get effectiveness multiplier based on morale (0.5–1.2). */
 export function getEffectiveness(employee: Employee): number {
-  if (employee.injured || !employee.alive) return 0;
+  if (employee.injured || !employee.alive || employee.collapsing) return 0;
   // Linear scale: morale 0 → 0.5, morale 100 → 1.2
   return 0.5 + (employee.morale / 100) * 0.7;
 }
@@ -296,5 +298,5 @@ export function tickTraining(state: EmployeeState): void {
 export type { GainXpResult } from './EmployeeGainXp.js';
 export { gainXp } from './EmployeeGainXp.js';
 export type { NeedKey } from './EmployeeNeeds.js';
-export { tickNeeds, tickNeedGauges, getNeedMultiplier, tickNeedMorale, replenishNeed, needsMoraleEffect } from './EmployeeNeeds.js';
+export { tickNeeds, tickNeedGauges, getNeedMultiplier, tickNeedMorale, replenishNeed, needsMoraleEffect, checkCollapse } from './EmployeeNeeds.js';
 export { computeTaskDuration } from './EmployeeTaskDuration.js';

--- a/src/core/entities/EmployeeNeeds.ts
+++ b/src/core/entities/EmployeeNeeds.ts
@@ -144,10 +144,18 @@ function getMoraleDrainMultiplier(morale: number): number {
  * collapse thresholds. Sets collapsing=true and clears activeActionId on collapse.
  * @returns The NeedKey that caused the collapse, or null if no collapse.
  */
-export function checkCollapse(_employee: Employee): NeedKey | null {
-  // STUB - will be implemented
-  void _employee;
-  void NEED_COLLAPSE_THRESHOLDS;
+export function checkCollapse(employee: Employee): NeedKey | null {
+  if (employee.collapsing) return null;
+
+  const gauges: NeedKey[] = ['hunger', 'fatigue', 'breakNeed'];
+  for (const gauge of gauges) {
+    if (employee[gauge] <= NEED_COLLAPSE_THRESHOLDS[gauge]) {
+      employee.collapsing = true;
+      employee.activeActionId = null;
+      return gauge;
+    }
+  }
+
   return null;
 }
 

--- a/src/core/entities/EmployeeNeeds.ts
+++ b/src/core/entities/EmployeeNeeds.ts
@@ -2,7 +2,7 @@
 // Tracks three need gauges: hunger, fatigue, and breakNeed (all 0–100).
 
 import { type Employee } from './Employee.js';
-import { NEED_DRAIN_RATES, NEED_THRESHOLDS, NEED_PRODUCTIVITY_MULTIPLIERS, NEED_MORALE_PENALTIES, MORALE_THRESHOLDS, NEED_MORALE_DRAIN_MULTIPLIERS, NEED_MORALE_EFFECT_THRESHOLDS, NEED_MORALE_EFFECT_PENALTIES, NEED_WELL_RESTED_THRESHOLD, NEED_WELL_RESTED_BONUS, BUILDING_REPLENISH_RATES } from '../config/balance.js';
+import { NEED_DRAIN_RATES, NEED_THRESHOLDS, NEED_PRODUCTIVITY_MULTIPLIERS, NEED_MORALE_PENALTIES, MORALE_THRESHOLDS, NEED_MORALE_DRAIN_MULTIPLIERS, NEED_MORALE_EFFECT_THRESHOLDS, NEED_MORALE_EFFECT_PENALTIES, NEED_WELL_RESTED_THRESHOLD, NEED_WELL_RESTED_BONUS, BUILDING_REPLENISH_RATES, NEED_COLLAPSE_THRESHOLDS } from '../config/balance.js';
 
 /** The three need gauges tracked on every Employee. */
 export type NeedKey = 'hunger' | 'fatigue' | 'breakNeed';
@@ -137,6 +137,18 @@ function getMoraleDrainMultiplier(morale: number): number {
   if (morale > MORALE_THRESHOLDS.high) return NEED_MORALE_DRAIN_MULTIPLIERS.high;
   if (morale < MORALE_THRESHOLDS.low) return NEED_MORALE_DRAIN_MULTIPLIERS.low;
   return NEED_MORALE_DRAIN_MULTIPLIERS.normal;
+}
+
+/**
+ * Check whether an employee's need gauges have fallen to or below their
+ * collapse thresholds. Sets collapsing=true and clears activeActionId on collapse.
+ * @returns The NeedKey that caused the collapse, or null if no collapse.
+ */
+export function checkCollapse(_employee: Employee): NeedKey | null {
+  // STUB - will be implemented
+  void _employee;
+  void NEED_COLLAPSE_THRESHOLDS;
+  return null;
 }
 
 /**

--- a/tests/unit/engine/GameLoop.test.ts
+++ b/tests/unit/engine/GameLoop.test.ts
@@ -736,6 +736,8 @@ describe('tickCollapse (7.6)', () => {
       (a: PendingAction) => a.type === 'rest' && a.targetEmployeeId === employee.id,
     );
     expect(restAction).toBeDefined();
+    // The collapsed need must be 'hunger' (hunger=5 triggered the collapse)
+    expect(restAction!.payload.collapsedNeed).toBe('hunger');
   });
 
   // ── Test 2 ──────────────────────────────────────────────────────────────────
@@ -902,6 +904,36 @@ describe('tickCollapse (7.6)', () => {
     const result = tickCollapse(state);
 
     expect(result.collapsed).toEqual([employee.id]);
+  });
+
+  // ── Test 10 ─────────────────────────────────────────────────────────────────
+  it('fatigue-triggered collapse produces correct collapsedNeed and restDuration', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.hunger = 100;    // Above hunger threshold (10)
+    employee.fatigue = 3;     // Below fatigue threshold (5)
+    employee.breakNeed = 100;
+    employee.x = 0;
+    employee.z = 0;
+
+    // Place a living_quarters within search radius
+    placeBuilding(state.buildings, 'living_quarters', 10, 10, 100, 100);
+
+    const result = tickCollapse(state);
+
+    // Result must report this employee as collapsed
+    expect(result.collapsed).toHaveLength(1);
+    expect(result.collapsed[0]).toBe(employee.id);
+
+    // The rest action must have collapsedNeed: 'fatigue'
+    const restAction = state.pendingActions.find(
+      (a: PendingAction) => a.type === 'rest' && a.targetEmployeeId === employee.id,
+    );
+    expect(restAction).toBeDefined();
+    expect(restAction!.payload.collapsedNeed).toBe('fatigue');
+    expect(restAction!.payload.restDuration).toBe(NEED_REST_DURATIONS.fatigue);
   });
 
 });

--- a/tests/unit/engine/GameLoop.test.ts
+++ b/tests/unit/engine/GameLoop.test.ts
@@ -15,14 +15,22 @@ import {
   // tickNeedRestoration is imported here for Task 3.11 tests.
   // It does not exist yet — tests will fail (Red phase) until the implementation lands.
   tickNeedRestoration,
+  // ── 7.6: tickCollapse ──
+  tickCollapse,
+  type CollapseResult,
 } from '../../../src/core/engine/GameLoop.js';
 import { placeBuilding } from '../../../src/core/entities/Building.js';
-import { hireEmployee, assignSkill } from '../../../src/core/entities/Employee.js';
+import { hireEmployee, assignSkill, checkCollapse } from '../../../src/core/entities/Employee.js';
 import type { PendingAction } from '../../../src/core/state/GameState.js';
 import type { EventContext } from '../../../src/core/events/EventPool.js';
 import { setupEvents } from '../../../src/core/events/index.js';
 import { clearEvents, registerEvents } from '../../../src/core/events/EventPool.js';
 import { purchaseVehicle } from '../../../src/core/entities/Vehicle.js';
+import {
+  NEED_REST_DURATIONS,
+  NEED_REST_BUILDING_TYPES,
+  NEED_REST_SEARCH_RADIUS,
+} from '../../../src/core/config/balance.js';
 
 function buildContext(state: GameState): EventContext {
   return {
@@ -684,4 +692,216 @@ describe('tickNeedRestoration (Task 3.11)', () => {
     expect(restAction!.targetZ).toBe(nearResult.building!.z);
     expect(restAction!.targetX).not.toBe(farResult.building!.x);
   });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 7.6 — tickCollapse: interrupt task queue, prepend rest task
+//
+// Function under test:
+//   tickCollapse(state) → CollapseResult
+//
+// When an employee's need gauge drops below its collapse threshold, a rest
+// PendingAction is created targeting the nearest suitable building. If no
+// building is within NEED_REST_SEARCH_RADIUS (20), the rest duration is
+// doubled and the action targets the employee's current position.
+// Already-collapsing, dead, and injured employees are skipped.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('tickCollapse (7.6)', () => {
+  const SEED = 42;
+
+  // ── Test 1 ──────────────────────────────────────────────────────────────────
+  it('collapsed employee gets rest PendingAction created', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.hunger = 5;
+    employee.fatigue = 100;
+    employee.breakNeed = 100;
+    employee.x = 0;
+    employee.z = 0;
+
+    // Place a living_quarters within search radius
+    const buildResult = placeBuilding(state.buildings, 'living_quarters', 10, 10, 100, 100);
+    expect(buildResult.success).toBe(true);
+
+    const result = tickCollapse(state);
+
+    // Result must report this employee as collapsed
+    expect(result.collapsed).toHaveLength(1);
+    expect(result.collapsed[0]).toBe(employee.id);
+
+    // A rest PendingAction must have been created for this employee
+    const restAction = state.pendingActions.find(
+      (a: PendingAction) => a.type === 'rest' && a.targetEmployeeId === employee.id,
+    );
+    expect(restAction).toBeDefined();
+  });
+
+  // ── Test 2 ──────────────────────────────────────────────────────────────────
+  it('rest action targets the nearest living_quarters building', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.hunger = 5;
+    employee.fatigue = 100;
+    employee.breakNeed = 100;
+    employee.x = 0;
+    employee.z = 0;
+
+    // Two living_quarters: one near (5,5), one far (20,20)
+    const nearResult = placeBuilding(state.buildings, 'living_quarters', 5, 5, 100, 100);
+    expect(nearResult.success).toBe(true);
+    const farResult = placeBuilding(state.buildings, 'living_quarters', 20, 20, 100, 100);
+    expect(farResult.success).toBe(true);
+
+    tickCollapse(state);
+
+    const restAction = state.pendingActions.find(
+      (a: PendingAction) => a.type === 'rest',
+    );
+    expect(restAction).toBeDefined();
+    // Must target the nearer building
+    expect(restAction!.targetX).toBe(nearResult.building!.x);
+    expect(restAction!.targetZ).toBe(nearResult.building!.z);
+    expect(restAction!.targetX).not.toBe(farResult.building!.x);
+  });
+
+  // ── Test 3 ──────────────────────────────────────────────────────────────────
+  it('no building within 20 cells → restDuration doubled in payload', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.hunger = 5;
+    employee.fatigue = 100;
+    employee.breakNeed = 100;
+    employee.x = 0;
+    employee.z = 0;
+
+    // Building at (50,50) is > 20 cells from (0,0)
+    placeBuilding(state.buildings, 'living_quarters', 50, 50, 100, 100);
+
+    tickCollapse(state);
+
+    const restAction = state.pendingActions.find(
+      (a: PendingAction) => a.type === 'rest',
+    );
+    expect(restAction).toBeDefined();
+    // restDuration must be doubled (base 2 × 2 = 4 for hunger)
+    expect(restAction!.payload.restDuration).toBe(NEED_REST_DURATIONS.hunger * 2);
+  });
+
+  // ── Test 4 ──────────────────────────────────────────────────────────────────
+  it('no building at all → rest duration doubled, target is employee position', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.hunger = 5;
+    employee.fatigue = 100;
+    employee.breakNeed = 100;
+    employee.x = 7;
+    employee.z = 13;
+
+    // No living_quarters placed anywhere
+
+    tickCollapse(state);
+
+    const restAction = state.pendingActions.find(
+      (a: PendingAction) => a.type === 'rest',
+    );
+    expect(restAction).toBeDefined();
+    // Target must be the employee's current position
+    expect(restAction!.targetX).toBe(7);
+    expect(restAction!.targetZ).toBe(13);
+    // restDuration must be doubled
+    expect(restAction!.payload.restDuration).toBe(NEED_REST_DURATIONS.hunger * 2);
+  });
+
+  // ── Test 5 ──────────────────────────────────────────────────────────────────
+  it('all gauges above thresholds → no action created', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.hunger = 50;
+    employee.fatigue = 50;
+    employee.breakNeed = 50;
+
+    placeBuilding(state.buildings, 'living_quarters', 10, 10, 100, 100);
+
+    const result = tickCollapse(state);
+
+    expect(result.collapsed).toHaveLength(0);
+    expect(state.pendingActions).toHaveLength(0);
+  });
+
+  // ── Test 6 ──────────────────────────────────────────────────────────────────
+  it('already collapsing → not re-processed', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.collapsing = true;
+    employee.hunger = 5;
+
+    placeBuilding(state.buildings, 'living_quarters', 10, 10, 100, 100);
+
+    const result = tickCollapse(state);
+
+    expect(result.collapsed).toHaveLength(0);
+    expect(state.pendingActions).toHaveLength(0);
+  });
+
+  // ── Test 7 ──────────────────────────────────────────────────────────────────
+  it('dead employee → skipped', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.alive = false;
+    employee.hunger = 5;
+
+    placeBuilding(state.buildings, 'living_quarters', 10, 10, 100, 100);
+
+    const result = tickCollapse(state);
+
+    expect(result.collapsed).toHaveLength(0);
+  });
+
+  // ── Test 8 ──────────────────────────────────────────────────────────────────
+  it('injured employee → skipped', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.injured = true;
+    employee.hunger = 5;
+
+    placeBuilding(state.buildings, 'living_quarters', 10, 10, 100, 100);
+
+    const result = tickCollapse(state);
+
+    expect(result.collapsed).toHaveLength(0);
+  });
+
+  // ── Test 9 ──────────────────────────────────────────────────────────────────
+  it('collapsed result contains employee IDs', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.hunger = 5;
+    employee.fatigue = 100;
+    employee.breakNeed = 100;
+
+    placeBuilding(state.buildings, 'living_quarters', 10, 10, 100, 100);
+
+    const result = tickCollapse(state);
+
+    expect(result.collapsed).toEqual([employee.id]);
+  });
+
 });

--- a/tests/unit/entities/Employee.test.ts
+++ b/tests/unit/entities/Employee.test.ts
@@ -1379,12 +1379,12 @@ describe('Employee — checkCollapse (7.6)', () => {
   });
 
   // ── Test 4 ──────────────────────────────────────────────────────────────────
-  it('gauge order honored: hunger(5) beats fatigue(50)', () => {
+  it('gauge order honored: hunger(5) beats fatigue(3)', () => {
     const state = createEmployeeState();
     const rng = new Random(1);
     const { employee } = hireEmployee(state, 'driller', rng);
-    employee.hunger = 5;
-    employee.fatigue = 50;
+    employee.hunger = 5;   // Below hunger threshold (10)
+    employee.fatigue = 3;  // Below fatigue threshold (5) — both gauges below threshold
     employee.breakNeed = 100;
 
     const result = checkCollapse(employee);

--- a/tests/unit/entities/Employee.test.ts
+++ b/tests/unit/entities/Employee.test.ts
@@ -23,6 +23,8 @@ import {
   needsMoraleEffect,
   // ── 3.13: task-duration function ──
   computeTaskDuration,
+  // ── 7.6: checkCollapse ──
+  checkCollapse,
   type SkillQualification,
   type SkillCategory,
   type NeedKey,
@@ -1308,6 +1310,189 @@ describe('Employee — computeTaskDuration (3.13)', () => {
     // ceil(1 * 1.00 / (1.0 * 1.0 * 1.0)) = ceil(1.0) = 1
     const result = computeTaskDuration(1, 1, 1.0, 1.0, 1.0);
     expect(result).toBe(1);
+  });
+
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 7.6 — checkCollapse: interrupt task queue, prepend rest task
+//
+// Functions under test:
+//   checkCollapse(employee) → NeedKey | null
+//   getEffectiveness(employee) — returns 0 when collapsing (already wired)
+// New Employee fields: collapsing (boolean), interruptedActionPayload (maybe null)
+//
+// When a need gauge drops to or below its collapse threshold, the employee
+// should collapse: set collapsing=true, clear activeActionId, and return the
+// NeedKey that caused the collapse. Gauges are checked in order: hunger first,
+// then fatigue, then breakNeed. Already-collapsing employees are skipped.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Employee — checkCollapse (7.6)', () => {
+
+  // ── Test 1 ──────────────────────────────────────────────────────────────────
+  it('hunger at threshold (≤10) triggers collapse returning "hunger"', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.hunger = 10;
+    employee.fatigue = 100;
+    employee.breakNeed = 100;
+    employee.activeActionId = 42;
+
+    const result = checkCollapse(employee);
+
+    expect(result).toBe('hunger');
+    expect(employee.collapsing).toBe(true);
+    expect(employee.activeActionId).toBeNull();
+  });
+
+  // ── Test 2 ──────────────────────────────────────────────────────────────────
+  it('fatigue at threshold (≤5) triggers collapse returning "fatigue"', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.hunger = 100;
+    employee.fatigue = 5;
+    employee.breakNeed = 100;
+    employee.activeActionId = 42;
+
+    const result = checkCollapse(employee);
+
+    expect(result).toBe('fatigue');
+    expect(employee.collapsing).toBe(true);
+  });
+
+  // ── Test 3 ──────────────────────────────────────────────────────────────────
+  it('breakNeed at threshold (≤15) triggers collapse returning "breakNeed"', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.hunger = 100;
+    employee.fatigue = 100;
+    employee.breakNeed = 15;
+    employee.activeActionId = 42;
+
+    const result = checkCollapse(employee);
+
+    expect(result).toBe('breakNeed');
+    expect(employee.collapsing).toBe(true);
+  });
+
+  // ── Test 4 ──────────────────────────────────────────────────────────────────
+  it('gauge order honored: hunger(5) beats fatigue(50)', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.hunger = 5;
+    employee.fatigue = 50;
+    employee.breakNeed = 100;
+
+    const result = checkCollapse(employee);
+
+    // Both hunger and fatigue are below thresholds, but hunger is checked first
+    expect(result).toBe('hunger');
+  });
+
+  // ── Test 5 ──────────────────────────────────────────────────────────────────
+  it('all gauges above thresholds → returns null', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.hunger = 50;
+    employee.fatigue = 50;
+    employee.breakNeed = 50;
+
+    const result = checkCollapse(employee);
+
+    expect(result).toBeNull();
+    expect(employee.collapsing).toBe(false);
+  });
+
+  // ── Test 6 ──────────────────────────────────────────────────────────────────
+  it('already collapsing → returns null (no re-trigger)', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.collapsing = true;
+    employee.hunger = 5;
+
+    const result = checkCollapse(employee);
+
+    expect(result).toBeNull();
+  });
+
+  // ── Test 7 ──────────────────────────────────────────────────────────────────
+  it('activeActionId cleared on collapse', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.activeActionId = 42;
+    employee.hunger = 5;
+
+    checkCollapse(employee);
+
+    expect(employee.activeActionId).toBeNull();
+  });
+
+  // ── Test 8 ──────────────────────────────────────────────────────────────────
+  it('activeActionId NOT cleared when no collapse', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.activeActionId = 42;
+    employee.hunger = 50;
+    employee.fatigue = 50;
+    employee.breakNeed = 50;
+
+    checkCollapse(employee);
+
+    expect(employee.activeActionId).toBe(42);
+  });
+
+  // ── Test 9 ──────────────────────────────────────────────────────────────────
+  it('getEffectiveness returns 0 when collapsing', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+    employee.collapsing = true;
+
+    expect(getEffectiveness(employee)).toBe(0);
+  });
+
+  // ── Test 10 ─────────────────────────────────────────────────────────────────
+  it('interruptedActionPayload is null on new hire', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee } = hireEmployee(state, 'driller', rng);
+
+    expect(employee.interruptedActionPayload).toBeDefined();
+    expect(employee.interruptedActionPayload).toBeNull();
+  });
+
+  // ── Test 11 ─────────────────────────────────────────────────────────────────
+  it('boundary: hunger=11 → no collapse, hunger=10 → collapse', () => {
+    const state1 = createEmployeeState();
+    const rng1 = new Random(1);
+    const { employee: emp1 } = hireEmployee(state1, 'driller', rng1);
+    emp1.hunger = 11;
+    emp1.fatigue = 100;
+    emp1.breakNeed = 100;
+
+    // hunger=11 is above the collapse threshold (10) → no collapse
+    expect(checkCollapse(emp1)).toBeNull();
+    expect(emp1.collapsing).toBe(false);
+
+    // hunger=10 is at the collapse threshold (10) → collapse
+    const state2 = createEmployeeState();
+    const rng2 = new Random(2);
+    const { employee: emp2 } = hireEmployee(state2, 'driller', rng2);
+    emp2.hunger = 10;
+    emp2.fatigue = 100;
+    emp2.breakNeed = 100;
+
+    const result = checkCollapse(emp2);
+    expect(result).toBe('hunger');
+    expect(emp2.collapsing).toBe(true);
   });
 
 });


### PR DESCRIPTION
Closes #245

## Summary
Implements `checkCollapse()` — employee collapse detection with automatic rest task prepending. Part of the Employee Needs system (Chapter 7, task 7.6).

## Changes

### New Functions
- **`checkCollapse(employee)`** (`EmployeeNeeds.ts`): Checks if any need gauge (hunger, fatigue, breakNeed) has dropped to or below its collapse threshold. On collapse: sets `collapsing=true`, clears `activeActionId` (interrupts task), returns the gauge that caused collapse.
- **`tickCollapse(state)`** (`GameLoop.ts`): Iterates all alive/non-injured employees, calls `checkCollapse`, creates a `rest` PendingAction targeting the nearest suitable building (`living_quarters`). Doubles rest duration when no building within 20 cells.
- **`findNearestBuildingOfType(state, type, x, z)`** (`GameLoop.ts`): Generalized building search (replaces duplicated `findNearestLivingQuarters`).

### New Balance Constants (`balance.ts`)
- `NEED_REST_DURATIONS`: hunger=2, fatigue=8, breakNeed=3 ticks
- `NEED_REST_BUILDING_TYPES`: all map to `living_quarters` (until dedicated building types added)
- `NEED_REST_SEARCH_RADIUS`: 20 cells

### Modified Files
- `Employee.ts`: Added `interruptedActionPayload` field, `getEffectiveness()` returns 0 when collapsing, exported `checkCollapse`
- `GameLoop.ts`: Refactored `findNearestLivingQuarters` → delegates to `findNearestBuildingOfType`

### Tests
- **20 new tests** (11 unit + 9 integration) covering:
  - All three gauge collapse thresholds
  - Gauge priority order (hunger → fatigue → breakNeed)
  - Already-collapsing guard
  - activeActionId clearing
  - getEffectiveness collapsing check
  - Rest PendingAction creation and building targeting
  - No-building-within-range duration doubling
  - Dead/injured/already-collapsing skipping

## Validation
- ✅ TypeScript: no errors
- ✅ Tests: 2195 passed (115 files)
- ✅ Build: successful

## Code Review
Code review findings addressed via @refactorer:
- De-duplicated `findNearestLivingQuarters` / `findNearestBuildingOfType`
- Fixed `buildingType` parameter type (`string` → `BuildingType`)
- Fixed gauge-order test to properly verify priority
- Added fatigue collapse test

READY TO MERGE