### PR TITLE
feat: Add event fire <id> subcommand (#311)

### DIFF
--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -241,6 +241,11 @@ export function eventCommand(
       return { success: true, output: lines.join('\n') };
     }
 
+    case 'fire': {
+      // TODO: implement in green phase
+      return { success: false, output: 'Not yet implemented' };
+    }
+
     default:
       return { success: false, output: 'Usage: event (status|choose|timers)' };
   }

--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -242,12 +242,34 @@ export function eventCommand(
     }
 
     case 'fire': {
-      // TODO: implement in green phase
-      return { success: false, output: 'Not yet implemented' };
+      const eventId = args[1];
+      if (!eventId) {
+        return { success: false, output: 'Usage: event fire <eventId>' };
+      }
+      const def = getEventById(eventId);
+      if (!def) {
+        return { success: false, output: `Event "${eventId}" not found in pool.` };
+      }
+      state.events.pendingEvent = { eventId: def.id, firedAtTick: state.tickCount };
+      if (!state.events.firedEventIds.includes(def.id)) {
+        state.events.firedEventIds.push(def.id);
+      }
+      state.events.lastEventTick = state.tickCount;
+      state.events.actionCountSinceEvent = 0;
+      state.isPaused = true;
+      const lines = [
+        `EVENT: ${t(def.titleKey)}`,
+        `  ${t(def.descKey)}`,
+      ];
+      for (let j = 0; j < def.options.length; j++) {
+        lines.push(`  [${j}] ${t(def.options[j]!.labelKey)}`);
+      }
+      lines.push('  → Use "event choose <index>" to decide.');
+      return { success: true, output: lines.join('\n') };
     }
 
     default:
-      return { success: false, output: 'Usage: event (status|choose|timers)' };
+      return { success: false, output: 'Usage: event (status|choose|timers|fire)' };
   }
 }
 

--- a/src/console/createRunner.ts
+++ b/src/console/createRunner.ts
@@ -167,7 +167,7 @@ export function createRunner(): RunnerWithContext {
   runner.register('tick', 'Advance time by N ticks (default 1)', (args, named) =>
     tickCommand(ctx, args, named),
   );
-  runner.register('event', 'Event system (status|choose|timers)', (args, named) =>
+  runner.register('event', 'Event system (status|choose|timers|fire)', (args, named) =>
     eventCommand(ctx, args, named),
   );
   runner.register('corrupt', 'Corruption (target:judge cost:50000)', (args, named) =>

--- a/src/core/events/index.ts
+++ b/src/core/events/index.ts
@@ -18,6 +18,8 @@ import { TRAFFIC_JAM_EVENTS } from './TrafficJamEvents.js';
 import { UNQUALIFIED_TASK_EVENTS } from './UnqualifiedTaskEvents.js';
 import { ORE_REPORT_EVENTS } from './OreReportEvents.js';
 
+export { clearEvents } from './EventPool.js';
+
 /** Register all 260 events into the global pool. Call once at app init. */
 export function setupEvents(): void {
   registerEvents(UNION_EVENTS_1);

--- a/tests/unit/events/TutorialEvents.test.ts
+++ b/tests/unit/events/TutorialEvents.test.ts
@@ -6,8 +6,9 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { type GameContext, newGameCommand } from '../../../src/console/commands/world.js';
 import { eventCommand } from '../../../src/console/commands/events.js';
 import { EventEmitter } from '../../../src/core/state/EventEmitter.js';
-import { setupEvents, clearEvents } from '../../../src/core/events/index.js';
-import { getEventById } from '../../../src/core/events/EventPool.js';
+import { setupEvents } from '../../../src/core/events/index.js';
+import { getEventById, clearEvents } from '../../../src/core/events/EventPool.js';
+import { t } from '../../../src/core/i18n/I18n.js';
 
 /** Build a fresh context with a real GameState (seed=42, desert biome). */
 function makeCtx(): GameContext {
@@ -26,37 +27,55 @@ describe('event fire subcommand', () => {
   });
 
   it('event fire <validId> sets pendingEvent and pauses game', () => {
-    // Arrange
-    // Act: call eventCommand(ctx, ['fire', 'union_coffee_uprising'], {})
-    // Assert: state.events.pendingEvent is not null
-    //         state.events.pendingEvent.eventId === 'union_coffee_uprising'
-    //         state.isPaused === true
-    expect(true).toBe(false);
+    // Act
+    const result = eventCommand(ctx, ['fire', 'union_coffee_uprising'], {});
+
+    // Assert
+    expect(result.success).toBe(true);
+    expect(ctx.state!.events.pendingEvent).not.toBeNull();
+    expect(ctx.state!.events.pendingEvent!.eventId).toBe('union_coffee_uprising');
+    expect(ctx.state!.events.pendingEvent!.firedAtTick).toBe(ctx.state!.tickCount);
+    expect(ctx.state!.isPaused).toBe(true);
+    expect(ctx.state!.events.firedEventIds).toContain('union_coffee_uprising');
+    expect(ctx.state!.events.lastEventTick).toBe(ctx.state!.tickCount);
+    expect(ctx.state!.events.actionCountSinceEvent).toBe(0);
   });
 
   it('event fire <validId> shows event details in output', () => {
-    // Arrange
-    // Act: call eventCommand(ctx, ['fire', 'union_coffee_uprising'], {})
-    // Assert: result.success === true
-    //         result.output contains event title (i18n-resolved)
-    //         result.output contains event description
-    //         result.output contains option labels
-    expect(true).toBe(false);
+    // Arrange — look up the event definition to know what i18n keys to expect
+    const def = getEventById('union_coffee_uprising');
+    expect(def).not.toBeNull();
+
+    // Act
+    const result = eventCommand(ctx, ['fire', 'union_coffee_uprising'], {});
+
+    // Assert
+    expect(result.success).toBe(true);
+    // Should contain the resolved event title
+    expect(result.output).toContain(t(def!.titleKey));
+    // Should contain the resolution hint
+    expect(result.output).toContain('→ Use "event choose <index>" to decide.');
+    // Should list option numbers for all options
+    for (let i = 0; i < def!.options.length; i++) {
+      expect(result.output).toContain(`[${i}]`);
+    }
   });
 
   it('event fire <invalidId> returns error', () => {
-    // Arrange: use a non-existent event ID
-    // Act: call eventCommand(ctx, ['fire', 'nonexistent_event_id'], {})
-    // Assert: result.success === false
-    //         result.output indicates the event was not found
-    expect(true).toBe(false);
+    // Act
+    const result = eventCommand(ctx, ['fire', 'nonexistent_event'], {});
+
+    // Assert
+    expect(result.success).toBe(false);
+    expect(result.output.toLowerCase()).toContain('not found');
   });
 
-  it('event fire (no args) returns error', () => {
-    // Arrange: pass only ['fire'] without an event ID
-    // Act: call eventCommand(ctx, ['fire'], {})
-    // Assert: result.success === false
-    //         result.output contains usage instructions
-    expect(true).toBe(false);
+  it('event fire with no arguments returns usage error', () => {
+    // Act — pass only ['fire'] without an event ID
+    const result = eventCommand(ctx, ['fire'], {});
+
+    // Assert
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('Usage');
   });
 });

--- a/tests/unit/events/TutorialEvents.test.ts
+++ b/tests/unit/events/TutorialEvents.test.ts
@@ -1,0 +1,62 @@
+// BlastSimulator2026 — Tests for tutorial-level event firing via console (event fire <id>)
+// Verifies that the `event fire <eventId>` subcommand sets the pending event,
+// pauses the game, and displays event details to the player.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { type GameContext, newGameCommand } from '../../../src/console/commands/world.js';
+import { eventCommand } from '../../../src/console/commands/events.js';
+import { EventEmitter } from '../../../src/core/state/EventEmitter.js';
+import { setupEvents, clearEvents } from '../../../src/core/events/index.js';
+import { getEventById } from '../../../src/core/events/EventPool.js';
+
+/** Build a fresh context with a real GameState (seed=42, desert biome). */
+function makeCtx(): GameContext {
+  const ctx: GameContext = { state: null, grid: null, emitter: new EventEmitter() };
+  newGameCommand(ctx, [], { mine_type: 'desert', seed: '42', size: '32' });
+  return ctx;
+}
+
+describe('event fire subcommand', () => {
+  let ctx: GameContext;
+
+  beforeEach(() => {
+    clearEvents();
+    setupEvents();
+    ctx = makeCtx();
+  });
+
+  it('event fire <validId> sets pendingEvent and pauses game', () => {
+    // Arrange
+    // Act: call eventCommand(ctx, ['fire', 'union_coffee_uprising'], {})
+    // Assert: state.events.pendingEvent is not null
+    //         state.events.pendingEvent.eventId === 'union_coffee_uprising'
+    //         state.isPaused === true
+    expect(true).toBe(false);
+  });
+
+  it('event fire <validId> shows event details in output', () => {
+    // Arrange
+    // Act: call eventCommand(ctx, ['fire', 'union_coffee_uprising'], {})
+    // Assert: result.success === true
+    //         result.output contains event title (i18n-resolved)
+    //         result.output contains event description
+    //         result.output contains option labels
+    expect(true).toBe(false);
+  });
+
+  it('event fire <invalidId> returns error', () => {
+    // Arrange: use a non-existent event ID
+    // Act: call eventCommand(ctx, ['fire', 'nonexistent_event_id'], {})
+    // Assert: result.success === false
+    //         result.output indicates the event was not found
+    expect(true).toBe(false);
+  });
+
+  it('event fire (no args) returns error', () => {
+    // Arrange: pass only ['fire'] without an event ID
+    // Act: call eventCommand(ctx, ['fire'], {})
+    // Assert: result.success === false
+    //         result.output contains usage instructions
+    expect(true).toBe(false);
+  });
+});

--- a/tests/unit/events/TutorialEvents.test.ts
+++ b/tests/unit/events/TutorialEvents.test.ts
@@ -53,6 +53,8 @@ describe('event fire subcommand', () => {
     expect(result.success).toBe(true);
     // Should contain the resolved event title
     expect(result.output).toContain(t(def!.titleKey));
+    // Should contain the event description
+    expect(result.output).toContain(t(def!.descKey));
     // Should contain the resolution hint
     expect(result.output).toContain('→ Use "event choose <index>" to decide.');
     // Should list option numbers for all options


### PR DESCRIPTION
Closes #311

## Summary
Adds an `event fire <eventId>` subcommand that directly fires any event by ID, bypassing timers, cooldowns, and canFire checks. This sets the pendingEvent, pauses the game, and displays the event to the player.

## Changes
- **src/console/commands/events.ts** — Added `case 'fire':` to `eventCommand` switch. Validates argument, looks up event via `getEventById`, sets `pendingEvent`, registers in `firedEventIds`, pauses game, formats event display matching tickCommand output format.
- **src/console/createRunner.ts** — Updated event command registration description to include `fire`.
- **tests/unit/events/TutorialEvents.test.ts** — New test file with 4 tests covering: valid fire (state+output), invalid ID error, missing arg error.

## Validation
- [x] Full test suite: 141 files, 2672 tests — all pass
- [x] TypeScript: `tsc --noEmit` — zero errors
- [x] Build: `npm run build` — success
- [x] Qualimetry: jscpd — all clones pre-existing
- [x] Security review: PASS — no issues
- [x] Quality review: PASS — no issues
- [x] i18n review: PASS — consistent with conventions
- [x] Semantic review: PASS — clean

## Usage
```
> event fire union_coffee_uprising
EVENT: Coffee Uprising
  The workers demand fair-trade coffee in the break room.
  [0] Give them premium coffee
  [1] Promise to look into it
  [2] Ignore them
  → Use "event choose <index>" to decide.
> event status
Pending event: Coffee Uprising
  ...
> event choose 0
Event resolved: union_coffee_uprising
...
```

READY TO MERGE