### PR TITLE
fix: Pipeline visual feedback loop — hard block on VISION:BLOCKED, draft enforcement, CI model fix

### DIFF
--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -25,6 +25,8 @@ Classify the task and load the relevant skill for detailed steps.
 
 Only `@visual-tester` has vision (multimodal) capability. No other agent can analyze images or screenshots. Any task requiring visual inspection of render output must route through `@visual-tester`.
 
+**Visual feedback loop blocking rule:** If @visual-tester reports that visual inspection could NOT be completed (e.g., vision model unavailable, screenshots unreadable), the pipeline MUST halt. Do NOT proceed to qualimetry or finalization. Mark the visual feedback step as FAILED, add a comment to the issue explaining why, and escalate with `ESCALATED: visual inspection blocked — human review required`.
+
 ## Classification Heuristics
 
 When selecting a pipeline, use these heuristics in order:
@@ -50,7 +52,7 @@ When selecting a pipeline, use these heuristics in order:
 5. **Merge code review findings** — After parallel reviewers complete, merge their findings into a single pass/fail decision (deduplicate, re-categorize, drop false positives, check issue alignment).
 6. **Enforce sequence** — Never skip phases. Tests before implementation. Always recreate pipeline branches from scratch for each issue — stale branches can corrupt the run. Multi-pipeline: each section's test/impl branches fork from the previous section's feature branch (not from main). This is deliberate accumulation, not an exception.
 7. **Report status** — After each agent completes, summarize what was done, commit SHA, and current branch.
-8. **PR management** — See `agentic-pipeline-pr-management` for PR status, draft/ready logic, and READY TO MERGE rules.
+8. **PR management** — See `agentic-pipeline-pr-management` for PR status, draft/ready logic, and READY TO MERGE rules. **CRITICAL:** If the visual feedback loop could not complete inspection (vision model unavailable or @visual-tester returned VISION: BLOCKED), the PR MUST be created as a draft (--draft) WITHOUT `READY TO MERGE`.
 
 ## Rules
 

--- a/.claude/agents/visual-tester.md
+++ b/.claude/agents/visual-tester.md
@@ -184,8 +184,18 @@ Browser exposes:
 - State dumps: {paths}
 ```
 
+### Blocked (cannot inspect)
+```
+## VISION: BLOCKED — visual inspection could not be completed
+- Reason: vision model unavailable / screenshots not generated / dev server not reachable
+- Screenshots captured: {count or N/A}
+- The orchestrator MUST halt the pipeline and escalate. Do NOT proceed to qualimetry or finalization.
+```
+
 **Severity levels:** SEVERE (missing/corrupt geometry), MODERATE (wrong colors/overlays/effects), MINOR (state mismatch, cosmetic).
 In visual feedback loop: report all issues found. @implementer fixes all of them, then re-invoke for another round.
+
+**If you cannot inspect screenshots** (vision model not available, images failed to load, dev server unreachable), you MUST report `## VISION: BLOCKED` instead of PASS or FAIL. Do NOT report PASS when screenshots were merely captured — you must visually inspect them.
 
 ## Key References
 

--- a/.claude/skills/agentic-pipeline-finalization/SKILL.md
+++ b/.claude/skills/agentic-pipeline-finalization/SKILL.md
@@ -12,6 +12,7 @@ Runs after qualimetry passes. Branch: `pipeline/feature-<N>`.
 
 **Parameters:**
 - `skip_refactorer` (default: `false`) — set to `true` for bug-fix pipelines to skip refactoring phase.
+- `visual_incomplete` (default: `false`) — set to `true` when visual feedback loop could NOT complete inspection (VISION: BLOCKED). When `true`, the PR MUST be created as draft (--draft) WITHOUT `READY TO MERGE`.
 
 ```
 [ ] = orchestrator-executed command  |  @agent = AI agent invocation
@@ -31,8 +32,9 @@ Runs after qualimetry passes. Branch: `pipeline/feature-<N>`.
  5. @validator           → Full validation: typecheck → tests → build
                             if fail → @implementer (big loop)
  6. [verify-commit]      → final commit check before PR
- 7. [open-pr]            → create PR from feature branch to main + READY TO MERGE.
-                            Evaluate draft/ready per `agentic-pipeline-pr-management` skill.
+ 7. [open-pr]            → create PR from feature branch to main.
+                             Evaluate draft/ready per `agentic-pipeline-pr-management` skill.
+                             **If `visual_incomplete=true` → MUST use --draft, NO `READY TO MERGE`.**
  8. [git-verify]         → confirm clean state: git status, branch, last commits
 ```
 

--- a/.claude/skills/agentic-pipeline-full/SKILL.md
+++ b/.claude/skills/agentic-pipeline-full/SKILL.md
@@ -20,8 +20,10 @@ description: >
                                 if fail → @fixer → re-run test-runner (tight loop, max 7 retries)
  6. [verify-commit]           → confirm fix commit; auto-commit if dirty
  7. [visual-feedback-loop]    → Visual feedback loop (visual-change ONLY).
-                                Skip for backend-only features.
-                                Loop on failure — see "Visual Feedback Loop" below.
+                                 Skip for backend-only features.
+                                 Loop on failure — see "Visual Feedback Loop" below.
+                                 **CRITICAL:** If @visual-tester returns VISION: BLOCKED (cannot inspect),
+                                 halt pipeline immediately. Do NOT proceed to qualimetry. Escalate.
   8. [qualimetry]              → jscpd syntactic duplication check
                                 if fail → @implementer (big loop)
   9. [finalization]            → Delegate to `agentic-pipeline-finalization` skill
@@ -39,6 +41,7 @@ description: >
 |------------|--------------|
 | @planner | @planner (self-retry) |
 | [visual-feedback-loop] | See loop below — self-iterating |
+| [visual-feedback-loop] VISION: BLOCKED | **HALT** — escalate, do not proceed to qualimetry |
 | [qualimetry] | @implementer (big loop) |
 | finalization phase | See `agentic-pipeline-finalization` |
 | @context-maintainer | Fix and commit, or do nothing — never blocks pipeline |
@@ -54,7 +57,8 @@ Runs after test-runner passes on feature branch, before qualimetry. Visual-chang
 ```
 LOOP:
   a. @visual-tester   → Run scenario tests with --shots, inspect ALL screenshots.
-                        Report ALL visual failures in one pass, ranked by severity.
+                        Must return VISUAL: PASS, VISUAL: FAIL, or VISION: BLOCKED.
+                        If VISION: BLOCKED → halt pipeline immediately (escalate).
                         If no failures → exit loop (continue to step 9).
   b. @implementer     → Fix ALL reported visual issues.
                         Runs on feature branch (branch-sanity: pipeline/feature-<N>).

--- a/.claude/skills/agentic-pipeline-pr-management/SKILL.md
+++ b/.claude/skills/agentic-pipeline-pr-management/SKILL.md
@@ -11,10 +11,11 @@ description: >
 Before open-pr step, evaluate: **is this PR ready to merge or should it be a draft?**
 
 Ask yourself:
-1. Did the visual feedback loop report persistent failures (3+ iterations without progress)? → draft (visuals need human review)
-2. Did the pipeline hit retry loops or heavy review findings? → draft (needs human review)
-3. Does the issue explicitly request human input? → draft
-4. Is this a simple fix or feature with full test coverage, no visual changes, and clean pipeline run? → ready
+1. Did the visual feedback loop report VISION: BLOCKED (could not inspect screenshots)? → **draft** (visual inspection incomplete, human review REQUIRED)
+2. Did the visual feedback loop report persistent failures (3+ iterations without progress)? → draft (visuals need human review)
+3. Did the pipeline hit retry loops or heavy review findings? → draft (needs human review)
+4. Does the issue explicitly request human input? → draft
+5. Is this a simple fix or feature with full test coverage, no visual changes, and clean pipeline run? → ready
 
 | Evaluation | Behavior | When |
 |------------|----------|------|
@@ -28,8 +29,9 @@ The open-pr step passes `--draft` to `gh pr create` when evaluation is `draft`.
 After creating the PR, the body must include `READY TO MERGE` on its own line. The `auto-assign-next.yml` workflow detects this and enables GitHub native auto-merge via a PAT token, ensuring downstream CI events trigger correctly.
 
 This is the **default**. Skip `READY TO MERGE` when:
-1. The issue requires human input (artistic direction, critical design decision).
-2. The pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs).
+1. Visual feedback loop was incomplete (VISION: BLOCKED) — human must inspect screenshots first.
+2. The issue requires human input (artistic direction, critical design decision).
+3. The pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs).
 
 When skipping, post a comment explaining why:
 

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -25,6 +25,8 @@ Classify the task and load the relevant skill for detailed steps.
 
 Only `@visual-tester` has vision (multimodal) capability. No other agent can analyze images or screenshots. Any task requiring visual inspection of render output must route through `@visual-tester`.
 
+**Visual feedback loop blocking rule:** If @visual-tester reports that visual inspection could NOT be completed (e.g., vision model unavailable, screenshots unreadable), the pipeline MUST halt. Do NOT proceed to qualimetry or finalization. Mark the visual feedback step as FAILED, add a comment to the issue explaining why, and escalate with `ESCALATED: visual inspection blocked — human review required`.
+
 ## Classification Heuristics
 
 When selecting a pipeline, use these heuristics in order:
@@ -50,7 +52,7 @@ When selecting a pipeline, use these heuristics in order:
 5. **Merge code review findings** — After parallel reviewers complete, merge their findings into a single pass/fail decision (deduplicate, re-categorize, drop false positives, check issue alignment).
 6. **Enforce sequence** — Never skip phases. Tests before implementation. Always recreate pipeline branches from scratch for each issue — stale branches can corrupt the run. Multi-pipeline: each section's test/impl branches fork from the previous section's feature branch (not from main). This is deliberate accumulation, not an exception.
 7. **Report status** — After each agent completes, summarize what was done, commit SHA, and current branch.
-8. **PR management** — See `agentic-pipeline-pr-management` for PR status, draft/ready logic, and READY TO MERGE rules.
+8. **PR management** — See `agentic-pipeline-pr-management` for PR status, draft/ready logic, and READY TO MERGE rules. **CRITICAL:** If the visual feedback loop could not complete inspection (vision model unavailable or @visual-tester returned VISION: BLOCKED), the PR MUST be created as a draft (--draft) WITHOUT `READY TO MERGE`.
 
 ## Rules
 

--- a/.github/agents/visual-tester.agent.md
+++ b/.github/agents/visual-tester.agent.md
@@ -179,8 +179,18 @@ Browser exposes:
 - State dumps: {paths}
 ```
 
+### Blocked (cannot inspect)
+```
+## VISION: BLOCKED — visual inspection could not be completed
+- Reason: vision model unavailable / screenshots not generated / dev server not reachable
+- Screenshots captured: {count or N/A}
+- The orchestrator MUST halt the pipeline and escalate. Do NOT proceed to qualimetry or finalization.
+```
+
 **Severity levels:** SEVERE (missing/corrupt geometry), MODERATE (wrong colors/overlays/effects), MINOR (state mismatch, cosmetic).
 In visual feedback loop: report all issues found. @implementer fixes all of them, then re-invoke for another round.
+
+**If you cannot inspect screenshots** (vision model not available, images failed to load, dev server unreachable), you MUST report `## VISION: BLOCKED` instead of PASS or FAIL. Do NOT report PASS when screenshots were merely captured — you must visually inspect them.
 
 ## Key References
 

--- a/.github/skills/agentic-pipeline-finalization/SKILL.md
+++ b/.github/skills/agentic-pipeline-finalization/SKILL.md
@@ -12,6 +12,7 @@ Runs after qualimetry passes. Branch: `pipeline/feature-<N>`.
 
 **Parameters:**
 - `skip_refactorer` (default: `false`) — set to `true` for bug-fix pipelines to skip refactoring phase.
+- `visual_incomplete` (default: `false`) — set to `true` when visual feedback loop could NOT complete inspection (VISION: BLOCKED). When `true`, the PR MUST be created as draft (--draft) WITHOUT `READY TO MERGE`.
 
 ```
 [ ] = orchestrator-executed command  |  @agent = AI agent invocation
@@ -31,8 +32,9 @@ Runs after qualimetry passes. Branch: `pipeline/feature-<N>`.
  5. @validator           → Full validation: typecheck → tests → build
                             if fail → @implementer (big loop)
  6. [verify-commit]      → final commit check before PR
- 7. [open-pr]            → create PR from feature branch to main + READY TO MERGE.
-                            Evaluate draft/ready per `agentic-pipeline-pr-management` skill.
+ 7. [open-pr]            → create PR from feature branch to main.
+                             Evaluate draft/ready per `agentic-pipeline-pr-management` skill.
+                             **If `visual_incomplete=true` → MUST use --draft, NO `READY TO MERGE`.**
  8. [git-verify]         → confirm clean state: git status, branch, last commits
 ```
 

--- a/.github/skills/agentic-pipeline-full/SKILL.md
+++ b/.github/skills/agentic-pipeline-full/SKILL.md
@@ -20,8 +20,10 @@ description: >
                                 if fail → @fixer → re-run test-runner (tight loop, max 7 retries)
  6. [verify-commit]           → confirm fix commit; auto-commit if dirty
  7. [visual-feedback-loop]    → Visual feedback loop (visual-change ONLY).
-                                Skip for backend-only features.
-                                Loop on failure — see "Visual Feedback Loop" below.
+                                 Skip for backend-only features.
+                                 Loop on failure — see "Visual Feedback Loop" below.
+                                 **CRITICAL:** If @visual-tester returns VISION: BLOCKED (cannot inspect),
+                                 halt pipeline immediately. Do NOT proceed to qualimetry. Escalate.
   8. [qualimetry]              → jscpd syntactic duplication check
                                 if fail → @implementer (big loop)
   9. [finalization]            → Delegate to `agentic-pipeline-finalization` skill
@@ -39,6 +41,7 @@ description: >
 |------------|--------------|
 | @planner | @planner (self-retry) |
 | [visual-feedback-loop] | See loop below — self-iterating |
+| [visual-feedback-loop] VISION: BLOCKED | **HALT** — escalate, do not proceed to qualimetry |
 | [qualimetry] | @implementer (big loop) |
 | finalization phase | See `agentic-pipeline-finalization` |
 | @context-maintainer | Fix and commit, or do nothing — never blocks pipeline |
@@ -54,7 +57,8 @@ Runs after test-runner passes on feature branch, before qualimetry. Visual-chang
 ```
 LOOP:
   a. @visual-tester   → Run scenario tests with --shots, inspect ALL screenshots.
-                        Report ALL visual failures in one pass, ranked by severity.
+                        Must return VISUAL: PASS, VISUAL: FAIL, or VISION: BLOCKED.
+                        If VISION: BLOCKED → halt pipeline immediately (escalate).
                         If no failures → exit loop (continue to step 9).
   b. @implementer     → Fix ALL reported visual issues.
                         Runs on feature branch (branch-sanity: pipeline/feature-<N>).

--- a/.github/skills/agentic-pipeline-pr-management/SKILL.md
+++ b/.github/skills/agentic-pipeline-pr-management/SKILL.md
@@ -11,10 +11,11 @@ description: >
 Before open-pr step, evaluate: **is this PR ready to merge or should it be a draft?**
 
 Ask yourself:
-1. Did the visual feedback loop report persistent failures (3+ iterations without progress)? → draft (visuals need human review)
-2. Did the pipeline hit retry loops or heavy review findings? → draft (needs human review)
-3. Does the issue explicitly request human input? → draft
-4. Is this a simple fix or feature with full test coverage, no visual changes, and clean pipeline run? → ready
+1. Did the visual feedback loop report VISION: BLOCKED (could not inspect screenshots)? → **draft** (visual inspection incomplete, human review REQUIRED)
+2. Did the visual feedback loop report persistent failures (3+ iterations without progress)? → draft (visuals need human review)
+3. Did the pipeline hit retry loops or heavy review findings? → draft (needs human review)
+4. Does the issue explicitly request human input? → draft
+5. Is this a simple fix or feature with full test coverage, no visual changes, and clean pipeline run? → ready
 
 | Evaluation | Behavior | When |
 |------------|----------|------|
@@ -28,8 +29,9 @@ The open-pr step passes `--draft` to `gh pr create` when evaluation is `draft`.
 After creating the PR, the body must include `READY TO MERGE` on its own line. The `auto-assign-next.yml` workflow detects this and enables GitHub native auto-merge via a PAT token, ensuring downstream CI events trigger correctly.
 
 This is the **default**. Skip `READY TO MERGE` when:
-1. The issue requires human input (artistic direction, critical design decision).
-2. The pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs).
+1. Visual feedback loop was incomplete (VISION: BLOCKED) — human must inspect screenshots first.
+2. The issue requires human input (artistic direction, critical design decision).
+3. The pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs).
 
 When skipping, post a comment explaining why:
 

--- a/.github/workflows/opencode-runner.yml
+++ b/.github/workflows/opencode-runner.yml
@@ -52,7 +52,6 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
           OPENCODE_PERMISSION: '{"external_directory":"allow","doom_loop":"deny"}'
         with:
-          model: opencode/deepseek-v4-flash-free
           mentions: '@opencode'
           prompt: |
             ${{ github.event_name == 'workflow_dispatch' && inputs.issue_number && format('Resolve GitHub issue #{0}. Follow the TDD pipeline: plan, write tests, implement, review, refactor, validate, and open a PR with Closes #{0}.', inputs.issue_number) || 'A user mentioned you in a comment. Read the PR/issue context and answer their question directly. If they ask a question, answer it using @ask. If they request a task, use the pipeline.' }}

--- a/.opencode/agents/orchestrator.md
+++ b/.opencode/agents/orchestrator.md
@@ -1,5 +1,6 @@
 ---
 model: opencode/mimo-v2.5-free
+reasoningEffort: high
 description:  Orchestrates the TDD development pipeline. Invokes specialist agents in the correct sequence. Does not write code directly — only delegates to sub-agents and manages workflow.
 mode: primary
 permission:
@@ -24,6 +25,8 @@ Classify the task and load the relevant skill for detailed steps.
 | Complex/mixed prompt | `agentic-pipeline-multi` |
 
 Only `@visual-tester` has vision (multimodal) capability. No other agent can analyze images or screenshots. Any task requiring visual inspection of render output must route through `@visual-tester`.
+
+**Visual feedback loop blocking rule:** If @visual-tester reports that visual inspection could NOT be completed (e.g., vision model unavailable, screenshots unreadable), the pipeline MUST halt. Do NOT proceed to qualimetry or finalization. Mark the visual feedback step as FAILED, add a comment to the issue explaining why, and escalate with `ESCALATED: visual inspection blocked — human review required`.
 
 ## Classification Heuristics
 
@@ -50,7 +53,7 @@ When selecting a pipeline, use these heuristics in order:
 5. **Merge code review findings** — After parallel reviewers complete, merge their findings into a single pass/fail decision (deduplicate, re-categorize, drop false positives, check issue alignment).
 6. **Enforce sequence** — Never skip phases. Tests before implementation. Always recreate pipeline branches from scratch for each issue — stale branches can corrupt the run. Multi-pipeline: each section's test/impl branches fork from the previous section's feature branch (not from main). This is deliberate accumulation, not an exception.
 7. **Report status** — After each agent completes, summarize what was done, commit SHA, and current branch.
-8. **PR management** — See `agentic-pipeline-pr-management` for PR status, draft/ready logic, and READY TO MERGE rules.
+8. **PR management** — See `agentic-pipeline-pr-management` for PR status, draft/ready logic, and READY TO MERGE rules. **CRITICAL:** If the visual feedback loop could not complete inspection (vision model unavailable or @visual-tester returned VISION: BLOCKED), the PR MUST be created as a draft (--draft) WITHOUT `READY TO MERGE`.
 
 ## Rules
 

--- a/.opencode/agents/visual-tester.md
+++ b/.opencode/agents/visual-tester.md
@@ -1,5 +1,6 @@
 ---
 model: opencode/mimo-v2.5-free
+reasoningEffort: high
 description:  Visual testing: Puppeteer scenario tests, screenshots, state dumps. Use when change affects rendering, UI, or visual presentation.
 mode: subagent
 permission:
@@ -191,8 +192,18 @@ Browser exposes:
 - State dumps: {paths}
 ```
 
+### Blocked (cannot inspect)
+```
+## VISION: BLOCKED — visual inspection could not be completed
+- Reason: vision model unavailable / screenshots not generated / dev server not reachable
+- Screenshots captured: {count or N/A}
+- The orchestrator MUST halt the pipeline and escalate. Do NOT proceed to qualimetry or finalization.
+```
+
 **Severity levels:** SEVERE (missing/corrupt geometry), MODERATE (wrong colors/overlays/effects), MINOR (state mismatch, cosmetic).
 In visual feedback loop: report all issues found. @implementer fixes all of them, then re-invoke for another round.
+
+**If you cannot inspect screenshots** (vision model not available, images failed to load, dev server unreachable), you MUST report `## VISION: BLOCKED` instead of PASS or FAIL. Do NOT report PASS when screenshots were merely captured — you must visually inspect them.
 
 ## Key References
 

--- a/.opencode/skills/agentic-pipeline-finalization/SKILL.md
+++ b/.opencode/skills/agentic-pipeline-finalization/SKILL.md
@@ -12,6 +12,7 @@ Runs after qualimetry passes. Branch: `pipeline/feature-<N>`.
 
 **Parameters:**
 - `skip_refactorer` (default: `false`) — set to `true` for bug-fix pipelines to skip refactoring phase.
+- `visual_incomplete` (default: `false`) — set to `true` when visual feedback loop could NOT complete inspection (VISION: BLOCKED). When `true`, the PR MUST be created as draft (--draft) WITHOUT `READY TO MERGE`.
 
 ```
 [ ] = orchestrator-executed command  |  @agent = AI agent invocation
@@ -31,8 +32,9 @@ Runs after qualimetry passes. Branch: `pipeline/feature-<N>`.
  5. @validator           → Full validation: typecheck → tests → build
                             if fail → @implementer (big loop)
  6. [verify-commit]      → final commit check before PR
- 7. [open-pr]            → create PR from feature branch to main + READY TO MERGE.
-                            Evaluate draft/ready per `agentic-pipeline-pr-management` skill.
+ 7. [open-pr]            → create PR from feature branch to main.
+                             Evaluate draft/ready per `agentic-pipeline-pr-management` skill.
+                             **If `visual_incomplete=true` → MUST use --draft, NO `READY TO MERGE`.**
  8. [git-verify]         → confirm clean state: git status, branch, last commits
 ```
 

--- a/.opencode/skills/agentic-pipeline-full/SKILL.md
+++ b/.opencode/skills/agentic-pipeline-full/SKILL.md
@@ -20,8 +20,10 @@ description: >
                                 if fail → @fixer → re-run test-runner (tight loop, max 7 retries)
  6. [verify-commit]           → confirm fix commit; auto-commit if dirty
  7. [visual-feedback-loop]    → Visual feedback loop (visual-change ONLY).
-                                Skip for backend-only features.
-                                Loop on failure — see "Visual Feedback Loop" below.
+                                 Skip for backend-only features.
+                                 Loop on failure — see "Visual Feedback Loop" below.
+                                 **CRITICAL:** If @visual-tester returns VISION: BLOCKED (cannot inspect),
+                                 halt pipeline immediately. Do NOT proceed to qualimetry. Escalate.
   8. [qualimetry]              → jscpd syntactic duplication check
                                 if fail → @implementer (big loop)
   9. [finalization]            → Delegate to `agentic-pipeline-finalization` skill
@@ -39,6 +41,7 @@ description: >
 |------------|--------------|
 | @planner | @planner (self-retry) |
 | [visual-feedback-loop] | See loop below — self-iterating |
+| [visual-feedback-loop] VISION: BLOCKED | **HALT** — escalate, do not proceed to qualimetry |
 | [qualimetry] | @implementer (big loop) |
 | finalization phase | See `agentic-pipeline-finalization` |
 | @context-maintainer | Fix and commit, or do nothing — never blocks pipeline |
@@ -54,7 +57,8 @@ Runs after test-runner passes on feature branch, before qualimetry. Visual-chang
 ```
 LOOP:
   a. @visual-tester   → Run scenario tests with --shots, inspect ALL screenshots.
-                        Report ALL visual failures in one pass, ranked by severity.
+                        Must return VISUAL: PASS, VISUAL: FAIL, or VISION: BLOCKED.
+                        If VISION: BLOCKED → halt pipeline immediately (escalate).
                         If no failures → exit loop (continue to step 8).
   b. @implementer     → Fix ALL reported visual issues.
                         Runs on feature branch (branch-sanity: pipeline/feature-<N>).

--- a/.opencode/skills/agentic-pipeline-pr-management/SKILL.md
+++ b/.opencode/skills/agentic-pipeline-pr-management/SKILL.md
@@ -11,10 +11,11 @@ description: >
 Before open-pr step, evaluate: **is this PR ready to merge or should it be a draft?**
 
 Ask yourself:
-1. Did the visual feedback loop report persistent failures (3+ iterations without progress)? → draft (visuals need human review)
-2. Did the pipeline hit retry loops or heavy review findings? → draft (needs human review)
-3. Does the issue explicitly request human input? → draft
-4. Is this a simple fix or feature with full test coverage, no visual changes, and clean pipeline run? → ready
+1. Did the visual feedback loop report VISION: BLOCKED (could not inspect screenshots)? → **draft** (visual inspection incomplete, human review REQUIRED)
+2. Did the visual feedback loop report persistent failures (3+ iterations without progress)? → draft (visuals need human review)
+3. Did the pipeline hit retry loops or heavy review findings? → draft (needs human review)
+4. Does the issue explicitly request human input? → draft
+5. Is this a simple fix or feature with full test coverage, no visual changes, and clean pipeline run? → ready
 
 | Evaluation | Behavior | When |
 |------------|----------|------|
@@ -28,8 +29,9 @@ The open-pr step passes `--draft` to `gh pr create` when evaluation is `draft`.
 After creating the PR, the body must include `READY TO MERGE` on its own line. The `auto-assign-next.yml` workflow detects this and enables GitHub native auto-merge via a PAT token, ensuring downstream CI events trigger correctly.
 
 This is the **default**. Skip `READY TO MERGE` when:
-1. The issue requires human input (artistic direction, critical design decision).
-2. The pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs).
+1. Visual feedback loop was incomplete (VISION: BLOCKED) — human must inspect screenshots first.
+2. The issue requires human input (artistic direction, critical design decision).
+3. The pipeline hit significant churn (repeated failure loops, heavy review findings, multiple implementer do-overs).
 
 When skipping, post a comment explaining why:
 


### PR DESCRIPTION
﻿## Summary

Fixes 3 root causes identified in the PR #397/Pipeline 265 investigation where visual scenarios were created but screenshots were never inspected, resulting in undetected UI bugs landing on main.

## Changes

### A. Visual feedback loop — hard block
When @visual-tester cannot inspect screenshots (vision model unavailable), it now reports VISION: BLOCKED. The orchestrator halts the pipeline instead of proceeding to qualimetry/finalization. No more "scenarios executed = visual check passed" conflation.

### C. CI model override removed
.github/workflows/opencode-runner.yml no longer forces deepseek-v4-flash-free on all agents. Each agent now uses its own declared model (visual-tester uses mimo-v2.5-free which has vision capability).

### D. Draft PR enforcement
When visual inspection is incomplete (visual_incomplete=true), the PR is created as draft without READY TO MERGE.

### Additional
- Added reasoningEffort: high to orchestrator and visual-tester agents
- All changes mirrored across .opencode/, .claude/, .github/ directories

## Files changed (16)
- .github/workflows/opencode-runner.yml — removed model override
- Agent definitions (6 files across 3 dirs): orchestrator + visual-tester
- Skills (9 files across 3 dirs): pipeline-full, pipeline-finalization, pipeline-pr-management

## Related
- Root cause analysis of PR #397 (Pipeline 265)
- Creates guardrails for issues #400, #401, #402
