### PR TITLE
feat: Add tutorial-playthrough scenario definition (Closes #330)

### DIFF
--- a/scripts/scenario-defs/tutorial-playthrough.json
+++ b/scripts/scenario-defs/tutorial-playthrough.json
@@ -1,5 +1,45 @@
 {
   "name": "tutorial-playthrough",
-  "description": "",
-  "steps": []
+  "description": "Full tutorial playthrough at Tutorial Pit: hiring employees, seismic surveying, drill planning, blasting, contract management, building infrastructure, and completing the campaign introduction",
+  "steps": [
+    "new_game seed:42",
+    "campaign start level:tutorial_pit",
+    "time speed:2",
+
+    "employee hire role:surveyor",
+    "employee assign_skill 1 skill:geology level:3",
+    "survey seismic x:15 z:15",
+
+    "employee hire role:driller",
+    "employee assign_skill 2 skill:blasting level:3",
+
+    "drill_plan grid rows:3 cols:3 spacing:5 depth:8 start:15,15",
+    "charge hole:* explosive:boomite amount:5 stemming:2",
+    "sequence auto delay_step:25",
+    "blast",
+    "scores",
+
+    "tick 3",
+    "event fire tutorial_synergy_consultant",
+    "event choose 0",
+
+    "employee hire role:manager",
+    "employee assign_skill 3 skill:management level:3",
+    "contract accept 1",
+
+    "employee hire role:driver",
+    "employee assign_skill 4 skill:driving.truck level:3",
+    "vehicle buy hauler",
+    "vehicle driver 1 4",
+
+    "build storage_depot at:12,8",
+    "contract deliver 1 amount:500",
+    "finances",
+
+    "build_ramp start:15,15 end:20,25",
+    "needs",
+    "set_policy mode:shift_8h",
+    "tick 10",
+    "campaign status"
+  ]
 }

--- a/scripts/scenario-defs/tutorial-playthrough.json
+++ b/scripts/scenario-defs/tutorial-playthrough.json
@@ -1,0 +1,5 @@
+{
+  "name": "tutorial-playthrough",
+  "description": "",
+  "steps": []
+}

--- a/tests/unit/scenario-defs.test.ts
+++ b/tests/unit/scenario-defs.test.ts
@@ -7,6 +7,7 @@ const currentDir = dirname(fileURLToPath(import.meta.url));
 const SCENARIO_DIR = resolve(currentDir, '../../scripts/scenario-defs');
 
 const PLAYTHROUGH_SCENARIO_NAMES = [
+  'tutorial-playthrough',
   'level1-playthrough-win',
   'level1-playthrough-revolt',
   'level2-playthrough-win',
@@ -46,7 +47,7 @@ const KNOWN_COMMANDS = [
   'corrupt', 'mafia', 'buy_software', 'weather', 'buy',
   'fragments', 'preview', 'blast_preview', 'install_tubing',
   'build_ramp', 'set_policy', 'terrain_info', 'help',
-  'blast_plan',
+  'blast_plan', 'needs',
 ];
 
 /** Commands that inspect state — valid as a final playthrough step */


### PR DESCRIPTION
Closes #330

## Changes
- Created `scripts/scenario-defs/tutorial-playthrough.json` — New Puppeteer scenario definition for the full tutorial playthrough with 31 steps covering: game setup, survey, drill/charge/blast, events, management hiring, contracts, vehicles, building, infrastructure, policy, and campaign completion
- Updated `tests/unit/scenario-defs.test.ts` — Added `tutorial-playthrough` to `PLAYTHROUGH_SCENARIO_NAMES` and `needs` to `KNOWN_COMMANDS` for auto-validation

## Validation Checklist
- [x] TypeScript type check (`npx tsc --noEmit`) — 0 errors
- [x] Scenario definitions tests — 234 passed (18 new tests for tutorial-playthrough)
- [x] Full test suite (`npx vitest run`) — 2761 passed, 0 failed (148 files)
- [x] Build (`npx vite build`) — success
- [x] jscpd duplication check — no new clones
- [x] Code review (security, quality, i18n, duplication, semantic) — all passed

## TDD Pipeline
Followed full TDD pipeline: planner -> skeleton -> test-writer -> implementer -> feature-branch cherry-pick -> qualimetry -> parallel code review -> refactorer -> validator -> PR

READY TO MERGE