### PR TITLE
feat: add event cooldown constants to balance.ts

### DIFF
--- a/src/core/config/balance.ts
+++ b/src/core/config/balance.ts
@@ -107,6 +107,15 @@ export const EVENT_BASE_TIMERS = {
   lawsuit: 35,
 } as const;
 
+/** Minimum ticks that must elapse between consecutive events. */
+export const MIN_EVENT_INTERVAL_TICKS = 0;
+
+/** Random additional ticks added to the per-event cooldown. */
+export const MIN_EVENT_INTERVAL_RANDOM_RANGE = 0;
+
+/** Minimum number of user-initiated actions required between events. */
+export const MIN_EVENT_INTERVAL_ACTIONS = 0;
+
 // ─── Traffic ───────────────────────────────────────────────────────────────────
 
 /** Minimum number of vehicles waiting on the same target cell to trigger a traffic jam. */

--- a/src/core/config/balance.ts
+++ b/src/core/config/balance.ts
@@ -107,14 +107,14 @@ export const EVENT_BASE_TIMERS = {
   lawsuit: 35,
 } as const;
 
-/** Minimum ticks that must elapse between consecutive events. */
-export const MIN_EVENT_INTERVAL_TICKS = 0;
+/** Minimum ticks that must elapse between consecutive events (2 min at 1× speed). */
+export const MIN_EVENT_INTERVAL_TICKS = 120;
 
-/** Random additional ticks added to the per-event cooldown. */
-export const MIN_EVENT_INTERVAL_RANDOM_RANGE = 0;
+/** Random additional ticks added to the per-event cooldown (0–60). */
+export const MIN_EVENT_INTERVAL_RANDOM_RANGE = 60;
 
 /** Minimum number of user-initiated actions required between events. */
-export const MIN_EVENT_INTERVAL_ACTIONS = 0;
+export const MIN_EVENT_INTERVAL_ACTIONS = 10;
 
 // ─── Traffic ───────────────────────────────────────────────────────────────────
 

--- a/src/core/config/balance.ts
+++ b/src/core/config/balance.ts
@@ -110,7 +110,7 @@ export const EVENT_BASE_TIMERS = {
 /** Minimum ticks that must elapse between consecutive events (2 min at 1× speed). */
 export const MIN_EVENT_INTERVAL_TICKS = 120;
 
-/** Random additional ticks added to the per-event cooldown (0–60). */
+/** Random additional ticks (0 to value-1, i.e. 0–59 for value=60) added to the per-event cooldown. */
 export const MIN_EVENT_INTERVAL_RANDOM_RANGE = 60;
 
 /** Minimum number of user-initiated actions required between events. */

--- a/tests/unit/config/balance.test.ts
+++ b/tests/unit/config/balance.test.ts
@@ -8,7 +8,9 @@ import { processFrame } from '../../../src/core/engine/GameLoop.js';
 import { Random } from '../../../src/core/math/Random.js';
 import {
   STARTING_CASH, PAY_CYCLE_TICKS, BASE_TICK_MS,
-  EVENT_BASE_TIMERS, BANKRUPTCY_THRESHOLD, SCORE_DECAY_RATE, MAX_FRAGMENTS_PER_VOXEL,
+  EVENT_BASE_TIMERS, MIN_EVENT_INTERVAL_TICKS, MIN_EVENT_INTERVAL_RANDOM_RANGE,
+  MIN_EVENT_INTERVAL_ACTIONS,
+  BANKRUPTCY_THRESHOLD, SCORE_DECAY_RATE, MAX_FRAGMENTS_PER_VOXEL,
   PROFICIENCY_MULTIPLIERS,
   XP_THRESHOLDS,
   NEED_WARNING_THRESHOLDS,
@@ -84,6 +86,58 @@ describe('Balance config (12.1)', () => {
   it('fragment count per voxel is reasonable', () => {
     expect(MAX_FRAGMENTS_PER_VOXEL).toBeGreaterThan(0);
     expect(MAX_FRAGMENTS_PER_VOXEL).toBeLessThanOrEqual(50);
+  });
+});
+
+// ─── Task 3.3: Event cooldown constants ───────────────────────────────────────
+
+describe('Event cooldown (3.3)', () => {
+  // ── MIN_EVENT_INTERVAL_TICKS ─────────────────────────────────────────────
+
+  it('MIN_EVENT_INTERVAL_TICKS is exported from balance.ts', () => {
+    expect(MIN_EVENT_INTERVAL_TICKS).toBeDefined();
+  });
+
+  it('MIN_EVENT_INTERVAL_RANDOM_RANGE is exported from balance.ts', () => {
+    expect(MIN_EVENT_INTERVAL_RANDOM_RANGE).toBeDefined();
+  });
+
+  it('MIN_EVENT_INTERVAL_ACTIONS is exported from balance.ts', () => {
+    expect(MIN_EVENT_INTERVAL_ACTIONS).toBeDefined();
+  });
+
+  // ── Exact values ───────────────────────────────────────────────────────────
+
+  it('MIN_EVENT_INTERVAL_TICKS is 120 — at least 120 ticks (5 game-days) must elapse between consecutive events', () => {
+    expect(MIN_EVENT_INTERVAL_TICKS).toBe(120);
+  });
+
+  it('MIN_EVENT_INTERVAL_RANDOM_RANGE is 60 — adds up to 60 ticks of random variance to each cooldown', () => {
+    expect(MIN_EVENT_INTERVAL_RANDOM_RANGE).toBe(60);
+  });
+
+  it('MIN_EVENT_INTERVAL_ACTIONS is 10 — at least 10 player actions must occur between events', () => {
+    expect(MIN_EVENT_INTERVAL_ACTIONS).toBe(10);
+  });
+
+  // ── Invariants ─────────────────────────────────────────────────────────────
+
+  it('MIN_EVENT_INTERVAL_TICKS exceeds all EVENT_BASE_TIMERS — cooldown overrides individual category timers to prevent event back-to-back', () => {
+    for (const [cat, ticks] of Object.entries(EVENT_BASE_TIMERS)) {
+      expect(
+        MIN_EVENT_INTERVAL_TICKS,
+        `${cat} base timer (${ticks}) must be less than cooldown (${MIN_EVENT_INTERVAL_TICKS})`,
+      ).toBeGreaterThan(ticks as number);
+    }
+  });
+
+  it('MIN_EVENT_INTERVAL_RANDOM_RANGE is positive — randomness adds unpredictability', () => {
+    expect(MIN_EVENT_INTERVAL_RANDOM_RANGE).toBeGreaterThan(0);
+  });
+
+  it('MIN_EVENT_INTERVAL_ACTIONS is positive and under 100 — requires meaningful player engagement but not excessive grind', () => {
+    expect(MIN_EVENT_INTERVAL_ACTIONS).toBeGreaterThan(0);
+    expect(MIN_EVENT_INTERVAL_ACTIONS).toBeLessThan(100);
   });
 });
 


### PR DESCRIPTION
Closes #305

## Summary
Adds three event cooldown constants to `src/core/config/balance.ts` that will prevent events from firing too frequently:
- `MIN_EVENT_INTERVAL_TICKS = 120` — minimum ticks (2 min at 1× speed) between events
- `MIN_EVENT_INTERVAL_RANDOM_RANGE = 60` — random additional cooldown jitter (0–59)
- `MIN_EVENT_INTERVAL_ACTIONS = 10` — minimum user actions between events

## Files Changed
- `src/core/config/balance.ts` — Added 3 `export const` constants in Event System section with JSDoc
- `tests/unit/config/balance.test.ts` — Added 9 tests verifying exact values, exportability, and relationship invariants

## Validation Checklist
- [x] TypeScript strict type-check passes
- [x] 2647 unit tests pass (140 test files)
- [x] 280 integration tests pass (26 test files)
- [x] 222 scenario definition tests pass
- [x] Production build succeeds
- [x] jscpd duplication check: no new clones introduced
- [x] Code review: quality, security, i18n, duplication, semantic — all clean
- [x] Constants placed in correct Event System section (after EVENT_BASE_TIMERS)
- [x] All constants follow `export const UPPER_SNAKE_CASE` with JSDoc conventions

## Test Coverage
- ✓ `MIN_EVENT_INTERVAL_TICKS` is 120 and > all EVENT_BASE_TIMERS values
- ✓ `MIN_EVENT_INTERVAL_RANDOM_RANGE` is 60 and positive
- ✓ `MIN_EVENT_INTERVAL_ACTIONS` is 10 and within (0, 100) range
- ✓ All three constants are exportable and defined

READY TO MERGE