### PR TITLE
Add tutorial level - Register tutorial event in setupEvents (#313)

### DIFF
--- a/tests/unit/events/TutorialEvents.test.ts
+++ b/tests/unit/events/TutorialEvents.test.ts
@@ -122,4 +122,32 @@ describe('tutorial event definitions', () => {
     expect(con.scoreDelta?.safety).toBe(-5);
     expect(con.cashDelta).toBeUndefined();
   });
+
+  it('weightCoeff returns a constant 0.5 regardless of scores', () => {
+    const ev = getEventById('tutorial_synergy_consultant')!;
+    const highScores = { wellBeing: 100, safety: 100, ecology: 100, nuisance: 100 };
+    const lowScores = { wellBeing: 0, safety: 0, ecology: 0, nuisance: 0 };
+
+    expect(ev.weightCoeff(highScores)).toBe(0.5);
+    expect(ev.weightCoeff(lowScores)).toBe(0.5);
+  });
+
+  it('canFire returns true for any context', () => {
+    const ev = getEventById('tutorial_synergy_consultant')!;
+    // Tutorial events should always be fireable
+    const ctx = {
+      scores: { wellBeing: 50, safety: 50, ecology: 50, nuisance: 50 },
+      employeeCount: 0,
+      deathCount: 0,
+      corruptionLevel: 0,
+      hasBuilding: () => false,
+      hasDrillPlan: false,
+      tickCount: 0,
+      lawsuitCount: 0,
+      activeContractCount: 0,
+      weatherId: 'sunny',
+    };
+
+    expect(ev.canFire(ctx)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

This PR registers the tutorial event in the global event pool so the event fire command can find it.

### Changes

- **No source code changes needed** — the `TUTORIAL_EVENTS` import and `registerEvents(TUTORIAL_EVENTS)` call in `setupEvents()` were already added to `src/core/events/index.ts` as part of PR #347 (#312).

- **tests/unit/events/TutorialEvents.test.ts** — Added 2 tests for the event's `weightCoeff` and `canFire` functions to meet the 40% global function coverage threshold. `TutorialEvents.ts` had 0% function coverage (the `() => 0.5` arrow function was never invoked), blocking validation.

### Verification

```
After setupEvents() runs, getEventById('tutorial_synergy_consultant') returns the tutorial event.
```

### Validation

- TypeScript type-check passes
- All 2678 unit tests pass (141 test files)
- Function coverage for `TutorialEvents.ts`: 0% to 100%
- All 287 integration tests pass (26 test files)
- All 222 scenario tests pass
- Vite build succeeds

Closes #313

READY TO MERGE
