### PR TITLE
[8.9] Update npm run validate to include integration tests and coverage gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "console": "tsx src/console.ts",
-    "validate": "tsc --noEmit && vitest run --reporter=verbose --coverage && vite build",
+    "validate": "tsc --noEmit && npm run test:coverage && npm run test:integration && npm run test:scenarios && vite build",
     "test:coverage": "vitest run --coverage",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/tests/unit/coverage/coverage-scripts.test.ts
+++ b/tests/unit/coverage/coverage-scripts.test.ts
@@ -30,9 +30,19 @@ describe('coverage npm scripts (8.1)', () => {
       expect(pkg.scripts).toHaveProperty('validate');
     });
 
-    it('contains the --coverage flag', () => {
+    it('includes npm run test:coverage (coverage gate)', () => {
       const script = pkg.scripts['validate'];
-      expect(script).toContain(COVERAGE_FLAG);
+      expect(script).toContain('npm run test:coverage');
+    });
+
+    it('includes npm run test:integration', () => {
+      const script = pkg.scripts['validate'];
+      expect(script).toContain('npm run test:integration');
+    });
+
+    it('includes npm run test:scenarios', () => {
+      const script = pkg.scripts['validate'];
+      expect(script).toContain('npm run test:scenarios');
     });
 
     it('includes tsc type-check', () => {


### PR DESCRIPTION
Closes #260

## Summary

Updated `npm run validate` to explicitly compose validation from sub-scripts, including the coverage gate and integration tests.

## Changes

### `package.json` (line 10)

**Before:**
```
"validate": "tsc --noEmit && vitest run --reporter=verbose --coverage && vite build"
```

**After:**
```
"validate": "tsc --noEmit && npm run test:coverage && npm run test:integration && npm run test:scenarios && vite build"
```

The validate pipeline now:
1. **`tsc --noEmit`** — TypeScript type-check (fastest failure)
2. **`npm run test:coverage`** — Runs all tests with coverage gate (enforces per-file thresholds from vitest.config.ts)
3. **`npm run test:integration`** — Explicitly runs integration test suite
4. **`npm run test:scenarios`** — Explicitly runs scenario definition tests
5. **`vite build`** — Production build as final validation

### `tests/unit/coverage/coverage-scripts.test.ts`

Added validation tests for the new script structure:
- `includes npm run test:coverage (coverage gate)`
- `includes npm run test:integration`
- `includes npm run test:scenarios`

## Test Results
- 2629/2629 tests passed (140 test files)
- TypeScript type-check: 0 errors
- Build: success

## Validation Checklist
- [x] tsc --noEmit passes
- [x] vitest run passes (all tests)
- [x] Coverage gate enforced via test:coverage sub-script
- [x] Integration tests run via test:integration sub-script
- [x] Scenario tests run via test:scenarios sub-script
- [x] vite build succeeds

READY TO MERGE