### PR TITLE
feat: Add Tutorial button to MainMenu (#321)

### DIFF
--- a/src/core/i18n/locales/en.json
+++ b/src/core/i18n/locales/en.json
@@ -1643,6 +1643,7 @@
   "tutorial.complete_text": "You've completed the tutorial. You're ready to run this mine!",
   "menu.title": "BlastSimulator 2026",
   "menu.new_campaign": "New Campaign",
+  "menu.tutorial": "Tutorial",
   "menu.continue": "Continue",
   "menu.load": "Load Game",
   "menu.settings": "Settings",

--- a/src/core/i18n/locales/fr.json
+++ b/src/core/i18n/locales/fr.json
@@ -1643,6 +1643,7 @@
   "tutorial.complete_text": "Vous avez terminé le tutoriel. Vous êtes prêt à gérer cette mine !",
   "menu.title": "BlastSimulator 2026",
   "menu.new_campaign": "Nouvelle campagne",
+  "menu.tutorial": "Tutoriel",
   "menu.continue": "Continuer",
   "menu.load": "Charger une partie",
   "menu.settings": "Paramètres",

--- a/src/ui/MainMenu.ts
+++ b/src/ui/MainMenu.ts
@@ -12,6 +12,7 @@ export type OnResumeLevel = (levelId: string) => void;
 export type OnStartLevel = (levelId: string) => void;
 export type OnLoad = () => void;
 export type OnSettings = () => void;
+export type OnTutorial = () => void;
 
 export class MainMenu {
   private readonly overlay: HTMLElement;
@@ -21,6 +22,7 @@ export class MainMenu {
   private onStartLevel?: OnStartLevel;
   private onLoad?: OnLoad;
   private onSettings?: OnSettings;
+  private onTutorial?: OnTutorial;
 
   constructor(container: HTMLElement) {
     this.overlay = document.createElement('div');
@@ -59,11 +61,12 @@ export class MainMenu {
     ].join(';');
 
     const newBtn = this.makeMenuBtn(t('menu.new_campaign'), 'primary', () => this.onNewCampaign?.());
+    const tutorialBtn = this.makeMenuBtn(t('menu.tutorial'), 'gold', () => { this.onTutorial?.(); });
     const continueBtn = this.makeMenuBtn(t('menu.continue'), '', () => this.showWorldMap(null));
     const loadBtn = this.makeMenuBtn(t('menu.load'), '', () => this.onLoad?.());
     const settingsBtn = this.makeMenuBtn(t('menu.settings'), '', () => this.onSettings?.());
 
-    this.menuBox.append(newBtn, continueBtn, loadBtn, settingsBtn);
+    this.menuBox.append(newBtn, tutorialBtn, continueBtn, loadBtn, settingsBtn);
 
     // ── World map box (hidden initially) ──
     this.worldMapBox = document.createElement('div');
@@ -84,6 +87,7 @@ export class MainMenu {
   setOnStartLevel(fn: OnStartLevel): void { this.onStartLevel = fn; }
   setOnLoad(fn: OnLoad): void { this.onLoad = fn; }
   setOnSettings(fn: OnSettings): void { this.onSettings = fn; }
+  setOnTutorial(fn: OnTutorial): void { this.onTutorial = fn; }
 
   show(): void { this.overlay.style.display = 'flex'; }
   hide(): void { this.overlay.style.display = 'none'; }

--- a/src/ui/MainMenu.ts
+++ b/src/ui/MainMenu.ts
@@ -202,6 +202,11 @@ export class MainMenu {
     btn.className = `bs-btn${variant === 'primary' ? ' bs-btn-primary' : ''}`;
     btn.style.cssText = 'width:100%;padding:10px 16px;font-size:13px;font-weight:600;text-align:left;pointer-events:all';
     btn.textContent = label;
+    if (variant === 'gold') {
+      btn.style.color = '#ffe090';
+      btn.style.borderColor = 'rgba(255,225,144,0.4)';
+      btn.style.background = 'rgba(255,225,144,0.08)';
+    }
     btn.addEventListener('click', onClick);
     return btn;
   }

--- a/src/ui/MainMenu.ts
+++ b/src/ui/MainMenu.ts
@@ -61,7 +61,7 @@ export class MainMenu {
     ].join(';');
 
     const newBtn = this.makeMenuBtn(t('menu.new_campaign'), 'primary', () => this.onNewCampaign?.());
-    const tutorialBtn = this.makeMenuBtn(t('menu.tutorial'), 'gold', () => { this.onTutorial?.(); });
+    const tutorialBtn = this.makeMenuBtn(t('menu.tutorial'), 'gold', () => this.onTutorial?.());
     const continueBtn = this.makeMenuBtn(t('menu.continue'), '', () => this.showWorldMap(null));
     const loadBtn = this.makeMenuBtn(t('menu.load'), '', () => this.onLoad?.());
     const settingsBtn = this.makeMenuBtn(t('menu.settings'), '', () => this.onSettings?.());
@@ -197,7 +197,7 @@ export class MainMenu {
 
   dispose(): void { this.overlay.remove(); }
 
-  private makeMenuBtn(label: string, variant: string, onClick: () => void): HTMLButtonElement {
+  private makeMenuBtn(label: string, variant: 'primary' | 'gold' | '', onClick: () => void): HTMLButtonElement {
     const btn = document.createElement('button');
     btn.className = `bs-btn${variant === 'primary' ? ' bs-btn-primary' : ''}`;
     btn.style.cssText = 'width:100%;padding:10px 16px;font-size:13px;font-weight:600;text-align:left;pointer-events:all';

--- a/tests/unit/ui/MainMenu.test.ts
+++ b/tests/unit/ui/MainMenu.test.ts
@@ -162,11 +162,11 @@ describe('MainMenu (12.8)', () => {
     menu.show();
     const buttons = Array.from(container.querySelectorAll('button'));
     const tutorialBtn = buttons.find(b => b.textContent?.includes('Tutorial'))!;
-    expect(tutorialBtn.style.color).toBe('#ffe090');
+    expect(tutorialBtn.style.color).toBe('rgb(255, 224, 144)');
     expect(tutorialBtn.style.borderColor).toContain('rgba');
-    expect(tutorialBtn.style.borderColor).toContain('255,225,144');
+    expect(tutorialBtn.style.borderColor).toContain('255, 225, 144');
     expect(tutorialBtn.style.background).toContain('rgba');
-    expect(tutorialBtn.style.background).toContain('255,225,144');
+    expect(tutorialBtn.style.background).toContain('255, 225, 144');
     menu.dispose();
   });
 

--- a/tests/unit/ui/MainMenu.test.ts
+++ b/tests/unit/ui/MainMenu.test.ts
@@ -146,4 +146,51 @@ describe('MainMenu (12.8)', () => {
     expect(cb).toHaveBeenCalledOnce();
     menu.dispose();
   });
+
+  it('renders tutorial button with correct text', () => {
+    const menu = new MainMenu(container);
+    menu.show();
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const tutorialBtn = buttons.find(b => b.textContent?.includes('Tutorial'));
+    expect(tutorialBtn).not.toBeNull();
+    expect(tutorialBtn).not.toBeUndefined();
+    menu.dispose();
+  });
+
+  it('tutorial button has gold accent inline style', () => {
+    const menu = new MainMenu(container);
+    menu.show();
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const tutorialBtn = buttons.find(b => b.textContent?.includes('Tutorial'))!;
+    expect(tutorialBtn.style.color).toBe('#ffe090');
+    expect(tutorialBtn.style.borderColor).toContain('rgba');
+    expect(tutorialBtn.style.borderColor).toContain('255,225,144');
+    expect(tutorialBtn.style.background).toContain('rgba');
+    expect(tutorialBtn.style.background).toContain('255,225,144');
+    menu.dispose();
+  });
+
+  it('tutorial button calls onTutorial callback when clicked', () => {
+    const cb = vi.fn();
+    const menu = new MainMenu(container);
+    menu.setOnTutorial(cb);
+    menu.show();
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const tutorialBtn = buttons.find(b => b.textContent?.includes('Tutorial'));
+    tutorialBtn?.click();
+    expect(cb).toHaveBeenCalledOnce();
+    menu.dispose();
+  });
+
+  it('tutorial button is ordered between New Campaign and Continue', () => {
+    const menu = new MainMenu(container);
+    menu.show();
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const idxCampaign = buttons.findIndex(b => b.textContent?.includes('New Campaign'));
+    const idxTutorial = buttons.findIndex(b => b.textContent?.includes('Tutorial'));
+    const idxContinue = buttons.findIndex(b => b.textContent?.includes('Continue'));
+    expect(idxCampaign).toBeLessThan(idxTutorial);
+    expect(idxTutorial).toBeLessThan(idxContinue);
+    menu.dispose();
+  });
 });


### PR DESCRIPTION
Closes #321

## Summary
Adds a gold-accented Tutorial button to the main menu, placed between New Campaign and Continue. This provides direct access to the tutorial level instead of going through the world map.

## Changes
- **src/ui/MainMenu.ts** — Added `OnTutorial` callback type, `onTutorial` private field, `setOnTutorial()` setter, gold-accented tutorial button (`#ffe090`) in the correct position, and `'gold'` variant handling in `makeMenuBtn`
- **src/core/i18n/locales/en.json** — Added `"menu.tutorial": "Tutorial"`
- **src/core/i18n/locales/fr.json** — Added `"menu.tutorial": "Tutoriel"`
- **tests/unit/ui/MainMenu.test.ts** — Added 4 new tests: button rendering, gold styling, callback invocation, and button ordering

## Validation Checklist
- [x] TypeScript strict check: 0 errors
- [x] Full test suite: 2,723 tests passing, 0 failures
- [x] Build: Successful
- [x] jscpd: No new duplication introduced
- [x] Code review: Security, quality, i18n, duplication, and semantic reviews all pass
- [x] 16 MainMenu tests all passing (4 new tutorial-specific tests)

## Button Order
New Campaign > Tutorial > Continue > Load > Settings

## Styling
Gold accent: color `#ffe090`, gold-tinted border and background — applied via inline styles per issue specification.

READY TO MERGE