### PR TITLE
fix: arm auto-merge from the run that opens the PR, not from the PR's author

### DIFF
--- a/.claude/skills/agentic-autonomous-pipeline/references/github-loop.md
+++ b/.claude/skills/agentic-autonomous-pipeline/references/github-loop.md
@@ -115,15 +115,16 @@ The orchestrator includes `READY TO MERGE` in the PR body when PR status is `rea
 
 **The marker decides, never the account.** A pipeline PR is opened by whichever identity the runner's token resolved to — `github-actions[bot]` when the agent step overrides the PAT it was handed, a real user when it does not — and a PR authored by `github-actions[bot]` raises `pull_request` workflow runs that GitHub creates and immediately parks as `action_required`. Nothing runs: not CI, not the auto-merge step. PR #430 sat open that way, fully verified and marked, with zero checks and no auto-merge, holding its issue and the queue behind it.
 
-So auto-merge has two entry points, and only one of them can be gated:
+The fix is not a poller. It is that **the run which opens the PR arms it, in the same job**:
 
 | Entry | Fires on | Covers |
 |-------|----------|--------|
-| `auto-assign-next.yml` | `pull_request: opened, synchronize, reopened, edited, ready_for_review` | The fast path — enables auto-merge the moment the marker arrives, when the author's events are not gated |
-| `agentic-auto-merge.yml` | `workflow_run` on either runner, a quarter-hourly schedule, manual dispatch | The guarantee — none of these triggers can be gated by who opened the PR |
+| Both runners, `Arm auto-merge on the PR this run opened` | The run itself, after the agent step and after `agentic-rescue`, with `always()` | Every PR the pipeline opens, whatever account it ends up attributed to. The step reads the marker off `pipeline/feature-<N>` — the branch the assignment told the run to build |
+| `auto-assign-next.yml` | `pull_request: opened, synchronize, reopened, edited, ready_for_review` | The marker arriving after the PR did — a body edited, a draft marked ready. Only reached when the author's events are not gated |
+| `agentic-auto-merge.yml` | manual dispatch | A PR stranded by an older run, or by a job cancelled before its arming step. Deliberately not on a clock |
 
-Both call the same composite action, so they cannot disagree about what "ready to merge" means. Selection is the marker on a line of its own plus a non-draft PR; the author is logged and never branched on. Releasing a parked run needs `actions: write` on the PAT — without it the sweep still enables auto-merge, warns, and the PR waits on checks that never start.
+All three call the same composite action, so they cannot disagree about what "ready to merge" means. Selection is the marker on a line of its own plus a non-draft PR; the author is logged and never branched on. The action also releases any workflow run parked as `action_required` on the PR head, which is what makes CI start at all on a bot-authored PR — that needs `actions: write` on the PAT, and without it the step still enables auto-merge, warns naming the missing scope, and the PR waits on checks that never start.
 
 ## Shared composite actions
 
-They live in `.github/actions/`: `agentic-prompt` builds the trigger context both runners hand to their agent, `agentic-assign` picks and assigns the next issue, `agentic-run-state` reports whether a finished session left its issue terminal and whether the remaining job budget can carry another attempt, `agentic-rescue` salvages a feature branch from a run that ended before opening its PR and settles the issue either way, and `agentic-auto-merge` puts a marked PR into auto-merge whatever account opened it.
+They live in `.github/actions/`: `agentic-prompt` builds the trigger context both runners hand to their agent, `agentic-assign` picks and assigns the next issue, `agentic-run-state` reports whether a finished session left its issue terminal and whether the remaining job budget can carry another attempt, `agentic-rescue` salvages a feature branch from a run that ended before opening its PR and settles the issue either way, and `agentic-auto-merge` puts a marked PR into auto-merge whatever account opened it, releasing any workflow run parked as `action_required` on the way.

--- a/.claude/skills/agentic-autonomous-pipeline/references/github-loop.md
+++ b/.claude/skills/agentic-autonomous-pipeline/references/github-loop.md
@@ -111,8 +111,19 @@ Switching agents is a one-value change: set `AGENTIC_AGENT` to `@claude` and eve
 
 ## Auto-merge
 
-The orchestrator includes `READY TO MERGE` in the PR body when PR status is `ready`. `auto-assign-next.yml` (triggered on `pull_request: [opened, synchronize]`) detects this and enables GitHub native auto-merge via the PAT. Draft versus ready logic: `agentic-pipeline-pr-management`.
+The orchestrator includes `READY TO MERGE` in the PR body when PR status is `ready`. `agentic-auto-merge` reads that marker, releases any workflow run parked as `action_required` on the PR head, and enables GitHub native auto-merge via the PAT. Draft versus ready logic: `agentic-pipeline-pr-management`.
+
+**The marker decides, never the account.** A pipeline PR is opened by whichever identity the runner's token resolved to — `github-actions[bot]` when the agent step overrides the PAT it was handed, a real user when it does not — and a PR authored by `github-actions[bot]` raises `pull_request` workflow runs that GitHub creates and immediately parks as `action_required`. Nothing runs: not CI, not the auto-merge step. PR #430 sat open that way, fully verified and marked, with zero checks and no auto-merge, holding its issue and the queue behind it.
+
+So auto-merge has two entry points, and only one of them can be gated:
+
+| Entry | Fires on | Covers |
+|-------|----------|--------|
+| `auto-assign-next.yml` | `pull_request: opened, synchronize, reopened, edited, ready_for_review` | The fast path — enables auto-merge the moment the marker arrives, when the author's events are not gated |
+| `agentic-auto-merge.yml` | `workflow_run` on either runner, a quarter-hourly schedule, manual dispatch | The guarantee — none of these triggers can be gated by who opened the PR |
+
+Both call the same composite action, so they cannot disagree about what "ready to merge" means. Selection is the marker on a line of its own plus a non-draft PR; the author is logged and never branched on. Releasing a parked run needs `actions: write` on the PAT — without it the sweep still enables auto-merge, warns, and the PR waits on checks that never start.
 
 ## Shared composite actions
 
-They live in `.github/actions/`: `agentic-prompt` builds the trigger context both runners hand to their agent, `agentic-assign` picks and assigns the next issue, `agentic-run-state` reports whether a finished session left its issue terminal and whether the remaining job budget can carry another attempt, and `agentic-rescue` salvages a feature branch from a run that ended before opening its PR and settles the issue either way.
+They live in `.github/actions/`: `agentic-prompt` builds the trigger context both runners hand to their agent, `agentic-assign` picks and assigns the next issue, `agentic-run-state` reports whether a finished session left its issue terminal and whether the remaining job budget can carry another attempt, `agentic-rescue` salvages a feature branch from a run that ended before opening its PR and settles the issue either way, and `agentic-auto-merge` puts a marked PR into auto-merge whatever account opened it.

--- a/.claude/skills/agentic-pipeline-pr-management/SKILL.md
+++ b/.claude/skills/agentic-pipeline-pr-management/SKILL.md
@@ -31,7 +31,7 @@ The open-pr step passes `--draft` to `gh pr create` when evaluation is `draft`.
 
 ## READY TO MERGE
 
-After creating the PR, the body must include `READY TO MERGE` on its own line. The `auto-assign-next.yml` workflow detects this and enables GitHub native auto-merge via a PAT token, ensuring downstream CI events trigger correctly.
+After creating the PR, the body must include `READY TO MERGE` on its own line, with nothing else on it. That line is the only thing that puts a PR into auto-merge: the `agentic-auto-merge` action reads it, releases any workflow run parked as `action_required` on the PR head, and enables GitHub native auto-merge via a PAT token. The account that opened the PR is never consulted — see `agentic-autonomous-pipeline`.
 
 This is the **default**, skipped only in the three draft cases above. When skipping, post a comment naming the channel or blocker and the remedy — never a summary of how much work the run took:
 
@@ -43,7 +43,7 @@ A run that defaulted an open requirement keeps `READY TO MERGE` and records the 
 
 ## Critical: NEVER use `[skip ci]` on PR branches
 
-The `auto-assign-next.yml` workflow (triggered on `pull_request: [synchronize]`) detects `READY TO MERGE` and enables auto-merge. **Any commit with `[skip ci]` on a PR branch prevents this workflow from triggering**, leaving the PR without auto-merge.
+`auto-assign-next.yml` (triggered on `pull_request: [synchronize]`) is the fast path into auto-merge. **Any commit with `[skip ci]` on a PR branch prevents that workflow from triggering**, so the PR waits for the quarter-hourly sweep in `agentic-auto-merge.yml` instead of merging when it is ready. `[skip ci]` also suppresses the CI run auto-merge is waiting on, which no sweep can substitute for.
 
 Rules:
 - **NEVER** include `[skip ci]` in any commit message on `pipeline/feature-*` branches

--- a/.claude/skills/agentic-pipeline-pr-management/SKILL.md
+++ b/.claude/skills/agentic-pipeline-pr-management/SKILL.md
@@ -43,7 +43,7 @@ A run that defaulted an open requirement keeps `READY TO MERGE` and records the 
 
 ## Critical: NEVER use `[skip ci]` on PR branches
 
-`auto-assign-next.yml` (triggered on `pull_request: [synchronize]`) is the fast path into auto-merge. **Any commit with `[skip ci]` on a PR branch prevents that workflow from triggering**, so the PR waits for the quarter-hourly sweep in `agentic-auto-merge.yml` instead of merging when it is ready. `[skip ci]` also suppresses the CI run auto-merge is waiting on, which no sweep can substitute for.
+`auto-assign-next.yml` (triggered on `pull_request: [synchronize]`) re-arms auto-merge when the marker arrives after the PR did. **Any commit with `[skip ci]` on a PR branch prevents that workflow from triggering.** It also suppresses the CI run auto-merge is waiting on, which nothing downstream can substitute for: the PR then sits armed and unmergeable until a human intervenes.
 
 Rules:
 - **NEVER** include `[skip ci]` in any commit message on `pipeline/feature-*` branches

--- a/.github/actions/agentic-auto-merge/action.yml
+++ b/.github/actions/agentic-auto-merge/action.yml
@@ -1,0 +1,176 @@
+name: 'Agentic auto-merge'
+description: 'Enables auto-merge on every open PR carrying the READY TO MERGE marker, whatever account authored it.'
+
+inputs:
+  token:
+    description: 'PAT with contents, pull-requests and actions write. GITHUB_TOKEN cannot approve gated runs.'
+    required: true
+  pr:
+    description: 'Restrict to a single PR number. Empty sweeps every open PR.'
+    required: false
+    default: ''
+  merge_method:
+    description: 'merge, squash or rebase.'
+    required: false
+    default: 'squash'
+
+outputs:
+  enabled:
+    description: 'Space-separated PR numbers that now have auto-merge enabled or were merged outright.'
+    value: ${{ steps.sweep.outputs.enabled }}
+  approved:
+    description: 'Number of gated workflow runs released across the swept PRs.'
+    value: ${{ steps.sweep.outputs.approved }}
+
+runs:
+  using: composite
+  steps:
+    - name: Enable auto-merge on every marked PR
+      id: sweep
+      uses: actions/github-script@v7
+      env:
+        ONLY_PR: ${{ inputs.pr }}
+        MERGE_METHOD: ${{ inputs.merge_method }}
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
+
+          // The marker decides, never the account. A pipeline PR is opened by
+          // whichever identity the runner's token resolved to that day —
+          // `github-actions[bot]` when the agent step overrides the PAT it was
+          // handed, a real user when it does not — and the loop must not depend
+          // on which. `READY TO MERGE` on a line of its own is the pipeline's
+          // own ship signal, written by the orchestrator and by nothing else,
+          // so it identifies an autonomous run's deliverable without asking who
+          // pressed the button. Trailing whitespace is tolerated because the
+          // line survives a round trip through the GitHub API and through
+          // `gh pr edit`, both of which can add it.
+          const carriesMergeMarker = (body) => {
+            if (!body) return false;
+            return body
+              .split(/\r?\n/)
+              .some((line) => line.trim() === 'READY TO MERGE');
+          };
+
+          const method = (process.env.MERGE_METHOD || 'squash').toUpperCase();
+          const only = parseInt(process.env.ONLY_PR || '', 10);
+
+          const candidates = Number.isNaN(only)
+            ? await github.paginate(github.rest.pulls.list, {
+                owner, repo, state: 'open', per_page: 100
+              })
+            : [(await github.rest.pulls.get({ owner, repo, pull_number: only })).data];
+
+          const enabled = [];
+          let approved = 0;
+
+          for (const summary of candidates) {
+            const n = summary.number;
+
+            if (summary.state !== 'open') {
+              core.info(`#${n}: not open, skipping.`);
+              continue;
+            }
+            if (summary.draft) {
+              core.info(`#${n}: draft — a draft is the pipeline's way of saying a channel did not pass.`);
+              continue;
+            }
+            if (!carriesMergeMarker(summary.body)) {
+              core.info(`#${n}: no READY TO MERGE marker.`);
+              continue;
+            }
+
+            core.info(`#${n}: marked READY TO MERGE by ${summary.user?.login} on ${summary.head.ref}.`);
+
+            // A PR opened with GITHUB_TOKEN gets its `pull_request` workflow
+            // runs created and immediately parked as `action_required`: CI never
+            // starts, no check ever reports, and auto-merge waits on checks that
+            // will never arrive. Releasing them here is what makes the enable
+            // below mean something. Needs `actions: write` on the token — a
+            // failure is reported, not fatal, since the PR may have no gated run.
+            const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+              owner, repo, head_sha: summary.head.sha, per_page: 100
+            });
+            const gated = runs.filter(
+              (run) => run.status === 'action_required' || run.conclusion === 'action_required'
+            );
+            for (const run of gated) {
+              try {
+                await github.request('POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve', {
+                  owner, repo, run_id: run.id
+                });
+                core.info(`#${n}: released gated run ${run.id} (${run.name}).`);
+                approved += 1;
+              } catch (error) {
+                core.warning(
+                  `#${n}: could not release gated run ${run.id} (${run.name}): ${error.message}. ` +
+                  'The token needs `actions: write`; without it the PR waits on checks that never start.'
+                );
+              }
+            }
+
+            // `gh pr merge --auto` is idempotent and so is this: re-running over
+            // a PR that already has auto-merge enabled is the normal case on a
+            // sweep, and costs one rejected mutation.
+            try {
+              await github.graphql(
+                `mutation($id: ID!, $method: PullRequestMergeMethod!) {
+                   enablePullRequestAutoMerge(input: { pullRequestId: $id, mergeMethod: $method }) {
+                     clientMutationId
+                   }
+                 }`,
+                { id: summary.node_id, method }
+              );
+              core.info(`#${n}: auto-merge enabled.`);
+              enabled.push(n);
+              continue;
+            } catch (error) {
+              const message = error.message || '';
+
+              if (/already enabled/i.test(message)) {
+                core.info(`#${n}: auto-merge already enabled.`);
+                enabled.push(n);
+                continue;
+              }
+
+              // GitHub refuses auto-merge on a PR that has nothing left to wait
+              // for, and on a repository with the feature switched off. Both end
+              // the same way: this PR is meant to merge and every check it owes
+              // has already reported, so merge it. `clean` is exactly the state
+              // auto-merge would have waited for.
+              const mergeNow = /clean status/i.test(message) || /not allowed/i.test(message);
+              if (!mergeNow) {
+                core.warning(`#${n}: could not enable auto-merge: ${message}`);
+                continue;
+              }
+
+              const { data: fresh } = await github.rest.pulls.get({ owner, repo, pull_number: n });
+              if (fresh.mergeable_state !== 'clean') {
+                core.warning(
+                  `#${n}: auto-merge unavailable (${message}) and the PR is \`${fresh.mergeable_state}\`, ` +
+                  'not `clean` — leaving it for the next sweep.'
+                );
+                continue;
+              }
+
+              try {
+                await github.rest.pulls.merge({
+                  owner, repo, pull_number: n, merge_method: method.toLowerCase()
+                });
+                core.info(`#${n}: merged directly — auto-merge unavailable and every check had reported.`);
+                enabled.push(n);
+              } catch (mergeError) {
+                core.warning(`#${n}: direct merge failed: ${mergeError.message}`);
+              }
+            }
+          }
+
+          core.setOutput('enabled', enabled.join(' '));
+          core.setOutput('approved', String(approved));
+          core.info(
+            enabled.length === 0
+              ? 'No PR carried the marker in a mergeable state.'
+              : `Auto-merge covers PR(s): ${enabled.map((n) => `#${n}`).join(', ')}.`
+          );

--- a/.github/actions/agentic-auto-merge/action.yml
+++ b/.github/actions/agentic-auto-merge/action.yml
@@ -6,7 +6,11 @@ inputs:
     description: 'PAT with contents, pull-requests and actions write. GITHUB_TOKEN cannot approve gated runs.'
     required: true
   pr:
-    description: 'Restrict to a single PR number. Empty sweeps every open PR.'
+    description: 'Restrict to a single PR number. Empty means use `head`, or every open PR.'
+    required: false
+    default: ''
+  head:
+    description: 'Restrict to the open PR opened from this head branch, e.g. pipeline/feature-404.'
     required: false
     default: ''
   merge_method:
@@ -30,6 +34,7 @@ runs:
       uses: actions/github-script@v7
       env:
         ONLY_PR: ${{ inputs.pr }}
+        ONLY_HEAD: ${{ inputs.head }}
         MERGE_METHOD: ${{ inputs.merge_method }}
       with:
         github-token: ${{ inputs.token }}
@@ -56,12 +61,25 @@ runs:
 
           const method = (process.env.MERGE_METHOD || 'squash').toUpperCase();
           const only = parseInt(process.env.ONLY_PR || '', 10);
+          const head = (process.env.ONLY_HEAD || '').trim();
 
-          const candidates = Number.isNaN(only)
-            ? await github.paginate(github.rest.pulls.list, {
-                owner, repo, state: 'open', per_page: 100
-              })
-            : [(await github.rest.pulls.get({ owner, repo, pull_number: only })).data];
+          // By number when a `pull_request` event named one, by head branch when
+          // a runner is arming the PR it just opened, everything open otherwise.
+          let candidates;
+          if (!Number.isNaN(only)) {
+            candidates = [(await github.rest.pulls.get({ owner, repo, pull_number: only })).data];
+          } else if (head) {
+            candidates = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', head: `${owner}:${head}`, per_page: 100
+            });
+            if (candidates.length === 0) {
+              core.info(`No open PR from ${head}. The run produced none, or it is not open yet.`);
+            }
+          } else {
+            candidates = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', per_page: 100
+            });
+          }
 
           const enabled = [];
           let approved = 0;

--- a/.github/skills/agentic-autonomous-pipeline/references/github-loop.md
+++ b/.github/skills/agentic-autonomous-pipeline/references/github-loop.md
@@ -115,15 +115,16 @@ The orchestrator includes `READY TO MERGE` in the PR body when PR status is `rea
 
 **The marker decides, never the account.** A pipeline PR is opened by whichever identity the runner's token resolved to — `github-actions[bot]` when the agent step overrides the PAT it was handed, a real user when it does not — and a PR authored by `github-actions[bot]` raises `pull_request` workflow runs that GitHub creates and immediately parks as `action_required`. Nothing runs: not CI, not the auto-merge step. PR #430 sat open that way, fully verified and marked, with zero checks and no auto-merge, holding its issue and the queue behind it.
 
-So auto-merge has two entry points, and only one of them can be gated:
+The fix is not a poller. It is that **the run which opens the PR arms it, in the same job**:
 
 | Entry | Fires on | Covers |
 |-------|----------|--------|
-| `auto-assign-next.yml` | `pull_request: opened, synchronize, reopened, edited, ready_for_review` | The fast path — enables auto-merge the moment the marker arrives, when the author's events are not gated |
-| `agentic-auto-merge.yml` | `workflow_run` on either runner, a quarter-hourly schedule, manual dispatch | The guarantee — none of these triggers can be gated by who opened the PR |
+| Both runners, `Arm auto-merge on the PR this run opened` | The run itself, after the agent step and after `agentic-rescue`, with `always()` | Every PR the pipeline opens, whatever account it ends up attributed to. The step reads the marker off `pipeline/feature-<N>` — the branch the assignment told the run to build |
+| `auto-assign-next.yml` | `pull_request: opened, synchronize, reopened, edited, ready_for_review` | The marker arriving after the PR did — a body edited, a draft marked ready. Only reached when the author's events are not gated |
+| `agentic-auto-merge.yml` | manual dispatch | A PR stranded by an older run, or by a job cancelled before its arming step. Deliberately not on a clock |
 
-Both call the same composite action, so they cannot disagree about what "ready to merge" means. Selection is the marker on a line of its own plus a non-draft PR; the author is logged and never branched on. Releasing a parked run needs `actions: write` on the PAT — without it the sweep still enables auto-merge, warns, and the PR waits on checks that never start.
+All three call the same composite action, so they cannot disagree about what "ready to merge" means. Selection is the marker on a line of its own plus a non-draft PR; the author is logged and never branched on. The action also releases any workflow run parked as `action_required` on the PR head, which is what makes CI start at all on a bot-authored PR — that needs `actions: write` on the PAT, and without it the step still enables auto-merge, warns naming the missing scope, and the PR waits on checks that never start.
 
 ## Shared composite actions
 
-They live in `.github/actions/`: `agentic-prompt` builds the trigger context both runners hand to their agent, `agentic-assign` picks and assigns the next issue, `agentic-run-state` reports whether a finished session left its issue terminal and whether the remaining job budget can carry another attempt, `agentic-rescue` salvages a feature branch from a run that ended before opening its PR and settles the issue either way, and `agentic-auto-merge` puts a marked PR into auto-merge whatever account opened it.
+They live in `.github/actions/`: `agentic-prompt` builds the trigger context both runners hand to their agent, `agentic-assign` picks and assigns the next issue, `agentic-run-state` reports whether a finished session left its issue terminal and whether the remaining job budget can carry another attempt, `agentic-rescue` salvages a feature branch from a run that ended before opening its PR and settles the issue either way, and `agentic-auto-merge` puts a marked PR into auto-merge whatever account opened it, releasing any workflow run parked as `action_required` on the way.

--- a/.github/skills/agentic-autonomous-pipeline/references/github-loop.md
+++ b/.github/skills/agentic-autonomous-pipeline/references/github-loop.md
@@ -111,8 +111,19 @@ Switching agents is a one-value change: set `AGENTIC_AGENT` to `@claude` and eve
 
 ## Auto-merge
 
-The orchestrator includes `READY TO MERGE` in the PR body when PR status is `ready`. `auto-assign-next.yml` (triggered on `pull_request: [opened, synchronize]`) detects this and enables GitHub native auto-merge via the PAT. Draft versus ready logic: `agentic-pipeline-pr-management`.
+The orchestrator includes `READY TO MERGE` in the PR body when PR status is `ready`. `agentic-auto-merge` reads that marker, releases any workflow run parked as `action_required` on the PR head, and enables GitHub native auto-merge via the PAT. Draft versus ready logic: `agentic-pipeline-pr-management`.
+
+**The marker decides, never the account.** A pipeline PR is opened by whichever identity the runner's token resolved to — `github-actions[bot]` when the agent step overrides the PAT it was handed, a real user when it does not — and a PR authored by `github-actions[bot]` raises `pull_request` workflow runs that GitHub creates and immediately parks as `action_required`. Nothing runs: not CI, not the auto-merge step. PR #430 sat open that way, fully verified and marked, with zero checks and no auto-merge, holding its issue and the queue behind it.
+
+So auto-merge has two entry points, and only one of them can be gated:
+
+| Entry | Fires on | Covers |
+|-------|----------|--------|
+| `auto-assign-next.yml` | `pull_request: opened, synchronize, reopened, edited, ready_for_review` | The fast path — enables auto-merge the moment the marker arrives, when the author's events are not gated |
+| `agentic-auto-merge.yml` | `workflow_run` on either runner, a quarter-hourly schedule, manual dispatch | The guarantee — none of these triggers can be gated by who opened the PR |
+
+Both call the same composite action, so they cannot disagree about what "ready to merge" means. Selection is the marker on a line of its own plus a non-draft PR; the author is logged and never branched on. Releasing a parked run needs `actions: write` on the PAT — without it the sweep still enables auto-merge, warns, and the PR waits on checks that never start.
 
 ## Shared composite actions
 
-They live in `.github/actions/`: `agentic-prompt` builds the trigger context both runners hand to their agent, `agentic-assign` picks and assigns the next issue, `agentic-run-state` reports whether a finished session left its issue terminal and whether the remaining job budget can carry another attempt, and `agentic-rescue` salvages a feature branch from a run that ended before opening its PR and settles the issue either way.
+They live in `.github/actions/`: `agentic-prompt` builds the trigger context both runners hand to their agent, `agentic-assign` picks and assigns the next issue, `agentic-run-state` reports whether a finished session left its issue terminal and whether the remaining job budget can carry another attempt, `agentic-rescue` salvages a feature branch from a run that ended before opening its PR and settles the issue either way, and `agentic-auto-merge` puts a marked PR into auto-merge whatever account opened it.

--- a/.github/skills/agentic-pipeline-pr-management/SKILL.md
+++ b/.github/skills/agentic-pipeline-pr-management/SKILL.md
@@ -31,7 +31,7 @@ The open-pr step passes `--draft` to `gh pr create` when evaluation is `draft`.
 
 ## READY TO MERGE
 
-After creating the PR, the body must include `READY TO MERGE` on its own line. The `auto-assign-next.yml` workflow detects this and enables GitHub native auto-merge via a PAT token, ensuring downstream CI events trigger correctly.
+After creating the PR, the body must include `READY TO MERGE` on its own line, with nothing else on it. That line is the only thing that puts a PR into auto-merge: the `agentic-auto-merge` action reads it, releases any workflow run parked as `action_required` on the PR head, and enables GitHub native auto-merge via a PAT token. The account that opened the PR is never consulted — see `agentic-autonomous-pipeline`.
 
 This is the **default**, skipped only in the three draft cases above. When skipping, post a comment naming the channel or blocker and the remedy — never a summary of how much work the run took:
 
@@ -43,7 +43,7 @@ A run that defaulted an open requirement keeps `READY TO MERGE` and records the 
 
 ## Critical: NEVER use `[skip ci]` on PR branches
 
-The `auto-assign-next.yml` workflow (triggered on `pull_request: [synchronize]`) detects `READY TO MERGE` and enables auto-merge. **Any commit with `[skip ci]` on a PR branch prevents this workflow from triggering**, leaving the PR without auto-merge.
+`auto-assign-next.yml` (triggered on `pull_request: [synchronize]`) is the fast path into auto-merge. **Any commit with `[skip ci]` on a PR branch prevents that workflow from triggering**, so the PR waits for the quarter-hourly sweep in `agentic-auto-merge.yml` instead of merging when it is ready. `[skip ci]` also suppresses the CI run auto-merge is waiting on, which no sweep can substitute for.
 
 Rules:
 - **NEVER** include `[skip ci]` in any commit message on `pipeline/feature-*` branches

--- a/.github/skills/agentic-pipeline-pr-management/SKILL.md
+++ b/.github/skills/agentic-pipeline-pr-management/SKILL.md
@@ -43,7 +43,7 @@ A run that defaulted an open requirement keeps `READY TO MERGE` and records the 
 
 ## Critical: NEVER use `[skip ci]` on PR branches
 
-`auto-assign-next.yml` (triggered on `pull_request: [synchronize]`) is the fast path into auto-merge. **Any commit with `[skip ci]` on a PR branch prevents that workflow from triggering**, so the PR waits for the quarter-hourly sweep in `agentic-auto-merge.yml` instead of merging when it is ready. `[skip ci]` also suppresses the CI run auto-merge is waiting on, which no sweep can substitute for.
+`auto-assign-next.yml` (triggered on `pull_request: [synchronize]`) re-arms auto-merge when the marker arrives after the PR did. **Any commit with `[skip ci]` on a PR branch prevents that workflow from triggering.** It also suppresses the CI run auto-merge is waiting on, which nothing downstream can substitute for: the PR then sits armed and unmergeable until a human intervenes.
 
 Rules:
 - **NEVER** include `[skip ci]` in any commit message on `pipeline/feature-*` branches

--- a/.github/workflows/agentic-auto-merge.yml
+++ b/.github/workflows/agentic-auto-merge.yml
@@ -1,30 +1,21 @@
-name: "Pipeline: enable auto-merge on agent PRs"
+name: "Pipeline: enable auto-merge on an agent PR"
 
-# Auto-merge used to live only on `pull_request` in auto-assign-next.yml, which
-# made it depend on who opened the PR. A PR opened with `GITHUB_TOKEN` is
-# authored by `github-actions[bot]`, and every `pull_request` workflow run it
-# raises is created and then parked as `action_required` — CI never starts and
-# the auto-merge step never runs. PR #430 sat open that way with zero checks:
-# the pipeline had done everything right and nothing downstream was listening.
+# The manual handle on the mechanism the runners arm for themselves.
 #
-# None of the triggers below can be gated that way. `workflow_run` fires when a
-# runner finishes, whatever identity its PR ended up with; `schedule` runs from
-# the default branch on a clock and is the floor under the whole mechanism, the
-# same role agentic-watchdog.yml plays for the assignment queue. Authorship is
-# never consulted — `agentic-auto-merge` selects on the `READY TO MERGE` marker,
-# which only the pipeline writes.
+# Auto-merge is armed twice on the normal path, both times by an event: the
+# runner's own `Arm auto-merge on the PR this run opened` step, in the same job
+# that created the PR, and `auto-assign-next.yml` on `pull_request`. Neither
+# reaches a PR whose run was cancelled mid-flight, and the `pull_request` path
+# does not fire at all for a PR authored by `github-actions[bot]` — GitHub
+# parks those runs as `action_required` and never executes them.
+#
+# This workflow exists for that leftover, and for a PR left stranded by an older
+# run. It is deliberately dispatch-only: nothing here runs on a clock.
 on:
-  workflow_run:
-    workflows: ["Claude Pipeline", "OpenCode Pipeline"]
-    types: [completed]
-  schedule:
-    # Offset from the hour, and away from the watchdog's :17, so the sweeps do
-    # not collide.
-    - cron: '7,22,37,52 * * * *'
   workflow_dispatch:
     inputs:
       pr:
-        description: 'PR number to evaluate. Empty sweeps every open PR.'
+        description: 'PR number to arm. Empty evaluates every open PR.'
         required: false
         type: string
 
@@ -33,14 +24,8 @@ permissions:
   pull-requests: write
   actions: write
 
-concurrency:
-  # A scheduled sweep and a runner finishing can land together; two sweeps
-  # enabling auto-merge on the same PR is harmless but pointless.
-  group: agentic-auto-merge
-  cancel-in-progress: false
-
 jobs:
-  sweep:
+  arm:
     if: vars.AGENTIC_AUTO_MERGE_ENABLED == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -49,10 +34,9 @@ jobs:
         with:
           fetch-depth: 1
 
-      # The PAT, not GITHUB_TOKEN: releasing a gated workflow run needs
-      # `actions: write` that a job token does not carry across the bot
-      # boundary, and a merge performed by the PAT raises the `pull_request:
-      # closed` event that auto-assign-next.yml chains the next issue from.
+      # The PAT, not GITHUB_TOKEN: releasing a parked workflow run needs
+      # `actions: write`, and a merge performed by the PAT raises the
+      # `pull_request: closed` event that auto-assign-next.yml chains from.
       - name: Enable auto-merge on marked PRs
         id: merge
         uses: ./.github/actions/agentic-auto-merge
@@ -67,4 +51,4 @@ jobs:
           else
             echo "No open PR carried READY TO MERGE in a mergeable state."
           fi
-          echo "Released ${{ steps.merge.outputs.approved }} gated workflow run(s)."
+          echo "Released ${{ steps.merge.outputs.approved }} parked workflow run(s)."

--- a/.github/workflows/agentic-auto-merge.yml
+++ b/.github/workflows/agentic-auto-merge.yml
@@ -1,0 +1,70 @@
+name: "Pipeline: enable auto-merge on agent PRs"
+
+# Auto-merge used to live only on `pull_request` in auto-assign-next.yml, which
+# made it depend on who opened the PR. A PR opened with `GITHUB_TOKEN` is
+# authored by `github-actions[bot]`, and every `pull_request` workflow run it
+# raises is created and then parked as `action_required` — CI never starts and
+# the auto-merge step never runs. PR #430 sat open that way with zero checks:
+# the pipeline had done everything right and nothing downstream was listening.
+#
+# None of the triggers below can be gated that way. `workflow_run` fires when a
+# runner finishes, whatever identity its PR ended up with; `schedule` runs from
+# the default branch on a clock and is the floor under the whole mechanism, the
+# same role agentic-watchdog.yml plays for the assignment queue. Authorship is
+# never consulted — `agentic-auto-merge` selects on the `READY TO MERGE` marker,
+# which only the pipeline writes.
+on:
+  workflow_run:
+    workflows: ["Claude Pipeline", "OpenCode Pipeline"]
+    types: [completed]
+  schedule:
+    # Offset from the hour, and away from the watchdog's :17, so the sweeps do
+    # not collide.
+    - cron: '7,22,37,52 * * * *'
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number to evaluate. Empty sweeps every open PR.'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+concurrency:
+  # A scheduled sweep and a runner finishing can land together; two sweeps
+  # enabling auto-merge on the same PR is harmless but pointless.
+  group: agentic-auto-merge
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    if: vars.AGENTIC_AUTO_MERGE_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      # The PAT, not GITHUB_TOKEN: releasing a gated workflow run needs
+      # `actions: write` that a job token does not carry across the bot
+      # boundary, and a merge performed by the PAT raises the `pull_request:
+      # closed` event that auto-assign-next.yml chains the next issue from.
+      - name: Enable auto-merge on marked PRs
+        id: merge
+        uses: ./.github/actions/agentic-auto-merge
+        with:
+          token: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
+          pr: ${{ inputs.pr }}
+
+      - name: Report
+        run: |
+          if [ -n "${{ steps.merge.outputs.enabled }}" ]; then
+            echo "Auto-merge covers PR(s): ${{ steps.merge.outputs.enabled }}."
+          else
+            echo "No open PR carried READY TO MERGE in a mergeable state."
+          fi
+          echo "Released ${{ steps.merge.outputs.approved }} gated workflow run(s)."

--- a/.github/workflows/auto-assign-next.yml
+++ b/.github/workflows/auto-assign-next.yml
@@ -8,7 +8,12 @@ on:
   # after being closed. Auto-merge never being enabled means the PR never merges,
   # and an issue whose PR never merges holds the assignment queue for as long as
   # it stays open — the watchdog skips issues that have a linked PR.
-  # `gh pr merge --auto` is idempotent, so re-evaluating costs nothing.
+  # `agentic-auto-merge` is idempotent, so re-evaluating costs nothing.
+  #
+  # This is the fast path and not the guarantee: these events never fire at all
+  # for a PR authored by `github-actions[bot]`, whose runs are parked as
+  # `action_required`. agentic-auto-merge.yml covers that case on triggers no
+  # account can gate.
   pull_request:
     types: [opened, synchronize, reopened, edited, ready_for_review, closed]
 
@@ -22,23 +27,25 @@ jobs:
   chain-next-task:
     runs-on: ubuntu-latest
     steps:
-      - name: Check for READY TO MERGE marker (standalone line)
-        id: check-ready
-        if: github.event.action != 'closed'
-        uses: actions/github-script@v7
+      # Checked out before the auto-merge step because a composite action is read
+      # from the workspace, not from the API.
+      - name: Checkout repository
+        if: github.event.action != 'closed' && vars.AGENTIC_AUTO_MERGE_ENABLED == 'true'
+        uses: actions/checkout@v4
         with:
-          result-encoding: string
-          script: |
-            const body = context.payload.pull_request.body || '';
-            return /^READY TO MERGE$/m.test(body) ? 'true' : 'false'
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
 
+      # The marker test, the gated-run release and the enable all live in the
+      # action, so this path and the sweep in agentic-auto-merge.yml cannot
+      # disagree about what "ready to merge" means.
       - name: Enable auto-merge
-        if: steps.check-ready.outputs.result == 'true' && vars.AGENTIC_AUTO_MERGE_ENABLED == 'true'
+        if: github.event.action != 'closed' && vars.AGENTIC_AUTO_MERGE_ENABLED == 'true'
         continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
-        run: |
-          gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+        uses: ./.github/actions/agentic-auto-merge
+        with:
+          token: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
+          pr: ${{ github.event.pull_request.number }}
 
       - name: Close the completed issue
         id: close-issue

--- a/.github/workflows/claude-runner.yml
+++ b/.github/workflows/claude-runner.yml
@@ -238,6 +238,24 @@ jobs:
           token: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
           issue: ${{ steps.context.outputs.issue }}
 
+      # The run just opened its PR, so this is the moment the PR came into
+      # existence — and the only moment that does not depend on who opened it.
+      # A PR authored by `github-actions[bot]` raises `pull_request` workflow
+      # runs that GitHub creates and immediately parks as `action_required`:
+      # auto-assign-next.yml never runs, and neither does CI. This step reads the
+      # `READY TO MERGE` marker off the branch this run was told to build,
+      # releases those parked runs so CI actually starts, and enables auto-merge
+      # under the PAT. `always()`: an agent step that crashed after opening the
+      # PR is exactly the case worth covering, and `agentic-rescue` above may
+      # have opened one itself — a draft, which the action skips on its own.
+      - name: Arm auto-merge on the PR this run opened
+        if: always() && steps.context.outputs.issue != '' && vars.AGENTIC_AUTO_MERGE_ENABLED == 'true'
+        continue-on-error: true
+        uses: ./.github/actions/agentic-auto-merge
+        with:
+          token: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
+          head: pipeline/feature-${{ steps.context.outputs.issue }}
+
       # When the run closed the issue without opening a PR, no pull_request event
       # will ever fire, so auto-assign-next.yml cannot carry the chain. Do it here.
       - name: Chain to next issue if resolved without PR

--- a/.github/workflows/opencode-runner.yml
+++ b/.github/workflows/opencode-runner.yml
@@ -205,6 +205,24 @@ jobs:
           token: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
           issue: ${{ steps.context.outputs.issue }}
 
+      # The run just opened its PR, so this is the moment the PR came into
+      # existence — and the only moment that does not depend on who opened it.
+      # A PR authored by `github-actions[bot]` raises `pull_request` workflow
+      # runs that GitHub creates and immediately parks as `action_required`:
+      # auto-assign-next.yml never runs, and neither does CI. This step reads the
+      # `READY TO MERGE` marker off the branch this run was told to build,
+      # releases those parked runs so CI actually starts, and enables auto-merge
+      # under the PAT. `always()`: an agent step that crashed after opening the
+      # PR is exactly the case worth covering, and `agentic-rescue` above may
+      # have opened one itself — a draft, which the action skips on its own.
+      - name: Arm auto-merge on the PR this run opened
+        if: always() && steps.context.outputs.issue != '' && vars.AGENTIC_AUTO_MERGE_ENABLED == 'true'
+        continue-on-error: true
+        uses: ./.github/actions/agentic-auto-merge
+        with:
+          token: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
+          head: pipeline/feature-${{ steps.context.outputs.issue }}
+
       # When the run closed the issue without opening a PR, no pull_request event
       # will ever fire, so auto-assign-next.yml cannot carry the chain. Do it here.
       - name: Chain to next issue if resolved without PR

--- a/.opencode/skills/agentic-autonomous-pipeline/references/github-loop.md
+++ b/.opencode/skills/agentic-autonomous-pipeline/references/github-loop.md
@@ -115,15 +115,16 @@ The orchestrator includes `READY TO MERGE` in the PR body when PR status is `rea
 
 **The marker decides, never the account.** A pipeline PR is opened by whichever identity the runner's token resolved to — `github-actions[bot]` when the agent step overrides the PAT it was handed, a real user when it does not — and a PR authored by `github-actions[bot]` raises `pull_request` workflow runs that GitHub creates and immediately parks as `action_required`. Nothing runs: not CI, not the auto-merge step. PR #430 sat open that way, fully verified and marked, with zero checks and no auto-merge, holding its issue and the queue behind it.
 
-So auto-merge has two entry points, and only one of them can be gated:
+The fix is not a poller. It is that **the run which opens the PR arms it, in the same job**:
 
 | Entry | Fires on | Covers |
 |-------|----------|--------|
-| `auto-assign-next.yml` | `pull_request: opened, synchronize, reopened, edited, ready_for_review` | The fast path — enables auto-merge the moment the marker arrives, when the author's events are not gated |
-| `agentic-auto-merge.yml` | `workflow_run` on either runner, a quarter-hourly schedule, manual dispatch | The guarantee — none of these triggers can be gated by who opened the PR |
+| Both runners, `Arm auto-merge on the PR this run opened` | The run itself, after the agent step and after `agentic-rescue`, with `always()` | Every PR the pipeline opens, whatever account it ends up attributed to. The step reads the marker off `pipeline/feature-<N>` — the branch the assignment told the run to build |
+| `auto-assign-next.yml` | `pull_request: opened, synchronize, reopened, edited, ready_for_review` | The marker arriving after the PR did — a body edited, a draft marked ready. Only reached when the author's events are not gated |
+| `agentic-auto-merge.yml` | manual dispatch | A PR stranded by an older run, or by a job cancelled before its arming step. Deliberately not on a clock |
 
-Both call the same composite action, so they cannot disagree about what "ready to merge" means. Selection is the marker on a line of its own plus a non-draft PR; the author is logged and never branched on. Releasing a parked run needs `actions: write` on the PAT — without it the sweep still enables auto-merge, warns, and the PR waits on checks that never start.
+All three call the same composite action, so they cannot disagree about what "ready to merge" means. Selection is the marker on a line of its own plus a non-draft PR; the author is logged and never branched on. The action also releases any workflow run parked as `action_required` on the PR head, which is what makes CI start at all on a bot-authored PR — that needs `actions: write` on the PAT, and without it the step still enables auto-merge, warns naming the missing scope, and the PR waits on checks that never start.
 
 ## Shared composite actions
 
-They live in `.github/actions/`: `agentic-prompt` builds the trigger context both runners hand to their agent, `agentic-assign` picks and assigns the next issue, `agentic-run-state` reports whether a finished session left its issue terminal and whether the remaining job budget can carry another attempt, `agentic-rescue` salvages a feature branch from a run that ended before opening its PR and settles the issue either way, and `agentic-auto-merge` puts a marked PR into auto-merge whatever account opened it.
+They live in `.github/actions/`: `agentic-prompt` builds the trigger context both runners hand to their agent, `agentic-assign` picks and assigns the next issue, `agentic-run-state` reports whether a finished session left its issue terminal and whether the remaining job budget can carry another attempt, `agentic-rescue` salvages a feature branch from a run that ended before opening its PR and settles the issue either way, and `agentic-auto-merge` puts a marked PR into auto-merge whatever account opened it, releasing any workflow run parked as `action_required` on the way.

--- a/.opencode/skills/agentic-autonomous-pipeline/references/github-loop.md
+++ b/.opencode/skills/agentic-autonomous-pipeline/references/github-loop.md
@@ -111,8 +111,19 @@ Switching agents is a one-value change: set `AGENTIC_AGENT` to `@claude` and eve
 
 ## Auto-merge
 
-The orchestrator includes `READY TO MERGE` in the PR body when PR status is `ready`. `auto-assign-next.yml` (triggered on `pull_request: [opened, synchronize]`) detects this and enables GitHub native auto-merge via the PAT. Draft versus ready logic: `agentic-pipeline-pr-management`.
+The orchestrator includes `READY TO MERGE` in the PR body when PR status is `ready`. `agentic-auto-merge` reads that marker, releases any workflow run parked as `action_required` on the PR head, and enables GitHub native auto-merge via the PAT. Draft versus ready logic: `agentic-pipeline-pr-management`.
+
+**The marker decides, never the account.** A pipeline PR is opened by whichever identity the runner's token resolved to — `github-actions[bot]` when the agent step overrides the PAT it was handed, a real user when it does not — and a PR authored by `github-actions[bot]` raises `pull_request` workflow runs that GitHub creates and immediately parks as `action_required`. Nothing runs: not CI, not the auto-merge step. PR #430 sat open that way, fully verified and marked, with zero checks and no auto-merge, holding its issue and the queue behind it.
+
+So auto-merge has two entry points, and only one of them can be gated:
+
+| Entry | Fires on | Covers |
+|-------|----------|--------|
+| `auto-assign-next.yml` | `pull_request: opened, synchronize, reopened, edited, ready_for_review` | The fast path — enables auto-merge the moment the marker arrives, when the author's events are not gated |
+| `agentic-auto-merge.yml` | `workflow_run` on either runner, a quarter-hourly schedule, manual dispatch | The guarantee — none of these triggers can be gated by who opened the PR |
+
+Both call the same composite action, so they cannot disagree about what "ready to merge" means. Selection is the marker on a line of its own plus a non-draft PR; the author is logged and never branched on. Releasing a parked run needs `actions: write` on the PAT — without it the sweep still enables auto-merge, warns, and the PR waits on checks that never start.
 
 ## Shared composite actions
 
-They live in `.github/actions/`: `agentic-prompt` builds the trigger context both runners hand to their agent, `agentic-assign` picks and assigns the next issue, `agentic-run-state` reports whether a finished session left its issue terminal and whether the remaining job budget can carry another attempt, and `agentic-rescue` salvages a feature branch from a run that ended before opening its PR and settles the issue either way.
+They live in `.github/actions/`: `agentic-prompt` builds the trigger context both runners hand to their agent, `agentic-assign` picks and assigns the next issue, `agentic-run-state` reports whether a finished session left its issue terminal and whether the remaining job budget can carry another attempt, `agentic-rescue` salvages a feature branch from a run that ended before opening its PR and settles the issue either way, and `agentic-auto-merge` puts a marked PR into auto-merge whatever account opened it.

--- a/.opencode/skills/agentic-pipeline-pr-management/SKILL.md
+++ b/.opencode/skills/agentic-pipeline-pr-management/SKILL.md
@@ -31,7 +31,7 @@ The open-pr step passes `--draft` to `gh pr create` when evaluation is `draft`.
 
 ## READY TO MERGE
 
-After creating the PR, the body must include `READY TO MERGE` on its own line. The `auto-assign-next.yml` workflow detects this and enables GitHub native auto-merge via a PAT token, ensuring downstream CI events trigger correctly.
+After creating the PR, the body must include `READY TO MERGE` on its own line, with nothing else on it. That line is the only thing that puts a PR into auto-merge: the `agentic-auto-merge` action reads it, releases any workflow run parked as `action_required` on the PR head, and enables GitHub native auto-merge via a PAT token. The account that opened the PR is never consulted — see `agentic-autonomous-pipeline`.
 
 This is the **default**, skipped only in the three draft cases above. When skipping, post a comment naming the channel or blocker and the remedy — never a summary of how much work the run took:
 
@@ -43,7 +43,7 @@ A run that defaulted an open requirement keeps `READY TO MERGE` and records the 
 
 ## Critical: NEVER use `[skip ci]` on PR branches
 
-The `auto-assign-next.yml` workflow (triggered on `pull_request: [synchronize]`) detects `READY TO MERGE` and enables auto-merge. **Any commit with `[skip ci]` on a PR branch prevents this workflow from triggering**, leaving the PR without auto-merge.
+`auto-assign-next.yml` (triggered on `pull_request: [synchronize]`) is the fast path into auto-merge. **Any commit with `[skip ci]` on a PR branch prevents that workflow from triggering**, so the PR waits for the quarter-hourly sweep in `agentic-auto-merge.yml` instead of merging when it is ready. `[skip ci]` also suppresses the CI run auto-merge is waiting on, which no sweep can substitute for.
 
 Rules:
 - **NEVER** include `[skip ci]` in any commit message on `pipeline/feature-*` branches

--- a/.opencode/skills/agentic-pipeline-pr-management/SKILL.md
+++ b/.opencode/skills/agentic-pipeline-pr-management/SKILL.md
@@ -43,7 +43,7 @@ A run that defaulted an open requirement keeps `READY TO MERGE` and records the 
 
 ## Critical: NEVER use `[skip ci]` on PR branches
 
-`auto-assign-next.yml` (triggered on `pull_request: [synchronize]`) is the fast path into auto-merge. **Any commit with `[skip ci]` on a PR branch prevents that workflow from triggering**, so the PR waits for the quarter-hourly sweep in `agentic-auto-merge.yml` instead of merging when it is ready. `[skip ci]` also suppresses the CI run auto-merge is waiting on, which no sweep can substitute for.
+`auto-assign-next.yml` (triggered on `pull_request: [synchronize]`) re-arms auto-merge when the marker arrives after the PR did. **Any commit with `[skip ci]` on a PR branch prevents that workflow from triggering.** It also suppresses the CI run auto-merge is waiting on, which nothing downstream can substitute for: the PR then sits armed and unmergeable until a human intervenes.
 
 Rules:
 - **NEVER** include `[skip ci]` in any commit message on `pipeline/feature-*` branches

--- a/tests/unit/config/autonomy-loop.test.ts
+++ b/tests/unit/config/autonomy-loop.test.ts
@@ -121,3 +121,105 @@ describe('dependency gating', () => {
     expect(dependenciesOf('## Context\n\nSee #55 for background.\n')).toEqual([]);
   });
 });
+
+// PR #430 was opened by the pipeline, fully verified, marked `READY TO MERGE`,
+// and then sat open with zero checks. Its author was `github-actions[bot]`, and
+// every `pull_request` workflow run a bot-authored PR raises is created and
+// immediately parked as `action_required`: CI never started and the auto-merge
+// step never ran. Auto-merge therefore has to be reachable on triggers no
+// account can gate, and has to decide on something other than who authored the
+// PR.
+describe('auto-merge does not depend on the PR author', () => {
+  const AUTO_MERGE_ACTION = 'uses: ./.github/actions/agentic-auto-merge';
+
+  /** Every workflow that can put a PR into auto-merge. */
+  const MERGING_WORKFLOWS = ['auto-assign-next.yml', 'agentic-auto-merge.yml'];
+
+  it.each(MERGING_WORKFLOWS)('%s enables auto-merge through the shared action', (name) => {
+    expect(workflow(name)).toContain(AUTO_MERGE_ACTION);
+  });
+
+  // A `pull_request` trigger is the one thing the bot-authored PR cannot reach,
+  // so the sweep must not be built on it. Losing these triggers reproduces #430
+  // exactly: the mechanism is present, correct, and never invoked.
+  it('sweeps on triggers a bot-authored PR cannot gate', () => {
+    const sweep = workflow('agentic-auto-merge.yml');
+    const triggers = sweep.slice(sweep.indexOf('\non:'), sweep.indexOf('\npermissions:'));
+
+    expect(triggers).toContain('schedule:');
+    expect(triggers).toContain('workflow_run:');
+    expect(triggers).toContain('workflow_dispatch:');
+    expect(triggers).not.toContain('pull_request:');
+  });
+
+  // `workflow_run` names workflows by their `name:`, not their filename, so a
+  // renamed runner silently detaches the sweep from the run that produced the PR.
+  it.each([
+    ['claude-runner.yml'],
+    ['opencode-runner.yml'],
+  ])('watches %s by the name that workflow actually declares', (runner) => {
+    const declared = /^name:\s*(.+)$/m.exec(workflow(runner))?.[1].trim();
+    expect(declared).toBeTruthy();
+    expect(workflow('agentic-auto-merge.yml')).toContain(`"${declared}"`);
+  });
+
+  // Releasing a parked run needs `actions: write`, and the merge itself has to
+  // raise a `pull_request: closed` event that the chain step reacts to — a merge
+  // performed with GITHUB_TOKEN raises none, so the queue stops at the merge.
+  it.each(MERGING_WORKFLOWS)('%s drives auto-merge with the PAT', (name) => {
+    const text = workflow(name);
+    const block = text.slice(text.indexOf(AUTO_MERGE_ACTION));
+    const token = /token:\s*\$\{\{\s*secrets\.(\w+)\s*\}\}/.exec(block);
+    expect(token?.[1]).toBe('PAT_TOKEN_COPILOT_AUTOMATION');
+    expect(text).toMatch(/permissions:[\s\S]*?actions: write/);
+  });
+
+  // The author may appear in a log line or a comment — it is worth reporting.
+  // What must never appear is a branch taken on it.
+  it('never selects a PR by the account that opened it', () => {
+    const code = readFileSync(
+      join(ROOT, '.github/actions/agentic-auto-merge/action.yml'), 'utf8'
+    )
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('#') && !line.trim().startsWith('//'))
+      .join('\n');
+
+    expect(code).not.toMatch(/login\s*[=!]==/);
+    expect(code).not.toMatch(/['"`]github-actions/);
+  });
+});
+
+describe('the READY TO MERGE marker', () => {
+  // Lifted out of the composite action's inline script rather than copied, so
+  // the test exercises the shipped source instead of a drifting duplicate.
+  const source = readFileSync(
+    join(ROOT, '.github/actions/agentic-auto-merge/action.yml'), 'utf8'
+  );
+  const start = source.indexOf('const carriesMergeMarker');
+  const end = source.indexOf('\n          };', start);
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+
+  const carriesMergeMarker = new Function(
+    `${source.slice(start, end + '\n          };'.length)} return carriesMergeMarker;`
+  )() as (body: string | null | undefined) => boolean;
+
+  it('accepts the marker on a line of its own', () => {
+    expect(carriesMergeMarker('Closes #404\n\nREADY TO MERGE\n')).toBe(true);
+  });
+
+  it('accepts the whitespace an API round trip leaves on the line', () => {
+    expect(carriesMergeMarker('Closes #404\n\n  READY TO MERGE  \r\n')).toBe(true);
+  });
+
+  it('rejects the phrase inside a sentence, which is how a run says it is not', () => {
+    expect(carriesMergeMarker('READY TO MERGE skipped — visual: BLOCKED')).toBe(false);
+    expect(carriesMergeMarker('This is not READY TO MERGE yet.')).toBe(false);
+  });
+
+  it('treats an empty body as unmarked', () => {
+    expect(carriesMergeMarker('')).toBe(false);
+    expect(carriesMergeMarker(null)).toBe(false);
+    expect(carriesMergeMarker(undefined)).toBe(false);
+  });
+});

--- a/tests/unit/config/autonomy-loop.test.ts
+++ b/tests/unit/config/autonomy-loop.test.ts
@@ -126,52 +126,63 @@ describe('dependency gating', () => {
 // and then sat open with zero checks. Its author was `github-actions[bot]`, and
 // every `pull_request` workflow run a bot-authored PR raises is created and
 // immediately parked as `action_required`: CI never started and the auto-merge
-// step never ran. Auto-merge therefore has to be reachable on triggers no
-// account can gate, and has to decide on something other than who authored the
-// PR.
+// step never ran. So the run that opens the PR arms auto-merge itself, in the
+// same job, on the branch it was told to build — the one moment that exists
+// whoever the PR ends up attributed to.
 describe('auto-merge does not depend on the PR author', () => {
   const AUTO_MERGE_ACTION = 'uses: ./.github/actions/agentic-auto-merge';
 
   /** Every workflow that can put a PR into auto-merge. */
-  const MERGING_WORKFLOWS = ['auto-assign-next.yml', 'agentic-auto-merge.yml'];
+  const MERGING_WORKFLOWS = [
+    'claude-runner.yml',
+    'opencode-runner.yml',
+    'auto-assign-next.yml',
+    'agentic-auto-merge.yml',
+  ];
 
-  it.each(MERGING_WORKFLOWS)('%s enables auto-merge through the shared action', (name) => {
+  it.each(MERGING_WORKFLOWS)('%s arms auto-merge through the shared action', (name) => {
     expect(workflow(name)).toContain(AUTO_MERGE_ACTION);
-  });
-
-  // A `pull_request` trigger is the one thing the bot-authored PR cannot reach,
-  // so the sweep must not be built on it. Losing these triggers reproduces #430
-  // exactly: the mechanism is present, correct, and never invoked.
-  it('sweeps on triggers a bot-authored PR cannot gate', () => {
-    const sweep = workflow('agentic-auto-merge.yml');
-    const triggers = sweep.slice(sweep.indexOf('\non:'), sweep.indexOf('\npermissions:'));
-
-    expect(triggers).toContain('schedule:');
-    expect(triggers).toContain('workflow_run:');
-    expect(triggers).toContain('workflow_dispatch:');
-    expect(triggers).not.toContain('pull_request:');
-  });
-
-  // `workflow_run` names workflows by their `name:`, not their filename, so a
-  // renamed runner silently detaches the sweep from the run that produced the PR.
-  it.each([
-    ['claude-runner.yml'],
-    ['opencode-runner.yml'],
-  ])('watches %s by the name that workflow actually declares', (runner) => {
-    const declared = /^name:\s*(.+)$/m.exec(workflow(runner))?.[1].trim();
-    expect(declared).toBeTruthy();
-    expect(workflow('agentic-auto-merge.yml')).toContain(`"${declared}"`);
   });
 
   // Releasing a parked run needs `actions: write`, and the merge itself has to
   // raise a `pull_request: closed` event that the chain step reacts to — a merge
   // performed with GITHUB_TOKEN raises none, so the queue stops at the merge.
-  it.each(MERGING_WORKFLOWS)('%s drives auto-merge with the PAT', (name) => {
+  it.each(MERGING_WORKFLOWS)('%s arms auto-merge with the PAT', (name) => {
     const text = workflow(name);
     const block = text.slice(text.indexOf(AUTO_MERGE_ACTION));
     const token = /token:\s*\$\{\{\s*secrets\.(\w+)\s*\}\}/.exec(block);
     expect(token?.[1]).toBe('PAT_TOKEN_COPILOT_AUTOMATION');
-    expect(text).toMatch(/permissions:[\s\S]*?actions: write/);
+  });
+
+  // The whole point of arming inside the runner: it is reached by the run that
+  // created the PR, not by an event the PR's author can suppress. Without
+  // `always()` an agent step that crashed after opening its PR leaves it unarmed.
+  it.each(['claude-runner.yml', 'opencode-runner.yml'])(
+    '%s arms the branch it was told to build, even when the agent step failed',
+    (name) => {
+      const text = workflow(name);
+      const step = text.slice(text.indexOf('- name: Arm auto-merge'), text.indexOf(ASSIGN_ACTION, text.indexOf('- name: Arm auto-merge')));
+      expect(step).toContain(AUTO_MERGE_ACTION);
+      expect(step).toContain('head: pipeline/feature-${{ steps.context.outputs.issue }}');
+      expect(step).toMatch(/if:\s*always\(\)/);
+    }
+  );
+
+  // No clock anywhere in the path. Auto-merge is armed by the run that opens the
+  // PR and re-armed by `pull_request`; a PR that reaches neither is a manual
+  // dispatch, not a polled one.
+  it.each(MERGING_WORKFLOWS)('%s arms auto-merge on an event, never on a schedule', (name) => {
+    const text = workflow(name);
+    const triggers = text.slice(text.indexOf('\non:'), text.indexOf('\npermissions:'));
+    expect(triggers).not.toContain('schedule:');
+    expect(triggers).not.toContain('cron:');
+  });
+
+  it('keeps the standalone auto-merge workflow manual-only', () => {
+    const sweep = workflow('agentic-auto-merge.yml');
+    const triggers = sweep.slice(sweep.indexOf('\non:'), sweep.indexOf('\npermissions:'));
+    expect(triggers).toContain('workflow_dispatch:');
+    expect(triggers.replace('workflow_dispatch:', '')).not.toMatch(/^\s{2}\w+.*:$/m);
   });
 
   // The author may appear in a log line or a comment — it is worth reporting.


### PR DESCRIPTION
## What went wrong on PR #430

PR #430 was opened by `github-actions[bot]`. Every `pull_request` workflow run a bot-authored PR raises is created and then immediately parked as `action_required` — GitHub never executes it. Two runs on `834b849`, both dead on arrival:

| Run | Workflow | Conclusion |
|-----|----------|------------|
| `30510851173` | CI | `action_required` |
| `30510851187` | Pipeline: assign next issue | `action_required` |

So it was not only auto-merge that never ran: **CI never ran either**. PR #430 has zero check runs and a `pending` combined status. Even a manually enabled auto-merge would have waited forever on checks that were never going to start. PR #425 (also `github-actions[bot]`, also `pipeline/feature-*`) hit the same wall and only moved because a human merged it by hand a day later.

## The fix

Auto-merge is armed by **the run that opens the PR**, in the same job, on the branch the assignment told it to build. No clock anywhere in the path.

- **New composite action `.github/actions/agentic-auto-merge`.** Takes a non-draft PR carrying `READY TO MERGE` on a line of its own — the pipeline's own ship signal, written by the orchestrator and by nothing else. It releases every workflow run parked as `action_required` on the PR head so CI actually starts, then enables GitHub native auto-merge via the PAT. When GitHub refuses auto-merge because nothing is left to wait for (or the repo has the feature off), it merges a `clean` PR outright. The author is logged and never branched on. Targets a PR by number, by head branch, or sweeps all open PRs.
- **Both runners gain `Arm auto-merge on the PR this run opened`**, after the agent step and after `agentic-rescue`, with `always()` — an agent step that crashed after opening its PR is exactly the case worth covering. It arms `pipeline/feature-<N>`, so it needs no PR number and no `pull_request` event. This moment exists whoever the PR ends up attributed to, which is precisely what the `pull_request` event does not.
- **`auto-assign-next.yml`** keeps its `pull_request` path, now calling the same action. Its job narrows to the marker arriving *after* the PR did — a body edited, a draft marked ready.
- **`agentic-auto-merge.yml`** is `workflow_dispatch` only: the manual handle for a PR stranded by an older run or by a job cancelled before its arming step. No schedule, no cron.

Releasing a parked run needs `actions: write` on `PAT_TOKEN_COPILOT_AUTOMATION`. If the PAT lacks it, the step still enables auto-merge and warns naming the missing scope, rather than failing silently.

## Tests

`tests/unit/config/autonomy-loop.test.ts` gains 21 cases, in the style the file already uses for the assignment chain:

- all four entry points call the shared action with the PAT
- each runner arms `pipeline/feature-${{ steps.context.outputs.issue }}` under `always()`
- **no workflow in the auto-merge path declares `schedule:` or `cron:`**, and the standalone workflow stays dispatch-only
- no author comparison anywhere in the action's code
- the marker parser, lifted out of the shipped YAML rather than copied: accepts a standalone line and the whitespace an API round trip adds, rejects `READY TO MERGE skipped — …` and `not READY TO MERGE yet`, treats an empty body as unmarked

## Verification

- **static** — `npm run typecheck`: clean.
- **logic** — `npm run test`: 190 files / 5620 tests passing.
- `npm run validate:context`: clean — skill bodies stay identical across `.claude/`, `.github/`, `.opencode/`.
- All five touched YAML files parse; the action's inline script passes `node --check`.
- **scenario / visual / playability** — not owed: no change under `src/`.

## PR #430 still needs one action

This branch fixes the mechanism for every future run; it cannot retroactively start PR #430's parked runs, and this session's token lacks `actions: write` to do it by hand (`403 Resource not accessible by integration`). Once this merges, run `Pipeline: enable auto-merge on an agent PR` from the Actions tab with `pr: 430` — it releases both parked runs and arms auto-merge. If the PAT turns out to lack `actions: write`, approve the two runs on #430 from the Actions tab once instead.