### PR TITLE
Hide tutorial_pit from world map (difficultyTier 0) (#304)

### DIFF
--- a/src/core/campaign/Campaign.ts
+++ b/src/core/campaign/Campaign.ts
@@ -39,7 +39,7 @@ export function createCampaignState(): CampaignState {
     const lvl = all[i]!;
     levels[lvl.id] = {
       levelId: lvl.id,
-      unlocked: i === 0, // Only first level starts unlocked
+      unlocked: i === 0 || lvl.difficultyTier === 1,
       completed: false,
       cumulativeProfit: 0,
       bestSessionProfit: 0,

--- a/src/ui/MainMenu.ts
+++ b/src/ui/MainMenu.ts
@@ -105,7 +105,7 @@ export class MainMenu {
 
     this.worldMapBox.appendChild(mapTitle);
 
-    const levels = getAllLevels();
+    const levels = getAllLevels().filter(l => l.difficultyTier > 0);
     for (const lvl of levels) {
       const prog = campaign?.levels[lvl.id];
       const unlocked = prog?.unlocked ?? (lvl.difficultyTier === 1);

--- a/tests/integration/campaign.integration.test.ts
+++ b/tests/integration/campaign.integration.test.ts
@@ -45,7 +45,7 @@ describe('Campaign', () => {
 
   // ── 1. Initial campaign state ─────────────────────────────────────────────
 
-  it('createCampaignState unlocks only tutorial_pit by default', () => {
+  it('createCampaignState unlocks tutorial_pit and first visible level by default', () => {
     const campaign = createCampaignState();
 
     // tutorial_pit (tier 0) should be unlocked
@@ -162,7 +162,7 @@ describe('Campaign', () => {
   it('recordProfit unlocks next level on completion', () => {
     const campaign = createCampaignState();
 
-    // Initially tutorial_pit + dusty_hollow unlocked, deeper levels locked
+    // Initially tutorial_pit and dusty_hollow unlocked, deeper levels locked
     expect(campaign.levels['dusty_hollow']!.unlocked).toBe(true);
     expect(campaign.levels['grumpstone_ridge']!.unlocked).toBe(false);
     expect(campaign.levels['treranium_depths']!.unlocked).toBe(false);
@@ -367,7 +367,7 @@ describe('Campaign', () => {
   // ── 11. Starting a locked level returns error ──────────────────────────────
 
   it('campaign start command rejects locked levels', () => {
-    // grumpstone_ridge is locked (tutorial_pit + dusty_hollow unlocked by default)
+    // grumpstone_ridge is locked (only tutorial_pit and dusty_hollow unlocked by default)
     const result = campaignStartCommand(ctx, [], { level: 'grumpstone_ridge' });
 
     expect(result.success).toBe(false);

--- a/tests/integration/campaign.integration.test.ts
+++ b/tests/integration/campaign.integration.test.ts
@@ -55,9 +55,9 @@ describe('Campaign', () => {
     expect(campaign.levels['tutorial_pit']!.cumulativeProfit).toBe(0);
     expect(campaign.levels['tutorial_pit']!.bestSessionProfit).toBe(0);
 
-    // dusty_hollow (tier 1) should be locked
+    // dusty_hollow (tier 1) should be unlocked (first tier>0 level)
     expect(campaign.levels['dusty_hollow']).toBeDefined();
-    expect(campaign.levels['dusty_hollow']!.unlocked).toBe(false);
+    expect(campaign.levels['dusty_hollow']!.unlocked).toBe(true);
 
     // grumpstone_ridge (tier 2) should be locked
     expect(campaign.levels['grumpstone_ridge']).toBeDefined();
@@ -162,36 +162,33 @@ describe('Campaign', () => {
   it('recordProfit unlocks next level on completion', () => {
     const campaign = createCampaignState();
 
-    // Initially only tutorial_pit unlocked
-    expect(campaign.levels['dusty_hollow']!.unlocked).toBe(false);
-    expect(campaign.levels['grumpstone_ridge']!.unlocked).toBe(false);
-    expect(campaign.levels['treranium_depths']!.unlocked).toBe(false);
-
-    // Complete tutorial_pit at threshold
-    recordProfit(campaign, 'tutorial_pit', 5000);
-
-    // dusty_hollow should now be unlocked, deeper levels stay locked
+    // Initially tutorial_pit + dusty_hollow unlocked, deeper levels locked
     expect(campaign.levels['dusty_hollow']!.unlocked).toBe(true);
     expect(campaign.levels['grumpstone_ridge']!.unlocked).toBe(false);
     expect(campaign.levels['treranium_depths']!.unlocked).toBe(false);
 
-    // Complete dusty_hollow
+    // Complete tutorial_pit at threshold — dusty_hollow was already unlocked
+    recordProfit(campaign, 'tutorial_pit', 5000);
+
+    // dusty_hollow stays unlocked, deeper levels stay locked
+    expect(campaign.levels['dusty_hollow']!.unlocked).toBe(true);
+    expect(campaign.levels['grumpstone_ridge']!.unlocked).toBe(false);
+    expect(campaign.levels['treranium_depths']!.unlocked).toBe(false);
+
+    // Complete dusty_hollow — grumpstone_ridge unlocks
     recordProfit(campaign, 'dusty_hollow', 80000);
 
-    // grumpstone_ridge should now be unlocked, treranium_depths stays locked
     expect(campaign.levels['grumpstone_ridge']!.unlocked).toBe(true);
     expect(campaign.levels['treranium_depths']!.unlocked).toBe(false);
 
-    // Complete grumpstone_ridge
+    // Complete grumpstone_ridge — treranium_depths unlocks
     recordProfit(campaign, 'grumpstone_ridge', 250000);
 
-    // treranium_depths should now be unlocked
     expect(campaign.levels['treranium_depths']!.unlocked).toBe(true);
 
-    // Complete treranium_depths
+    // Complete treranium_depths — campaign complete
     recordProfit(campaign, 'treranium_depths', 800000);
 
-    // Campaign should be complete
     expect(campaign.campaignComplete).toBe(true);
   });
 
@@ -236,8 +233,17 @@ describe('Campaign', () => {
     returnToWorldMap(campaign);
     expect(campaign.activeLevelId).toBeNull();
 
-    // Starting locked dusty_hollow fails
-    const lockedResult = startLevel(campaign, 'dusty_hollow');
+    // Starting unlocked dusty_hollow now succeeds (was locked before tier 0 hide)
+    const dustyResult = startLevel(campaign, 'dusty_hollow');
+    expect(dustyResult).toBe(true);
+    expect(campaign.activeLevelId).toBe('dusty_hollow');
+
+    // Return to map
+    returnToWorldMap(campaign);
+    expect(campaign.activeLevelId).toBeNull();
+
+    // Starting locked grumpstone_ridge fails
+    const lockedResult = startLevel(campaign, 'grumpstone_ridge');
     expect(lockedResult).toBe(false);
     expect(campaign.activeLevelId).toBeNull();
 
@@ -361,8 +367,8 @@ describe('Campaign', () => {
   // ── 11. Starting a locked level returns error ──────────────────────────────
 
   it('campaign start command rejects locked levels', () => {
-    // dusty_hollow is locked (only tutorial_pit unlocked by default)
-    const result = campaignStartCommand(ctx, [], { level: 'dusty_hollow' });
+    // grumpstone_ridge is locked (tutorial_pit + dusty_hollow unlocked by default)
+    const result = campaignStartCommand(ctx, [], { level: 'grumpstone_ridge' });
 
     expect(result.success).toBe(false);
     expect(result.output).toContain('locked');

--- a/tests/unit/campaign/Campaign.test.ts
+++ b/tests/unit/campaign/Campaign.test.ts
@@ -12,15 +12,18 @@ import { createGame } from '../../../src/core/state/GameState.js';
 // LevelProgress is part of campaign state — no extra imports needed
 
 describe('Campaign state and progression (7.2)', () => {
-  it('new campaign has only level 1 unlocked', () => {
+  it('new campaign unlocks tutorial and first campaign level', () => {
     const campaign = createCampaignState();
     const levels = getAllLevels();
+    // tutorial_pit (index 0) is unlocked as the tutorial level
     expect(getLevelProgress(campaign, levels[0]!.id)?.unlocked).toBe(true);
+    // dusty_hollow (index 1, difficultyTier 1) is unlocked as the first visible campaign level
     expect(getLevelProgress(campaign, levels[1]!.id)?.unlocked).toBe(true);
+    // grumpstone_ridge (index 2) stays locked
     expect(getLevelProgress(campaign, levels[2]!.id)?.unlocked).toBe(false);
   });
 
-  it('reaching profit threshold on level 1 unlocks level 2', () => {
+  it('completing dusty_hollow unlocks grumpstone_ridge', () => {
     const campaign = createCampaignState();
     const levels = getAllLevels();
     const lvl1 = levels[1]!; // dusty_hollow — starts unlocked
@@ -32,10 +35,10 @@ describe('Campaign state and progression (7.2)', () => {
     expect(getLevelProgress(campaign, lvl2.id)?.unlocked).toBe(true);
   });
 
-  it('reaching profit threshold on level 2 unlocks level 3', () => {
+  it('completing grumpstone_ridge unlocks treranium_depths', () => {
     const campaign = createCampaignState();
     const levels = getAllLevels();
-    // Manually unlock and complete level 1 first
+    // Complete tutorial_pit then dusty_hollow to unlock grumpstone_ridge
     const lvl1 = levels[0]!;
     const lvl2 = levels[1]!;
     const lvl3 = levels[2]!;
@@ -47,7 +50,7 @@ describe('Campaign state and progression (7.2)', () => {
     expect(getLevelProgress(campaign, lvl3.id)?.unlocked).toBe(true);
   });
 
-  it('completing all 3 levels is tracked as campaign complete', () => {
+  it('completing all campaign levels is tracked as campaign complete', () => {
     const campaign = createCampaignState();
     const levels = getAllLevels();
 
@@ -60,10 +63,10 @@ describe('Campaign state and progression (7.2)', () => {
     expect(campaign.campaignComplete).toBe(true);
   });
 
-  it('player can start a new game on any unlocked level', () => {
+  it('player can start a game on tutorial level', () => {
     const campaign = createCampaignState();
     const levels = getAllLevels();
-    // Level 1 is unlocked
+    // tutorial_pit (index 0) is unlocked as the tutorial level
     expect(startLevel(campaign, levels[0]!.id)).toBe(true);
     expect(campaign.activeLevelId).toBe(levels[0]!.id);
   });

--- a/tests/unit/campaign/Campaign.test.ts
+++ b/tests/unit/campaign/Campaign.test.ts
@@ -16,16 +16,17 @@ describe('Campaign state and progression (7.2)', () => {
     const campaign = createCampaignState();
     const levels = getAllLevels();
     expect(getLevelProgress(campaign, levels[0]!.id)?.unlocked).toBe(true);
-    expect(getLevelProgress(campaign, levels[1]!.id)?.unlocked).toBe(false);
+    expect(getLevelProgress(campaign, levels[1]!.id)?.unlocked).toBe(true);
     expect(getLevelProgress(campaign, levels[2]!.id)?.unlocked).toBe(false);
   });
 
   it('reaching profit threshold on level 1 unlocks level 2', () => {
     const campaign = createCampaignState();
     const levels = getAllLevels();
-    const lvl1 = levels[0]!;
-    const lvl2 = levels[1]!;
+    const lvl1 = levels[1]!; // dusty_hollow — starts unlocked
+    const lvl2 = levels[2]!; // grumpstone_ridge — starts locked
 
+    expect(getLevelProgress(campaign, lvl1.id)?.unlocked).toBe(true);
     expect(getLevelProgress(campaign, lvl2.id)?.unlocked).toBe(false);
     recordProfit(campaign, lvl1.id, lvl1.unlockThreshold);
     expect(getLevelProgress(campaign, lvl2.id)?.unlocked).toBe(true);
@@ -70,7 +71,7 @@ describe('Campaign state and progression (7.2)', () => {
   it('starting a locked level returns false', () => {
     const campaign = createCampaignState();
     const levels = getAllLevels();
-    expect(startLevel(campaign, levels[1]!.id)).toBe(false);
+    expect(startLevel(campaign, levels[2]!.id)).toBe(false);
     expect(campaign.activeLevelId).toBeNull();
   });
 

--- a/tests/unit/campaign/LevelTransition.test.ts
+++ b/tests/unit/campaign/LevelTransition.test.ts
@@ -91,9 +91,9 @@ describe('Level completion and transition (7.3)', () => {
 
   it('createGameForLevel returns null for a locked level', () => {
     const campaign = createCampaignState();
-    const level2 = getAllLevels()[1]!;
-    // Level 2 is locked at start
-    expect(createGameForLevel(campaign, level2.id)).toBeNull();
+    const level3 = getAllLevels()[2]!;
+    // Level 3 (grumpstone_ridge) is locked at start
+    expect(createGameForLevel(campaign, level3.id)).toBeNull();
   });
 
   it('continuing after completion allows further play (threshold check idempotent)', () => {

--- a/tests/unit/ui/MainMenu.test.ts
+++ b/tests/unit/ui/MainMenu.test.ts
@@ -84,6 +84,27 @@ describe('MainMenu (12.8)', () => {
     menu.dispose();
   });
 
+  it('showWorldMap excludes tutorial_pit (difficultyTier 0) when campaign state provided', () => {
+    const menu = new MainMenu(container);
+    menu.show();
+    menu.showWorldMap(makeCampaign());
+    const text = container.textContent ?? '';
+    expect(text).not.toContain('Tutorial Pit');
+    expect(text).toContain('Dusty Hollow');
+    expect(text).toContain('Grumpstone Ridge');
+    menu.dispose();
+  });
+
+  it('showWorldMap excludes tutorial_pit with null campaign', () => {
+    const menu = new MainMenu(container);
+    menu.show();
+    menu.showWorldMap(null);
+    const text = container.textContent ?? '';
+    expect(text).not.toContain('Tutorial Pit');
+    expect(text).toContain('Dusty Hollow');
+    menu.dispose();
+  });
+
   it('showWorldMap shows stars for completed level', () => {
     const menu = new MainMenu(container);
     menu.show();


### PR DESCRIPTION
Closes #304

## Summary
Hide the tutorial level (`tutorial_pit`, `difficultyTier: 0`) from the world map UI. The tutorial will be accessible from its own dedicated button (future work).

## Changes
### Source
- **src/core/campaign/Campaign.ts** — `createCampaignState()` now unlocks both `tutorial_pit` (index 0) and the first visible campaign level `dusty_hollow` (`difficultyTier === 1`) so the world map shows at least one unlocked level
- **src/ui/MainMenu.ts** — `showWorldMap()` filters `getAllLevels()` to exclude `difficultyTier === 0` levels

### Tests
- **tests/unit/campaign/Campaign.test.ts** — Updated assertions for new unlock behavior (dusty_hollow now unlocked by default)
- **tests/unit/ui/MainMenu.test.ts** — Added 2 tests verifying tutorial_pit is excluded from world map rendering
- **tests/unit/campaign/LevelTransition.test.ts** — Fixed locked-level test to use grumpstone_ridge
- **tests/integration/campaign.integration.test.ts** — Updated 4 tests for new unlock behavior

## Verification
- ✅ TypeScript type-check: 0 errors
- ✅ All 2,638 tests pass (140 files)
- ✅ Build: success (dist/)
- ✅ No new duplication (jscpd: 4.31% pre-existing)
- ✅ Security review: clean
- ✅ Quality review: clean
- ✅ i18n review: clean

READY TO MERGE