### PR TITLE
[7.9] Implement shift cycle for Bunkhouse Tier 2+

### DIFF
--- a/src/core/config/balance.ts
+++ b/src/core/config/balance.ts
@@ -456,6 +456,12 @@ export const SITE_POLICY_DEFAULT_THRESHOLDS = {
   socialBreak: 20,
 } as const;
 
+/** Number of ticks an employee works before shift cycle rest is forced. */
+export const WORK_DURATION_TICKS = 6;
+
+/** Number of ticks an employee rests during a shift-cycle sleep when bunkhouse tier >= 2. */
+export const SHIFT_SLEEP_DURATION_TICKS = 8;
+
 // ─── Survey System ────────────────────────────────────────────────────────────
 
 /** Baseline noise std-dev applied to ore density estimates before skill adjustment. */

--- a/src/core/config/balance.ts
+++ b/src/core/config/balance.ts
@@ -441,6 +441,11 @@ export const NEED_REST_COSTS = {
   breakNeed: 20,
 } as const;
 
+// ─── General ───────────────────────────────────────────────────────────────────
+
+/** Maximum value for all need gauges (0–100 range). */
+export const MAX_NEED_GAUGE = 100;
+
 // ─── Shift / Rest Scheduling ────────────────────────────────────────────────
 
 /** Shift duration in ticks for each policy mode. 1 tick = 1 game-hour. */

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -14,7 +14,7 @@ import { replenishNeed } from '../entities/EmployeeNeeds.js';
 
 // ── Config ──
 
-import { BASE_TICK_MS as _BASE_TICK_MS, VALID_SPEEDS as _VALID_SPEEDS, NEED_REST_DURATIONS, NEED_REST_BUILDING_TYPES, NEED_REST_SEARCH_RADIUS, NEED_WARNING_THRESHOLDS, NEED_REST_COSTS, WORK_DURATION_TICKS, SHIFT_SLEEP_DURATION_TICKS } from '../config/balance.js';
+import { BASE_TICK_MS as _BASE_TICK_MS, VALID_SPEEDS as _VALID_SPEEDS, MAX_NEED_GAUGE, NEED_REST_DURATIONS, NEED_REST_BUILDING_TYPES, NEED_REST_SEARCH_RADIUS, NEED_WARNING_THRESHOLDS, NEED_REST_COSTS, WORK_DURATION_TICKS, SHIFT_SLEEP_DURATION_TICKS } from '../config/balance.js';
 
 /** Milliseconds per base tick at 1x speed. */
 export const BASE_TICK_MS = _BASE_TICK_MS;
@@ -531,7 +531,7 @@ export function processShiftCycle(
         replenishNeed(emp, 'fatigue', building.tier, def.capacity);
       } else {
         // Fallback — no building found (shouldn't happen since we checked hasBunkhouse)
-        emp.fatigue = 100;
+        emp.fatigue = MAX_NEED_GAUGE;
       }
 
       deductRestCost(state, 'fatigue');
@@ -552,6 +552,12 @@ export function processShiftCycle(
     if (!emp.alive || emp.injured) continue;
     if (emp.activeActionId === null) continue;
     if (emp.restTicksRemaining !== null) continue;
+
+    // Skip if employee has a pending rest action (voluntary rest)
+    const hasRestAction = state.pendingActions.some(
+      a => a.type === 'rest' && a.targetEmployeeId === emp.id,
+    );
+    if (hasRestAction) continue;
 
     emp.ticksWorked += 1;
   }
@@ -586,6 +592,7 @@ export function processShiftCycle(
       payload: { needType: 'fatigue', triggeredBy: 'shift_cycle', buildingId },
     });
 
+    state.pendingActions.push(restAction);
     emp.activeActionId = restAction.id;
     shiftRested.push(emp.id);
     firedEvents.push({ eventId: 'employee_shift_change', firedAtTick: state.tickCount });

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -4,13 +4,13 @@
 
 import type { GameState, PendingAction } from '../state/GameState.js';
 import type { Vehicle } from '../entities/Vehicle.js';
-import type { Building, BuildingType } from '../entities/Building.js';
+import { getBuildingDef, getDefSize, type Building, type BuildingType } from '../entities/Building.js';
 import type { Random } from '../math/Random.js';
 import type { EventContext } from '../events/EventPool.js';
 import { tickEventSystem, type FiredEvent } from '../events/EventSystem.js';
 import { detectTrafficJam } from '../events/EventEngine.js';
 import { checkCollapse, type NeedKey } from '../entities/Employee.js';
-import { tickNeedGauges, needsMoraleEffect } from '../entities/EmployeeNeeds.js';
+import { replenishNeed } from '../entities/EmployeeNeeds.js';
 
 // ── Config ──
 
@@ -501,13 +501,95 @@ export interface ShiftCycleResult {
  * @returns Result summary of shift transitions
  */
 export function processShiftCycle(
-  _state: GameState,
-  _firedEvents: FiredEvent[],
+  state: GameState,
+  firedEvents: FiredEvent[],
 ): ShiftCycleResult {
-  void tickNeedGauges;
-  void needsMoraleEffect;
-  void WORK_DURATION_TICKS;
-  void SHIFT_SLEEP_DURATION_TICKS;
-  // TODO: implement shift cycle logic
-  return { restCompleted: [], shiftRested: [], active: false };
+  // Check for a bunkhouse (living_quarters tier >= 2)
+  const hasBunkhouse = state.buildings.buildings.some(
+    b => b.type === 'living_quarters' && b.tier >= 2 && b.active,
+  );
+
+  if (!hasBunkhouse) {
+    return { restCompleted: [], shiftRested: [], active: false };
+  }
+
+  const restCompleted: number[] = [];
+  const shiftRested: number[] = [];
+
+  // ── Phase 1: Complete rests ────────────────────────────────────────────
+  for (const emp of state.employees.employees) {
+    if (!emp.alive || emp.injured) continue;
+    if (emp.restTicksRemaining === null) continue;
+
+    emp.restTicksRemaining -= 1;
+
+    if (emp.restTicksRemaining <= 0) {
+      // Find nearest active living_quarters for replenishment
+      const building = findNearestLivingQuarters(state, emp.x, emp.z);
+      if (building) {
+        const def = getBuildingDef(building.type, building.tier);
+        replenishNeed(emp, 'fatigue', building.tier, def.capacity);
+      } else {
+        // Fallback — no building found (shouldn't happen since we checked hasBunkhouse)
+        emp.fatigue = 100;
+      }
+
+      deductRestCost(state, 'fatigue');
+
+      if (emp.collapsing) {
+        emp.collapsing = false;
+      }
+
+      emp.restTicksRemaining = null;
+      emp.activeActionId = null;
+      emp.ticksWorked = 0;
+      restCompleted.push(emp.id);
+    }
+  }
+
+  // ── Phase 2: Increment ticksWorked for active employees not resting ────
+  for (const emp of state.employees.employees) {
+    if (!emp.alive || emp.injured) continue;
+    if (emp.activeActionId === null) continue;
+    if (emp.restTicksRemaining !== null) continue;
+
+    emp.ticksWorked += 1;
+  }
+
+  // ── Phase 3: Force shift rest for employees who've worked enough ───────
+  for (const emp of state.employees.employees) {
+    if (!emp.alive || emp.injured) continue;
+    if (emp.restTicksRemaining !== null) continue;
+    if (emp.activeActionId === null) continue;
+    if (emp.ticksWorked < WORK_DURATION_TICKS) continue;
+
+    // Find nearest living_quarters for target coordinates
+    const building = findNearestLivingQuarters(state, emp.x, emp.z);
+    let targetX = emp.x;
+    let targetZ = emp.z;
+    let buildingId: number | undefined;
+
+    if (building) {
+      const def = getBuildingDef(building.type, building.tier);
+      const { sizeX, sizeZ } = getDefSize(def);
+      targetX = building.x + sizeX / 2;
+      targetZ = building.z + sizeZ / 2;
+      buildingId = building.id;
+    }
+
+    emp.restTicksRemaining = SHIFT_SLEEP_DURATION_TICKS;
+
+    const restAction = createRestPendingAction(state, {
+      targetX,
+      targetZ,
+      targetEmployeeId: emp.id,
+      payload: { needType: 'fatigue', triggeredBy: 'shift_cycle', buildingId },
+    });
+
+    emp.activeActionId = restAction.id;
+    shiftRested.push(emp.id);
+    firedEvents.push({ eventId: 'employee_shift_change', firedAtTick: state.tickCount });
+  }
+
+  return { restCompleted, shiftRested, active: true };
 }

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -10,10 +10,11 @@ import type { EventContext } from '../events/EventPool.js';
 import { tickEventSystem, type FiredEvent } from '../events/EventSystem.js';
 import { detectTrafficJam } from '../events/EventEngine.js';
 import { checkCollapse, type NeedKey } from '../entities/Employee.js';
+import { tickNeedGauges, needsMoraleEffect } from '../entities/EmployeeNeeds.js';
 
 // ── Config ──
 
-import { BASE_TICK_MS as _BASE_TICK_MS, VALID_SPEEDS as _VALID_SPEEDS, NEED_REST_DURATIONS, NEED_REST_BUILDING_TYPES, NEED_REST_SEARCH_RADIUS, NEED_WARNING_THRESHOLDS, NEED_REST_COSTS } from '../config/balance.js';
+import { BASE_TICK_MS as _BASE_TICK_MS, VALID_SPEEDS as _VALID_SPEEDS, NEED_REST_DURATIONS, NEED_REST_BUILDING_TYPES, NEED_REST_SEARCH_RADIUS, NEED_WARNING_THRESHOLDS, NEED_REST_COSTS, WORK_DURATION_TICKS, SHIFT_SLEEP_DURATION_TICKS } from '../config/balance.js';
 
 /** Milliseconds per base tick at 1x speed. */
 export const BASE_TICK_MS = _BASE_TICK_MS;
@@ -477,4 +478,36 @@ export function deductRestCost(state: GameState, needKey: NeedKey): number {
 
   state.cash = Math.max(0, state.cash - cost);
   return cost;
+}
+
+// ── Shift cycle (Bunkhouse Tier 2+) ──
+
+export interface ShiftCycleResult {
+  /** Employee IDs whose rest period completed this tick. */
+  restCompleted: number[];
+  /** Employee IDs that transitioned from shift-working to shift-resting this tick. */
+  shiftRested: number[];
+  /** Whether any employee shift logic was processed this tick. */
+  active: boolean;
+}
+
+/**
+ * Process the shift/rest cycle for employees with bunkhouse tier >= 2.
+ * Empties restTicksRemaining on completion and transitions employees
+ * between working and resting states.
+ *
+ * @param state - The game state (mutated in place)
+ * @param firedEvents - Accumulator for events fired this tick
+ * @returns Result summary of shift transitions
+ */
+export function processShiftCycle(
+  _state: GameState,
+  _firedEvents: FiredEvent[],
+): ShiftCycleResult {
+  void tickNeedGauges;
+  void needsMoraleEffect;
+  void WORK_DURATION_TICKS;
+  void SHIFT_SLEEP_DURATION_TICKS;
+  // TODO: implement shift cycle logic
+  return { restCompleted: [], shiftRested: [], active: false };
 }

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -9,7 +9,7 @@ import type { Random } from '../math/Random.js';
 import type { EventContext } from '../events/EventPool.js';
 import { tickEventSystem, type FiredEvent } from '../events/EventSystem.js';
 import { detectTrafficJam } from '../events/EventEngine.js';
-import { checkCollapse, type NeedKey } from '../entities/Employee.js';
+import { checkCollapse, type NeedKey, type Employee } from '../entities/Employee.js';
 import { replenishNeed } from '../entities/EmployeeNeeds.js';
 
 // ── Config ──
@@ -496,6 +496,11 @@ export interface ShiftCycleResult {
  * Empties restTicksRemaining on completion and transitions employees
  * between working and resting states.
  *
+ * Each employee is processed in a single pass through three sequential phases:
+ *   1. Complete rests — decrement restTicksRemaining, replenish fatigue on completion
+ *   2. Increment ticksWorked — for active employees not currently resting
+ *   3. Force shift rest — when ticksWorked reaches the work-duration threshold
+ *
  * @param state - The game state (mutated in place)
  * @param firedEvents - Accumulator for events fired this tick
  * @returns Result summary of shift transitions
@@ -516,87 +521,128 @@ export function processShiftCycle(
   const restCompleted: number[] = [];
   const shiftRested: number[] = [];
 
-  // ── Phase 1: Complete rests ────────────────────────────────────────────
+  // Single pass per employee — phases are independent per-employee so
+  // merging from three loops to one produces identical behaviour.
   for (const emp of state.employees.employees) {
     if (!emp.alive || emp.injured) continue;
-    if (emp.restTicksRemaining === null) continue;
 
-    emp.restTicksRemaining -= 1;
+    // Phase 1: Decrement rest, replenish fatigue on completion
+    completeRestTick(state, emp, restCompleted);
 
-    if (emp.restTicksRemaining <= 0) {
-      // Find nearest active living_quarters for replenishment
-      const building = findNearestLivingQuarters(state, emp.x, emp.z);
-      if (building) {
-        const def = getBuildingDef(building.type, building.tier);
-        replenishNeed(emp, 'fatigue', building.tier, def.capacity);
-      } else {
-        // Fallback — no building found (shouldn't happen since we checked hasBunkhouse)
-        emp.fatigue = MAX_NEED_GAUGE;
-      }
+    // Phase 2: Count work ticks for active employees not resting
+    incrementWorkTick(state, emp);
 
-      deductRestCost(state, 'fatigue');
-
-      if (emp.collapsing) {
-        emp.collapsing = false;
-      }
-
-      emp.restTicksRemaining = null;
-      emp.activeActionId = null;
-      emp.ticksWorked = 0;
-      restCompleted.push(emp.id);
-    }
-  }
-
-  // ── Phase 2: Increment ticksWorked for active employees not resting ────
-  for (const emp of state.employees.employees) {
-    if (!emp.alive || emp.injured) continue;
-    if (emp.activeActionId === null) continue;
-    if (emp.restTicksRemaining !== null) continue;
-
-    // Skip if employee has a pending rest action (voluntary rest)
-    const hasRestAction = state.pendingActions.some(
-      a => a.type === 'rest' && a.targetEmployeeId === emp.id,
-    );
-    if (hasRestAction) continue;
-
-    emp.ticksWorked += 1;
-  }
-
-  // ── Phase 3: Force shift rest for employees who've worked enough ───────
-  for (const emp of state.employees.employees) {
-    if (!emp.alive || emp.injured) continue;
-    if (emp.restTicksRemaining !== null) continue;
-    if (emp.activeActionId === null) continue;
-    if (emp.ticksWorked < WORK_DURATION_TICKS) continue;
-
-    // Find nearest living_quarters for target coordinates
-    const building = findNearestLivingQuarters(state, emp.x, emp.z);
-    let targetX = emp.x;
-    let targetZ = emp.z;
-    let buildingId: number | undefined;
-
-    if (building) {
-      const def = getBuildingDef(building.type, building.tier);
-      const { sizeX, sizeZ } = getDefSize(def);
-      targetX = building.x + sizeX / 2;
-      targetZ = building.z + sizeZ / 2;
-      buildingId = building.id;
-    }
-
-    emp.restTicksRemaining = SHIFT_SLEEP_DURATION_TICKS;
-
-    const restAction = createRestPendingAction(state, {
-      targetX,
-      targetZ,
-      targetEmployeeId: emp.id,
-      payload: { needType: 'fatigue', triggeredBy: 'shift_cycle', buildingId },
-    });
-
-    state.pendingActions.push(restAction);
-    emp.activeActionId = restAction.id;
-    shiftRested.push(emp.id);
-    firedEvents.push({ eventId: 'employee_shift_change', firedAtTick: state.tickCount });
+    // Phase 3: Force shift rest when work quota is met
+    forceShiftRestIfNeeded(state, emp, firedEvents, shiftRested);
   }
 
   return { restCompleted, shiftRested, active: true };
+}
+
+/**
+ * Decrement restTicksRemaining for an employee who is currently resting.
+ * If rest is complete (reaches ≤ 0), replenish fatigue, clear state, and record completion.
+ */
+function completeRestTick(
+  state: GameState,
+  emp: Employee,
+  restCompleted: number[],
+): void {
+  if (emp.restTicksRemaining === null) return;
+
+  emp.restTicksRemaining -= 1;
+
+  if (emp.restTicksRemaining <= 0) {
+    // Find nearest active living_quarters for replenishment
+    const building = findNearestLivingQuarters(state, emp.x, emp.z);
+    if (building) {
+      const def = getBuildingDef(building.type, building.tier);
+      replenishNeed(emp, 'fatigue', building.tier, def.capacity);
+    } else {
+      // Fallback — no building found (shouldn't happen since we checked hasBunkhouse)
+      emp.fatigue = MAX_NEED_GAUGE;
+    }
+
+    deductRestCost(state, 'fatigue');
+
+    if (emp.collapsing) {
+      emp.collapsing = false;
+    }
+
+    emp.restTicksRemaining = null;
+    emp.activeActionId = null;
+    emp.ticksWorked = 0;
+    restCompleted.push(emp.id);
+  }
+}
+
+/**
+ * Increment ticksWorked for an active (non-idle) employee who is not currently resting
+ * and does not already have a pending rest action queued.
+ */
+function incrementWorkTick(
+  state: GameState,
+  emp: Employee,
+): void {
+  if (emp.activeActionId === null) return;
+  if (emp.restTicksRemaining !== null) return;
+
+  // Skip if employee already has a pending rest action (voluntary rest)
+  const hasRestAction = state.pendingActions.some(
+    a => a.type === 'rest' && a.targetEmployeeId === emp.id,
+  );
+  if (hasRestAction) return;
+
+  emp.ticksWorked += 1;
+}
+
+/**
+ * If an active employee has worked enough ticks, force a shift rest:
+ * find the nearest living_quarters, create a rest PendingAction, and set restTicksRemaining.
+ */
+function forceShiftRestIfNeeded(
+  state: GameState,
+  emp: Employee,
+  firedEvents: FiredEvent[],
+  shiftRested: number[],
+): void {
+  if (emp.restTicksRemaining !== null) return;
+  if (emp.activeActionId === null) return;
+  if (emp.ticksWorked < WORK_DURATION_TICKS) return;
+
+  // Find nearest living_quarters for target coordinates
+  const building = findNearestLivingQuarters(state, emp.x, emp.z);
+  let targetX = emp.x;
+  let targetZ = emp.z;
+  let buildingId: number | undefined;
+
+  if (building) {
+    const center = getBuildingCenter(building);
+    targetX = center.x;
+    targetZ = center.z;
+    buildingId = building.id;
+  }
+
+  emp.restTicksRemaining = SHIFT_SLEEP_DURATION_TICKS;
+
+  const restAction = createRestPendingAction(state, {
+    targetX,
+    targetZ,
+    targetEmployeeId: emp.id,
+    payload: { needType: 'fatigue', triggeredBy: 'shift_cycle', buildingId },
+  });
+
+  state.pendingActions.push(restAction);
+  emp.activeActionId = restAction.id;
+  shiftRested.push(emp.id);
+  firedEvents.push({ eventId: 'employee_shift_change', firedAtTick: state.tickCount });
+}
+
+/**
+ * Compute the centre position of a building based on its definition size.
+ */
+function getBuildingCenter(building: Building): { x: number; z: number } {
+  const def = getBuildingDef(building.type, building.tier);
+  const { sizeX, sizeZ } = getDefSize(def);
+  return { x: building.x + sizeX / 2, z: building.z + sizeZ / 2 };
 }

--- a/src/core/entities/Employee.ts
+++ b/src/core/entities/Employee.ts
@@ -85,6 +85,10 @@ export interface Employee {
   breakNeed: number; // 0-100
   collapsing: boolean;
   interruptedActionPayload: Record<string, unknown> | null;
+  /** Number of ticks the employee has worked in the current shift. */
+  ticksWorked: number;
+  /** Ticks of rest remaining when employee is in bunkhouse rest mode, or null if not resting. */
+  restTicksRemaining: number | null;
 }
 
 // ── Employee state ──
@@ -133,6 +137,8 @@ export function hireEmployee(
     breakNeed: 100,
     collapsing: false,
     interruptedActionPayload: null,
+    ticksWorked: 0,
+    restTicksRemaining: null,
   };
   state.employees.push(employee);
   return { employee, hiringCost: HIRING_COSTS[role] };

--- a/tests/unit/engine/GameLoop.test.ts
+++ b/tests/unit/engine/GameLoop.test.ts
@@ -23,12 +23,16 @@ import {
   type NeedInsertionResult,
   // ── 7.8: deductRestCost ──
   deductRestCost,
+  // ── 7.9: shift cycle ──
+  processShiftCycle,
+  type ShiftCycleResult,
 } from '../../../src/core/engine/GameLoop.js';
 import { placeBuilding } from '../../../src/core/entities/Building.js';
 import { hireEmployee, assignSkill, checkCollapse } from '../../../src/core/entities/Employee.js';
 import type { NeedKey } from '../../../src/core/entities/Employee.js';
 import type { PendingAction } from '../../../src/core/state/GameState.js';
 import type { EventContext } from '../../../src/core/events/EventPool.js';
+import type { FiredEvent } from '../../../src/core/events/EventSystem.js';
 import { setupEvents } from '../../../src/core/events/index.js';
 import { clearEvents, registerEvents } from '../../../src/core/events/EventPool.js';
 import { purchaseVehicle } from '../../../src/core/entities/Vehicle.js';
@@ -38,6 +42,8 @@ import {
   NEED_REST_SEARCH_RADIUS,
   NEED_WARNING_THRESHOLDS,
   NEED_REST_COSTS,
+  WORK_DURATION_TICKS,
+  SHIFT_SLEEP_DURATION_TICKS,
 } from '../../../src/core/config/balance.js';
 
 function buildContext(state: GameState): EventContext {
@@ -1461,5 +1467,291 @@ describe('deductRestCost', () => {
 
     expect(state.cash).toBe(0);
     expect(deducted).toBe(NEED_REST_COSTS.hunger);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 7.9 — processShiftCycle: Bunkhouse Tier 2+ shift scheduling
+//
+// Function under test:
+//   processShiftCycle(state, firedEvents) → ShiftCycleResult
+//
+// When a Tier 2+ living_quarters building exists, an 8-tick shift cycle
+// activates: employees work WORK_DURATION_TICKS (6) ticks then enter
+// SHIFT_SLEEP_DURATION_TICKS (8) ticks of forced rest. The cycle resets
+// upon rest completion. Dead/injured employees are skipped.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('processShiftCycle (7.9)', () => {
+  const SEED = 42;
+
+  // ── Test 1 ──────────────────────────────────────────────────────────────────
+  it('inactive when no living_quarters buildings exist', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.activeActionId = 10; // working
+
+    const firedEvents: FiredEvent[] = [];
+    const result = processShiftCycle(state, firedEvents);
+
+    expect(result.active).toBe(false);
+    expect(result.restCompleted).toEqual([]);
+    expect(result.shiftRested).toEqual([]);
+  });
+
+  // ── Test 2 ──────────────────────────────────────────────────────────────────
+  it('inactive when only tier 1 living_quarters exists', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    hireEmployee(state.employees, 'driller', rng);
+    placeBuilding(state.buildings, 'living_quarters', 0, 0, 100, 100, 1);
+
+    const firedEvents: FiredEvent[] = [];
+    const result = processShiftCycle(state, firedEvents);
+
+    expect(result.active).toBe(false);
+  });
+
+  // ── Test 3 ──────────────────────────────────────────────────────────────────
+  it('active when tier 2 living_quarters exists', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    hireEmployee(state.employees, 'driller', rng);
+    placeBuilding(state.buildings, 'living_quarters', 0, 0, 100, 100, 2);
+
+    const firedEvents: FiredEvent[] = [];
+    const result = processShiftCycle(state, firedEvents);
+
+    expect(result.active).toBe(true);
+  });
+
+  // ── Test 4 ──────────────────────────────────────────────────────────────────
+  it('active when tier 3 living_quarters exists', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    hireEmployee(state.employees, 'driller', rng);
+    placeBuilding(state.buildings, 'living_quarters', 0, 0, 100, 100, 3);
+
+    const firedEvents: FiredEvent[] = [];
+    const result = processShiftCycle(state, firedEvents);
+
+    expect(result.active).toBe(true);
+  });
+
+  // ── Test 5 ──────────────────────────────────────────────────────────────────
+  it('ticksWorked increments for working employees', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.activeActionId = 10;
+    employee.ticksWorked = 0;
+
+    placeBuilding(state.buildings, 'living_quarters', 0, 0, 100, 100, 2);
+
+    const firedEvents: FiredEvent[] = [];
+    processShiftCycle(state, firedEvents);
+
+    expect(employee.ticksWorked).toBe(1);
+  });
+
+  // ── Test 6 ──────────────────────────────────────────────────────────────────
+  it('ticksWorked NOT incremented for idle employees', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.activeActionId = null; // idle
+    employee.ticksWorked = 0;
+
+    placeBuilding(state.buildings, 'living_quarters', 0, 0, 100, 100, 2);
+
+    const firedEvents: FiredEvent[] = [];
+    const result = processShiftCycle(state, firedEvents);
+
+    // Active = true because T2 exists; ticksWorked must remain 0 for idle
+    expect(result.active).toBe(true);
+    expect(employee.ticksWorked).toBe(0);
+  });
+
+  // ── Test 7 ──────────────────────────────────────────────────────────────────
+  it('forced rest when ticksWorked reaches WORK_DURATION_TICKS (6)', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const ORIGINAL_ACTION_ID = 100;
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.activeActionId = ORIGINAL_ACTION_ID;
+    employee.ticksWorked = WORK_DURATION_TICKS - 1; // 5 — next tick triggers shift rest
+
+    placeBuilding(state.buildings, 'living_quarters', 0, 0, 100, 100, 2);
+
+    const firedEvents: FiredEvent[] = [];
+    const result = processShiftCycle(state, firedEvents);
+
+    expect(result.shiftRested).toContain(employee.id);
+    expect(employee.restTicksRemaining).toBe(SHIFT_SLEEP_DURATION_TICKS);
+    // Employee should be claimed by a rest action (activeActionId changed)
+    expect(employee.activeActionId).not.toBe(ORIGINAL_ACTION_ID);
+    expect(employee.activeActionId).not.toBeNull();
+  });
+
+  // ── Test 8 ──────────────────────────────────────────────────────────────────
+  it('restTicksRemaining decrements each tick while resting', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.restTicksRemaining = 5;
+    employee.activeActionId = 200; // busy with rest
+
+    placeBuilding(state.buildings, 'living_quarters', 0, 0, 100, 100, 2);
+
+    const firedEvents: FiredEvent[] = [];
+    processShiftCycle(state, firedEvents);
+
+    expect(employee.restTicksRemaining).toBe(4);
+  });
+
+  // ── Test 9 ──────────────────────────────────────────────────────────────────
+  it('rest completes after SHIFT_SLEEP_DURATION_TICKS ticks', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.restTicksRemaining = 1; // one more tick → rest completes
+    employee.activeActionId = 300;  // in shift rest
+    employee.ticksWorked = 5;       // previous shift value
+    employee.fatigue = 20;          // fatigued before rest
+
+    placeBuilding(state.buildings, 'living_quarters', 0, 0, 100, 100, 2);
+
+    const firedEvents: FiredEvent[] = [];
+    const result = processShiftCycle(state, firedEvents);
+
+    expect(result.restCompleted).toContain(employee.id);
+    expect(employee.restTicksRemaining).toBeNull();
+    expect(employee.activeActionId).toBeNull(); // freed up after rest
+    expect(employee.ticksWorked).toBe(0);       // reset for next shift
+    // Fatigue should be restored (increased) upon rest completion
+    expect(employee.fatigue).toBeGreaterThan(20);
+  });
+
+  // ── Test 10 ─────────────────────────────────────────────────────────────────
+  it('employee_shift_change event fired when employee enters shift rest', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.activeActionId = 400;
+    employee.ticksWorked = WORK_DURATION_TICKS - 1; // 5 — triggers shift rest
+
+    placeBuilding(state.buildings, 'living_quarters', 0, 0, 100, 100, 2);
+
+    const firedEvents: FiredEvent[] = [];
+    processShiftCycle(state, firedEvents);
+
+    expect(firedEvents.length).toBeGreaterThanOrEqual(1);
+    expect(firedEvents[0]!.eventId).toBe('employee_shift_change');
+  });
+
+  // ── Test 11 ─────────────────────────────────────────────────────────────────
+  it('dead employees are skipped', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.alive = false;
+    employee.activeActionId = 500;
+    employee.ticksWorked = 3;
+
+    placeBuilding(state.buildings, 'living_quarters', 0, 0, 100, 100, 2);
+
+    const firedEvents: FiredEvent[] = [];
+    const result = processShiftCycle(state, firedEvents);
+
+    // Shift logic is active (T2 exists) but dead employee is skipped
+    expect(result.active).toBe(true);
+    expect(employee.ticksWorked).toBe(3); // unchanged
+    expect(employee.restTicksRemaining).toBeNull(); // not put to rest
+    expect(result.shiftRested).not.toContain(employee.id);
+  });
+
+  // ── Test 12 ─────────────────────────────────────────────────────────────────
+  it('injured employees are skipped', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.injured = true;
+    employee.activeActionId = 600;
+    employee.ticksWorked = 3;
+
+    placeBuilding(state.buildings, 'living_quarters', 0, 0, 100, 100, 2);
+
+    const firedEvents: FiredEvent[] = [];
+    const result = processShiftCycle(state, firedEvents);
+
+    expect(result.active).toBe(true);
+    expect(employee.ticksWorked).toBe(3); // unchanged
+    expect(employee.restTicksRemaining).toBeNull(); // not put to rest
+    expect(result.shiftRested).not.toContain(employee.id);
+  });
+
+  // ── Test 13 ─────────────────────────────────────────────────────────────────
+  it('employee with restTicksRemaining does NOT increment ticksWorked', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.restTicksRemaining = 4; // currently resting
+    employee.activeActionId = 700;
+    employee.ticksWorked = 3; // previous shift work count
+
+    placeBuilding(state.buildings, 'living_quarters', 0, 0, 100, 100, 2);
+
+    const firedEvents: FiredEvent[] = [];
+    const result = processShiftCycle(state, firedEvents);
+
+    // Active because T2 building exists
+    expect(result.active).toBe(true);
+    // ticksWorked must NOT be incremented for a resting employee
+    expect(employee.ticksWorked).toBe(3);
+    // restTicksRemaining should have decremented (not skipped entirely)
+    expect(employee.restTicksRemaining).toBe(3);
+  });
+
+  // ── Test 14 ─────────────────────────────────────────────────────────────────
+  it('multiple employees cycle independently', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee: emp1 } = hireEmployee(state.employees, 'driller', rng);
+    emp1.activeActionId = 800;
+    emp1.ticksWorked = WORK_DURATION_TICKS - 1; // 5 — will trigger shift rest
+
+    const { employee: emp2 } = hireEmployee(state.employees, 'blaster', rng);
+    emp2.activeActionId = 801;
+    emp2.ticksWorked = 2; // still working
+
+    placeBuilding(state.buildings, 'living_quarters', 0, 0, 100, 100, 2);
+
+    const firedEvents: FiredEvent[] = [];
+    const result = processShiftCycle(state, firedEvents);
+
+    // Only emp1 should transition to shift rest
+    expect(result.shiftRested).toContain(emp1.id);
+    expect(result.shiftRested).not.toContain(emp2.id);
+
+    // emp1's rest timer starts
+    expect(emp1.restTicksRemaining).toBe(SHIFT_SLEEP_DURATION_TICKS);
+
+    // emp2 continues working
+    expect(emp2.ticksWorked).toBe(3);
+    expect(emp2.restTicksRemaining).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #248

## Summary
Implements shift cycle for Bunkhouse Tier 2+ (Backlog task 7.9).

## Changes
- **Employee.ts**: Added `ticksWorked` and `restTicksRemaining` fields
- **balance.ts**: Added `WORK_DURATION_TICKS` (6), `SHIFT_SLEEP_DURATION_TICKS` (8), `MAX_NEED_GAUGE` (100) constants
- **GameLoop.ts**: Implemented `processShiftCycle()` with 3-phase logic:
  - Phase 1: Complete shift rests (decrement timer, replenish fatigue, reset state)
  - Phase 2: Increment ticksWorked for working employees
  - Phase 3: Force shift rest when ticksWorked ≥ 6
  - Extracted helpers: `completeRestTick()`, `incrementWorkTick()`, `forceShiftRestIfNeeded()`, `getBuildingCenter()`
- **14 new tests** covering activation, work tracking, forced rest, rest completion, events, edge cases

## Behavior
- Shift cycle activates only when `living_quarters` tier 2+ exists
- Employees work 6 ticks → forced 8-tick rest at bunkhouse
- `employee_shift_change` event fired at shift boundaries
- Without T2+ bunkhouse: employees remain awake (no shift cycle)
- Dead/injured employees skipped
- Voluntary rests don't increment shift timer

## Validation
- ✅ TypeScript: 0 errors
- ✅ All 2230 tests pass (115 files)
- ✅ Build: success

READY TO MERGE