### PR TITLE
feat: wire action counting to console bridge in main.ts (#308)

### DIFF
--- a/.skeleton-marker-308
+++ b/.skeleton-marker-308
@@ -1,0 +1,2 @@
+Skeleton phase for #308 — wire incrementActionCount into __gameConsole bridge in main.ts
+No new stubs needed; incrementActionCount already exists at src/core/events/EventSystem.ts:135

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { IndexedDBPersistence } from './persistence/IndexedDBPersistence.js';
 import { DownloadPersistence } from './persistence/DownloadPersistence.js';
 import { createRunner } from './console/createRunner.js';
 import { BASE_TICK_MS } from './core/engine/GameLoop.js';
+import { incrementActionCount } from './core/events/EventSystem.js';
 
 // --- 3D Scene ---
 const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
@@ -108,6 +109,11 @@ window.__gameConsole = (cmd: string) => {
   // Sync the renderer after every command so visual changes appear immediately
   gameRenderer.syncFromContext(ctx);
   const cmdName = cmd.trim().split(/\s+/)[0] ?? '';
+
+  // Increment action count for non-meta commands (event cooldown gating)
+  if (ctx.state && !['tick', 'speed', 'pause', 'time'].includes(cmdName)) {
+    incrementActionCount(ctx.state.events);
+  }
 
   // Trigger blast effects and terrain rebuild after a blast
   if (cmdName === 'blast' && result.success && ctx.state) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,8 +13,12 @@ import { AudioHooks } from './audio/AudioHooks.js';
 import { IndexedDBPersistence } from './persistence/IndexedDBPersistence.js';
 import { DownloadPersistence } from './persistence/DownloadPersistence.js';
 import { createRunner } from './console/createRunner.js';
+import { parseCommand } from './console/ConsoleRunner.js';
 import { BASE_TICK_MS } from './core/engine/GameLoop.js';
 import { incrementActionCount } from './core/events/EventSystem.js';
+
+/** Console commands that should not count as user actions for event cooldown gating. */
+const META_COMMANDS = ['tick', 'speed', 'pause', 'time'] as const;
 
 // --- 3D Scene ---
 const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
@@ -108,10 +112,10 @@ window.__gameConsole = (cmd: string) => {
   const result = runner.run(cmd);
   // Sync the renderer after every command so visual changes appear immediately
   gameRenderer.syncFromContext(ctx);
-  const cmdName = cmd.trim().split(/\s+/)[0] ?? '';
+  const cmdName = parseCommand(cmd).command;
 
   // Increment action count for non-meta commands (event cooldown gating)
-  if (ctx.state && !['tick', 'speed', 'pause', 'time'].includes(cmdName)) {
+  if (ctx.state && !META_COMMANDS.includes(cmdName as typeof META_COMMANDS[number])) {
     incrementActionCount(ctx.state.events);
   }
 

--- a/tests/integration/events.integration.test.ts
+++ b/tests/integration/events.integration.test.ts
@@ -12,6 +12,7 @@ import {
   tickEventSystem,
   clearPendingEvent,
   queueFollowUp,
+  incrementActionCount,
 } from '../../src/core/events/EventSystem.js';
 import {
   detectTrafficJam,
@@ -21,6 +22,7 @@ import {
 import { Random } from '../../src/core/math/Random.js';
 import { setupEvents } from '../../src/core/events/index.js';
 import { clearEvents } from '../../src/core/events/EventPool.js';
+import { createRunner } from '../../src/console/createRunner.js';
 
 // ── Shared helpers ──────────────────────────────────────────────────────────
 
@@ -464,5 +466,94 @@ describe('Event system', () => {
 
     expect(result.success).toBe(false);
     expect(result.output).toContain('Usage:');
+  });
+
+  // ── 11. Console bridge action count ──────────────────────────────────────────
+
+  describe('console bridge action count', () => {
+    beforeEach(() => {
+      clearEvents();
+      setupEvents();
+    });
+
+    /**
+     * Simulate the post-processing that window.__gameConsole performs in main.ts:
+     * run the command, extract cmdName, guard on meta commands, call incrementActionCount.
+     */
+    function simulateBridge(runner: import('../../src/console/ConsoleRunner.js').ConsoleRunner, ctx: GameContext, cmd: string) {
+      const result = runner.run(cmd);
+      const cmdName = cmd.trim().split(/\s+/)[0] ?? '';
+      if (ctx.state && !['tick', 'speed', 'pause', 'time'].includes(cmdName)) {
+        incrementActionCount(ctx.state.events);
+      }
+      return result;
+    }
+
+    it('non-meta command increments actionCountSinceEvent via bridge', () => {
+      const { runner, ctx } = createRunner();
+      runner.run('new_game mine_type:desert seed:42 size:32');
+
+      expect(ctx.state!.events.actionCountSinceEvent).toBe(0);
+
+      simulateBridge(runner, ctx, 'employee hire role:blaster');
+
+      expect(ctx.state!.events.actionCountSinceEvent).toBe(1);
+    });
+
+    it('meta command tick does NOT increment actionCountSinceEvent', () => {
+      const { runner, ctx } = createRunner();
+      runner.run('new_game mine_type:desert seed:42 size:32');
+
+      simulateBridge(runner, ctx, 'tick 1');
+
+      expect(ctx.state!.events.actionCountSinceEvent).toBe(0);
+    });
+
+    it('meta command time does NOT increment actionCountSinceEvent', () => {
+      const { runner, ctx } = createRunner();
+      runner.run('new_game mine_type:desert seed:42 size:32');
+
+      simulateBridge(runner, ctx, 'time status');
+
+      expect(ctx.state!.events.actionCountSinceEvent).toBe(0);
+    });
+
+    it('multiple non-meta commands accumulate action count', () => {
+      const { runner, ctx } = createRunner();
+      runner.run('new_game mine_type:desert seed:42 size:32');
+
+      simulateBridge(runner, ctx, 'employee hire role:blaster');
+      simulateBridge(runner, ctx, 'employee hire role:driller');
+      simulateBridge(runner, ctx, 'finances');
+
+      expect(ctx.state!.events.actionCountSinceEvent).toBe(3);
+    });
+
+    it('mixed meta and non-meta — only non-meta increments', () => {
+      const { runner, ctx } = createRunner();
+      runner.run('new_game mine_type:desert seed:42 size:32');
+
+      simulateBridge(runner, ctx, 'tick 1');
+      simulateBridge(runner, ctx, 'employee hire role:blaster');
+      simulateBridge(runner, ctx, 'time status');
+      simulateBridge(runner, ctx, 'finances');
+
+      // 2 non-meta commands: employee, finances
+      expect(ctx.state!.events.actionCountSinceEvent).toBe(2);
+    });
+
+    it('no crash when ctx.state is null (no game initialized)', () => {
+      const { runner, ctx } = createRunner();
+      // ctx.state is null — no new_game called
+
+      // Should not throw
+      expect(() => {
+        const result = runner.run('employee list');
+        const cmdName = 'employee';
+        if (ctx.state && !['tick', 'speed', 'pause', 'time'].includes(cmdName)) {
+          incrementActionCount(ctx.state.events);
+        }
+      }).not.toThrow();
+    });
   });
 });

--- a/tests/integration/events.integration.test.ts
+++ b/tests/integration/events.integration.test.ts
@@ -23,6 +23,7 @@ import { Random } from '../../src/core/math/Random.js';
 import { setupEvents } from '../../src/core/events/index.js';
 import { clearEvents } from '../../src/core/events/EventPool.js';
 import { createRunner } from '../../src/console/createRunner.js';
+import { parseCommand } from '../../src/console/ConsoleRunner.js';
 
 // ── Shared helpers ──────────────────────────────────────────────────────────
 
@@ -471,6 +472,9 @@ describe('Event system', () => {
   // ── 11. Console bridge action count ──────────────────────────────────────────
 
   describe('console bridge action count', () => {
+    /** Console commands that should not count as user actions for event cooldown gating. */
+    const META_COMMANDS = ['tick', 'speed', 'pause', 'time'] as const;
+
     beforeEach(() => {
       clearEvents();
       setupEvents();
@@ -482,8 +486,8 @@ describe('Event system', () => {
      */
     function simulateBridge(runner: import('../../src/console/ConsoleRunner.js').ConsoleRunner, ctx: GameContext, cmd: string) {
       const result = runner.run(cmd);
-      const cmdName = cmd.trim().split(/\s+/)[0] ?? '';
-      if (ctx.state && !['tick', 'speed', 'pause', 'time'].includes(cmdName)) {
+      const cmdName = parseCommand(cmd).command;
+      if (ctx.state && !META_COMMANDS.includes(cmdName as typeof META_COMMANDS[number])) {
         incrementActionCount(ctx.state.events);
       }
       return result;
@@ -550,7 +554,7 @@ describe('Event system', () => {
       expect(() => {
         const result = runner.run('employee list');
         const cmdName = 'employee';
-        if (ctx.state && !['tick', 'speed', 'pause', 'time'].includes(cmdName)) {
+        if (ctx.state && !META_COMMANDS.includes(cmdName as typeof META_COMMANDS[number])) {
           incrementActionCount(ctx.state.events);
         }
       }).not.toThrow();


### PR DESCRIPTION
Closes #308

## Summary
Wires `incrementActionCount` into the `__gameConsole` bridge in `src/main.ts`. Every non-meta command (excluding tick, speed, pause, time) now increments the action counter on EventSystemState, enabling event cooldown gating by player activity.

## Changes
- **src/main.ts**: Import `incrementActionCount` from `./core/events/EventSystem.js`. After each console command, if state exists and the command is not a meta command, increment the action counter. Refactored to use shared `parseCommand` and extracted `META_COMMANDS` constant.
- **tests/integration/events.integration.test.ts**: 6 new tests verifying non-meta commands increment, meta commands don't, multiple commands accumulate, mixed sequences work, and null-state doesn't crash.

## Validation Checklist
- [x] TypeScript type-check (`tsc --noEmit`) — 0 errors
- [x] Unit + integration tests (`vitest run`) — 2666 passed, 0 failed
- [x] Production build (`vite build`) — success
- [x] jscpd duplication check — no new clones introduced
- [x] Code review — Security, Quality, i18n, Duplication, Semantic — all clean

READY TO MERGE