### PR TITLE
[8.2] Create tests/integration/full-level/ directory and update test runner config

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:coverage": "vitest run --coverage",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:scenarios": "vitest run tests/unit/scenario-defs.test.ts"
+    "test:scenarios": "vitest run tests/unit/scenario-defs.test.ts",
+    "test:integration": "vitest run tests/integration"
   },
   "dependencies": {
     "cannon-es": "^0.20.0",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,11 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['tests/**/*.test.ts'],
+    include: [
+      'tests/unit/**/*.test.ts',
+      'tests/integration/**/*.test.ts',
+      'tests/integration/full-level/**/*.test.ts',
+    ],
     coverage: {
       provider: 'v8',
       reportsDirectory: 'coverage',


### PR DESCRIPTION
Closes #253

## Summary
Create tests/integration/full-level/ directory and add both tests/integration/ and tests/integration/full-level/ to the test runner config.

## Changes
- **tests/integration/full-level/.gitkeep**: New empty directory for full-level integration tests
- **vitest.config.ts**: Replaced single blanket glob with explicit include patterns for test directories
- **package.json**: Added `test:integration` npm script

## Validation Checklist
- [x] TypeScript: `npx tsc --noEmit` — 0 errors
- [x] All tests: `npx vitest run` — 118 test files, 2289 tests, all passed
- [x] Integration tests: `npm run test:integration` — 6 files, 105 tests, all passed
- [x] Build: `npx vite build` — success
- [x] jscpd: 3.75% duplication (pre-existing, no new duplication introduced)
- [x] Security review: PASS
- [x] Quality review: PASS
- [x] i18n review: PASS
- [x] Duplication review: PASS
- [x] Semantic review: PASS

## Notes
The explicit include patterns make the test runner configuration self-documenting. The `tests/integration/full-level/` pattern is intentionally included alongside `tests/integration/` per the issue requirement.

READY TO MERGE