### PR TITLE
fix: Resolve #373 — Backface-culled square visible below terrain

### DIFF
--- a/src/renderer/TerrainMesh.ts
+++ b/src/renderer/TerrainMesh.ts
@@ -84,7 +84,7 @@ export class TerrainMesh {
     this.material = new THREE.MeshPhongMaterial({
       vertexColors: true,
       shininess: 12,
-      side: THREE.FrontSide,
+      side: THREE.DoubleSide,
     });
   }
 

--- a/tests/unit/renderer/TerrainMesh.test.ts
+++ b/tests/unit/renderer/TerrainMesh.test.ts
@@ -145,6 +145,23 @@ describe('TerrainMesh', () => {
     expect(elapsed).toBeLessThan(200);
     tm.dispose();
   });
+
+  it('material uses DoubleSide so terrain is visible from below', () => {
+    const scene = makeScene();
+    const grid = new VoxelGrid(8, 8, 8);
+    // Fill bottom half solid, top half air — creates mesh
+    for (let x = 0; x < 8; x++)
+      for (let y = 0; y < 4; y++)
+        for (let z = 0; z < 8; z++)
+          grid.setVoxel(x, y, z, makeSolidVoxel());
+    const tm = new TerrainMesh(scene, grid);
+    tm.buildAll();
+    const mesh = scene.children.find(c => c instanceof THREE.Mesh) as THREE.Mesh;
+    expect(mesh).toBeDefined();
+    const mat = mesh.material as THREE.MeshPhongMaterial;
+    expect(mat.side).toBe(THREE.DoubleSide);
+    tm.dispose();
+  });
 });
 
 // ─── Survey Confidence Overlay ──────────────────────────────────────────────────


### PR DESCRIPTION
Closes #373

## Summary
Changes the terrain mesh material from `side: THREE.FrontSide` to `side: THREE.DoubleSide` in `src/renderer/TerrainMesh.ts` line 87. When the camera is lowered below the terrain surface, the FrontSide culling made the downward-facing triangles invisible, revealing the square footprint of the voxel grid boundary. DoubleSide rendering makes the terrain visible from all angles.

## Changes
- `src/renderer/TerrainMesh.ts` — one-line change: `THREE.FrontSide` → `THREE.DoubleSide`
- `tests/unit/renderer/TerrainMesh.test.ts` — added test asserting material side is DoubleSide

## Tests
2792 tests — all passing

## Review
- ✅ Security: PASS
- ✅ Quality: PASS
- ✅ i18n: PASS
- ✅ Duplication: PASS
- ✅ Semantic: PASS
- ✅ Validation: PASS

READY TO MERGE