### PR TITLE
Add tutorial level - Create tutorial_synergy_consultant event definition (#312)

### DIFF
--- a/src/core/events/EventPool.ts
+++ b/src/core/events/EventPool.ts
@@ -5,7 +5,7 @@ import type { ScoreState } from '../scores/ScoreManager.js';
 
 // ── Event types ──
 
-export type EventCategory = 'union' | 'politics' | 'weather' | 'mafia' | 'lawsuit' | 'traffic' | 'mining';
+export type EventCategory = 'union' | 'politics' | 'weather' | 'mafia' | 'lawsuit' | 'traffic' | 'mining' | 'tutorial';
 
 export interface EventOption {
   /** i18n key for option text. */

--- a/src/core/events/EventSystem.ts
+++ b/src/core/events/EventSystem.ts
@@ -13,7 +13,7 @@ import { EVENT_BASE_TIMERS, MIN_EVENT_INTERVAL_TICKS, MIN_EVENT_INTERVAL_RANDOM_
  * Categories that use the countdown-timer system.
  * 'traffic' and 'mining' are excluded because they are detected by EventEngine, not timers.
  */
-export type TimerCategory = Exclude<EventCategory, 'traffic' | 'mining'>;
+export type TimerCategory = Exclude<EventCategory, 'traffic' | 'mining' | 'tutorial'>;
 
 /** Base timer reset values per timer category (in ticks). */
 const BASE_TIMER: Record<TimerCategory, number> = { ...EVENT_BASE_TIMERS };

--- a/src/core/events/TutorialEvents.ts
+++ b/src/core/events/TutorialEvents.ts
@@ -1,5 +1,15 @@
 // BlastSimulator2026 — Tutorial events
 // Events that guide the player through the first levels of the campaign.
+import { ev } from './EventBuilder.js';
 import type { EventDef } from './EventPool.js';
 
-export const TUTORIAL_EVENTS: EventDef[] = [];
+export const TUTORIAL_EVENTS: EventDef[] = [
+  ev('tutorial_synergy_consultant', 'tutorial', {
+    weight: () => 0.5,
+    options: [
+      { cashDelta: -3000, scoreDelta: { wellBeing: 15 } },
+      { scoreDelta: { wellBeing: -10, safety: -5 } },
+      { scoreDelta: { wellBeing: 5, safety: -5 } },
+    ],
+  }),
+];

--- a/src/core/events/TutorialEvents.ts
+++ b/src/core/events/TutorialEvents.ts
@@ -1,0 +1,5 @@
+// BlastSimulator2026 — Tutorial events
+// Events that guide the player through the first levels of the campaign.
+import type { EventDef } from './EventPool.js';
+
+export const TUTORIAL_EVENTS: EventDef[] = [];

--- a/src/core/events/TutorialEvents.ts
+++ b/src/core/events/TutorialEvents.ts
@@ -1,5 +1,6 @@
 // BlastSimulator2026 — Tutorial events
 // Events that guide the player through the first levels of the campaign.
+
 import { ev } from './EventBuilder.js';
 import type { EventDef } from './EventPool.js';
 

--- a/src/core/events/index.ts
+++ b/src/core/events/index.ts
@@ -17,6 +17,7 @@ import { FOLLOWUP_EVENTS } from './FollowUpEvents.js';
 import { TRAFFIC_JAM_EVENTS } from './TrafficJamEvents.js';
 import { UNQUALIFIED_TASK_EVENTS } from './UnqualifiedTaskEvents.js';
 import { ORE_REPORT_EVENTS } from './OreReportEvents.js';
+import { TUTORIAL_EVENTS } from './TutorialEvents.js';
 
 export { clearEvents } from './EventPool.js';
 
@@ -36,4 +37,5 @@ export function setupEvents(): void {
   registerEvents(TRAFFIC_JAM_EVENTS);
   registerEvents(UNQUALIFIED_TASK_EVENTS);
   registerEvents(ORE_REPORT_EVENTS);
+  registerEvents(TUTORIAL_EVENTS);
 }

--- a/src/core/events/index.ts
+++ b/src/core/events/index.ts
@@ -21,7 +21,7 @@ import { TUTORIAL_EVENTS } from './TutorialEvents.js';
 
 export { clearEvents } from './EventPool.js';
 
-/** Register all 260 events into the global pool. Call once at app init. */
+/** Register all event definitions into the global pool. Call once at app init. */
 export function setupEvents(): void {
   registerEvents(UNION_EVENTS_1);
   registerEvents(UNION_EVENTS_2);

--- a/tests/unit/events/TutorialEvents.test.ts
+++ b/tests/unit/events/TutorialEvents.test.ts
@@ -81,3 +81,45 @@ describe('event fire subcommand', () => {
     expect(result.output).toContain('Usage');
   });
 });
+
+describe('tutorial event definitions', () => {
+  beforeEach(() => {
+    clearEvents();
+    setupEvents();
+  });
+
+  it('getEventById returns the tutorial_synergy_consultant event', () => {
+    const ev = getEventById('tutorial_synergy_consultant');
+    expect(ev).toBeDefined();
+    expect(ev!.category).toBe('tutorial');
+    expect(ev!.options.length).toBe(3);
+    expect(ev!.consequences.length).toBe(ev!.options.length);
+  });
+
+  it('option 0 — Hire consultant: cash cost and well-being boost', () => {
+    const ev = getEventById('tutorial_synergy_consultant')!;
+    const con = ev.consequences[0]!;
+
+    expect(con.cashDelta).toBe(-3000);
+    expect(con.scoreDelta?.wellBeing).toBe(15);
+    expect(con.corruptionDelta).toBeUndefined();
+  });
+
+  it('option 1 — Dismiss consultant: well-being and safety penalties, no cash change', () => {
+    const ev = getEventById('tutorial_synergy_consultant')!;
+    const con = ev.consequences[1]!;
+
+    expect(con.scoreDelta?.wellBeing).toBe(-10);
+    expect(con.scoreDelta?.safety).toBe(-5);
+    expect(con.cashDelta).toBeUndefined();
+  });
+
+  it('option 2 — Equity deal: well-being boost, safety penalty, no cash change', () => {
+    const ev = getEventById('tutorial_synergy_consultant')!;
+    const con = ev.consequences[2]!;
+
+    expect(con.scoreDelta?.wellBeing).toBe(5);
+    expect(con.scoreDelta?.safety).toBe(-5);
+    expect(con.cashDelta).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Adds the `tutorial` event category and the `tutorial_synergy_consultant` scripted event for the tutorial level.

## Changes
- **New file:** `src/core/events/TutorialEvents.ts` — Defines `TUTORIAL_EVENTS` with one event: `tutorial_synergy_consultant` (satirical consultant encounter, 3 options)
- **Modified:** `src/core/events/EventPool.ts` — Added `'tutorial'` to `EventCategory` union
- **Modified:** `src/core/events/EventSystem.ts` — Excluded `'tutorial'` from `TimerCategory` (tutorial events are scripted, not timer-driven)
- **Modified:** `src/core/events/index.ts` — Imported and registered `TUTORIAL_EVENTS`
- **Modified:** `tests/unit/events/TutorialEvents.test.ts` — Added 4 tests verifying event definition, category, option count, and per-option consequences

## Event: tutorial_synergy_consultant
| Option | Effect |
|--------|--------|
| Hire consultant | -3000 cash, +15 well-being |
| Dismiss consultant | -10 well-being, -5 safety |
| Equity deal | +5 well-being, -5 safety |

## Verification
- ✅ TypeScript typecheck: `tsc --noEmit` — 0 errors
- ✅ Tests: 2676 passed, 0 failed (141 test files)
- ✅ Build: `vite build` — success
- ✅ All 8 `TutorialEvents.test.ts` tests pass (4 original + 4 new)

Closes #312

READY TO MERGE