### PR TITLE
Add tutorial level - Extend EventSystemState with cooldown fields (#306)

### DIFF
--- a/src/core/events/EventSystem.ts
+++ b/src/core/events/EventSystem.ts
@@ -84,6 +84,7 @@ export function tickEventSystem(
     if (!state.firedEventIds.includes(eventId)) {
       state.firedEventIds.push(eventId);
       state.pendingEvent = { eventId, firedAtTick: ctx.tickCount };
+      state.lastEventTick = ctx.tickCount;
       return state.pendingEvent;
     }
   }
@@ -100,6 +101,7 @@ export function tickEventSystem(
       if (event) {
         state.firedEventIds.push(event.id);
         state.pendingEvent = { eventId: event.id, firedAtTick: ctx.tickCount };
+        state.lastEventTick = ctx.tickCount;
         return state.pendingEvent;
       }
     }

--- a/src/core/events/EventSystem.ts
+++ b/src/core/events/EventSystem.ts
@@ -34,6 +34,10 @@ export interface EventSystemState {
   followUpQueue: string[];
   /** IDs of events that have already fired this level — each fires at most once. */
   firedEventIds: string[];
+  /** Tick count of the most recent event fire. Used to gate events by player activity. */
+  lastEventTick: number;
+  /** Number of player actions since the last event. Used for cooldown gating. */
+  actionCountSinceEvent: number;
 }
 
 export interface FiredEvent {
@@ -52,6 +56,8 @@ export function createEventSystemState(): EventSystemState {
     pendingEvent: null,
     followUpQueue: [],
     firedEventIds: [],
+    lastEventTick: 0,
+    actionCountSinceEvent: 0,
   };
 }
 
@@ -110,6 +116,11 @@ export function clearPendingEvent(state: EventSystemState): void {
 /** Queue a follow-up event. */
 export function queueFollowUp(state: EventSystemState, eventId: string): void {
   state.followUpQueue.push(eventId);
+}
+
+/** Increment the action count since the last event. Used for cooldown gating. */
+export function incrementActionCount(state: EventSystemState): void {
+  state.actionCountSinceEvent++;
 }
 
 // ── Selection ──

--- a/src/core/state/SaveLoad.ts
+++ b/src/core/state/SaveLoad.ts
@@ -93,6 +93,16 @@ export function deserialize(json: string): GameState {
     eventsRaw['firedEventIds'] = [];
   }
 
+  // Ensure lastEventTick and actionCountSinceEvent exist for saves created before they were added
+  if (eventsRaw) {
+    if (typeof eventsRaw['lastEventTick'] !== 'number') {
+      eventsRaw['lastEventTick'] = 0;
+    }
+    if (typeof eventsRaw['actionCountSinceEvent'] !== 'number') {
+      eventsRaw['actionCountSinceEvent'] = 0;
+    }
+  }
+
   // v4 → v5: collectedOre field added
   if (typeof obj['collectedOre'] !== 'object' || obj['collectedOre'] === null) {
     (obj as Record<string, unknown>)['collectedOre'] = {};

--- a/src/core/state/SaveLoad.ts
+++ b/src/core/state/SaveLoad.ts
@@ -40,8 +40,6 @@ export function deserialize(json: string): GameState {
     );
   }
 
-  // Future: add migration logic for older versions here.
-
   // v2 → v3: waitingTicks added to Vehicle interface.
   // Older saves may have vehicles without this field — default to 0.
   if ((obj['version'] as number) < 3) {
@@ -87,14 +85,12 @@ export function deserialize(json: string): GameState {
     }
   }
 
-  // Ensure firedEventIds exists for saves created before it was added
+  // Ensure event system fields exist for saves created before they were added
   const eventsRaw = obj['events'] as Record<string, unknown> | undefined;
-  if (eventsRaw && !Array.isArray(eventsRaw['firedEventIds'])) {
-    eventsRaw['firedEventIds'] = [];
-  }
-
-  // Ensure lastEventTick and actionCountSinceEvent exist for saves created before they were added
   if (eventsRaw) {
+    if (!Array.isArray(eventsRaw['firedEventIds'])) {
+      eventsRaw['firedEventIds'] = [];
+    }
     if (typeof eventsRaw['lastEventTick'] !== 'number') {
       eventsRaw['lastEventTick'] = 0;
     }

--- a/tests/unit/events/EventSystem.test.ts
+++ b/tests/unit/events/EventSystem.test.ts
@@ -7,6 +7,7 @@ import {
   queueFollowUp,
   selectEvent,
   BASE_TIMER,
+  incrementActionCount,
 } from '../../../src/core/events/EventSystem.js';
 import {
   registerEvents,
@@ -205,5 +206,41 @@ describe('Event system engine', () => {
     const longInterval = unionTimer.remaining;
 
     expect(shortInterval).toBeLessThan(longInterval);
+  });
+
+  it('lastEventTick is 0 in fresh state', () => {
+    const state = createEventSystemState();
+    expect(state.lastEventTick).toBe(0);
+  });
+
+  it('actionCountSinceEvent is 0 in fresh state', () => {
+    const state = createEventSystemState();
+    expect(state.actionCountSinceEvent).toBe(0);
+  });
+
+  it('incrementActionCount increments by 1', () => {
+    const state = createEventSystemState();
+    expect(state.actionCountSinceEvent).toBe(0);
+    incrementActionCount(state);
+    expect(state.actionCountSinceEvent).toBe(1);
+  });
+
+  it('incrementActionCount increments from non-zero', () => {
+    const state = createEventSystemState();
+    state.actionCountSinceEvent = 5;
+    incrementActionCount(state);
+    expect(state.actionCountSinceEvent).toBe(6);
+  });
+
+  it('lastEventTick and actionCountSinceEvent survive JSON round-trip', () => {
+    const state = createEventSystemState();
+    state.lastEventTick = 42;
+    state.actionCountSinceEvent = 7;
+
+    const serialized = JSON.stringify(state);
+    const restored = JSON.parse(serialized) as typeof state;
+
+    expect(restored.lastEventTick).toBe(42);
+    expect(restored.actionCountSinceEvent).toBe(7);
   });
 });


### PR DESCRIPTION
Closes #306

## Summary
Extends `EventSystemState` with cooldown tracking fields:

- **`lastEventTick: number`** — Tracks the tick count when the most recent event fired (initialized to 0, set by `tickEventSystem()`)
- **`actionCountSinceEvent: number`** — Counts player-initiated actions since the last event (initialized to 0)
- **`incrementActionCount(state)`** — Exported function that increments `actionCountSinceEvent`

## Changes

### `src/core/events/EventSystem.ts`
- Added `lastEventTick` and `actionCountSinceEvent` to `EventSystemState` interface
- Both initialized to `0` in `createEventSystemState()`
- Added exported `incrementActionCount(state)` function
- `tickEventSystem()` now sets `state.lastEventTick = ctx.tickCount` when events fire (both follow-up and timer paths)

### `src/core/state/SaveLoad.ts`
- Added migration for old saves: defaults `lastEventTick` and `actionCountSinceEvent` to `0` if missing (same pattern as `firedEventIds` migration)

### `tests/unit/events/EventSystem.test.ts`
- 5 new tests:
  - `lastEventTick is 0 in fresh state`
  - `actionCountSinceEvent is 0 in fresh state`
  - `incrementActionCount increments by 1`
  - `incrementActionCount increments from non-zero`
  - `lastEventTick and actionCountSinceEvent survive JSON round-trip`

## Verification
- ✅ TypeScript: clean (no errors)
- ✅ Tests: 2652 passed (140 test files) — all existing + 5 new
- ✅ Build: success
- ✅ Qualimetry: 4.3% duplication (pre-existing)
- ✅ Security review: clean
- ✅ Quality review: clean
- ✅ i18n review: clean
- ✅ Code review: all findings resolved

## Cooldown Constants (already in `balance.ts`)
- `MIN_EVENT_INTERVAL_TICKS = 120`
- `MIN_EVENT_INTERVAL_RANDOM_RANGE = 60`
- `MIN_EVENT_INTERVAL_ACTIONS = 10"

READY TO MERGE