### PR TITLE
feat: wire need events into event system (#249)

### DIFF
--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -300,6 +300,8 @@ export function tickCollapse(state: GameState, _firedEvents?: FiredEvent[], _emi
     if (!collapsedGauge) continue;
 
     result.collapsed.push(emp.id);
+    _firedEvents?.push({ eventId: 'employee_collapsed', firedAtTick: state.tickCount });
+    _emitter?.emit('employee:collapsed', { employeeId: emp.id, needKey: collapsedGauge });
 
     // Determine rest duration
     let restDuration = NEED_REST_DURATIONS[collapsedGauge];
@@ -385,6 +387,8 @@ export function autoInsertNeedTasks(state: GameState, _firedEvents?: FiredEvent[
       // Record all triggered gauges as skipped
       for (const gauge of triggeredGauges) {
         result.skipped.push({ employeeId: emp.id, needKey: gauge, reason: 'rest_action_already_queued' });
+        _firedEvents?.push({ eventId: 'need_warning', firedAtTick: state.tickCount });
+        _emitter?.emit('employee:need_warning', { employeeId: emp.id, needKey: gauge });
       }
       continue;
     }
@@ -535,7 +539,7 @@ export function processShiftCycle(
     incrementWorkTick(state, emp);
 
     // Phase 3: Force shift rest when work quota is met
-    forceShiftRestIfNeeded(state, emp, firedEvents, shiftRested);
+    forceShiftRestIfNeeded(state, emp, firedEvents, shiftRested, _emitter);
   }
 
   return { restCompleted, shiftRested, active: true };
@@ -607,6 +611,7 @@ function forceShiftRestIfNeeded(
   emp: Employee,
   firedEvents: FiredEvent[],
   shiftRested: number[],
+  emitter?: EventEmitter,
 ): void {
   if (emp.restTicksRemaining !== null) return;
   if (emp.activeActionId === null) return;
@@ -638,6 +643,7 @@ function forceShiftRestIfNeeded(
   emp.activeActionId = restAction.id;
   shiftRested.push(emp.id);
   firedEvents.push({ eventId: 'employee_shift_change', firedAtTick: state.tickCount });
+  emitter?.emit('employee:shift_change', { employeeId: emp.id });
 }
 
 /**

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -611,7 +611,7 @@ function forceShiftRestIfNeeded(
   emp: Employee,
   firedEvents: FiredEvent[],
   shiftRested: number[],
-  emitter?: EventEmitter,
+  _emitter?: EventEmitter,
 ): void {
   if (emp.restTicksRemaining !== null) return;
   if (emp.activeActionId === null) return;
@@ -643,7 +643,7 @@ function forceShiftRestIfNeeded(
   emp.activeActionId = restAction.id;
   shiftRested.push(emp.id);
   firedEvents.push({ eventId: 'employee_shift_change', firedAtTick: state.tickCount });
-  emitter?.emit('employee:shift_change', { employeeId: emp.id });
+  _emitter?.emit('employee:shift_change', { employeeId: emp.id });
 }
 
 /**

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -11,6 +11,7 @@ import { tickEventSystem, type FiredEvent } from '../events/EventSystem.js';
 import { detectTrafficJam } from '../events/EventEngine.js';
 import { checkCollapse, type NeedKey, type Employee } from '../entities/Employee.js';
 import { replenishNeed } from '../entities/EmployeeNeeds.js';
+import type { EventEmitter } from '../state/EventEmitter.js';
 
 // ── Config ──
 
@@ -289,7 +290,7 @@ export interface NeedInsertionResult {
  * Check all alive, non-injured employees for collapse thresholds.
  * On collapse, creates a rest PendingAction targeting nearest suitable building.
  */
-export function tickCollapse(state: GameState): CollapseResult {
+export function tickCollapse(state: GameState, _firedEvents?: FiredEvent[], _emitter?: EventEmitter): CollapseResult {
   const result: CollapseResult = { collapsed: [] };
 
   for (const emp of state.employees.employees) {
@@ -352,7 +353,7 @@ export function tickCollapse(state: GameState): CollapseResult {
  * Dead, injured, and collapsing employees are skipped.
  * Employees that already have a rest PendingAction in the queue are skipped.
  */
-export function autoInsertNeedTasks(state: GameState): NeedInsertionResult {
+export function autoInsertNeedTasks(state: GameState, _firedEvents?: FiredEvent[], _emitter?: EventEmitter): NeedInsertionResult {
   const result: NeedInsertionResult = { inserted: [], skipped: [] };
 
   for (const emp of state.employees.employees) {
@@ -508,6 +509,7 @@ export interface ShiftCycleResult {
 export function processShiftCycle(
   state: GameState,
   firedEvents: FiredEvent[],
+  _emitter?: EventEmitter,
 ): ShiftCycleResult {
   // Check for a bunkhouse (living_quarters tier >= 2)
   const hasBunkhouse = state.buildings.buildings.some(

--- a/src/core/state/EventEmitter.ts
+++ b/src/core/state/EventEmitter.ts
@@ -21,6 +21,11 @@ export interface GameEventMap {
   'revolt:warning': { ticksRemaining: number };
   'revolt:triggered': Record<string, never>;
   'employee:levelup': { employeeId: number; category: SkillCategory; oldLevel: number; newLevel: number };
+
+  // Phase 8 — Employee need events
+  'employee:need_warning': { employeeId: number; needKey: string };
+  'employee:collapsed': { employeeId: number; needKey: string };
+  'employee:shift_change': { employeeId: number };
 }
 
 type EventHandler<T> = (data: T) => void;

--- a/tests/unit/engine/GameLoop.test.ts
+++ b/tests/unit/engine/GameLoop.test.ts
@@ -33,6 +33,7 @@ import type { NeedKey } from '../../../src/core/entities/Employee.js';
 import type { PendingAction } from '../../../src/core/state/GameState.js';
 import type { EventContext } from '../../../src/core/events/EventPool.js';
 import type { FiredEvent } from '../../../src/core/events/EventSystem.js';
+import type { EventEmitter } from '../../../src/core/state/EventEmitter.js';
 import { setupEvents } from '../../../src/core/events/index.js';
 import { clearEvents, registerEvents } from '../../../src/core/events/EventPool.js';
 import { purchaseVehicle } from '../../../src/core/entities/Vehicle.js';
@@ -950,6 +951,98 @@ describe('tickCollapse (7.6)', () => {
     expect(restAction!.payload.restDuration).toBe(NEED_REST_DURATIONS.fatigue);
   });
 
+  // ── Test 11 ─────────────────────────────────────────────────────────────────
+  it('adds employee_collapsed to firedEvents when employee collapses', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.hunger = 5;
+    employee.fatigue = 100;
+    employee.breakNeed = 100;
+    employee.x = 0;
+    employee.z = 0;
+
+    placeBuilding(state.buildings, 'living_quarters', 10, 10, 100, 100);
+
+    const firedEvents: FiredEvent[] = [];
+    tickCollapse(state, firedEvents);
+
+    expect(firedEvents).toHaveLength(1);
+    expect(firedEvents[0]!.eventId).toBe('employee_collapsed');
+    expect(firedEvents[0]!.firedAtTick).toBe(state.tickCount);
+  });
+
+  // ── Test 12 ─────────────────────────────────────────────────────────────────
+  it('emits employee:collapsed via emitter when employee collapses', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.hunger = 5;
+    employee.fatigue = 100;
+    employee.breakNeed = 100;
+    employee.x = 0;
+    employee.z = 0;
+
+    placeBuilding(state.buildings, 'living_quarters', 10, 10, 100, 100);
+
+    const events: string[] = [];
+    const mockEmitter = { emit: (event: string) => { events.push(event); } } as unknown as EventEmitter;
+    const firedEvents: FiredEvent[] = [];
+
+    tickCollapse(state, firedEvents, mockEmitter);
+
+    expect(events).toContain('employee:collapsed');
+  });
+
+  // ── Test 13 ─────────────────────────────────────────────────────────────────
+  it('does not emit employee_collapsed when employee is not collapsing', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.hunger = 50;
+    employee.fatigue = 50;
+    employee.breakNeed = 50;
+
+    placeBuilding(state.buildings, 'living_quarters', 10, 10, 100, 100);
+
+    const firedEvents: FiredEvent[] = [];
+    tickCollapse(state, firedEvents);
+
+    expect(firedEvents).toHaveLength(0);
+  });
+
+  // ── Test 14 ─────────────────────────────────────────────────────────────────
+  it('emits one employee_collapsed per collapsed employee', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee: emp1 } = hireEmployee(state.employees, 'driller', rng);
+    emp1.hunger = 5;
+    emp1.fatigue = 100;
+    emp1.breakNeed = 100;
+    emp1.x = 0;
+    emp1.z = 0;
+
+    const { employee: emp2 } = hireEmployee(state.employees, 'blaster', rng);
+    emp2.hunger = 5;
+    emp2.fatigue = 100;
+    emp2.breakNeed = 100;
+    emp2.x = 0;
+    emp2.z = 0;
+
+    placeBuilding(state.buildings, 'living_quarters', 10, 10, 100, 100);
+
+    const firedEvents: FiredEvent[] = [];
+    tickCollapse(state, firedEvents);
+
+    expect(firedEvents).toHaveLength(2);
+    expect(firedEvents[0]!.eventId).toBe('employee_collapsed');
+    expect(firedEvents[1]!.eventId).toBe('employee_collapsed');
+  });
+
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1391,6 +1484,118 @@ describe('autoInsertNeedTasks (7.7)', () => {
     // nextPendingActionId must have been incremented (one rest action inserted)
     expect(state.nextPendingActionId).toBe(beforeId + 1);
   });
+
+  // ── Test 16 ─────────────────────────────────────────────────────────────────
+  it('adds need_warning to firedEvents when rest action already queued', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.x = 0;
+    employee.z = 0;
+    employee.hunger = 30; // below threshold
+    employee.fatigue = 80;
+    employee.breakNeed = 80;
+    employee.activeActionId = null;
+
+    // Pre-insert a rest action for this employee
+    state.pendingActions.push({
+      id: state.nextPendingActionId++,
+      type: 'rest',
+      requiredSkill: null,
+      requiredVehicleRole: null,
+      targetX: 0,
+      targetZ: 0,
+      targetY: 0,
+      payload: {},
+      targetEmployeeId: employee.id,
+    });
+
+    placeBuilding(state.buildings, 'living_quarters', 5, 5, 100, 100);
+
+    const firedEvents: FiredEvent[] = [];
+    autoInsertNeedTasks(state, firedEvents);
+
+    expect(firedEvents).toHaveLength(1);
+    expect(firedEvents[0]!.eventId).toBe('need_warning');
+    expect(firedEvents[0]!.firedAtTick).toBe(state.tickCount);
+  });
+
+  // ── Test 17 ─────────────────────────────────────────────────────────────────
+  it('emits employee:need_warning via emitter when insertion skipped', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.x = 0;
+    employee.z = 0;
+    employee.hunger = 30;
+    employee.fatigue = 80;
+    employee.breakNeed = 80;
+    employee.activeActionId = null;
+
+    // Pre-insert a rest action for this employee
+    state.pendingActions.push({
+      id: state.nextPendingActionId++,
+      type: 'rest',
+      requiredSkill: null,
+      requiredVehicleRole: null,
+      targetX: 0,
+      targetZ: 0,
+      targetY: 0,
+      payload: {},
+      targetEmployeeId: employee.id,
+    });
+
+    placeBuilding(state.buildings, 'living_quarters', 5, 5, 100, 100);
+
+    const events: string[] = [];
+    const mockEmitter = { emit: (event: string) => { events.push(event); } } as unknown as EventEmitter;
+    const firedEvents: FiredEvent[] = [];
+
+    autoInsertNeedTasks(state, firedEvents, mockEmitter);
+
+    expect(events).toContain('employee:need_warning');
+  });
+
+  // ── Test 18 ─────────────────────────────────────────────────────────────────
+  it('does not emit need_warning when rest action is inserted', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.x = 0;
+    employee.z = 0;
+    employee.hunger = 30;
+    employee.fatigue = 80;
+    employee.breakNeed = 80;
+    employee.activeActionId = null;
+
+    placeBuilding(state.buildings, 'living_quarters', 5, 5, 100, 100);
+
+    const firedEvents: FiredEvent[] = [];
+    autoInsertNeedTasks(state, firedEvents);
+
+    expect(firedEvents).toHaveLength(0);
+  });
+
+  // ── Test 19 ─────────────────────────────────────────────────────────────────
+  it('does not emit need_warning when gauges are above thresholds', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.hunger = 80;
+    employee.fatigue = 80;
+    employee.breakNeed = 80;
+
+    placeBuilding(state.buildings, 'living_quarters', 5, 5, 100, 100);
+
+    const firedEvents: FiredEvent[] = [];
+    autoInsertNeedTasks(state, firedEvents);
+
+    expect(firedEvents).toHaveLength(0);
+  });
 });
 
 // ─── 7.8: deductRestCost ──────────────────────────────────────────────────────
@@ -1753,5 +1958,25 @@ describe('processShiftCycle (7.9)', () => {
     // emp2 continues working
     expect(emp2.ticksWorked).toBe(3);
     expect(emp2.restTicksRemaining).toBeNull();
+  });
+
+  // ── Test 15 ─────────────────────────────────────────────────────────────────
+  it('emits employee:shift_change via emitter when shift rest starts', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.activeActionId = 900;
+    employee.ticksWorked = WORK_DURATION_TICKS - 1; // triggers shift rest
+
+    placeBuilding(state.buildings, 'living_quarters', 0, 0, 100, 100, 2);
+
+    const events: string[] = [];
+    const mockEmitter = { emit: (event: string) => { events.push(event); } } as unknown as EventEmitter;
+    const firedEvents: FiredEvent[] = [];
+
+    processShiftCycle(state, firedEvents, mockEmitter);
+
+    expect(events).toContain('employee:shift_change');
   });
 });


### PR DESCRIPTION
Closes #249

## Summary

Wires three need-related events into the game's event system, completing backlog task 7.10:
- **`need_warning`** — emitted when proactive need insertion is skipped (employee already has a rest action queued)
- **`employee_collapsed`** — emitted when an employee's need gauge drops below its collapse threshold
- **`employee_shift_change`** — emitted when an employee transitions to shift-mandated rest (was partially wired; now also emitted via EventEmitter)

## Changes

### `src/core/state/EventEmitter.ts`
- Added 3 new event types to `GameEventMap`:
  - `'employee:need_warning': { employeeId, needKey }`
  - `'employee:collapsed': { employeeId, needKey }`
  - `'employee:shift_change': { employeeId }`

### `src/core/engine/GameLoop.ts`
- **`tickCollapse`**: Added optional `firedEvents` and `emitter` parameters; pushes `'employee_collapsed'` and emits `'employee:collapsed'` on collapse
- **`autoInsertNeedTasks`**: Added optional `firedEvents` and `emitter` parameters; pushes `'need_warning'` and emits `'employee:need_warning'` when insertion is skipped
- **`processShiftCycle`**: Added optional `emitter` parameter; emits `'employee:shift_change'` via emitter (existing `firedEvents` push unchanged)
- `forceShiftRestIfNeeded`: Threaded `emitter` parameter through for EventEmitter emission

### `tests/unit/engine/GameLoop.test.ts`
- 9 new tests covering all event emission paths:
  - `tickCollapse`: `employee_collapsed` in firedEvents, via emitter, per-collapsed-employee, negative case
  - `autoInsertNeedTasks`: `need_warning` in firedEvents, via emitter, both positive and negative cases
  - `processShiftCycle`: `employee:shift_change` via emitter

## Validation
- ✅ TypeScript: 0 errors (`tsc --noEmit`)
- ✅ Tests: 2,239 passed (9 new, 0 regressions)
- ✅ Build: Vite production build succeeds
- ✅ Qualimetry: 1.52% duplication (under 5% threshold)
- ✅ Security review: No issues
- ✅ i18n review: No issues
- ✅ Duplication review: No issues
- ✅ Semantic review: All test names match logic

READY TO MERGE