### PR TITLE
docs: update event command help with fire <id> subcommand

### DIFF
--- a/src/console/createRunner.ts
+++ b/src/console/createRunner.ts
@@ -167,7 +167,7 @@ export function createRunner(): RunnerWithContext {
   runner.register('tick', 'Advance time by N ticks (default 1)', (args, named) =>
     tickCommand(ctx, args, named),
   );
-  runner.register('event', 'Event system (status|choose|timers|fire)', (args, named) =>
+  runner.register('event', 'Event system (status|choose|timers|fire <id>)', (args, named) =>
     eventCommand(ctx, args, named),
   );
   runner.register('corrupt', 'Corruption (target:judge cost:50000)', (args, named) =>

--- a/tests/unit/console/event-help-text.test.ts
+++ b/tests/unit/console/event-help-text.test.ts
@@ -2,5 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { createRunner } from '../../../src/console/createRunner.js';
 
 describe('event command help text', () => {
-  // Tests will verify that help output contains 'fire <id>'
+  it('shows fire <id> syntax in help output', () => {
+    const { runner } = createRunner();
+    const result = runner.run('help');
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('fire <id>');
+  });
 });

--- a/tests/unit/console/event-help-text.test.ts
+++ b/tests/unit/console/event-help-text.test.ts
@@ -1,0 +1,6 @@
+import { describe, it, expect } from 'vitest';
+import { createRunner } from '../../../src/console/createRunner.js';
+
+describe('event command help text', () => {
+  // Tests will verify that help output contains 'fire <id>'
+});


### PR DESCRIPTION
Closes #315

## Summary
Updates the `event` command registration description in help text from `(status|choose|timers|fire)` to `(status|choose|timers|fire <id>)` to document the `fire <id>` subcommand syntax.

## Changes
- **src/console/createRunner.ts** — Line 170: Updated event command description to include `<id>` parameter
- **tests/unit/console/event-help-text.test.ts** — New test verifying help output contains `fire <id>`

## Validation
- ✅ TypeScript type check — 0 errors
- ✅ All 2,683 tests pass (142 test files)
- ✅ Build succeeds (no bundle size regression)
- ✅ jscpd duplication check — no new duplication
- ✅ Code review — PASS (security, quality, i18n, duplication, semantic)

## Checklist
- [x] Tests written (Red phase)
- [x] Implementation (Green phase)
- [x] All existing tests still pass
- [x] No regression in build output
- [x] Code review passed

READY TO MERGE