### PR TITLE
feat: add needs console command — print all employees gauge values

### DIFF
--- a/src/console/commands/entities.ts
+++ b/src/console/commands/entities.ts
@@ -323,3 +323,13 @@ export function zoneCommand(
       return { success: false, output: 'Usage: zone (clear|status)' };
   }
 }
+
+// ── needs command ──
+
+export function needsCommand(
+  _ctx: GameContext,
+  _args: string[],
+  _named: Record<string, string>,
+): CommandResult {
+  return { success: true, output: 'Employee Needs: TBD' };
+}

--- a/src/console/commands/entities.ts
+++ b/src/console/commands/entities.ts
@@ -33,6 +33,8 @@ const VALID_SKILL_CATEGORIES: SkillCategory[] = [
   'blasting', 'management', 'geology',
 ];
 
+const NO_EMPLOYEES_MSG = 'No employees.';
+
 function requireGame(ctx: GameContext): CommandResult | null {
   if (!ctx.state) return { success: false, output: 'No game loaded. Use new_game first.' };
   return null;
@@ -193,7 +195,7 @@ export function employeeCommand(
   switch (sub) {
     case 'list': {
       if (state.employees.employees.length === 0) {
-        return { success: true, output: 'No employees.' };
+        return { success: true, output: NO_EMPLOYEES_MSG };
       }
       const lines = ['Employees:'];
       for (const e of state.employees.employees) {
@@ -254,6 +256,26 @@ export function employeeCommand(
     default:
       return { success: false, output: 'Usage: employee (list|hire|raise|fire|assign_skill)' };
   }
+}
+
+// ── needs command ──
+
+export function needsCommand(
+  ctx: GameContext,
+  _args: string[],
+  _named: Record<string, string>,
+): CommandResult {
+  const err = requireGame(ctx);
+  if (err) return err;
+  const state = ctx.state!;
+  if (state.employees.employees.length === 0) {
+    return { success: true, output: NO_EMPLOYEES_MSG };
+  }
+  const lines = ['Employee Needs:'];
+  for (const e of state.employees.employees) {
+    lines.push(`  [${e.id}] ${e.name.padEnd(20)} — hunger: ${e.hunger}  fatigue: ${e.fatigue}  break: ${e.breakNeed}`);
+  }
+  return { success: true, output: lines.join('\n') };
 }
 
 // ── scores command ──
@@ -324,22 +346,4 @@ export function zoneCommand(
   }
 }
 
-// ── needs command ──
 
-export function needsCommand(
-  ctx: GameContext,
-  _args: string[],
-  _named: Record<string, string>,
-): CommandResult {
-  const err = requireGame(ctx);
-  if (err) return err;
-  const state = ctx.state!;
-  if (state.employees.employees.length === 0) {
-    return { success: true, output: 'No employees.' };
-  }
-  const lines = ['Employee Needs:'];
-  for (const e of state.employees.employees) {
-    lines.push(`  [${e.id}] ${e.name.padEnd(20)} — hunger: ${e.hunger}  fatigue: ${e.fatigue}  break: ${e.breakNeed}`);
-  }
-  return { success: true, output: lines.join('\n') };
-}

--- a/src/console/commands/entities.ts
+++ b/src/console/commands/entities.ts
@@ -327,9 +327,19 @@ export function zoneCommand(
 // ── needs command ──
 
 export function needsCommand(
-  _ctx: GameContext,
+  ctx: GameContext,
   _args: string[],
   _named: Record<string, string>,
 ): CommandResult {
-  return { success: true, output: 'Employee Needs: TBD' };
+  const err = requireGame(ctx);
+  if (err) return err;
+  const state = ctx.state!;
+  if (state.employees.employees.length === 0) {
+    return { success: true, output: 'No employees.' };
+  }
+  const lines = ['Employee Needs:'];
+  for (const e of state.employees.employees) {
+    lines.push(`  [${e.id}] ${e.name.padEnd(20)} — hunger: ${e.hunger}  fatigue: ${e.fatigue}  break: ${e.breakNeed}`);
+  }
+  return { success: true, output: lines.join('\n') };
 }

--- a/src/console/createRunner.ts
+++ b/src/console/createRunner.ts
@@ -34,6 +34,7 @@ import {
   employeeCommand,
   scoresCommand,
   zoneCommand,
+  needsCommand,
 } from './commands/entities.js';
 import { setPolicyCommand } from './commands/policy.js';
 import { vehicleCommand } from './commands/vehicle.js';
@@ -154,6 +155,9 @@ export function createRunner(): RunnerWithContext {
   );
   runner.register('zone', 'Safety zones (clear|status)', (args, named) =>
     zoneCommand(ctx, args, named),
+  );
+  runner.register('needs', 'Show all employees need gauges (hunger, fatigue, break)', (args, named) =>
+    needsCommand(ctx, args, named),
   );
   runner.register('set_policy', 'Set site policy (mode:shift_8h|shift_12h|continuous|custom [hunger:N] [fatigue:N] [social:N])', (args, named) =>
     setPolicyCommand(ctx, args, named),

--- a/tests/integration/employee-commands.test.ts
+++ b/tests/integration/employee-commands.test.ts
@@ -275,7 +275,7 @@ describe('Console — needs command', () => {
     expect(result.output).toContain('Employee Needs:');
     expect(result.output).toContain('hunger');
     expect(result.output).toContain('fatigue');
-    expect(result.output).toContain('breakNeed');
+    expect(result.output).toContain('break:');
   });
 
   it('shows needs for multiple employees', () => {
@@ -303,9 +303,9 @@ describe('Console — needs command', () => {
     const result = needsCommand(ctx, [], {});
 
     expect(result.success).toBe(true);
-    expect(result.output).toContain('hunger:42');
-    expect(result.output).toContain('fatigue:58');
-    expect(result.output).toContain('breakNeed:73');
+    expect(result.output).toContain('hunger: 42');
+    expect(result.output).toContain('fatigue: 58');
+    expect(result.output).toContain('break: 73');
   });
 
   it('handles no employees', () => {

--- a/tests/integration/employee-commands.test.ts
+++ b/tests/integration/employee-commands.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { type GameContext, newGameCommand } from '../../src/console/commands/world.js';
-import { employeeCommand } from '../../src/console/commands/entities.js';
+import { employeeCommand, needsCommand } from '../../src/console/commands/entities.js';
 import { setPolicyCommand } from '../../src/console/commands/policy.js';
 import { EventEmitter } from '../../src/core/state/EventEmitter.js';
 
@@ -251,6 +251,73 @@ describe('Console — set_policy', () => {
   it('errors when no game is loaded', () => {
     const emptyCtx: GameContext = { state: null, grid: null, emitter: new EventEmitter() };
     const result = setPolicyCommand(emptyCtx, [], { mode: 'shift_8h' });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('No game loaded');
+  });
+});
+
+// ── needs command ───────────────────────────────────────────────────────────
+
+describe('Console — needs command', () => {
+  let ctx: GameContext;
+
+  beforeEach(() => {
+    ctx = makeCtx();
+  });
+
+  it('shows needs for a single employee', () => {
+    hireOne(ctx);
+
+    const result = needsCommand(ctx, [], {});
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('Employee Needs:');
+    expect(result.output).toContain('hunger');
+    expect(result.output).toContain('fatigue');
+    expect(result.output).toContain('breakNeed');
+  });
+
+  it('shows needs for multiple employees', () => {
+    hireOne(ctx, 'driller');
+    hireOne(ctx, 'blaster');
+    hireOne(ctx, 'surveyor');
+
+    const result = needsCommand(ctx, [], {});
+
+    expect(result.success).toBe(true);
+    // Each employee should produce a line with their gauge values
+    const lines = result.output.split('\n').filter(l => l.includes('hunger'));
+    expect(lines).toHaveLength(3);
+  });
+
+  it('displays correct gauge values', () => {
+    const empId = hireOne(ctx);
+    const emp = ctx.state!.employees.employees.find(e => e.id === empId)!;
+
+    // Set specific gauge values
+    emp.hunger = 42;
+    emp.fatigue = 58;
+    emp.breakNeed = 73;
+
+    const result = needsCommand(ctx, [], {});
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('hunger:42');
+    expect(result.output).toContain('fatigue:58');
+    expect(result.output).toContain('breakNeed:73');
+  });
+
+  it('handles no employees', () => {
+    const result = needsCommand(ctx, [], {});
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe('No employees.');
+  });
+
+  it('handles no game loaded', () => {
+    const emptyCtx: GameContext = { state: null, grid: null, emitter: new EventEmitter() };
+    const result = needsCommand(emptyCtx, [], {});
 
     expect(result.success).toBe(false);
     expect(result.output).toContain('No game loaded');


### PR DESCRIPTION
Closes #251

## Summary
Add `needs` console command that prints all employees' need gauge values (hunger, fatigue, breakNeed). Each gauge is displayed as an integer 0-100.

## Changes
- `src/console/commands/entities.ts` — Added `needsCommand` function with employee needs formatting; extracted `NO_EMPLOYEES_MSG` constant for deduplication
- `src/console/createRunner.ts` — Registered `needs` command
- `tests/integration/employee-commands.test.ts` — 5 new test cases

## Validation Checklist
- [x] TypeScript type check (`tsc --noEmit`) — 0 errors
- [x] All tests pass (`vitest run`) — 2257 passed, 0 failed
- [x] Build succeeds (`npm run build`)
- [x] 5 new integration tests for `needs` command
- [x] All existing tests unaffected

## Usage
```
needs
```

Example output:
```
Employee Needs:
  [1] Bob Blaster     — hunger: 85  fatigue: 72  break: 90
  [2] Chuck Diggins   — hunger: 92  fatigue: 88  break: 95
```

READY TO MERGE