### PR TITLE
Add tutorial level - Enforce event cooldown in tickEventSystem (#307)

### DIFF
--- a/src/core/events/EventSystem.ts
+++ b/src/core/events/EventSystem.ts
@@ -5,7 +5,7 @@ import type { Random } from '../math/Random.js';
 import type { ScoreState } from '../scores/ScoreManager.js';
 import type { EventDef, EventCategory, EventContext } from './EventPool.js';
 import { getEventsByCategory } from './EventPool.js';
-import { EVENT_BASE_TIMERS } from '../config/balance.js';
+import { EVENT_BASE_TIMERS, MIN_EVENT_INTERVAL_TICKS, MIN_EVENT_INTERVAL_RANDOM_RANGE, MIN_EVENT_INTERVAL_ACTIONS } from '../config/balance.js';
 
 // ── Config (imported from centralized balance) ──
 
@@ -196,4 +196,9 @@ function getModulatedInterval(
   return Math.max(5, Math.round(baseInterval * multiplier));
 }
 
-export { BASE_TIMER };
+export {
+  BASE_TIMER,
+  MIN_EVENT_INTERVAL_TICKS,
+  MIN_EVENT_INTERVAL_RANDOM_RANGE,
+  MIN_EVENT_INTERVAL_ACTIONS,
+};

--- a/src/core/events/EventSystem.ts
+++ b/src/core/events/EventSystem.ts
@@ -101,6 +101,7 @@ export function tickEventSystem(
       const minInterval = MIN_EVENT_INTERVAL_TICKS + rng.nextInt(0, MIN_EVENT_INTERVAL_RANDOM_RANGE);
       const ticksSinceLastEvent = ctx.tickCount - state.lastEventTick;
       if (ticksSinceLastEvent < minInterval || state.actionCountSinceEvent < MIN_EVENT_INTERVAL_ACTIONS) {
+        // Short retry delay (5 ticks) before re-checking cooldown — avoids tight loop
         timer.remaining = 5;
         continue;
       }
@@ -203,12 +204,8 @@ function getModulatedInterval(
       break;
   }
 
+  // Floor of 5 ticks ensures a minimum gap even with extreme score modulation
   return Math.max(5, Math.round(baseInterval * multiplier));
 }
 
-export {
-  BASE_TIMER,
-  MIN_EVENT_INTERVAL_TICKS,
-  MIN_EVENT_INTERVAL_RANDOM_RANGE,
-  MIN_EVENT_INTERVAL_ACTIONS,
-};
+

--- a/src/core/events/EventSystem.ts
+++ b/src/core/events/EventSystem.ts
@@ -85,6 +85,7 @@ export function tickEventSystem(
       state.firedEventIds.push(eventId);
       state.pendingEvent = { eventId, firedAtTick: ctx.tickCount };
       state.lastEventTick = ctx.tickCount;
+      state.actionCountSinceEvent = 0;
       return state.pendingEvent;
     }
   }
@@ -96,12 +97,21 @@ export function tickEventSystem(
       // Reset timer with score-modulated interval
       timer.remaining = getModulatedInterval(timer.category, ctx.scores, timer.baseInterval);
 
+      // Cooldown check — prevent events from firing too rapidly
+      const minInterval = MIN_EVENT_INTERVAL_TICKS + rng.nextInt(0, MIN_EVENT_INTERVAL_RANDOM_RANGE);
+      const ticksSinceLastEvent = ctx.tickCount - state.lastEventTick;
+      if (ticksSinceLastEvent < minInterval || state.actionCountSinceEvent < MIN_EVENT_INTERVAL_ACTIONS) {
+        timer.remaining = 5;
+        continue;
+      }
+
       // Try to fire an event from this category (already-fired events excluded)
       const event = selectEvent(timer.category, ctx, rng, state.firedEventIds);
       if (event) {
         state.firedEventIds.push(event.id);
         state.pendingEvent = { eventId: event.id, firedAtTick: ctx.tickCount };
         state.lastEventTick = ctx.tickCount;
+        state.actionCountSinceEvent = 0;
         return state.pendingEvent;
       }
     }

--- a/tests/unit/engine/GameLoop.test.ts
+++ b/tests/unit/engine/GameLoop.test.ts
@@ -105,6 +105,9 @@ describe('GameLoop', () => {
   it('auto-pauses when event fires (requires decision)', () => {
     // Register a simple event that always fires
     setupEvents();
+    // Bypass cooldown gate so the event can fire on the first tick
+    state.events.lastEventTick = -200;
+    state.events.actionCountSinceEvent = 10;
     // Set timers to fire immediately by advancing close to trigger
     for (const timer of state.events.timers) {
       timer.remaining = 1;

--- a/tests/unit/events/EventSystem.test.ts
+++ b/tests/unit/events/EventSystem.test.ts
@@ -6,10 +6,9 @@ import {
   clearPendingEvent,
   queueFollowUp,
   selectEvent,
-  BASE_TIMER,
   incrementActionCount,
-  MIN_EVENT_INTERVAL_ACTIONS,
 } from '../../../src/core/events/EventSystem.js';
+import { MIN_EVENT_INTERVAL_ACTIONS } from '../../../src/core/config/balance.js';
 import {
   registerEvents,
   clearEvents,

--- a/tests/unit/events/EventSystem.test.ts
+++ b/tests/unit/events/EventSystem.test.ts
@@ -8,6 +8,7 @@ import {
   selectEvent,
   BASE_TIMER,
   incrementActionCount,
+  MIN_EVENT_INTERVAL_ACTIONS,
 } from '../../../src/core/events/EventSystem.js';
 import {
   registerEvents,
@@ -64,9 +65,10 @@ describe('Event system engine', () => {
     registerEvents([makeEvent('test1', 'union')]);
     const state = createEventSystemState();
     const unionTimer = state.timers.find(t => t.category === 'union')!;
+    state.actionCountSinceEvent = MIN_EVENT_INTERVAL_ACTIONS;
     unionTimer.remaining = 1; // Will fire next tick
 
-    const ctx = makeCtx();
+    const ctx = makeCtx({ tickCount: 200 });
     const fired = tickEventSystem(state, ctx, new Random(42));
     expect(fired).not.toBeNull();
     expect(fired!.eventId).toBe('test1');
@@ -131,14 +133,16 @@ describe('Event system engine', () => {
     const unionTimer = state.timers.find(t => t.category === 'union')!;
 
     // Fire the event once
+    state.actionCountSinceEvent = MIN_EVENT_INTERVAL_ACTIONS;
     unionTimer.remaining = 1;
-    const first = tickEventSystem(state, makeCtx(), new Random(42));
+    const first = tickEventSystem(state, makeCtx({ tickCount: 200 }), new Random(42));
     expect(first?.eventId).toBe('once_only');
     clearPendingEvent(state);
 
     // Attempt to fire again
+    state.actionCountSinceEvent = MIN_EVENT_INTERVAL_ACTIONS;
     unionTimer.remaining = 1;
-    const second = tickEventSystem(state, makeCtx(), new Random(42));
+    const second = tickEventSystem(state, makeCtx({ tickCount: 400 }), new Random(42));
     expect(second).toBeNull();
     expect(state.firedEventIds).toContain('once_only');
   });
@@ -190,17 +194,19 @@ describe('Event system engine', () => {
     registerEvents([makeEvent('test1', 'union')]);
     const state = createEventSystemState();
     const unionTimer = state.timers.find(t => t.category === 'union')!;
-    unionTimer.remaining = 1;
 
     // Low well-being → shorter interval
-    const lowCtx = makeCtx({ scores: { ...createScoreState(), wellBeing: 10 } });
+    state.actionCountSinceEvent = MIN_EVENT_INTERVAL_ACTIONS;
+    unionTimer.remaining = 1;
+    const lowCtx = makeCtx({ scores: { ...createScoreState(), wellBeing: 10 }, tickCount: 200 });
     tickEventSystem(state, lowCtx, new Random(42));
     clearPendingEvent(state);
     const shortInterval = unionTimer.remaining;
 
     // Reset and try with high well-being
+    state.actionCountSinceEvent = MIN_EVENT_INTERVAL_ACTIONS;
     unionTimer.remaining = 1;
-    const highCtx = makeCtx({ scores: { ...createScoreState(), wellBeing: 90 } });
+    const highCtx = makeCtx({ scores: { ...createScoreState(), wellBeing: 90 }, tickCount: 400 });
     tickEventSystem(state, highCtx, new Random(42));
     clearPendingEvent(state);
     const longInterval = unionTimer.remaining;
@@ -242,5 +248,114 @@ describe('Event system engine', () => {
 
     expect(restored.lastEventTick).toBe(42);
     expect(restored.actionCountSinceEvent).toBe(7);
+  });
+
+  // ── Cooldown gating tests ──
+
+  it('cooldown blocks event when tick interval not met', () => {
+    registerEvents([makeEvent('test1', 'union')]);
+    const state = createEventSystemState();
+    state.lastEventTick = 190;
+    state.actionCountSinceEvent = MIN_EVENT_INTERVAL_ACTIONS;
+    const unionTimer = state.timers.find(t => t.category === 'union')!;
+    unionTimer.remaining = 1;
+
+    const ctx = makeCtx({ tickCount: 200 });
+    const fired = tickEventSystem(state, ctx, new Random(42));
+    expect(fired).toBeNull();
+    expect(unionTimer.remaining).toBe(5);
+  });
+
+  it('cooldown blocks event when action count not met', () => {
+    registerEvents([makeEvent('test1', 'union')]);
+    const state = createEventSystemState();
+    state.lastEventTick = 0;
+    state.actionCountSinceEvent = 0;
+    const unionTimer = state.timers.find(t => t.category === 'union')!;
+    unionTimer.remaining = 1;
+
+    const ctx = makeCtx({ tickCount: 200 });
+    const fired = tickEventSystem(state, ctx, new Random(42));
+    expect(fired).toBeNull();
+    expect(unionTimer.remaining).toBe(5);
+  });
+
+  it('cooldown allows event when both conditions met', () => {
+    registerEvents([makeEvent('test1', 'union')]);
+    const state = createEventSystemState();
+    state.lastEventTick = 0;
+    state.actionCountSinceEvent = MIN_EVENT_INTERVAL_ACTIONS;
+    const unionTimer = state.timers.find(t => t.category === 'union')!;
+    unionTimer.remaining = 1;
+
+    const ctx = makeCtx({ tickCount: 200 });
+    const fired = tickEventSystem(state, ctx, new Random(42));
+    expect(fired).not.toBeNull();
+    expect(fired!.eventId).toBe('test1');
+  });
+
+  it('timer resets to 5 on cooldown failure, not to modulated interval', () => {
+    registerEvents([makeEvent('test1', 'union')]);
+    const state = createEventSystemState();
+    state.lastEventTick = 190;
+    state.actionCountSinceEvent = MIN_EVENT_INTERVAL_ACTIONS;
+    const unionTimer = state.timers.find(t => t.category === 'union')!;
+    unionTimer.remaining = 1;
+
+    const ctx = makeCtx({ tickCount: 200 });
+    tickEventSystem(state, ctx, new Random(42));
+    // Modulated interval for union at default scores (wellBeing: 50) would be ~25.
+    // On cooldown failure it must be exactly 5.
+    expect(unionTimer.remaining).toBe(5);
+  });
+
+  it('actionCountSinceEvent resets to 0 after event fires', () => {
+    registerEvents([makeEvent('test1', 'union')]);
+    const state = createEventSystemState();
+    state.actionCountSinceEvent = MIN_EVENT_INTERVAL_ACTIONS;
+    const unionTimer = state.timers.find(t => t.category === 'union')!;
+    unionTimer.remaining = 1;
+
+    const ctx = makeCtx({ tickCount: 200 });
+    tickEventSystem(state, ctx, new Random(42));
+    expect(state.actionCountSinceEvent).toBe(0);
+  });
+
+  it('lastEventTick updates after event fires through timer', () => {
+    registerEvents([makeEvent('test1', 'union')]);
+    const state = createEventSystemState();
+    state.actionCountSinceEvent = MIN_EVENT_INTERVAL_ACTIONS;
+    const unionTimer = state.timers.find(t => t.category === 'union')!;
+    unionTimer.remaining = 1;
+
+    const ctx = makeCtx({ tickCount: 200 });
+    tickEventSystem(state, ctx, new Random(42));
+    expect(state.lastEventTick).toBe(200);
+  });
+
+  it('actionCountSinceEvent resets to 0 after follow-up event fires', () => {
+    registerEvents([makeEvent('followup_ev', 'union')]);
+    const state = createEventSystemState();
+    state.actionCountSinceEvent = 5;
+    queueFollowUp(state, 'followup_ev');
+
+    const ctx = makeCtx({ tickCount: 200 });
+    const fired = tickEventSystem(state, ctx, new Random(42));
+    expect(fired).not.toBeNull();
+    expect(fired!.eventId).toBe('followup_ev');
+    expect(state.actionCountSinceEvent).toBe(0);
+  });
+
+  it('follow-up queue events bypass cooldown check', () => {
+    registerEvents([makeEvent('followup_ev', 'union')]);
+    const state = createEventSystemState();
+    state.lastEventTick = 190;
+    state.actionCountSinceEvent = 0;
+    queueFollowUp(state, 'followup_ev');
+
+    const ctx = makeCtx({ tickCount: 200 });
+    const fired = tickEventSystem(state, ctx, new Random(42));
+    expect(fired).not.toBeNull();
+    expect(fired!.eventId).toBe('followup_ev');
   });
 });


### PR DESCRIPTION
Closes #307

## Changes

### src/core/events/EventSystem.ts (+16 lines)
- Added import of MIN_EVENT_INTERVAL_TICKS (120), MIN_EVENT_INTERVAL_RANDOM_RANGE (60), MIN_EVENT_INTERVAL_ACTIONS (10) from balance
- Added cooldown gate in timer loop: before selectEvent, checks tickCount - lastEventTick >= 120+rng(0..60) AND actionCountSinceEvent >= 10
- On cooldown failure: timer resets to 5 ticks for retry
- On successful event fire: resets actionCountSinceEvent = 0
- Follow-up queue events also reset actionCountSinceEvent = 0 (but bypass cooldown check)

### tests/unit/events/EventSystem.test.ts (+121 lines)
- Updated 3 existing tests to satisfy cooldown (tickCount >= 200, actionCountSinceEvent = 10)
- Added 8 new cooldown-specific tests:
  - cooldown blocks event when tick interval not met
  - cooldown blocks event when action count not met
  - cooldown allows event when both conditions met
  - timer resets to 5 on cooldown failure, not to modulated interval
  - actionCountSinceEvent resets to 0 after event fires
  - lastEventTick updates after event fires through timer
  - actionCountSinceEvent resets to 0 after follow-up event fires
  - follow-up queue events bypass cooldown check

### tests/unit/engine/GameLoop.test.ts (+3 lines)
- Seed cooldown state to bypass new gate in existing GameLoop test

## Validation
- [x] TypeScript: tsc --noEmit passes (zero errors)
- [x] Unit tests: 24/24 EventSystem tests pass
- [x] Integration tests: 31/31 events.integration tests pass
- [x] Coverage: 2660/2660 tests pass across 140 files
- [x] Build: vite build succeeds

READY TO MERGE