### PR TITLE
feat: fix navmesh scenario visual coherence, wire dead vehicle/employee tick movement (#407)

### DIFF
--- a/scripts/scenario-defs/nav-cell-types-visual.json
+++ b/scripts/scenario-defs/nav-cell-types-visual.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-cell-types-visual",
-  "description": "Tests all 5 NavCell types (walkable, blocked, drill_hole, ramp, void) are visible",
+  "description": "Tests the 4 console-reachable NavCell types (walkable, blocked, drill_hole, ramp) render on the overlay",
   "steps": [
     {
       "command": "new_game seed:42",
@@ -8,6 +8,10 @@
         {
           "type": "command",
           "command": "new_game seed:42"
+        },
+        {
+          "type": "keypress",
+          "key": "KeyN"
         }
       ]
     },

--- a/scripts/scenario-defs/nav-dynamic-updates-visual.json
+++ b/scripts/scenario-defs/nav-dynamic-updates-visual.json
@@ -67,7 +67,7 @@
     },
     {
       "command": "vehicle buy debris_hauler",
-      "description": "Purchase a vehicle and send it across the grid — its parking/departure should trigger a single-cell NavGrid vehicleOccupied update per tick.",
+      "description": "Purchase a vehicle and send it across the grid — its position should advance tick by tick via the NavGrid-aware pathfinding stepper.",
       "interaction": [
         {
           "type": "command",
@@ -95,7 +95,7 @@
     },
     {
       "command": "state full",
-      "description": "Final state dump — vehicle parked/departed cell(s) should show the single-cell NavGrid occupancy update.",
+      "description": "Final state dump — vehicle should have advanced toward its destination along the NavGrid path.",
       "interaction": [
         {
           "type": "command",

--- a/scripts/scenario-defs/nav-dynamic-updates-visual.json
+++ b/scripts/scenario-defs/nav-dynamic-updates-visual.json
@@ -64,6 +64,44 @@
           "command": "state full"
         }
       ]
+    },
+    {
+      "command": "vehicle buy debris_hauler",
+      "description": "Purchase a vehicle and send it across the grid — its parking/departure should trigger a single-cell NavGrid vehicleOccupied update per tick.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle buy debris_hauler"
+        }
+      ]
+    },
+    {
+      "command": "vehicle move 1 to:15,15",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle move 1 to:15,15"
+        }
+      ]
+    },
+    {
+      "command": "tick 5",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 5"
+        }
+      ]
+    },
+    {
+      "command": "state full",
+      "description": "Final state dump — vehicle parked/departed cell(s) should show the single-cell NavGrid occupancy update.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "state full"
+        }
+      ]
     }
   ],
   "shots": [

--- a/scripts/scenario-defs/nav-dynamic-updates-visual.json
+++ b/scripts/scenario-defs/nav-dynamic-updates-visual.json
@@ -21,11 +21,11 @@
       ]
     },
     {
-      "command": "charge hole:H1 explosive:boomite amount:500kg stemming:2m",
+      "command": "charge hole:H1 explosive:boomite amount:8kg stemming:2m",
       "interaction": [
         {
           "type": "command",
-          "command": "charge hole:H1 explosive:boomite amount:500kg stemming:2m"
+          "command": "charge hole:H1 explosive:boomite amount:8kg stemming:2m"
         }
       ]
     },

--- a/scripts/scenario-defs/nav-minimap-integration-visual.json
+++ b/scripts/scenario-defs/nav-minimap-integration-visual.json
@@ -8,6 +8,10 @@
         {
           "type": "command",
           "command": "new_game seed:42"
+        },
+        {
+          "type": "keypress",
+          "key": "KeyN"
         }
       ]
     },

--- a/scripts/scenario-defs/nav-move-costs-visual.json
+++ b/scripts/scenario-defs/nav-move-costs-visual.json
@@ -8,6 +8,10 @@
         {
           "type": "command",
           "command": "new_game seed:42"
+        },
+        {
+          "type": "keypress",
+          "key": "KeyN"
         }
       ]
     },
@@ -30,6 +34,25 @@
       ]
     },
     {
+      "command": "vehicle buy debris_hauler",
+      "description": "Buy a vehicle and send it moving across cells of different NavGrid cost (walkable, drill_hole) so per-tick progress is visible.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle buy debris_hauler"
+        }
+      ]
+    },
+    {
+      "command": "vehicle move 1 to:5,9",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle move 1 to:5,9"
+        }
+      ]
+    },
+    {
       "command": "state full",
       "interaction": [
         {
@@ -39,11 +62,21 @@
       ]
     },
     {
-      "command": "tick 5",
+      "command": "tick 10",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 5"
+          "command": "tick 10"
+        }
+      ]
+    },
+    {
+      "command": "state full",
+      "description": "Final state dump — vehicle x/z should have advanced toward (5,9) across the drill_hole row.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "state full"
         }
       ]
     }

--- a/scripts/scenario-defs/nav-path-following-visual.json
+++ b/scripts/scenario-defs/nav-path-following-visual.json
@@ -39,6 +39,16 @@
       ]
     },
     {
+      "command": "employee dispatch 1 x:0 z:0",
+      "description": "Send employee #1 walking toward the far corner — the management_office placed below will land on this path and block it.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "employee dispatch 1 x:0 z:0"
+        }
+      ]
+    },
+    {
       "command": "tick 10",
       "interaction": [
         {

--- a/scripts/scenario-defs/nav-path-following-visual.json
+++ b/scripts/scenario-defs/nav-path-following-visual.json
@@ -40,7 +40,7 @@
     },
     {
       "command": "employee dispatch 1 x:0 z:0",
-      "description": "Send employee #1 walking toward the far corner — the management_office placed below will land on this path and block it.",
+      "description": "Send employee #1 walking toward the far corner — a 3-building wall placed below will completely seal that corner off, with no detour around it.",
       "interaction": [
         {
           "type": "command",
@@ -49,20 +49,52 @@
       ]
     },
     {
-      "command": "tick 10",
+      "command": "tick 19",
+      "description": "Let employee #1 travel most of the way toward (0,0) before the wall goes up, so it lands right at the wall once blocked.",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 10"
+          "command": "tick 19"
         }
       ]
     },
     {
-      "command": "build management_office at:3,3",
+      "command": "build management_office at:2,0",
+      "description": "First wall segment: seals the east side of the (0,0) corner (x:2-3, z:0-1).",
       "interaction": [
         {
           "type": "command",
-          "command": "build management_office at:3,3"
+          "command": "build management_office at:2,0"
+        }
+      ]
+    },
+    {
+      "command": "build management_office at:0,2",
+      "description": "Second wall segment: seals the south side of the (0,0) corner (x:0-1, z:2-3).",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "build management_office at:0,2"
+        }
+      ]
+    },
+    {
+      "command": "build management_office at:2,2",
+      "description": "Third wall segment: fills the diagonal corner gap (x:2-3, z:2-3) so no 8-directional diagonal move can slip past the wall.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "build management_office at:2,2"
+        }
+      ]
+    },
+    {
+      "command": "tick 5",
+      "description": "Every re-route attempt now fails since (0,0) is fully enclosed — after STUCK_THRESHOLD consecutive failures employee #1 flips to the stuck state.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 5"
         }
       ]
     },
@@ -76,21 +108,39 @@
       ]
     },
     {
-      "command": "tick 15",
+      "command": "tick 10",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 15"
+          "command": "tick 10"
         }
       ]
     },
     {
       "command": "build destroy 1",
-      "description": "Demolish the blocking management_office — the previously stuck agent should be able to resume movement once the footprint clears.",
       "interaction": [
         {
           "type": "command",
           "command": "build destroy 1"
+        }
+      ]
+    },
+    {
+      "command": "build destroy 2",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "build destroy 2"
+        }
+      ]
+    },
+    {
+      "command": "build destroy 3",
+      "description": "Demolish all three wall segments — the previously stuck agent should be able to resume movement once the corner is fully open again.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "build destroy 3"
         }
       ]
     },

--- a/scripts/scenario-defs/nav-path-following-visual.json
+++ b/scripts/scenario-defs/nav-path-following-visual.json
@@ -73,6 +73,26 @@
           "command": "tick 15"
         }
       ]
+    },
+    {
+      "command": "build destroy 1",
+      "description": "Demolish the blocking management_office — the previously stuck agent should be able to resume movement once the footprint clears.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "build destroy 1"
+        }
+      ]
+    },
+    {
+      "command": "tick 15",
+      "description": "Advance ticks after demolition — the stuck agent should resume moving toward its destination.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 15"
+        }
+      ]
     }
   ],
   "shots": [

--- a/scripts/scenario-defs/nav-pathfinding-visual.json
+++ b/scripts/scenario-defs/nav-pathfinding-visual.json
@@ -57,6 +57,16 @@
       ]
     },
     {
+      "command": "employee dispatch 1 x:2 z:2",
+      "description": "Send the driller toward the far corner beyond the 3-building cluster at (5,5)/(5,7)/(7,5), forcing A* to route around them.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "employee dispatch 1 x:2 z:2"
+        }
+      ]
+    },
+    {
       "command": "tick 20",
       "interaction": [
         {

--- a/scripts/scenario-defs/nav-ramp-routing-visual.json
+++ b/scripts/scenario-defs/nav-ramp-routing-visual.json
@@ -12,11 +12,60 @@
       ]
     },
     {
+      "command": "vehicle buy debris_hauler",
+      "description": "Purchase a vehicle before the ramp exists — its route request below must fail (found:false) since the lower bench is not yet connected.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle buy debris_hauler"
+        }
+      ]
+    },
+    {
+      "command": "vehicle move 1 to:8,20",
+      "description": "Request a route to the not-yet-connected lower bench — expect the vehicle to remain stuck (no ramp connects the levels yet).",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle move 1 to:8,20"
+        }
+      ]
+    },
+    {
+      "command": "tick 5",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 5"
+        }
+      ]
+    },
+    {
+      "command": "state full",
+      "description": "Pre-ramp state dump — vehicle should not have reached (8,20); routing found:false.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "state full"
+        }
+      ]
+    },
+    {
       "command": "build_ramp origin:5,15 direction:south length:10 depth:8",
       "interaction": [
         {
           "type": "command",
           "command": "build_ramp origin:5,15 direction:south length:10 depth:8"
+        }
+      ]
+    },
+    {
+      "command": "vehicle move 1 to:8,20",
+      "description": "Re-request the same route now that the ramp connects the two levels — expect routing found:true this time.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle move 1 to:8,20"
         }
       ]
     },

--- a/scripts/scenario-defs/nav-ramp-routing-visual.json
+++ b/scripts/scenario-defs/nav-ramp-routing-visual.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-ramp-routing-visual",
-  "description": "Tests multi-level ramp routing with agents walking across levels",
+  "description": "Tests vehicle/employee NavGrid-aware movement and build_ramp construction on the same map. Note: generated 'desert' terrain at this seed is a single flat bench (see #407 code-review verification) — the ramp does not gate reachability of (8,20) here, but the scenario still exercises real A*-routed, tick-by-tick vehicle movement plus ramp construction end to end.",
   "steps": [
     {
       "command": "new_game seed:42",
@@ -13,7 +13,7 @@
     },
     {
       "command": "vehicle buy debris_hauler",
-      "description": "Purchase a vehicle before the ramp exists — its route request below must fail (found:false) since the lower bench is not yet connected.",
+      "description": "Purchase a vehicle before the ramp exists.",
       "interaction": [
         {
           "type": "command",
@@ -23,7 +23,7 @@
     },
     {
       "command": "vehicle move 1 to:8,20",
-      "description": "Request a route to the not-yet-connected lower bench — expect the vehicle to remain stuck (no ramp connects the levels yet).",
+      "description": "Request a route across freshly-generated (single-bench, flat) terrain — the vehicle routes and walks there via real NavGrid A* pathfinding (#407), progressing gradually tick over tick rather than teleporting.",
       "interaction": [
         {
           "type": "command",
@@ -42,7 +42,7 @@
     },
     {
       "command": "state full",
-      "description": "Pre-ramp state dump — vehicle should not have reached (8,20); routing found:false.",
+      "description": "Pre-ramp state dump — vehicle is mid-route toward (8,20), advancing at its own speed each tick rather than jumping straight there.",
       "interaction": [
         {
           "type": "command",
@@ -61,7 +61,7 @@
     },
     {
       "command": "vehicle move 1 to:8,20",
-      "description": "Re-request the same route now that the ramp connects the two levels — expect routing found:true this time.",
+      "description": "Re-request the same route after build_ramp — still resolves via real A* routing; the ramp construction runs cleanly alongside vehicle movement without breaking navigation.",
       "interaction": [
         {
           "type": "command",

--- a/scripts/scenario-defs/nav-ramp-routing-visual.json
+++ b/scripts/scenario-defs/nav-ramp-routing-visual.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-ramp-routing-visual",
-  "description": "Tests vehicle/employee NavGrid-aware movement and build_ramp construction on the same map. Note: generated 'desert' terrain at this seed is a single flat bench (see #407 code-review verification) — the ramp does not gate reachability of (8,20) here, but the scenario still exercises real A*-routed, tick-by-tick vehicle movement plus ramp construction end to end.",
+  "description": "Tests vehicle/employee NavGrid-aware movement and build_ramp construction on the same map. Note: generated 'desert' terrain at this seed is a single flat bench (see #407 code-review verification) — the ramp does not gate reachability of (8,20) here, but the scenario still exercises real A*-routed, tick-by-tick vehicle movement, employee movement, and ramp construction end to end.",
   "steps": [
     {
       "command": "new_game seed:42",
@@ -75,6 +75,16 @@
         {
           "type": "command",
           "command": "employee hire role:driller"
+        }
+      ]
+    },
+    {
+      "command": "employee dispatch 1 x:8 z:20",
+      "description": "Send the hired driller walking toward (8,20) via the same real A*-routed, tick-by-tick NavGrid movement as the vehicle above (#407 review round 2) — this is what the scenario's own description claims but the driller previously never received a destination.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "employee dispatch 1 x:8 z:20"
         }
       ]
     },

--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -19,7 +19,7 @@ import { processPayCycle } from '../../core/entities/Employee.js';
 import { tickTraining } from '../../core/entities/EmployeeTraining.js';
 import { tickNeedGauges, needsMoraleEffect } from '../../core/entities/EmployeeNeeds.js';
 import type { FiredEvent } from '../../core/events/EventSystem.js';
-import { tickCollapse, autoInsertNeedTasks, processShiftCycle, tickEmployees, tickGeneralRestCompletion, tickTaskProgress } from '../../core/engine/GameLoop.js';
+import { tickCollapse, autoInsertNeedTasks, processShiftCycle, tickEmployees, tickGeneralRestCompletion, tickTaskProgress, tickVehicle, tickEmployeeMovement } from '../../core/engine/GameLoop.js';
 import { detectUnqualifiedTask } from '../../core/events/EventEngine.js';
 import { estimateSurveyResult, type SurveyMethod } from '../../core/mining/SurveyCalc.js';
 import { checkDeadlines, generateContracts } from '../../core/economy/Contract.js';
@@ -215,6 +215,22 @@ export function tickCommand(
       if (progress.leveledUp) {
         lines.push(`[tick ${state.tickCount}] LEVELUP: ${emp.name} reached level ${progress.newLevel} in ${progress.skill}.`);
       }
+    }
+
+    // 8f. Vehicle movement — advance every vehicle currently task='moving' one
+    // step toward its target (moveVehicle/vehicle-move-command only set the
+    // target; nothing advanced x/z toward it before this).
+    for (const vehicle of state.vehicles.vehicles) {
+      tickVehicle(state, vehicle);
+    }
+
+    // 8g. Employee movement — walk employees with a destination (set by
+    // tickEmployees/tickCollapse/tickNeedRestoration/forceShiftRestIfNeeded
+    // above) one tick's worth of movement along a NavGrid path.
+    const movementResult = tickEmployeeMovement(state, emitter);
+    for (const empId of movementResult.stuck) {
+      const emp = state.employees.employees.find(e => e.id === empId);
+      lines.push(`[tick ${state.tickCount}] STUCK: ${emp?.name ?? `employee #${empId}`} can't find a path — waiting.`);
     }
 
     // 9. Level stats snapshot + campaign profit check

--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -221,7 +221,7 @@ export function tickCommand(
     // step toward its target (moveVehicle/vehicle-move-command only set the
     // target; nothing advanced x/z toward it before this).
     for (const vehicle of state.vehicles.vehicles) {
-      tickVehicle(state, vehicle);
+      tickVehicle(state, vehicle, emitter);
     }
 
     // 8g. Employee movement — walk employees with a destination (set by

--- a/src/core/config/balance.ts
+++ b/src/core/config/balance.ts
@@ -281,6 +281,9 @@ export const STUCK_THRESHOLD = 3;
 /** Employee agent walking speed in grid cells per tick (1 tick = 1 game-hour). */
 export const AGENT_WALK_SPEED = 2;
 
+/** Morale penalty applied per tick to an employee stuck with no walkable path (see NEED_MORALE_PENALTIES for the analogous need-driven table). */
+export const STUCK_MORALE_PENALTY = 2;
+
 /** Height of one bench level in voxels. Affects benchLevel computation in NavGrid. */
 export const NAV_BENCH_HEIGHT = 5;
 

--- a/src/core/engine/EntityMovementTick.ts
+++ b/src/core/engine/EntityMovementTick.ts
@@ -1,0 +1,273 @@
+// BlastSimulator2026 — Per-tick movement for vehicles and employees.
+// Extracted from GameLoop.ts (#407 refactor) — both steppers share the same
+// find-path/advance pipeline (AgentAdvance.advanceAlongPath) and were added
+// together to wire vehicles and employees onto the NavGrid, so they live in
+// one cohesive module rather than the general tick orchestration in GameLoop.ts.
+
+import type { GameState } from '../state/GameState.js';
+import { getVehicleDefByTier, type Vehicle } from '../entities/Vehicle.js';
+import type { EventEmitter } from '../state/EventEmitter.js';
+import { findPath } from '../nav/Pathfinding.js';
+import { advanceAlongPath } from '../nav/AgentAdvance.js';
+import { AGENT_WALK_SPEED, STUCK_MORALE_PENALTY } from '../config/balance.js';
+
+// ── Vehicle movement ──
+
+/**
+ * Process one vehicle movement step toward vehicle.targetX/targetZ.
+ *
+ * With a NavGrid built (state.navGrid !== null), routes via Pathfinding.findPath
+ * and advances via AgentMovement.advanceAgent — the same pipeline
+ * tickEmployeeMovement uses — so ramps, blocked cells, and NavCell move costs
+ * (walkable:1.0, ramp:1.8, drill_hole:5.0, blocked/void: impassable) all affect
+ * a vehicle's route exactly as they do an employee's. Previously this stepped
+ * a flat one grid cell per tick in a straight line, ignoring the NavGrid
+ * entirely regardless of terrain (#407).
+ *
+ * With no NavGrid yet (e.g. before a world is generated), falls back to the
+ * original direct-line, one-cell-per-tick stepper — unchanged from before
+ * this fix, and still exercised by callers/tests that construct a GameState
+ * without a NavGrid.
+ *
+ * Vehicle-vs-vehicle collision avoidance is a separate, simpler mechanism
+ * from NavCell.vehicleOccupied — no caller in src/ ever sets that flag true,
+ * so Pathfinding/AgentMovement's own avoidVehicles checks against it are
+ * always a no-op today. tickVehicle instead checks other vehicles' live x/z
+ * directly via isCellOccupiedByOtherVehicle before committing to the next
+ * grid cell, which is what actually stops two vehicles from occupying the
+ * same cell. On the NavGrid path this is only checked for the immediate next
+ * cell, not every cell a multi-cell-per-tick (speed > 1) vehicle would cross
+ * in the same tick — a vehicle already mid-tick will not stop for one that
+ * enters a farther cell of its path within that same tick.
+ */
+export function tickVehicle(state: GameState, vehicle: Vehicle, emitter?: EventEmitter): void {
+  if (!canTickVehicle(vehicle)) return;
+
+  if (vehicle.x === vehicle.targetX && vehicle.z === vehicle.targetZ) {
+    setVehicleIdle(vehicle);
+    return;
+  }
+
+  if (state.navGrid) {
+    tickVehicleOnNavGrid(state, vehicle, emitter);
+  } else {
+    tickVehicleDirectLine(state, vehicle);
+  }
+}
+
+/** Original pre-#407 stepper: one grid cell per tick in a straight line, ignoring terrain. */
+function tickVehicleDirectLine(state: GameState, vehicle: Vehicle): void {
+  const deltaX = vehicle.targetX - vehicle.x;
+  const deltaZ = vehicle.targetZ - vehicle.z;
+
+  let nextX = vehicle.x;
+  let nextZ = vehicle.z;
+  if (deltaX !== 0) {
+    nextX += Math.sign(deltaX);
+  } else if (deltaZ !== 0) {
+    nextZ += Math.sign(deltaZ);
+  }
+
+  if (isCellOccupiedByOtherVehicle(state, vehicle, nextX, nextZ)) {
+    markVehicleWaiting(vehicle);
+    return;
+  }
+
+  vehicle.x = nextX;
+  vehicle.z = nextZ;
+  vehicle.state = 'moving';
+  vehicle.waitingTicks = 0;
+
+  if (vehicle.x === vehicle.targetX && vehicle.z === vehicle.targetZ) {
+    setVehicleIdle(vehicle);
+  }
+}
+
+/** NavGrid-aware stepper: routes via A*, respects move costs, tracks stuck state. */
+function tickVehicleOnNavGrid(state: GameState, vehicle: Vehicle, emitter?: EventEmitter): void {
+  const path = findPath(state.navGrid!, {
+    agentId: vehicle.id,
+    fromX: vehicle.x,
+    fromZ: vehicle.z,
+    toX: vehicle.targetX,
+    toZ: vehicle.targetZ,
+    avoidVehicles: false,
+  });
+
+  const outcome = advanceAlongPath({
+    x: vehicle.x,
+    z: vehicle.z,
+    walkSpeed: getVehicleDefByTier(vehicle.type, vehicle.tier).speed,
+    destinationX: vehicle.targetX,
+    destinationZ: vehicle.targetZ,
+    consecutiveFailures: vehicle.moveConsecutiveFailures,
+    isStuck: vehicle.isMoveStuck,
+    path,
+  });
+
+  vehicle.moveConsecutiveFailures = outcome.consecutiveFailures;
+  vehicle.isMoveStuck = outcome.isStuck;
+
+  if (!outcome.pathFound) {
+    if (outcome.becameStuck) {
+      emitter?.emit('vehicle:stuck', { vehicleId: vehicle.id });
+    }
+    markVehicleWaiting(vehicle);
+    return;
+  }
+
+  const nextStep = nextGridStep(vehicle, path.waypoints);
+  if (nextStep && isCellOccupiedByOtherVehicle(state, vehicle, nextStep.x, nextStep.z)) {
+    markVehicleWaiting(vehicle);
+    return;
+  }
+
+  vehicle.x = outcome.x;
+  vehicle.z = outcome.z;
+  vehicle.state = 'moving';
+  vehicle.waitingTicks = 0;
+
+  if (outcome.isPathComplete) {
+    vehicle.x = vehicle.targetX;
+    vehicle.z = vehicle.targetZ;
+    setVehicleIdle(vehicle);
+  }
+}
+
+/** The immediate next grid cell along a found path — the one occupancy is checked against. */
+function nextGridStep(
+  vehicle: Vehicle,
+  waypoints: Array<{ x: number; z: number }>,
+): { x: number; z: number } | null {
+  if (waypoints.length === 0) return null;
+  const first = waypoints[0]!;
+  const atFirst = Math.floor(vehicle.x) === first.x && Math.floor(vehicle.z) === first.z;
+  if (atFirst && waypoints.length > 1) return waypoints[1]!;
+  return first;
+}
+
+function markVehicleWaiting(vehicle: Vehicle): void {
+  if (vehicle.state !== 'waiting') {
+    vehicle.state = 'waiting';
+    vehicle.waitingTicks = 1;
+  } else {
+    vehicle.waitingTicks = (vehicle.waitingTicks ?? 0) + 1;
+  }
+}
+
+function canTickVehicle(vehicle: Vehicle): boolean {
+  // moveVehicle() sets task='moving'; vehicle state may still be 'idle' on the very first tick.
+  return vehicle.task === 'moving' &&
+    (vehicle.state === 'idle' || vehicle.state === 'moving' || vehicle.state === 'waiting');
+}
+
+function setVehicleIdle(vehicle: Vehicle): void {
+  vehicle.task = 'idle';
+  vehicle.state = 'idle';
+  vehicle.waitingTicks = 0;
+}
+
+function isCellOccupiedByOtherVehicle(state: GameState, vehicle: Vehicle, x: number, z: number): boolean {
+  return state.vehicles.vehicles.some(v => v.id !== vehicle.id && v.x === x && v.z === z);
+}
+
+// ── Employee movement ──
+
+export interface EmployeeMovementResult {
+  /** Employee IDs that advanced position this tick. */
+  moved: number[];
+  /** Employee IDs that reached destinationX/destinationZ this tick. */
+  arrived: number[];
+  /** Employee IDs that newly entered the stuck state this tick. */
+  stuck: number[];
+}
+
+/**
+ * Advance every alive employee with a destination (set by tickEmployees on
+ * claim, or by the rest self-claim paths in tickCollapse/tickNeedRestoration/
+ * forceShiftRestIfNeeded, all in GameLoop.ts) one tick's worth of movement
+ * toward it, using the NavGrid-aware A* pathfinder (Pathfinding.findPath) and
+ * the generic per-tick advancer (AgentMovement.advanceAgent) — the "already
+ * implemented, already unit-tested" navmesh pieces that nothing wired to a
+ * caller before.
+ *
+ * The path is recomputed fresh every tick rather than cached on the employee:
+ * this doubles as the "re-request from current position" behaviour the
+ * gameplay-navmesh spec calls for whenever the next step is blocked, without
+ * needing to persist a waypoint list on GameState. A path that repeatedly
+ * fails to resolve (STUCK_THRESHOLD consecutive ticks) marks the employee
+ * stuck — idle, morale −2/tick — until the grid changes and a path resolves
+ * again, at which point movement resumes on its own the very next tick.
+ *
+ * With no NavGrid built yet (state.navGrid === null), falls back to a direct
+ * line toward the destination, ignoring obstacles — better than the total
+ * non-movement this replaces, and consistent with tickVehicle's own
+ * pre-navmesh behaviour.
+ */
+export function tickEmployeeMovement(state: GameState, emitter?: EventEmitter): EmployeeMovementResult {
+  const result: EmployeeMovementResult = { moved: [], arrived: [], stuck: [] };
+
+  for (const emp of state.employees.employees) {
+    if (!emp.alive) continue;
+    if (emp.destinationX === null || emp.destinationZ === null) continue;
+
+    if (emp.x === emp.destinationX && emp.z === emp.destinationZ) {
+      emp.destinationX = null;
+      emp.destinationZ = null;
+      continue;
+    }
+
+    const path = state.navGrid
+      ? findPath(state.navGrid, {
+        agentId: emp.id,
+        fromX: emp.x,
+        fromZ: emp.z,
+        toX: emp.destinationX,
+        toZ: emp.destinationZ,
+        avoidVehicles: false,
+      })
+      // No NavGrid yet: synthesize a direct two-point path (start, destination) —
+      // findPath is never called, so this always "succeeds", matching the
+      // pre-navmesh direct-line fallback tickVehicle also falls back to.
+      : { found: true, waypoints: [{ x: emp.x, z: emp.z }, { x: emp.destinationX, z: emp.destinationZ }] };
+
+    const outcome = advanceAlongPath({
+      x: emp.x,
+      z: emp.z,
+      walkSpeed: AGENT_WALK_SPEED,
+      destinationX: emp.destinationX,
+      destinationZ: emp.destinationZ,
+      consecutiveFailures: emp.moveConsecutiveFailures,
+      isStuck: emp.isMoveStuck,
+      path,
+    });
+
+    emp.moveConsecutiveFailures = outcome.consecutiveFailures;
+    emp.isMoveStuck = outcome.isStuck;
+
+    if (!outcome.pathFound) {
+      if (emp.isMoveStuck) {
+        if (outcome.becameStuck) {
+          result.stuck.push(emp.id);
+          emitter?.emit('agent:stuck', { employeeId: emp.id });
+        }
+        emp.morale = Math.max(0, emp.morale - STUCK_MORALE_PENALTY);
+      }
+      continue;
+    }
+
+    emp.x = outcome.x;
+    emp.z = outcome.z;
+    result.moved.push(emp.id);
+
+    if (outcome.isPathComplete) {
+      emp.x = emp.destinationX;
+      emp.z = emp.destinationZ;
+      emp.destinationX = null;
+      emp.destinationZ = null;
+      result.arrived.push(emp.id);
+    }
+  }
+
+  return result;
+}

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -15,10 +15,12 @@ import { replenishNeed, getNeedMultiplier } from '../entities/EmployeeNeeds.js';
 import { getLivingQuartersWellbeingMultiplier } from '../entities/BuildingWellbeing.js';
 import type { EventEmitter } from '../state/EventEmitter.js';
 import { addExpense } from '../economy/Finance.js';
+import { findPath } from '../nav/Pathfinding.js';
+import { advanceAgent } from '../nav/AgentMovement.js';
 
 // ── Config ──
 
-import { BASE_TICK_MS as _BASE_TICK_MS, VALID_SPEEDS as _VALID_SPEEDS, NEED_REST_DURATIONS, NEED_REST_NO_BUILDING_CAP, NEED_REST_NO_BUILDING_DURATION_MULTIPLIER, NEED_REST_BUILDING_TYPES, NEED_REST_SEARCH_RADIUS, NEED_WARNING_THRESHOLDS, NEED_REST_COSTS, WORK_DURATION_TICKS, SHIFT_SLEEP_DURATION_TICKS, BASE_TASK_DURATION_TICKS } from '../config/balance.js';
+import { BASE_TICK_MS as _BASE_TICK_MS, VALID_SPEEDS as _VALID_SPEEDS, NEED_REST_DURATIONS, NEED_REST_NO_BUILDING_CAP, NEED_REST_NO_BUILDING_DURATION_MULTIPLIER, NEED_REST_BUILDING_TYPES, NEED_REST_SEARCH_RADIUS, NEED_WARNING_THRESHOLDS, NEED_REST_COSTS, WORK_DURATION_TICKS, SHIFT_SLEEP_DURATION_TICKS, BASE_TASK_DURATION_TICKS, AGENT_WALK_SPEED, STUCK_THRESHOLD } from '../config/balance.js';
 
 /** Milliseconds per base tick at 1x speed. */
 export const BASE_TICK_MS = _BASE_TICK_MS;
@@ -225,6 +227,12 @@ export function tickEmployees(state: GameState): TickEmployeesResult {
     result.claimed.push(action.id);
     // action is consumed — not pushed to remaining
 
+    // Send the employee walking toward the action's location — targetX/targetZ
+    // is documented on PendingAction as existing for exactly this purpose
+    // ("ghost rendering and employee pathfinding"), previously unused.
+    idleMatch.destinationX = action.targetX;
+    idleMatch.destinationZ = action.targetZ;
+
     // This is the actual claim path the tick loop uses (claimPendingAction in
     // TaskDispatch.ts is a separate helper nothing here calls), so it owns
     // clearing the ghost preview too — otherwise the blue marker never
@@ -326,6 +334,8 @@ export function tickNeedRestoration(state: GameState): NeedRestorationResult {
     // Immediately claimed (unlike autoInsertNeedTasks) — start the rest timer now.
     emp.restTicksRemaining = restDuration;
     emp.restNeedKey = needKey;
+    emp.destinationX = building.x;
+    emp.destinationZ = building.z;
     result.routed.push(emp.id);
   }
 
@@ -408,6 +418,8 @@ export function tickCollapse(state: GameState, _firedEvents?: FiredEvent[], _emi
     // Immediately claimed — start the rest timer now (mirrors tickNeedRestoration).
     emp.restTicksRemaining = restDuration;
     emp.restNeedKey = collapsedGauge;
+    emp.destinationX = targetX;
+    emp.destinationZ = targetZ;
   }
 
   return result;
@@ -863,6 +875,8 @@ function forceShiftRestIfNeeded(
 
   state.pendingActions.push(restAction);
   emp.activeActionId = restAction.id;
+  emp.destinationX = targetX;
+  emp.destinationZ = targetZ;
   shiftRested.push(emp.id);
   firedEvents.push({ eventId: 'employee_shift_change', firedAtTick: state.tickCount });
   _emitter?.emit('employee:shift_change', { employeeId: emp.id });
@@ -875,4 +889,112 @@ function getBuildingCenter(building: Building): { x: number; z: number } {
   const def = getBuildingDef(building.type, building.tier);
   const { sizeX, sizeZ } = getDefSize(def);
   return { x: building.x + sizeX / 2, z: building.z + sizeZ / 2 };
+}
+
+// ── Employee movement ──
+
+export interface EmployeeMovementResult {
+  /** Employee IDs that advanced position this tick. */
+  moved: number[];
+  /** Employee IDs that reached destinationX/destinationZ this tick. */
+  arrived: number[];
+  /** Employee IDs that newly entered the stuck state this tick. */
+  stuck: number[];
+}
+
+/**
+ * Advance every alive employee with a destination (set by tickEmployees on
+ * claim, or by the rest self-claim paths in tickCollapse/tickNeedRestoration/
+ * forceShiftRestIfNeeded) one tick's worth of movement toward it, using the
+ * NavGrid-aware A* pathfinder (Pathfinding.findPath) and the generic
+ * per-tick advancer (AgentMovement.advanceAgent) — the "already implemented,
+ * already unit-tested" navmesh pieces that nothing wired to a caller before.
+ *
+ * The path is recomputed fresh every tick rather than cached on the employee:
+ * this doubles as the "re-request from current position" behaviour the
+ * gameplay-navmesh spec calls for whenever the next step is blocked, without
+ * needing to persist a waypoint list on GameState. A path that repeatedly
+ * fails to resolve (STUCK_THRESHOLD consecutive ticks) marks the employee
+ * stuck — idle, morale −2/tick — until the grid changes and a path resolves
+ * again, at which point movement resumes on its own the very next tick.
+ *
+ * With no NavGrid built yet (state.navGrid === null), falls back to a direct
+ * line toward the destination, ignoring obstacles — better than the total
+ * non-movement this replaces, and consistent with tickVehicle's own
+ * pre-navmesh behaviour.
+ */
+export function tickEmployeeMovement(state: GameState, emitter?: EventEmitter): EmployeeMovementResult {
+  const result: EmployeeMovementResult = { moved: [], arrived: [], stuck: [] };
+
+  for (const emp of state.employees.employees) {
+    if (!emp.alive) continue;
+    if (emp.destinationX === null || emp.destinationZ === null) continue;
+
+    if (emp.x === emp.destinationX && emp.z === emp.destinationZ) {
+      emp.destinationX = null;
+      emp.destinationZ = null;
+      continue;
+    }
+
+    let waypoints: Array<{ x: number; z: number }>;
+    let pathFound: boolean;
+
+    if (state.navGrid) {
+      const path = findPath(state.navGrid, {
+        agentId: emp.id,
+        fromX: emp.x,
+        fromZ: emp.z,
+        toX: emp.destinationX,
+        toZ: emp.destinationZ,
+        avoidVehicles: false,
+      });
+      pathFound = path.found;
+      waypoints = path.waypoints;
+    } else {
+      pathFound = true;
+      waypoints = [{ x: emp.x, z: emp.z }, { x: emp.destinationX, z: emp.destinationZ }];
+    }
+
+    if (!pathFound) {
+      emp.moveConsecutiveFailures += 1;
+      if (emp.moveConsecutiveFailures >= STUCK_THRESHOLD) {
+        if (!emp.moveStuck) {
+          emp.moveStuck = true;
+          result.stuck.push(emp.id);
+          emitter?.emit('agent:stuck', { employeeId: emp.id });
+        }
+        emp.morale = Math.max(0, emp.morale - 2);
+      }
+      continue;
+    }
+
+    emp.moveConsecutiveFailures = 0;
+    emp.moveStuck = false;
+
+    const advance = advanceAgent({
+      x: emp.x,
+      z: emp.z,
+      waypoints,
+      waypointIndex: 0,
+      walkSpeed: AGENT_WALK_SPEED,
+      destinationX: emp.destinationX,
+      destinationZ: emp.destinationZ,
+      consecutiveFailures: emp.moveConsecutiveFailures,
+      isStuck: emp.moveStuck,
+    });
+
+    emp.x = advance.x;
+    emp.z = advance.z;
+    result.moved.push(emp.id);
+
+    if (advance.isPathComplete) {
+      emp.x = emp.destinationX;
+      emp.z = emp.destinationZ;
+      emp.destinationX = null;
+      emp.destinationZ = null;
+      result.arrived.push(emp.id);
+    }
+  }
+
+  return result;
 }

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -3,7 +3,6 @@
 // Pure logic: no timers, no DOM. The caller drives the loop.
 
 import type { GameState, PendingAction } from '../state/GameState.js';
-import { getVehicleDefByTier, type Vehicle } from '../entities/Vehicle.js';
 import { getBuildingDef, getDefSize, type Building, type BuildingType } from '../entities/Building.js';
 import type { Random } from '../math/Random.js';
 import type { EventContext } from '../events/EventPool.js';
@@ -15,12 +14,16 @@ import { replenishNeed, getNeedMultiplier } from '../entities/EmployeeNeeds.js';
 import { getLivingQuartersWellbeingMultiplier } from '../entities/BuildingWellbeing.js';
 import type { EventEmitter } from '../state/EventEmitter.js';
 import { addExpense } from '../economy/Finance.js';
-import { findPath } from '../nav/Pathfinding.js';
-import { advanceAlongPath } from '../nav/AgentAdvance.js';
+import { tickVehicle, tickEmployeeMovement, type EmployeeMovementResult } from './EntityMovementTick.js';
 
 // ── Config ──
 
-import { BASE_TICK_MS as _BASE_TICK_MS, VALID_SPEEDS as _VALID_SPEEDS, NEED_REST_DURATIONS, NEED_REST_NO_BUILDING_CAP, NEED_REST_NO_BUILDING_DURATION_MULTIPLIER, NEED_REST_BUILDING_TYPES, NEED_REST_SEARCH_RADIUS, NEED_WARNING_THRESHOLDS, NEED_REST_COSTS, WORK_DURATION_TICKS, SHIFT_SLEEP_DURATION_TICKS, BASE_TASK_DURATION_TICKS, AGENT_WALK_SPEED, STUCK_MORALE_PENALTY } from '../config/balance.js';
+import { BASE_TICK_MS as _BASE_TICK_MS, VALID_SPEEDS as _VALID_SPEEDS, NEED_REST_DURATIONS, NEED_REST_NO_BUILDING_CAP, NEED_REST_NO_BUILDING_DURATION_MULTIPLIER, NEED_REST_BUILDING_TYPES, NEED_REST_SEARCH_RADIUS, NEED_WARNING_THRESHOLDS, NEED_REST_COSTS, WORK_DURATION_TICKS, SHIFT_SLEEP_DURATION_TICKS, BASE_TASK_DURATION_TICKS } from '../config/balance.js';
+
+// Vehicle and employee per-tick movement (NavGrid pathing, stuck-tracking) live
+// in EntityMovementTick.ts (#407 refactor) — re-exported here so GameLoop.ts
+// stays the single public surface for tick-orchestration callers.
+export { tickVehicle, tickEmployeeMovement, type EmployeeMovementResult };
 
 /** Milliseconds per base tick at 1x speed. */
 export const BASE_TICK_MS = _BASE_TICK_MS;
@@ -123,164 +126,6 @@ export function resume(state: GameState): void {
 /** Check if a speed value is valid. */
 export function isValidSpeed(speed: number): speed is SpeedMultiplier {
   return VALID_SPEEDS.includes(speed as SpeedMultiplier);
-}
-
-/**
- * Process one vehicle movement step toward vehicle.targetX/targetZ.
- *
- * With a NavGrid built (state.navGrid !== null), routes via Pathfinding.findPath
- * and advances via AgentMovement.advanceAgent — the same pipeline
- * tickEmployeeMovement uses — so ramps, blocked cells, and NavCell move costs
- * (walkable:1.0, ramp:1.8, drill_hole:5.0, blocked/void: impassable) all affect
- * a vehicle's route exactly as they do an employee's. Previously this stepped
- * a flat one grid cell per tick in a straight line, ignoring the NavGrid
- * entirely regardless of terrain (#407).
- *
- * With no NavGrid yet (e.g. before a world is generated), falls back to the
- * original direct-line, one-cell-per-tick stepper — unchanged from before
- * this fix, and still exercised by callers/tests that construct a GameState
- * without a NavGrid.
- *
- * Vehicle-vs-vehicle collision avoidance is a separate, simpler mechanism
- * from NavCell.vehicleOccupied — no caller in src/ ever sets that flag true,
- * so Pathfinding/AgentMovement's own avoidVehicles checks against it are
- * always a no-op today. tickVehicle instead checks other vehicles' live x/z
- * directly via isCellOccupiedByOtherVehicle before committing to the next
- * grid cell, which is what actually stops two vehicles from occupying the
- * same cell. On the NavGrid path this is only checked for the immediate next
- * cell, not every cell a multi-cell-per-tick (speed > 1) vehicle would cross
- * in the same tick — a vehicle already mid-tick will not stop for one that
- * enters a farther cell of its path within that same tick.
- */
-export function tickVehicle(state: GameState, vehicle: Vehicle, emitter?: EventEmitter): void {
-  if (!canTickVehicle(vehicle)) return;
-
-  if (vehicle.x === vehicle.targetX && vehicle.z === vehicle.targetZ) {
-    setVehicleIdle(vehicle);
-    return;
-  }
-
-  if (state.navGrid) {
-    tickVehicleOnNavGrid(state, vehicle, emitter);
-  } else {
-    tickVehicleDirectLine(state, vehicle);
-  }
-}
-
-/** Original pre-#407 stepper: one grid cell per tick in a straight line, ignoring terrain. */
-function tickVehicleDirectLine(state: GameState, vehicle: Vehicle): void {
-  const deltaX = vehicle.targetX - vehicle.x;
-  const deltaZ = vehicle.targetZ - vehicle.z;
-
-  let nextX = vehicle.x;
-  let nextZ = vehicle.z;
-  if (deltaX !== 0) {
-    nextX += Math.sign(deltaX);
-  } else if (deltaZ !== 0) {
-    nextZ += Math.sign(deltaZ);
-  }
-
-  if (isCellOccupiedByOtherVehicle(state, vehicle, nextX, nextZ)) {
-    markVehicleWaiting(vehicle);
-    return;
-  }
-
-  vehicle.x = nextX;
-  vehicle.z = nextZ;
-  vehicle.state = 'moving';
-  vehicle.waitingTicks = 0;
-
-  if (vehicle.x === vehicle.targetX && vehicle.z === vehicle.targetZ) {
-    setVehicleIdle(vehicle);
-  }
-}
-
-/** NavGrid-aware stepper: routes via A*, respects move costs, tracks stuck state. */
-function tickVehicleOnNavGrid(state: GameState, vehicle: Vehicle, emitter?: EventEmitter): void {
-  const path = findPath(state.navGrid!, {
-    agentId: vehicle.id,
-    fromX: vehicle.x,
-    fromZ: vehicle.z,
-    toX: vehicle.targetX,
-    toZ: vehicle.targetZ,
-    avoidVehicles: false,
-  });
-
-  const outcome = advanceAlongPath({
-    x: vehicle.x,
-    z: vehicle.z,
-    walkSpeed: getVehicleDefByTier(vehicle.type, vehicle.tier).speed,
-    destinationX: vehicle.targetX,
-    destinationZ: vehicle.targetZ,
-    consecutiveFailures: vehicle.moveConsecutiveFailures,
-    isStuck: vehicle.isMoveStuck,
-    path,
-  });
-
-  vehicle.moveConsecutiveFailures = outcome.consecutiveFailures;
-  vehicle.isMoveStuck = outcome.isStuck;
-
-  if (!outcome.pathFound) {
-    if (outcome.becameStuck) {
-      emitter?.emit('vehicle:stuck', { vehicleId: vehicle.id });
-    }
-    markVehicleWaiting(vehicle);
-    return;
-  }
-
-  const nextStep = nextGridStep(vehicle, path.waypoints);
-  if (nextStep && isCellOccupiedByOtherVehicle(state, vehicle, nextStep.x, nextStep.z)) {
-    markVehicleWaiting(vehicle);
-    return;
-  }
-
-  vehicle.x = outcome.x;
-  vehicle.z = outcome.z;
-  vehicle.state = 'moving';
-  vehicle.waitingTicks = 0;
-
-  if (outcome.isPathComplete) {
-    vehicle.x = vehicle.targetX;
-    vehicle.z = vehicle.targetZ;
-    setVehicleIdle(vehicle);
-  }
-}
-
-/** The immediate next grid cell along a found path — the one occupancy is checked against. */
-function nextGridStep(
-  vehicle: Vehicle,
-  waypoints: Array<{ x: number; z: number }>,
-): { x: number; z: number } | null {
-  if (waypoints.length === 0) return null;
-  const first = waypoints[0]!;
-  const atFirst = Math.floor(vehicle.x) === first.x && Math.floor(vehicle.z) === first.z;
-  if (atFirst && waypoints.length > 1) return waypoints[1]!;
-  return first;
-}
-
-function markVehicleWaiting(vehicle: Vehicle): void {
-  if (vehicle.state !== 'waiting') {
-    vehicle.state = 'waiting';
-    vehicle.waitingTicks = 1;
-  } else {
-    vehicle.waitingTicks = (vehicle.waitingTicks ?? 0) + 1;
-  }
-}
-
-function canTickVehicle(vehicle: Vehicle): boolean {
-  // moveVehicle() sets task='moving'; vehicle state may still be 'idle' on the very first tick.
-  return vehicle.task === 'moving' &&
-    (vehicle.state === 'idle' || vehicle.state === 'moving' || vehicle.state === 'waiting');
-}
-
-function setVehicleIdle(vehicle: Vehicle): void {
-  vehicle.task = 'idle';
-  vehicle.state = 'idle';
-  vehicle.waitingTicks = 0;
-}
-
-function isCellOccupiedByOtherVehicle(state: GameState, vehicle: Vehicle, x: number, z: number): boolean {
-  return state.vehicles.vehicles.some(v => v.id !== vehicle.id && v.x === x && v.z === z);
 }
 
 // ── Employee dispatch ──
@@ -993,104 +838,4 @@ function getBuildingCenter(building: Building): { x: number; z: number } {
   const def = getBuildingDef(building.type, building.tier);
   const { sizeX, sizeZ } = getDefSize(def);
   return { x: building.x + sizeX / 2, z: building.z + sizeZ / 2 };
-}
-
-// ── Employee movement ──
-
-export interface EmployeeMovementResult {
-  /** Employee IDs that advanced position this tick. */
-  moved: number[];
-  /** Employee IDs that reached destinationX/destinationZ this tick. */
-  arrived: number[];
-  /** Employee IDs that newly entered the stuck state this tick. */
-  stuck: number[];
-}
-
-/**
- * Advance every alive employee with a destination (set by tickEmployees on
- * claim, or by the rest self-claim paths in tickCollapse/tickNeedRestoration/
- * forceShiftRestIfNeeded) one tick's worth of movement toward it, using the
- * NavGrid-aware A* pathfinder (Pathfinding.findPath) and the generic
- * per-tick advancer (AgentMovement.advanceAgent) — the "already implemented,
- * already unit-tested" navmesh pieces that nothing wired to a caller before.
- *
- * The path is recomputed fresh every tick rather than cached on the employee:
- * this doubles as the "re-request from current position" behaviour the
- * gameplay-navmesh spec calls for whenever the next step is blocked, without
- * needing to persist a waypoint list on GameState. A path that repeatedly
- * fails to resolve (STUCK_THRESHOLD consecutive ticks) marks the employee
- * stuck — idle, morale −2/tick — until the grid changes and a path resolves
- * again, at which point movement resumes on its own the very next tick.
- *
- * With no NavGrid built yet (state.navGrid === null), falls back to a direct
- * line toward the destination, ignoring obstacles — better than the total
- * non-movement this replaces, and consistent with tickVehicle's own
- * pre-navmesh behaviour.
- */
-export function tickEmployeeMovement(state: GameState, emitter?: EventEmitter): EmployeeMovementResult {
-  const result: EmployeeMovementResult = { moved: [], arrived: [], stuck: [] };
-
-  for (const emp of state.employees.employees) {
-    if (!emp.alive) continue;
-    if (emp.destinationX === null || emp.destinationZ === null) continue;
-
-    if (emp.x === emp.destinationX && emp.z === emp.destinationZ) {
-      emp.destinationX = null;
-      emp.destinationZ = null;
-      continue;
-    }
-
-    const path = state.navGrid
-      ? findPath(state.navGrid, {
-        agentId: emp.id,
-        fromX: emp.x,
-        fromZ: emp.z,
-        toX: emp.destinationX,
-        toZ: emp.destinationZ,
-        avoidVehicles: false,
-      })
-      // No NavGrid yet: synthesize a direct two-point path (start, destination) —
-      // findPath is never called, so this always "succeeds", matching the
-      // pre-navmesh direct-line fallback tickVehicle also falls back to.
-      : { found: true, waypoints: [{ x: emp.x, z: emp.z }, { x: emp.destinationX, z: emp.destinationZ }] };
-
-    const outcome = advanceAlongPath({
-      x: emp.x,
-      z: emp.z,
-      walkSpeed: AGENT_WALK_SPEED,
-      destinationX: emp.destinationX,
-      destinationZ: emp.destinationZ,
-      consecutiveFailures: emp.moveConsecutiveFailures,
-      isStuck: emp.isMoveStuck,
-      path,
-    });
-
-    emp.moveConsecutiveFailures = outcome.consecutiveFailures;
-    emp.isMoveStuck = outcome.isStuck;
-
-    if (!outcome.pathFound) {
-      if (emp.isMoveStuck) {
-        if (outcome.becameStuck) {
-          result.stuck.push(emp.id);
-          emitter?.emit('agent:stuck', { employeeId: emp.id });
-        }
-        emp.morale = Math.max(0, emp.morale - STUCK_MORALE_PENALTY);
-      }
-      continue;
-    }
-
-    emp.x = outcome.x;
-    emp.z = outcome.z;
-    result.moved.push(emp.id);
-
-    if (outcome.isPathComplete) {
-      emp.x = emp.destinationX;
-      emp.z = emp.destinationZ;
-      emp.destinationX = null;
-      emp.destinationZ = null;
-      result.arrived.push(emp.id);
-    }
-  }
-
-  return result;
 }

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -16,7 +16,7 @@ import { getLivingQuartersWellbeingMultiplier } from '../entities/BuildingWellbe
 import type { EventEmitter } from '../state/EventEmitter.js';
 import { addExpense } from '../economy/Finance.js';
 import { findPath } from '../nav/Pathfinding.js';
-import { advanceAgent, recordStuckFailure, resetStuckState, type AgentState } from '../nav/AgentMovement.js';
+import { advanceAlongPath } from '../nav/AgentAdvance.js';
 
 // ── Config ──
 
@@ -206,33 +206,27 @@ function tickVehicleOnNavGrid(state: GameState, vehicle: Vehicle, emitter?: Even
     avoidVehicles: false,
   });
 
-  const stuckInput: AgentState = {
+  const outcome = advanceAlongPath({
     x: vehicle.x,
     z: vehicle.z,
-    waypoints: [],
-    waypointIndex: 0,
     walkSpeed: getVehicleDefByTier(vehicle.type, vehicle.tier).speed,
     destinationX: vehicle.targetX,
     destinationZ: vehicle.targetZ,
     consecutiveFailures: vehicle.moveConsecutiveFailures,
     isStuck: vehicle.isMoveStuck,
-  };
+    path,
+  });
 
-  if (!path.found) {
-    const wasStuck = vehicle.isMoveStuck;
-    const next = recordStuckFailure(stuckInput);
-    vehicle.moveConsecutiveFailures = next.consecutiveFailures;
-    vehicle.isMoveStuck = next.isStuck;
-    if (vehicle.isMoveStuck && !wasStuck) {
+  vehicle.moveConsecutiveFailures = outcome.consecutiveFailures;
+  vehicle.isMoveStuck = outcome.isStuck;
+
+  if (!outcome.pathFound) {
+    if (outcome.becameStuck) {
       emitter?.emit('vehicle:stuck', { vehicleId: vehicle.id });
     }
     markVehicleWaiting(vehicle);
     return;
   }
-
-  const reset = resetStuckState(stuckInput);
-  vehicle.moveConsecutiveFailures = reset.consecutiveFailures;
-  vehicle.isMoveStuck = reset.isStuck;
 
   const nextStep = nextGridStep(vehicle, path.waypoints);
   if (nextStep && isCellOccupiedByOtherVehicle(state, vehicle, nextStep.x, nextStep.z)) {
@@ -240,24 +234,12 @@ function tickVehicleOnNavGrid(state: GameState, vehicle: Vehicle, emitter?: Even
     return;
   }
 
-  const advance = advanceAgent({
-    x: vehicle.x,
-    z: vehicle.z,
-    waypoints: path.waypoints,
-    waypointIndex: 0,
-    walkSpeed: getVehicleDefByTier(vehicle.type, vehicle.tier).speed,
-    destinationX: vehicle.targetX,
-    destinationZ: vehicle.targetZ,
-    consecutiveFailures: vehicle.moveConsecutiveFailures,
-    isStuck: vehicle.isMoveStuck,
-  });
-
-  vehicle.x = advance.x;
-  vehicle.z = advance.z;
+  vehicle.x = outcome.x;
+  vehicle.z = outcome.z;
   vehicle.state = 'moving';
   vehicle.waitingTicks = 0;
 
-  if (advance.isPathComplete) {
+  if (outcome.isPathComplete) {
     vehicle.x = vehicle.targetX;
     vehicle.z = vehicle.targetZ;
     setVehicleIdle(vehicle);
@@ -1058,44 +1040,37 @@ export function tickEmployeeMovement(state: GameState, emitter?: EventEmitter): 
       continue;
     }
 
-    let waypoints: Array<{ x: number; z: number }>;
-    let pathFound: boolean;
-
-    if (state.navGrid) {
-      const path = findPath(state.navGrid, {
+    const path = state.navGrid
+      ? findPath(state.navGrid, {
         agentId: emp.id,
         fromX: emp.x,
         fromZ: emp.z,
         toX: emp.destinationX,
         toZ: emp.destinationZ,
         avoidVehicles: false,
-      });
-      pathFound = path.found;
-      waypoints = path.waypoints;
-    } else {
-      pathFound = true;
-      waypoints = [{ x: emp.x, z: emp.z }, { x: emp.destinationX, z: emp.destinationZ }];
-    }
+      })
+      // No NavGrid yet: synthesize a direct two-point path (start, destination) —
+      // findPath is never called, so this always "succeeds", matching the
+      // pre-navmesh direct-line fallback tickVehicle also falls back to.
+      : { found: true, waypoints: [{ x: emp.x, z: emp.z }, { x: emp.destinationX, z: emp.destinationZ }] };
 
-    const stuckInput: AgentState = {
+    const outcome = advanceAlongPath({
       x: emp.x,
       z: emp.z,
-      waypoints: [],
-      waypointIndex: 0,
       walkSpeed: AGENT_WALK_SPEED,
       destinationX: emp.destinationX,
       destinationZ: emp.destinationZ,
       consecutiveFailures: emp.moveConsecutiveFailures,
       isStuck: emp.isMoveStuck,
-    };
+      path,
+    });
 
-    if (!pathFound) {
-      const wasStuck = emp.isMoveStuck;
-      const next = recordStuckFailure(stuckInput);
-      emp.moveConsecutiveFailures = next.consecutiveFailures;
-      emp.isMoveStuck = next.isStuck;
+    emp.moveConsecutiveFailures = outcome.consecutiveFailures;
+    emp.isMoveStuck = outcome.isStuck;
+
+    if (!outcome.pathFound) {
       if (emp.isMoveStuck) {
-        if (!wasStuck) {
+        if (outcome.becameStuck) {
           result.stuck.push(emp.id);
           emitter?.emit('agent:stuck', { employeeId: emp.id });
         }
@@ -1104,27 +1079,11 @@ export function tickEmployeeMovement(state: GameState, emitter?: EventEmitter): 
       continue;
     }
 
-    const reset = resetStuckState(stuckInput);
-    emp.moveConsecutiveFailures = reset.consecutiveFailures;
-    emp.isMoveStuck = reset.isStuck;
-
-    const advance = advanceAgent({
-      x: emp.x,
-      z: emp.z,
-      waypoints,
-      waypointIndex: 0,
-      walkSpeed: AGENT_WALK_SPEED,
-      destinationX: emp.destinationX,
-      destinationZ: emp.destinationZ,
-      consecutiveFailures: emp.moveConsecutiveFailures,
-      isStuck: emp.isMoveStuck,
-    });
-
-    emp.x = advance.x;
-    emp.z = advance.z;
+    emp.x = outcome.x;
+    emp.z = outcome.z;
     result.moved.push(emp.id);
 
-    if (advance.isPathComplete) {
+    if (outcome.isPathComplete) {
       emp.x = emp.destinationX;
       emp.z = emp.destinationZ;
       emp.destinationX = null;

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -3,7 +3,7 @@
 // Pure logic: no timers, no DOM. The caller drives the loop.
 
 import type { GameState, PendingAction } from '../state/GameState.js';
-import type { Vehicle } from '../entities/Vehicle.js';
+import { getVehicleDefByTier, type Vehicle } from '../entities/Vehicle.js';
 import { getBuildingDef, getDefSize, type Building, type BuildingType } from '../entities/Building.js';
 import type { Random } from '../math/Random.js';
 import type { EventContext } from '../events/EventPool.js';
@@ -16,11 +16,11 @@ import { getLivingQuartersWellbeingMultiplier } from '../entities/BuildingWellbe
 import type { EventEmitter } from '../state/EventEmitter.js';
 import { addExpense } from '../economy/Finance.js';
 import { findPath } from '../nav/Pathfinding.js';
-import { advanceAgent } from '../nav/AgentMovement.js';
+import { advanceAgent, recordStuckFailure, resetStuckState, type AgentState } from '../nav/AgentMovement.js';
 
 // ── Config ──
 
-import { BASE_TICK_MS as _BASE_TICK_MS, VALID_SPEEDS as _VALID_SPEEDS, NEED_REST_DURATIONS, NEED_REST_NO_BUILDING_CAP, NEED_REST_NO_BUILDING_DURATION_MULTIPLIER, NEED_REST_BUILDING_TYPES, NEED_REST_SEARCH_RADIUS, NEED_WARNING_THRESHOLDS, NEED_REST_COSTS, WORK_DURATION_TICKS, SHIFT_SLEEP_DURATION_TICKS, BASE_TASK_DURATION_TICKS, AGENT_WALK_SPEED, STUCK_THRESHOLD } from '../config/balance.js';
+import { BASE_TICK_MS as _BASE_TICK_MS, VALID_SPEEDS as _VALID_SPEEDS, NEED_REST_DURATIONS, NEED_REST_NO_BUILDING_CAP, NEED_REST_NO_BUILDING_DURATION_MULTIPLIER, NEED_REST_BUILDING_TYPES, NEED_REST_SEARCH_RADIUS, NEED_WARNING_THRESHOLDS, NEED_REST_COSTS, WORK_DURATION_TICKS, SHIFT_SLEEP_DURATION_TICKS, BASE_TASK_DURATION_TICKS, AGENT_WALK_SPEED, STUCK_MORALE_PENALTY } from '../config/balance.js';
 
 /** Milliseconds per base tick at 1x speed. */
 export const BASE_TICK_MS = _BASE_TICK_MS;
@@ -125,14 +125,52 @@ export function isValidSpeed(speed: number): speed is SpeedMultiplier {
   return VALID_SPEEDS.includes(speed as SpeedMultiplier);
 }
 
-/** Process one vehicle movement step; advances at most one grid cell per tick, waits if the next cell is occupied. */
-export function tickVehicle(state: GameState, vehicle: Vehicle): void {
+/**
+ * Process one vehicle movement step toward vehicle.targetX/targetZ.
+ *
+ * With a NavGrid built (state.navGrid !== null), routes via Pathfinding.findPath
+ * and advances via AgentMovement.advanceAgent — the same pipeline
+ * tickEmployeeMovement uses — so ramps, blocked cells, and NavCell move costs
+ * (walkable:1.0, ramp:1.8, drill_hole:5.0, blocked/void: impassable) all affect
+ * a vehicle's route exactly as they do an employee's. Previously this stepped
+ * a flat one grid cell per tick in a straight line, ignoring the NavGrid
+ * entirely regardless of terrain (#407).
+ *
+ * With no NavGrid yet (e.g. before a world is generated), falls back to the
+ * original direct-line, one-cell-per-tick stepper — unchanged from before
+ * this fix, and still exercised by callers/tests that construct a GameState
+ * without a NavGrid.
+ *
+ * Vehicle-vs-vehicle collision avoidance is a separate, simpler mechanism
+ * from NavCell.vehicleOccupied — no caller in src/ ever sets that flag true,
+ * so Pathfinding/AgentMovement's own avoidVehicles checks against it are
+ * always a no-op today. tickVehicle instead checks other vehicles' live x/z
+ * directly via isCellOccupiedByOtherVehicle before committing to the next
+ * grid cell, which is what actually stops two vehicles from occupying the
+ * same cell. On the NavGrid path this is only checked for the immediate next
+ * cell, not every cell a multi-cell-per-tick (speed > 1) vehicle would cross
+ * in the same tick — a vehicle already mid-tick will not stop for one that
+ * enters a farther cell of its path within that same tick.
+ */
+export function tickVehicle(state: GameState, vehicle: Vehicle, emitter?: EventEmitter): void {
   if (!canTickVehicle(vehicle)) return;
 
+  if (vehicle.x === vehicle.targetX && vehicle.z === vehicle.targetZ) {
+    setVehicleIdle(vehicle);
+    return;
+  }
+
+  if (state.navGrid) {
+    tickVehicleOnNavGrid(state, vehicle, emitter);
+  } else {
+    tickVehicleDirectLine(state, vehicle);
+  }
+}
+
+/** Original pre-#407 stepper: one grid cell per tick in a straight line, ignoring terrain. */
+function tickVehicleDirectLine(state: GameState, vehicle: Vehicle): void {
   const deltaX = vehicle.targetX - vehicle.x;
   const deltaZ = vehicle.targetZ - vehicle.z;
-
-  if (deltaX === 0 && deltaZ === 0) return setVehicleIdle(vehicle);
 
   let nextX = vehicle.x;
   let nextZ = vehicle.z;
@@ -142,14 +180,8 @@ export function tickVehicle(state: GameState, vehicle: Vehicle): void {
     nextZ += Math.sign(deltaZ);
   }
 
-  const isOccupied = isCellOccupiedByOtherVehicle(state, vehicle, nextX, nextZ);
-  if (isOccupied) {
-    if (vehicle.state !== 'waiting') {
-      vehicle.state = 'waiting';
-      vehicle.waitingTicks = 1;
-    } else {
-      vehicle.waitingTicks = (vehicle.waitingTicks ?? 0) + 1;
-    }
+  if (isCellOccupiedByOtherVehicle(state, vehicle, nextX, nextZ)) {
+    markVehicleWaiting(vehicle);
     return;
   }
 
@@ -160,6 +192,96 @@ export function tickVehicle(state: GameState, vehicle: Vehicle): void {
 
   if (vehicle.x === vehicle.targetX && vehicle.z === vehicle.targetZ) {
     setVehicleIdle(vehicle);
+  }
+}
+
+/** NavGrid-aware stepper: routes via A*, respects move costs, tracks stuck state. */
+function tickVehicleOnNavGrid(state: GameState, vehicle: Vehicle, emitter?: EventEmitter): void {
+  const path = findPath(state.navGrid!, {
+    agentId: vehicle.id,
+    fromX: vehicle.x,
+    fromZ: vehicle.z,
+    toX: vehicle.targetX,
+    toZ: vehicle.targetZ,
+    avoidVehicles: false,
+  });
+
+  const stuckInput: AgentState = {
+    x: vehicle.x,
+    z: vehicle.z,
+    waypoints: [],
+    waypointIndex: 0,
+    walkSpeed: getVehicleDefByTier(vehicle.type, vehicle.tier).speed,
+    destinationX: vehicle.targetX,
+    destinationZ: vehicle.targetZ,
+    consecutiveFailures: vehicle.moveConsecutiveFailures,
+    isStuck: vehicle.isMoveStuck,
+  };
+
+  if (!path.found) {
+    const wasStuck = vehicle.isMoveStuck;
+    const next = recordStuckFailure(stuckInput);
+    vehicle.moveConsecutiveFailures = next.consecutiveFailures;
+    vehicle.isMoveStuck = next.isStuck;
+    if (vehicle.isMoveStuck && !wasStuck) {
+      emitter?.emit('vehicle:stuck', { vehicleId: vehicle.id });
+    }
+    markVehicleWaiting(vehicle);
+    return;
+  }
+
+  const reset = resetStuckState(stuckInput);
+  vehicle.moveConsecutiveFailures = reset.consecutiveFailures;
+  vehicle.isMoveStuck = reset.isStuck;
+
+  const nextStep = nextGridStep(vehicle, path.waypoints);
+  if (nextStep && isCellOccupiedByOtherVehicle(state, vehicle, nextStep.x, nextStep.z)) {
+    markVehicleWaiting(vehicle);
+    return;
+  }
+
+  const advance = advanceAgent({
+    x: vehicle.x,
+    z: vehicle.z,
+    waypoints: path.waypoints,
+    waypointIndex: 0,
+    walkSpeed: getVehicleDefByTier(vehicle.type, vehicle.tier).speed,
+    destinationX: vehicle.targetX,
+    destinationZ: vehicle.targetZ,
+    consecutiveFailures: vehicle.moveConsecutiveFailures,
+    isStuck: vehicle.isMoveStuck,
+  });
+
+  vehicle.x = advance.x;
+  vehicle.z = advance.z;
+  vehicle.state = 'moving';
+  vehicle.waitingTicks = 0;
+
+  if (advance.isPathComplete) {
+    vehicle.x = vehicle.targetX;
+    vehicle.z = vehicle.targetZ;
+    setVehicleIdle(vehicle);
+  }
+}
+
+/** The immediate next grid cell along a found path — the one occupancy is checked against. */
+function nextGridStep(
+  vehicle: Vehicle,
+  waypoints: Array<{ x: number; z: number }>,
+): { x: number; z: number } | null {
+  if (waypoints.length === 0) return null;
+  const first = waypoints[0]!;
+  const atFirst = Math.floor(vehicle.x) === first.x && Math.floor(vehicle.z) === first.z;
+  if (atFirst && waypoints.length > 1) return waypoints[1]!;
+  return first;
+}
+
+function markVehicleWaiting(vehicle: Vehicle): void {
+  if (vehicle.state !== 'waiting') {
+    vehicle.state = 'waiting';
+    vehicle.waitingTicks = 1;
+  } else {
+    vehicle.waitingTicks = (vehicle.waitingTicks ?? 0) + 1;
   }
 }
 
@@ -955,21 +1077,36 @@ export function tickEmployeeMovement(state: GameState, emitter?: EventEmitter): 
       waypoints = [{ x: emp.x, z: emp.z }, { x: emp.destinationX, z: emp.destinationZ }];
     }
 
+    const stuckInput: AgentState = {
+      x: emp.x,
+      z: emp.z,
+      waypoints: [],
+      waypointIndex: 0,
+      walkSpeed: AGENT_WALK_SPEED,
+      destinationX: emp.destinationX,
+      destinationZ: emp.destinationZ,
+      consecutiveFailures: emp.moveConsecutiveFailures,
+      isStuck: emp.isMoveStuck,
+    };
+
     if (!pathFound) {
-      emp.moveConsecutiveFailures += 1;
-      if (emp.moveConsecutiveFailures >= STUCK_THRESHOLD) {
-        if (!emp.moveStuck) {
-          emp.moveStuck = true;
+      const wasStuck = emp.isMoveStuck;
+      const next = recordStuckFailure(stuckInput);
+      emp.moveConsecutiveFailures = next.consecutiveFailures;
+      emp.isMoveStuck = next.isStuck;
+      if (emp.isMoveStuck) {
+        if (!wasStuck) {
           result.stuck.push(emp.id);
           emitter?.emit('agent:stuck', { employeeId: emp.id });
         }
-        emp.morale = Math.max(0, emp.morale - 2);
+        emp.morale = Math.max(0, emp.morale - STUCK_MORALE_PENALTY);
       }
       continue;
     }
 
-    emp.moveConsecutiveFailures = 0;
-    emp.moveStuck = false;
+    const reset = resetStuckState(stuckInput);
+    emp.moveConsecutiveFailures = reset.consecutiveFailures;
+    emp.isMoveStuck = reset.isStuck;
 
     const advance = advanceAgent({
       x: emp.x,
@@ -980,7 +1117,7 @@ export function tickEmployeeMovement(state: GameState, emitter?: EventEmitter): 
       destinationX: emp.destinationX,
       destinationZ: emp.destinationZ,
       consecutiveFailures: emp.moveConsecutiveFailures,
-      isStuck: emp.moveStuck,
+      isStuck: emp.isMoveStuck,
     });
 
     emp.x = advance.x;

--- a/src/core/entities/Employee.ts
+++ b/src/core/entities/Employee.ts
@@ -124,7 +124,7 @@ export interface Employee {
    * Grid position the employee is currently walking toward (set from a claimed
    * PendingAction's targetX/targetZ, or a self-claimed rest action's building
    * location), or null when the employee has nowhere to walk. Consumed by
-   * tickEmployeeMovement in GameLoop.ts — cleared on arrival.
+   * tickEmployeeMovement in EntityMovementTick.ts — cleared on arrival.
    */
   destinationX: number | null;
   destinationZ: number | null;

--- a/src/core/entities/Employee.ts
+++ b/src/core/entities/Employee.ts
@@ -131,7 +131,7 @@ export interface Employee {
   /** Consecutive ticks tickEmployeeMovement failed to find a path to destinationX/Z. */
   moveConsecutiveFailures: number;
   /** True once moveConsecutiveFailures reaches STUCK_THRESHOLD — idle, morale −2/tick until the path clears. */
-  moveStuck: boolean;
+  isMoveStuck: boolean;
 }
 
 // ── Employee state ──
@@ -194,7 +194,7 @@ export function hireEmployee(
     destinationX: null,
     destinationZ: null,
     moveConsecutiveFailures: 0,
-    moveStuck: false,
+    isMoveStuck: false,
   };
   // Keep the stored salary consistent with the qualification just granted —
   // calculateSalary() sums qualification bonuses, so a base-only salary would

--- a/src/core/entities/Employee.ts
+++ b/src/core/entities/Employee.ts
@@ -120,6 +120,18 @@ export interface Employee {
    * state, and the key decides which completion path owns the employee.
    */
   restNeedKey: NeedKey | null;
+  /**
+   * Grid position the employee is currently walking toward (set from a claimed
+   * PendingAction's targetX/targetZ, or a self-claimed rest action's building
+   * location), or null when the employee has nowhere to walk. Consumed by
+   * tickEmployeeMovement in GameLoop.ts — cleared on arrival.
+   */
+  destinationX: number | null;
+  destinationZ: number | null;
+  /** Consecutive ticks tickEmployeeMovement failed to find a path to destinationX/Z. */
+  moveConsecutiveFailures: number;
+  /** True once moveConsecutiveFailures reaches STUCK_THRESHOLD — idle, morale −2/tick until the path clears. */
+  moveStuck: boolean;
 }
 
 // ── Employee state ──
@@ -179,6 +191,10 @@ export function hireEmployee(
     restNeedKey: null,
     taskTicksRemaining: null,
     activeTaskSkill: null,
+    destinationX: null,
+    destinationZ: null,
+    moveConsecutiveFailures: 0,
+    moveStuck: false,
   };
   // Keep the stored salary consistent with the qualification just granted —
   // calculateSalary() sums qualification bonuses, so a base-only salary would

--- a/src/core/entities/Vehicle.ts
+++ b/src/core/entities/Vehicle.ts
@@ -132,6 +132,10 @@ export interface Vehicle {
   payloadKg: number;
   /** Number of consecutive ticks the vehicle has spent in the waiting state. */
   waitingTicks: number;
+  /** Consecutive ticks tickVehicle failed to find a NavGrid path to targetX/Z. */
+  moveConsecutiveFailures: number;
+  /** True once moveConsecutiveFailures reaches STUCK_THRESHOLD — idle until the path clears. */
+  isMoveStuck: boolean;
 }
 
 // ── Fleet state ──
@@ -169,6 +173,8 @@ export function purchaseVehicle(
     state: 'idle',
     payloadKg: 0,
     waitingTicks: 0,
+    moveConsecutiveFailures: 0,
+    isMoveStuck: false,
   };
   state.vehicles.push(vehicle);
   return { vehicle, cost: def.purchaseCost };

--- a/src/core/i18n/locales/en.json
+++ b/src/core/i18n/locales/en.json
@@ -1732,6 +1732,7 @@
   "shortcuts.employees": "E: Employees",
   "shortcuts.survey": "S: Survey Mode",
   "shortcuts.map": "M: Mini-map",
+  "shortcuts.navgrid": "N: Toggle NavGrid Overlay",
   "shortcuts.saves": "F5: Quick Save",
   "shortcuts.settings": "Esc: Settings",
   "building.driving_center.name": "Driving Center",

--- a/src/core/i18n/locales/fr.json
+++ b/src/core/i18n/locales/fr.json
@@ -1732,6 +1732,7 @@
   "shortcuts.employees": "E : Équipe",
   "shortcuts.survey": "S : Mode sondage",
   "shortcuts.map": "M : Mini-carte",
+  "shortcuts.navgrid": "N : Afficher la grille de navigation",
   "shortcuts.saves": "F5 : Sauvegarde rapide",
   "shortcuts.settings": "Échap : Paramètres",
   "building.driving_center.name": "Centre de Conduite",

--- a/src/core/mining/Ramp.ts
+++ b/src/core/mining/Ramp.ts
@@ -112,4 +112,24 @@ export function buildRamp(
   };
 }
 
-export { RAMP_COST_PER_METER, RAMP_WIDTH };
+// ── Local column surface resolution ──
+
+/**
+ * Resolve the local surface Y for column (x, z) — the highest voxel with
+ * density >= 0.5, matching NavGrid.computeSurfaceY's contract. Duplicated
+ * locally (not imported from '../nav/NavGrid.js') to avoid introducing a
+ * core/mining -> core/nav dependency edge; core/nav already depends on
+ * core/mining (DrillPlan, BlastExecution), so the reverse edge would cycle.
+ * Returns -1 if the column is entirely void.
+ *
+ * TODO: implement — buildRamp() will call this per-column so carved depth
+ * is relative to actual local terrain height instead of absolute world Y.
+ */
+function computeColumnSurfaceY(grid: VoxelGrid, x: number, z: number): number {
+  void grid;
+  void x;
+  void z;
+  throw new Error('not implemented');
+}
+
+export { RAMP_COST_PER_METER, RAMP_WIDTH, computeColumnSurfaceY };

--- a/src/core/mining/Ramp.ts
+++ b/src/core/mining/Ramp.ts
@@ -3,7 +3,7 @@
 // Each ramp clears a diagonal column of voxels from surface to target depth.
 
 import { formatMoney } from '../economy/formatMoney.js';
-import type { VoxelGrid } from '../world/VoxelGrid.js';
+import { computeVoxelColumnSurfaceY, type VoxelGrid } from '../world/VoxelGrid.js';
 
 // ── Config ──
 
@@ -123,23 +123,14 @@ export function buildRamp(
 
 /**
  * Resolve the local surface Y for column (x, z) — the highest voxel with
- * density >= 0.5, matching NavGrid.computeSurfaceY's contract. Duplicated
- * locally (not imported from '../nav/NavGrid.js') to avoid introducing a
- * core/mining -> core/nav dependency edge; core/nav already depends on
- * core/mining (DrillPlan, BlastExecution), so the reverse edge would cycle.
- * Returns -1 if the column is entirely void.
- *
+ * density >= 0.5, matching NavGrid.computeSurfaceY's contract. Both delegate
+ * to VoxelGrid.computeVoxelColumnSurfaceY (a leaf-module free function) so
+ * core/mining doesn't need to import from core/nav (core/nav already depends
+ * on core/mining — DrillPlan, BlastExecution — so the reverse edge would
+ * cycle). Returns -1 if the column is entirely void.
  */
 function computeColumnSurfaceY(grid: VoxelGrid, x: number, z: number): number {
-  if (grid.sizeX <= 0 || grid.sizeZ <= 0) return -1;
-
-  const cx = Math.max(0, Math.min(grid.sizeX - 1, Math.floor(x)));
-  const cz = Math.max(0, Math.min(grid.sizeZ - 1, Math.floor(z)));
-  for (let y = grid.sizeY - 1; y >= 0; y--) {
-    const voxel = grid.getVoxel(cx, y, cz);
-    if (voxel && voxel.density >= 0.5) return y;
-  }
-  return -1;
+  return computeVoxelColumnSurfaceY(grid, x, z);
 }
 
 export { RAMP_COST_PER_METER, RAMP_WIDTH, computeColumnSurfaceY };

--- a/src/core/mining/Ramp.ts
+++ b/src/core/mining/Ramp.ts
@@ -80,7 +80,7 @@ export function buildRamp(
   const halfWidth = Math.floor(RAMP_WIDTH / 2);
 
   for (let step = 0; step < ramp.length; step++) {
-    // Current Y level: descends linearly from 0 to targetDepth
+    // Depth of descent at this step: grows linearly from 0 to targetDepth
     const currentDepth = Math.floor((step / ramp.length) * ramp.targetDepth);
     // Height clearance for vehicles: 3 voxels
     const clearanceHeight = 3;
@@ -88,11 +88,18 @@ export function buildRamp(
     const cx = ramp.originX + offset.dx * step;
     const cz = ramp.originZ + offset.dz * step;
 
+    // Carve relative to this column's live surface height, not an absolute
+    // world Y — real terrain sits far above y=0, so an absolute band would
+    // land buried under solid rock and never change the surface.
+    const surfaceY = computeColumnSurfaceY(grid, cx, cz);
+    const floorY = surfaceY - currentDepth;
+    const ceilingY = surfaceY + clearanceHeight;
+
     for (let w = -halfWidth; w <= halfWidth; w++) {
       const wx = cx + perpDx * w;
       const wz = cz + perpDz * w;
 
-      for (let y = currentDepth; y < currentDepth + clearanceHeight; y++) {
+      for (let y = floorY; y < ceilingY; y++) {
         if (grid.isInBounds(wx, y, wz)) {
           const voxel = grid.getVoxel(wx, y, wz);
           if (voxel && voxel.density > 0) {
@@ -122,14 +129,17 @@ export function buildRamp(
  * core/mining (DrillPlan, BlastExecution), so the reverse edge would cycle.
  * Returns -1 if the column is entirely void.
  *
- * TODO: implement — buildRamp() will call this per-column so carved depth
- * is relative to actual local terrain height instead of absolute world Y.
  */
 function computeColumnSurfaceY(grid: VoxelGrid, x: number, z: number): number {
-  void grid;
-  void x;
-  void z;
-  throw new Error('not implemented');
+  if (grid.sizeX <= 0 || grid.sizeZ <= 0) return -1;
+
+  const cx = Math.max(0, Math.min(grid.sizeX - 1, Math.floor(x)));
+  const cz = Math.max(0, Math.min(grid.sizeZ - 1, Math.floor(z)));
+  for (let y = grid.sizeY - 1; y >= 0; y--) {
+    const voxel = grid.getVoxel(cx, y, cz);
+    if (voxel && voxel.density >= 0.5) return y;
+  }
+  return -1;
 }
 
 export { RAMP_COST_PER_METER, RAMP_WIDTH, computeColumnSurfaceY };

--- a/src/core/nav/AgentAdvance.ts
+++ b/src/core/nav/AgentAdvance.ts
@@ -1,8 +1,8 @@
 // BlastSimulator2026 — AgentAdvance: shared find-path/stuck-tracking/advance skeleton
-// Factored out of GameLoop.ts's tickVehicleOnNavGrid and tickEmployeeMovement (#407
-// review round 2), which ran the identical stuck-detection + per-tick-advance sequence
-// end to end, differing only in field names and caller-specific bookkeeping (vehicle
-// occupancy pre-check, employee morale penalty).
+// Factored out of EntityMovementTick.ts's tickVehicleOnNavGrid and tickEmployeeMovement
+// (#407 review round 2), which ran the identical stuck-detection + per-tick-advance
+// sequence end to end, differing only in field names and caller-specific bookkeeping
+// (vehicle occupancy pre-check, employee morale penalty).
 
 import { advanceAgent, recordStuckFailure, resetStuckState, type AgentState } from './AgentMovement.js';
 

--- a/src/core/nav/AgentAdvance.ts
+++ b/src/core/nav/AgentAdvance.ts
@@ -1,0 +1,103 @@
+// BlastSimulator2026 — AgentAdvance: shared find-path/stuck-tracking/advance skeleton
+// Factored out of GameLoop.ts's tickVehicleOnNavGrid and tickEmployeeMovement (#407
+// review round 2), which ran the identical stuck-detection + per-tick-advance sequence
+// end to end, differing only in field names and caller-specific bookkeeping (vehicle
+// occupancy pre-check, employee morale penalty).
+
+import { advanceAgent, recordStuckFailure, resetStuckState, type AgentState } from './AgentMovement.js';
+
+/** A pre-resolved path — either from Pathfinding.findPath or synthesized directly. */
+export interface AgentPath {
+  found: boolean;
+  waypoints: Array<{ x: number; z: number }>;
+}
+
+export interface AdvanceAlongPathInput {
+  x: number;
+  z: number;
+  walkSpeed: number;
+  destinationX: number;
+  destinationZ: number;
+  consecutiveFailures: number;
+  isStuck: boolean;
+  path: AgentPath;
+}
+
+export interface AdvanceAlongPathOutcome {
+  /** Whether a path was found this tick — false means the agent did not move. */
+  pathFound: boolean;
+  /** New position — unchanged from input when pathFound is false. */
+  x: number;
+  z: number;
+  /** Updated stuck-tracker fields, to be written back onto the entity. */
+  consecutiveFailures: number;
+  isStuck: boolean;
+  /** True only on the falling edge into stuck (was not stuck, now is) — callers
+   *  emit their "stuck" event exactly once on this transition. */
+  becameStuck: boolean;
+  /** True when the agent reached the final waypoint this tick. */
+  isPathComplete: boolean;
+}
+
+/**
+ * Shared per-tick movement skeleton for any entity walking a NavGrid path:
+ * on a failed path, record a stuck-failure and report whether this tick is the
+ * falling edge into stuck; on a found path, reset stuck-tracking and advance
+ * the entity along the waypoints one tick's worth via AgentMovement.advanceAgent.
+ *
+ * Callers own everything path-independent: computing/synthesizing `path`,
+ * any pre-move checks (e.g. vehicle-occupancy on the next cell), writing the
+ * returned position/stuck fields back onto their entity, snapping to the exact
+ * destination and clearing it on isPathComplete, and entity-specific side
+ * effects (vehicle waitingTicks/state, employee morale penalty).
+ */
+export function advanceAlongPath(input: AdvanceAlongPathInput): AdvanceAlongPathOutcome {
+  const stuckInput: AgentState = {
+    x: input.x,
+    z: input.z,
+    waypoints: [],
+    waypointIndex: 0,
+    walkSpeed: input.walkSpeed,
+    destinationX: input.destinationX,
+    destinationZ: input.destinationZ,
+    consecutiveFailures: input.consecutiveFailures,
+    isStuck: input.isStuck,
+  };
+
+  if (!input.path.found) {
+    const wasStuck = input.isStuck;
+    const next = recordStuckFailure(stuckInput);
+    return {
+      pathFound: false,
+      x: input.x,
+      z: input.z,
+      consecutiveFailures: next.consecutiveFailures,
+      isStuck: next.isStuck,
+      becameStuck: next.isStuck && !wasStuck,
+      isPathComplete: false,
+    };
+  }
+
+  const reset = resetStuckState(stuckInput);
+  const advance = advanceAgent({
+    x: input.x,
+    z: input.z,
+    waypoints: input.path.waypoints,
+    waypointIndex: 0,
+    walkSpeed: input.walkSpeed,
+    destinationX: input.destinationX,
+    destinationZ: input.destinationZ,
+    consecutiveFailures: reset.consecutiveFailures,
+    isStuck: reset.isStuck,
+  });
+
+  return {
+    pathFound: true,
+    x: advance.x,
+    z: advance.z,
+    consecutiveFailures: reset.consecutiveFailures,
+    isStuck: reset.isStuck,
+    becameStuck: false,
+    isPathComplete: advance.isPathComplete,
+  };
+}

--- a/src/core/nav/NavGrid.ts
+++ b/src/core/nav/NavGrid.ts
@@ -2,7 +2,7 @@
 // Each cell represents walkability for A* pathfinding.
 // Part of the navmesh system.
 
-import type { VoxelGrid } from '../world/VoxelGrid.js';
+import { computeVoxelColumnSurfaceY, type VoxelGrid } from '../world/VoxelGrid.js';
 import type { Building } from '../entities/Building.js';
 import type { DrillHole } from '../mining/DrillPlan.js';
 import type { BlastRegion } from '../mining/BlastExecution.js';
@@ -18,6 +18,16 @@ export interface NavCell {
   type: NavCellType;
   moveCost: number;
   benchLevel: number;
+  /**
+   * Reserved for a future per-cell vehicle-occupancy pass (checked by
+   * Pathfinding.findPath/AgentMovement.isPathBlocked when a caller requests
+   * avoidVehicles). No caller in src/ ever sets this true — GameLoop's
+   * tickVehicle/tickEmployeeMovement both request avoidVehicles:false and
+   * instead do vehicle-vs-vehicle collision avoidance by comparing live x/z
+   * directly (see isCellOccupiedByOtherVehicle in GameLoop.ts) — so this
+   * field is always false today and the avoidVehicles checks against it are
+   * a no-op.
+   */
   vehicleOccupied: boolean;
 }
 
@@ -41,16 +51,7 @@ export class NavGrid {
    * Out-of-bounds (x, z) coordinates are clamped to the grid limits.
    */
   static computeSurfaceY(voxelGrid: VoxelGrid, x: number, z: number): number {
-    // Guard against degenerate grids with zero dimensions
-    if (voxelGrid.sizeX <= 0 || voxelGrid.sizeZ <= 0) return -1;
-
-    const cx = Math.max(0, Math.min(voxelGrid.sizeX - 1, Math.floor(x)));
-    const cz = Math.max(0, Math.min(voxelGrid.sizeZ - 1, Math.floor(z)));
-    for (let y = voxelGrid.sizeY - 1; y >= 0; y--) {
-      const voxel = voxelGrid.getVoxel(cx, y, cz);
-      if (voxel && voxel.density >= 0.5) return y;
-    }
-    return -1;
+    return computeVoxelColumnSurfaceY(voxelGrid, x, z);
   }
 
   /**

--- a/src/core/nav/NavGrid.ts
+++ b/src/core/nav/NavGrid.ts
@@ -21,12 +21,12 @@ export interface NavCell {
   /**
    * Reserved for a future per-cell vehicle-occupancy pass (checked by
    * Pathfinding.findPath/AgentMovement.isPathBlocked when a caller requests
-   * avoidVehicles). No caller in src/ ever sets this true — GameLoop's
+   * avoidVehicles). No caller in src/ ever sets this true — EntityMovementTick's
    * tickVehicle/tickEmployeeMovement both request avoidVehicles:false and
    * instead do vehicle-vs-vehicle collision avoidance by comparing live x/z
-   * directly (see isCellOccupiedByOtherVehicle in GameLoop.ts) — so this
-   * field is always false today and the avoidVehicles checks against it are
-   * a no-op.
+   * directly (see isCellOccupiedByOtherVehicle in EntityMovementTick.ts) — so
+   * this field is always false today and the avoidVehicles checks against it
+   * are a no-op.
    */
   vehicleOccupied: boolean;
 }

--- a/src/core/state/EventEmitter.ts
+++ b/src/core/state/EventEmitter.ts
@@ -27,6 +27,9 @@ export interface GameEventMap {
   'employee:need_warning': { employeeId: number; needKey: string };
   'employee:collapsed': { employeeId: number; needKey: string };
   'employee:shift_change': { employeeId: number };
+
+  // Phase 9 — Navmesh path-following
+  'agent:stuck': { employeeId: number };
 }
 
 type EventHandler<T> = (data: T) => void;

--- a/src/core/state/EventEmitter.ts
+++ b/src/core/state/EventEmitter.ts
@@ -30,6 +30,7 @@ export interface GameEventMap {
 
   // Phase 9 — Navmesh path-following
   'agent:stuck': { employeeId: number };
+  'vehicle:stuck': { vehicleId: number };
 }
 
 type EventHandler<T> = (data: T) => void;

--- a/src/core/world/VoxelGrid.ts
+++ b/src/core/world/VoxelGrid.ts
@@ -119,3 +119,26 @@ export class VoxelGrid {
     return results;
   }
 }
+
+/**
+ * Resolve the surface Y for column (x, z) — the highest voxel with density
+ * >= 0.5. Returns -1 if the column is entirely void. Out-of-bounds (x, z)
+ * coordinates are clamped to the grid limits.
+ *
+ * Shared by NavGrid.computeSurfaceY and Ramp.ts's local column-surface
+ * resolution — both need this exact scan and previously kept independent
+ * copies to avoid a core/mining <-> core/nav import cycle (core/nav already
+ * depends on core/mining). VoxelGrid is a true leaf module (no imports of its
+ * own), so both can import from here instead.
+ */
+export function computeVoxelColumnSurfaceY(grid: VoxelGrid, x: number, z: number): number {
+  if (grid.sizeX <= 0 || grid.sizeZ <= 0) return -1;
+
+  const cx = Math.max(0, Math.min(grid.sizeX - 1, Math.floor(x)));
+  const cz = Math.max(0, Math.min(grid.sizeZ - 1, Math.floor(z)));
+  for (let y = grid.sizeY - 1; y >= 0; y--) {
+    const voxel = grid.getVoxel(cx, y, cz);
+    if (voxel && voxel.density >= 0.5) return y;
+  }
+  return -1;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -369,6 +369,7 @@ new KeyboardShortcuts({
   togglePanel: (name) => uiManager.togglePanel(name),
   quickSave: () => { if (ctx.state) void saveLoadUI['autoSave'](ctx.state); },
   openSettings: () => uiManager.togglePanel('settings'),
+  onToggleNavGrid: () => uiManager.toggleNavGridOverlay(),
 });
 
 // --- Render loop + game tick timer ---

--- a/src/ui/KeyboardShortcuts.ts
+++ b/src/ui/KeyboardShortcuts.ts
@@ -13,6 +13,8 @@ export interface ShortcutCallbacks {
   togglePanel: (name: PanelName) => void;
   quickSave: () => void;
   openSettings: () => void;
+  /** Toggle the NavGrid overlay on the MiniMap. */
+  onToggleNavGrid?: () => void;
 }
 
 export class KeyboardShortcuts {
@@ -40,6 +42,7 @@ export class KeyboardShortcuts {
         case 'KeyV': callbacks.togglePanel('vehicles'); break;
         case 'KeyE': callbacks.togglePanel('employees'); break;
         case 'KeyS': callbacks.togglePanel('survey'); break;
+        case 'KeyN': callbacks.onToggleNavGrid?.(); break;
         case 'F5':
           e.preventDefault();
           callbacks.quickSave();

--- a/src/ui/KeyboardShortcuts.ts
+++ b/src/ui/KeyboardShortcuts.ts
@@ -73,8 +73,8 @@ export class KeyboardShortcuts {
       'shortcuts.pause', 'shortcuts.speed',
       'shortcuts.blast', 'shortcuts.contracts',
       'shortcuts.vehicles', 'shortcuts.employees',
-      'shortcuts.survey', 'shortcuts.saves',
-      'shortcuts.settings',
+      'shortcuts.survey', 'shortcuts.navgrid',
+      'shortcuts.saves', 'shortcuts.settings',
     ] as const;
 
     for (const key of keys) {

--- a/src/ui/MiniMap.ts
+++ b/src/ui/MiniMap.ts
@@ -24,11 +24,11 @@ const SHADE_MAX = 1.15;
 
 /** Semi-transparent color overlay per NavCellType — shared across frames to avoid re-allocation. */
 const NAV_GRID_COLOR_MAP: Record<NavCellType, string> = {
-  walkable: 'rgba(0, 180, 0, 0.15)',
-  blocked: 'rgba(180, 0, 0, 0.3)',
-  drill_hole: 'rgba(180, 120, 0, 0.4)',
-  ramp: 'rgba(180, 180, 0, 0.3)',
-  void: 'rgba(0, 0, 0, 0.4)',
+  walkable: 'rgba(0, 180, 0, 0.25)',
+  blocked: 'rgba(180, 0, 0, 0.45)',
+  drill_hole: 'rgba(180, 120, 0, 0.55)',
+  ramp: 'rgba(180, 180, 0, 0.45)',
+  void: 'rgba(0, 0, 0, 0.5)',
 };
 
 /** Multiply an RGB triplet by `factor` and return a CSS colour. */

--- a/src/ui/UIManager.ts
+++ b/src/ui/UIManager.ts
@@ -118,8 +118,11 @@ export class UIManager {
 
   update(state: GameState, weather?: WeatherState): void {
     this.hud.update(state, weather);
-    this.miniMap.update(state);
+    // setNavGrid before update() — otherwise the overlay draws against the
+    // previous tick's navgrid for one frame after any navgrid change (new
+    // game, fresh ramp, blast).
     this.miniMap.setNavGrid(state.navGrid ?? null);
+    this.miniMap.update(state);
 
     // Update active panel
     if (this.blastUI.visible) this.blastUI.update(state);

--- a/src/ui/UIManager.ts
+++ b/src/ui/UIManager.ts
@@ -162,6 +162,15 @@ export class UIManager {
     this.syncToolbarActive();
   }
 
+  /**
+   * Toggle the NavGrid overlay on the MiniMap.
+   * TODO: implement — wire state.navGrid into this.miniMap via
+   * setNavGrid/setNavGridVisible.
+   */
+  toggleNavGridOverlay(): void {
+    // TODO: implement
+  }
+
   dispose(): void {
     this.hud.dispose();
     this.blastUI.dispose();

--- a/src/ui/UIManager.ts
+++ b/src/ui/UIManager.ts
@@ -119,6 +119,7 @@ export class UIManager {
   update(state: GameState, weather?: WeatherState): void {
     this.hud.update(state, weather);
     this.miniMap.update(state);
+    this.miniMap.setNavGrid(state.navGrid ?? null);
 
     // Update active panel
     if (this.blastUI.visible) this.blastUI.update(state);
@@ -162,13 +163,9 @@ export class UIManager {
     this.syncToolbarActive();
   }
 
-  /**
-   * Toggle the NavGrid overlay on the MiniMap.
-   * TODO: implement — wire state.navGrid into this.miniMap via
-   * setNavGrid/setNavGridVisible.
-   */
+  /** Toggle the NavGrid overlay on the MiniMap. */
   toggleNavGridOverlay(): void {
-    // TODO: implement
+    this.miniMap.setNavGridVisible(!this.miniMap.navGridVisible);
   }
 
   dispose(): void {

--- a/tests/integration/navmesh.integration.test.ts
+++ b/tests/integration/navmesh.integration.test.ts
@@ -8,6 +8,7 @@ import { VoxelGrid } from '../../src/core/world/VoxelGrid.js';
 import { createBuildingState, placeBuilding } from '../../src/core/entities/Building.js';
 import { generateTerrain } from '../../src/core/world/TerrainGen.js';
 import { getMinePreset } from '../../src/core/world/MineType.js';
+import { buildRamp } from '../../src/core/mining/Ramp.js';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -20,6 +21,16 @@ function fillSolid(grid: VoxelGrid, yMax: number) {
           composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
           density: 1.0, oreDensities: {}, fractureModifier: 1.0,
         });
+}
+
+/** Fill a single column with solid rock from y=0 to yMax (inclusive). */
+function fillSolidColumn(grid: VoxelGrid, x: number, z: number, yMax: number) {
+  for (let y = 0; y <= yMax; y++) {
+    grid.setVoxel(x, y, z, {
+      composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] },
+      density: 1.0, oreDensities: {}, fractureModifier: 1.0,
+    });
+  }
 }
 
 // ── NavMesh and pathfinding ──────────────────────────────────────────────────
@@ -249,6 +260,67 @@ describe('NavMesh and pathfinding', () => {
 
     // Same point: h = 0
     expect(octileHeuristic(3, 3, 3, 3)).toBe(0);
+  });
+
+  // ── Multi-level via ramp (real Ramp.buildRamp() on realistic terrain) ──────
+  // Regression coverage for issue #407: buildRamp treated depth as absolute
+  // world Y, so on realistic (elevated, non-flat-from-0) terrain it never
+  // changed any column's surface height and multi-level routing could never
+  // discover a ramp connection between benches.
+
+  it('multi-level routing succeeds via a ramp built on realistic (elevated) terrain', () => {
+    const grid = new VoxelGrid(20, 30, 30);
+    fillSolid(grid, 22); // flat plateau, surface Y=22 — not flat-from-0
+
+    // Before carving: uniformly flat, single bench everywhere, no ramp connections.
+    const navBefore = NavGrid.buildNavGrid(grid, [], []);
+    expect(findRampConnections(navBefore)).toEqual([]);
+
+    const rampResult = buildRamp(grid, {
+      originX: 10, originZ: 5, direction: 'south', length: 12, targetDepth: 10,
+    }, 100000);
+    expect(rampResult.success).toBe(true);
+
+    const navAfter = NavGrid.buildNavGrid(grid, [], []);
+
+    // The fix must produce at least one ramp connector spanning two distinct
+    // bench levels.
+    const connections = findRampConnections(navAfter);
+    expect(connections.length).toBeGreaterThan(0);
+
+    const conn = connections[0]!;
+    expect(conn.upperLevel).not.toBe(conn.lowerLevel);
+
+    // Pathfinding from the upper side of the connection to the lower side
+    // must succeed now that the ramp physically exists.
+    const result = findPath(navAfter, {
+      agentId: 1, fromX: conn.upperX, fromZ: conn.upperZ,
+      toX: conn.lowerX, toZ: conn.lowerZ, avoidVehicles: false,
+    });
+    expect(result.found).toBe(true);
+  });
+
+  it('multi-level routing returns found:false when no ramp connects two separated benches', () => {
+    const grid = new VoxelGrid(20, 30, 30);
+    // Upper bench: z=0..9, surface Y=22.
+    for (let z = 0; z <= 9; z++) {
+      for (let x = 0; x < grid.sizeX; x++) fillSolidColumn(grid, x, z, 22);
+    }
+    // Void gap: z=10..19 — left entirely empty, genuinely impassable and wide
+    // enough that no cardinal adjacency crosses it.
+    // Lower bench: z=20..29, surface Y=10.
+    for (let z = 20; z < grid.sizeZ; z++) {
+      for (let x = 0; x < grid.sizeX; x++) fillSolidColumn(grid, x, z, 10);
+    }
+
+    const nav = NavGrid.buildNavGrid(grid, [], []);
+    // No ramp connects the two benches.
+    expect(findRampConnections(nav)).toEqual([]);
+
+    const result = findPath(nav, {
+      agentId: 1, fromX: 10, fromZ: 5, toX: 10, toZ: 25, avoidVehicles: false,
+    });
+    expect(result.found).toBe(false);
   });
 
 });

--- a/tests/integration/vehicles.integration.test.ts
+++ b/tests/integration/vehicles.integration.test.ts
@@ -159,12 +159,16 @@ describe('Vehicle fleet', () => {
     v.state = 'idle';
 
     const origX = v.x;
+    // makeCtx() runs new_game, which builds a NavGrid — tickVehicle routes via
+    // Pathfinding.findPath and advances at debris_hauler's own speed (3
+    // cells/tick, see VEHICLE_BASE_STATS) rather than a flat 1 cell/tick (#407).
+    const debrisHaulerSpeed = 3;
 
     tickVehicle(ctx.state!, v);
 
-    // Should have moved one cell closer to target (20, 16)
+    // Should have moved debrisHaulerSpeed cells closer to target (20, 16)
     if (v.task === 'moving') {
-      expect(v.x).toBe(origX + 1);
+      expect(v.x).toBe(origX + debrisHaulerSpeed);
     }
     // If the vehicle arrived, task becomes 'idle' and x == targetX
     if (v.task === 'idle') {

--- a/tests/unit/engine/EntityMovementTick.test.ts
+++ b/tests/unit/engine/EntityMovementTick.test.ts
@@ -1,0 +1,338 @@
+// BlastSimulator2026 — Tests for vehicle and employee per-tick movement
+// (tickVehicle, tickEmployeeMovement). Split out of GameLoop.test.ts (#407
+// refactor) alongside the EntityMovementTick.ts module extraction — these
+// describe blocks are self-contained and exercise nothing else in GameLoop.ts.
+
+import { describe, it, expect } from 'vitest';
+import { createGame } from '../../../src/core/state/GameState.js';
+import { Random } from '../../../src/core/math/Random.js';
+import { tickVehicle, tickEmployeeMovement } from '../../../src/core/engine/EntityMovementTick.js';
+import { hireEmployee } from '../../../src/core/entities/Employee.js';
+import { EventEmitter } from '../../../src/core/state/EventEmitter.js';
+import { purchaseVehicle } from '../../../src/core/entities/Vehicle.js';
+import { NavGrid } from '../../../src/core/nav/NavGrid.js';
+import { VoxelGrid } from '../../../src/core/world/VoxelGrid.js';
+import { AGENT_WALK_SPEED, STUCK_THRESHOLD, STUCK_MORALE_PENALTY } from '../../../src/core/config/balance.js';
+
+const VEHICLE_TICK_SEED = 42;
+
+describe('tickVehicle (Task 2.7)', () => {
+  it('advances a moving vehicle toward its target cell', () => {
+    const state = createGame({ seed: VEHICLE_TICK_SEED });
+    const { vehicle } = purchaseVehicle(state.vehicles, 'rock_digger', 0, 0);
+    vehicle.task = 'moving';
+    vehicle.state = 'moving';
+    vehicle.targetX = 2;
+    vehicle.targetZ = 0;
+
+    tickVehicle(state, vehicle);
+    expect(vehicle.x).toBe(1);
+    expect(vehicle.z).toBe(0);
+    expect(vehicle.state).toBe('moving');
+    expect(vehicle.task).toBe('moving');
+
+    tickVehicle(state, vehicle);
+    expect(vehicle.x).toBe(2);
+    expect(vehicle.z).toBe(0);
+    expect(vehicle.state).toBe('idle');
+    expect(vehicle.task).toBe('idle');
+  });
+
+  it('puts one vehicle into waiting when two vehicles converge on the same target cell', () => {
+    const state = createGame({ seed: VEHICLE_TICK_SEED });
+    const { vehicle: left } = purchaseVehicle(state.vehicles, 'rock_digger', 0, 0);
+    const { vehicle: right } = purchaseVehicle(state.vehicles, 'drill_rig', 2, 0);
+
+    left.task = 'moving';
+    left.state = 'moving';
+    left.targetX = 1;
+    left.targetZ = 0;
+
+    right.task = 'moving';
+    right.state = 'moving';
+    right.targetX = 1;
+    right.targetZ = 0;
+
+    tickVehicle(state, left);
+    tickVehicle(state, right);
+
+    const waitingVehicles = [left, right].filter(v => v.state === 'waiting');
+    expect(waitingVehicles).toHaveLength(1);
+    const movingVehicles = [left, right].filter(v => v.state !== 'waiting');
+    expect(movingVehicles).toHaveLength(1);
+    expect(movingVehicles[0]!.x).toBe(1);
+    expect(movingVehicles[0]!.z).toBe(0);
+  });
+
+  it('resumes waiting vehicle movement when the blocked cell becomes free', () => {
+    const state = createGame({ seed: VEHICLE_TICK_SEED });
+    const { vehicle: blocker } = purchaseVehicle(state.vehicles, 'rock_digger', 0, 0);
+    const { vehicle: waiting } = purchaseVehicle(state.vehicles, 'drill_rig', 2, 0);
+
+    blocker.task = 'moving';
+    blocker.state = 'moving';
+    blocker.targetX = 1;
+    blocker.targetZ = 0;
+
+    waiting.task = 'moving';
+    waiting.state = 'moving';
+    waiting.targetX = 1;
+    waiting.targetZ = 0;
+
+    tickVehicle(state, blocker);
+    tickVehicle(state, waiting);
+    expect(waiting.state).toBe('waiting');
+
+    blocker.task = 'moving';
+    blocker.state = 'moving';
+    blocker.targetX = 0;
+    blocker.targetZ = 0;
+    tickVehicle(state, blocker);
+
+    tickVehicle(state, waiting);
+    expect(waiting.x).toBe(1);
+    expect(waiting.z).toBe(0);
+    expect(waiting.state).toBe('idle');
+  });
+});
+
+// ── tickVehicle — NavGrid stuck detection (issue #407 review round 2) ────────
+// Mirrors the tickEmployeeMovement stuck-threshold test below: the
+// tickVehicleOnNavGrid stuck branch (findPath fails every tick) previously had
+// zero test coverage — every tickVehicle test above runs with state.navGrid
+// null, which only ever exercises tickVehicleDirectLine.
+
+describe('tickVehicle — NavGrid stuck detection (issue #407 review round 2)', () => {
+  /** Solid rock voxel used to build a small hand-crafted NavGrid below. */
+  function solidVoxel() {
+    return { composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] }, density: 1.0, oreDensities: {}, fractureModifier: 1.0 };
+  }
+
+  it('crosses STUCK_THRESHOLD when no path exists: emits vehicle:stuck once, sets isMoveStuck, and moves the vehicle into waiting', () => {
+    const state = createGame({ seed: VEHICLE_TICK_SEED });
+
+    // A 5×5×5 NavGrid with rock only under (0,0) — every other column stays
+    // void (density 0 everywhere), so a target there is impassable and
+    // findPath returns found:false on every tick, forever.
+    const vg = new VoxelGrid(5, 5, 5);
+    vg.setVoxel(0, 0, 0, solidVoxel());
+    vg.setVoxel(0, 1, 0, solidVoxel());
+    state.navGrid = NavGrid.buildNavGrid(vg, [], []);
+
+    const { vehicle } = purchaseVehicle(state.vehicles, 'rock_digger', 0, 0);
+    vehicle.task = 'moving';
+    vehicle.state = 'moving';
+    vehicle.targetX = 3;
+    vehicle.targetZ = 3; // void column — unreachable
+
+    const emitter = new EventEmitter();
+    const stuckEvents: number[] = [];
+    emitter.on('vehicle:stuck', ({ vehicleId }) => stuckEvents.push(vehicleId));
+
+    for (let i = 0; i < STUCK_THRESHOLD; i++) {
+      tickVehicle(state, vehicle, emitter);
+    }
+
+    expect(vehicle.isMoveStuck).toBe(true);
+    expect(vehicle.moveConsecutiveFailures).toBe(STUCK_THRESHOLD);
+    expect(stuckEvents).toEqual([vehicle.id]); // fired exactly once, on the crossing tick
+    expect(vehicle.x).toBe(0); // never moved — no path ever resolved
+    expect(vehicle.z).toBe(0);
+    expect(vehicle.state).toBe('waiting');
+    expect(vehicle.waitingTicks).toBe(STUCK_THRESHOLD);
+
+    // One more failed tick past the threshold — still stuck, but the event
+    // does not re-fire on every subsequent tick, only on the falling edge.
+    tickVehicle(state, vehicle, emitter);
+    expect(stuckEvents).toEqual([vehicle.id]);
+    expect(vehicle.isMoveStuck).toBe(true);
+    expect(vehicle.waitingTicks).toBe(STUCK_THRESHOLD + 1);
+  });
+});
+
+// ── Task 2.8: Vehicle.waitingTicks tracking ──────────────────────────────────
+
+describe('tickVehicle — waitingTicks (Task 2.8)', () => {
+  it('increments waitingTicks by 1 on each tick the vehicle remains in waiting state', () => {
+    const state = createGame({ seed: VEHICLE_TICK_SEED });
+    const { vehicle: blocker } = purchaseVehicle(state.vehicles, 'rock_digger', 0, 0);
+    const { vehicle: waiting } = purchaseVehicle(state.vehicles, 'debris_hauler', 2, 0);
+
+    // Both vehicles head for the same cell (1, 0)
+    blocker.task = 'moving'; blocker.state = 'moving';
+    blocker.targetX = 1;     blocker.targetZ = 0;
+
+    waiting.task = 'moving'; waiting.state = 'moving';
+    waiting.targetX = 1;     waiting.targetZ = 0;
+
+    // Tick 1 — blocker arrives at (1,0); debris_hauler is blocked → waiting
+    tickVehicle(state, blocker);
+    tickVehicle(state, waiting);
+    expect(waiting.state).toBe('waiting');
+    expect(waiting.waitingTicks).toBe(1);
+
+    // Tick 2 — blocker is idle at (1,0), still blocking; waitingTicks → 2
+    tickVehicle(state, blocker); // no-op (task = 'idle')
+    tickVehicle(state, waiting);
+    expect(waiting.waitingTicks).toBe(2);
+
+    // Tick 3 — same situation; waitingTicks → 3
+    tickVehicle(state, blocker);
+    tickVehicle(state, waiting);
+    expect(waiting.waitingTicks).toBe(3);
+  });
+
+  it('resets waitingTicks to 0 when the vehicle transitions from waiting to moving', () => {
+    const state = createGame({ seed: VEHICLE_TICK_SEED });
+    const { vehicle: blocker } = purchaseVehicle(state.vehicles, 'rock_digger', 0, 0);
+    const { vehicle: waiting } = purchaseVehicle(state.vehicles, 'debris_hauler', 2, 0);
+
+    blocker.task = 'moving'; blocker.state = 'moving';
+    blocker.targetX = 1;     blocker.targetZ = 0;
+
+    waiting.task = 'moving'; waiting.state = 'moving';
+    waiting.targetX = 1;     waiting.targetZ = 0;
+
+    // Build up waitingTicks
+    tickVehicle(state, blocker);
+    tickVehicle(state, waiting);
+    expect(waiting.state).toBe('waiting');
+    expect(waiting.waitingTicks).toBe(1);
+
+    tickVehicle(state, blocker); // no-op
+    tickVehicle(state, waiting);
+    expect(waiting.waitingTicks).toBe(2);
+
+    // Teleport the blocker away so cell (1,0) is free
+    blocker.x = 99;
+    blocker.z = 99;
+
+    // Next tickVehicle — waiting vehicle finally moves; waitingTicks must reset
+    tickVehicle(state, waiting);
+    expect(waiting.state).not.toBe('waiting');
+    expect(waiting.waitingTicks).toBe(0);
+  });
+
+  it('resets waitingTicks to 0 when the vehicle reaches its target and becomes idle', () => {
+    const state = createGame({ seed: VEHICLE_TICK_SEED });
+    const { vehicle: v } = purchaseVehicle(state.vehicles, 'debris_hauler', 0, 0);
+
+    // Manually prime waitingTicks to a non-zero value (simulates prior waiting)
+    v.waitingTicks = 5;
+
+    // Vehicle moves straight to its target — no blocking
+    v.task = 'moving'; v.state = 'moving';
+    v.targetX = 1;     v.targetZ = 0;
+
+    tickVehicle(state, v);
+
+    // Vehicle reached target → idle; waitingTicks must be 0
+    expect(v.state).toBe('idle');
+    expect(v.waitingTicks).toBe(0);
+  });
+});
+
+// ── tickEmployeeMovement (issue #407) ────────────────────────────────────────
+
+describe('tickEmployeeMovement', () => {
+  const SEED = 42;
+
+  /** Solid rock voxel used to build small hand-crafted NavGrids below. */
+  function solidVoxel() {
+    return { composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] }, density: 1.0, oreDensities: {}, fractureModifier: 1.0 };
+  }
+
+  it('is a no-op for an employee with no destination set', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.x = 5;
+    employee.z = 7;
+    employee.destinationX = null;
+    employee.destinationZ = null;
+
+    const result = tickEmployeeMovement(state);
+
+    expect(employee.x).toBe(5);
+    expect(employee.z).toBe(7);
+    expect(employee.destinationX).toBeNull();
+    expect(employee.destinationZ).toBeNull();
+    expect(result).toEqual({ moved: [], arrived: [], stuck: [] });
+  });
+
+  it('falls back to a direct line toward the destination when no NavGrid has been built yet, without crashing', () => {
+    const state = createGame({ seed: SEED });
+    expect(state.navGrid).toBeNull();
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.x = 0;
+    employee.z = 0;
+    employee.destinationX = 10;
+    employee.destinationZ = 0;
+
+    let result;
+    expect(() => { result = tickEmployeeMovement(state); }).not.toThrow();
+
+    // AGENT_WALK_SPEED cells covered this tick, straight toward (10, 0) — not yet arrived.
+    expect(employee.x).toBeCloseTo(AGENT_WALK_SPEED, 5);
+    expect(employee.z).toBe(0);
+    expect(employee.destinationX).toBe(10);
+    expect(result!.moved).toEqual([employee.id]);
+    expect(result!.arrived).toEqual([]);
+  });
+
+  it('reaches its destination in one tick when already within walking speed — position exact, destination cleared', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.x = 0;
+    employee.z = 0;
+    employee.destinationX = 1; // 1 cell away, well within AGENT_WALK_SPEED
+    employee.destinationZ = 0;
+
+    const result = tickEmployeeMovement(state);
+
+    expect(employee.x).toBe(1);
+    expect(employee.z).toBe(0);
+    expect(employee.destinationX).toBeNull();
+    expect(employee.destinationZ).toBeNull();
+    expect(result.arrived).toEqual([employee.id]);
+  });
+
+  it('crosses STUCK_THRESHOLD when no path exists: emits agent:stuck once, sets isMoveStuck, applies the morale penalty', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+
+    // A 5×5×5 NavGrid with rock only under (0,0) — every other column stays
+    // void (density 0 everywhere), so a destination there is impassable and
+    // findPath returns found:false on every tick, forever.
+    const vg = new VoxelGrid(5, 5, 5);
+    vg.setVoxel(0, 0, 0, solidVoxel());
+    vg.setVoxel(0, 1, 0, solidVoxel());
+    state.navGrid = NavGrid.buildNavGrid(vg, [], []);
+
+    employee.x = 0;
+    employee.z = 0;
+    employee.destinationX = 3;
+    employee.destinationZ = 3; // void column — unreachable
+    employee.morale = 60;
+
+    const emitter = new EventEmitter();
+    const stuckEvents: number[] = [];
+    emitter.on('agent:stuck', ({ employeeId }) => stuckEvents.push(employeeId));
+
+    let result;
+    for (let i = 0; i < STUCK_THRESHOLD; i++) {
+      result = tickEmployeeMovement(state, emitter);
+    }
+
+    expect(employee.isMoveStuck).toBe(true);
+    expect(employee.moveConsecutiveFailures).toBe(STUCK_THRESHOLD);
+    expect(stuckEvents).toEqual([employee.id]); // fired exactly once, on the crossing tick
+    expect(result!.stuck).toEqual([employee.id]);
+    expect(employee.x).toBe(0); // never moved — no path ever resolved
+    expect(employee.z).toBe(0);
+    expect(employee.morale).toBe(60 - STUCK_MORALE_PENALTY);
+  });
+});

--- a/tests/unit/engine/GameLoop.test.ts
+++ b/tests/unit/engine/GameLoop.test.ts
@@ -10,7 +10,6 @@ import {
   resume,
   isValidSpeed,
   BASE_TICK_MS,
-  tickVehicle,
   tickEmployees,
   // tickNeedRestoration is imported here for Task 3.11 tests.
   // It does not exist yet — tests will fail (Red phase) until the implementation lands.
@@ -32,8 +31,6 @@ import {
   // ── tickTaskProgress: task-duration countdown + tick-driven XP (issue #406) ──
   // Stub as of this branch — the tests below are the Red-phase spec for it.
   tickTaskProgress,
-  // ── tickEmployeeMovement: NavGrid-aware movement (issue #407) ──
-  tickEmployeeMovement,
 } from '../../../src/core/engine/GameLoop.js';
 import { placeBuilding } from '../../../src/core/entities/Building.js';
 import {
@@ -46,10 +43,7 @@ import type { FiredEvent } from '../../../src/core/events/EventSystem.js';
 import { EventEmitter } from '../../../src/core/state/EventEmitter.js';
 import { setupEvents } from '../../../src/core/events/index.js';
 import { clearEvents, registerEvents } from '../../../src/core/events/EventPool.js';
-import { purchaseVehicle } from '../../../src/core/entities/Vehicle.js';
 import { getLivingQuartersWellbeingMultiplier } from '../../../src/core/entities/BuildingWellbeing.js';
-import { NavGrid } from '../../../src/core/nav/NavGrid.js';
-import { VoxelGrid } from '../../../src/core/world/VoxelGrid.js';
 import {
   NEED_REST_DURATIONS,
   NEED_REST_BUILDING_TYPES,
@@ -63,9 +57,6 @@ import {
   NEED_REST_NO_BUILDING_DURATION_MULTIPLIER,
   BASE_TASK_DURATION_TICKS,
   XP_THRESHOLDS,
-  AGENT_WALK_SPEED,
-  STUCK_THRESHOLD,
-  STUCK_MORALE_PENALTY,
 } from '../../../src/core/config/balance.js';
 
 function buildContext(state: GameState): EventContext {
@@ -182,224 +173,6 @@ describe('GameLoop', () => {
     expect(isValidSpeed(3)).toBe(false);
     expect(isValidSpeed(0)).toBe(false);
     expect(isValidSpeed(16)).toBe(false);
-  });
-});
-
-const VEHICLE_TICK_SEED = 42;
-
-describe('tickVehicle (Task 2.7)', () => {
-  it('advances a moving vehicle toward its target cell', () => {
-    const state = createGame({ seed: VEHICLE_TICK_SEED });
-    const { vehicle } = purchaseVehicle(state.vehicles, 'rock_digger', 0, 0);
-    vehicle.task = 'moving';
-    vehicle.state = 'moving';
-    vehicle.targetX = 2;
-    vehicle.targetZ = 0;
-
-    tickVehicle(state, vehicle);
-    expect(vehicle.x).toBe(1);
-    expect(vehicle.z).toBe(0);
-    expect(vehicle.state).toBe('moving');
-    expect(vehicle.task).toBe('moving');
-
-    tickVehicle(state, vehicle);
-    expect(vehicle.x).toBe(2);
-    expect(vehicle.z).toBe(0);
-    expect(vehicle.state).toBe('idle');
-    expect(vehicle.task).toBe('idle');
-  });
-
-  it('puts one vehicle into waiting when two vehicles converge on the same target cell', () => {
-    const state = createGame({ seed: VEHICLE_TICK_SEED });
-    const { vehicle: left } = purchaseVehicle(state.vehicles, 'rock_digger', 0, 0);
-    const { vehicle: right } = purchaseVehicle(state.vehicles, 'drill_rig', 2, 0);
-
-    left.task = 'moving';
-    left.state = 'moving';
-    left.targetX = 1;
-    left.targetZ = 0;
-
-    right.task = 'moving';
-    right.state = 'moving';
-    right.targetX = 1;
-    right.targetZ = 0;
-
-    tickVehicle(state, left);
-    tickVehicle(state, right);
-
-    const waitingVehicles = [left, right].filter(v => v.state === 'waiting');
-    expect(waitingVehicles).toHaveLength(1);
-    const movingVehicles = [left, right].filter(v => v.state !== 'waiting');
-    expect(movingVehicles).toHaveLength(1);
-    expect(movingVehicles[0]!.x).toBe(1);
-    expect(movingVehicles[0]!.z).toBe(0);
-  });
-
-  it('resumes waiting vehicle movement when the blocked cell becomes free', () => {
-    const state = createGame({ seed: VEHICLE_TICK_SEED });
-    const { vehicle: blocker } = purchaseVehicle(state.vehicles, 'rock_digger', 0, 0);
-    const { vehicle: waiting } = purchaseVehicle(state.vehicles, 'drill_rig', 2, 0);
-
-    blocker.task = 'moving';
-    blocker.state = 'moving';
-    blocker.targetX = 1;
-    blocker.targetZ = 0;
-
-    waiting.task = 'moving';
-    waiting.state = 'moving';
-    waiting.targetX = 1;
-    waiting.targetZ = 0;
-
-    tickVehicle(state, blocker);
-    tickVehicle(state, waiting);
-    expect(waiting.state).toBe('waiting');
-
-    blocker.task = 'moving';
-    blocker.state = 'moving';
-    blocker.targetX = 0;
-    blocker.targetZ = 0;
-    tickVehicle(state, blocker);
-
-    tickVehicle(state, waiting);
-    expect(waiting.x).toBe(1);
-    expect(waiting.z).toBe(0);
-    expect(waiting.state).toBe('idle');
-  });
-});
-
-// ── tickVehicle — NavGrid stuck detection (issue #407 review round 2) ────────
-// Mirrors the tickEmployeeMovement stuck-threshold test below: the
-// tickVehicleOnNavGrid stuck branch (findPath fails every tick) previously had
-// zero test coverage — every tickVehicle test above runs with state.navGrid
-// null, which only ever exercises tickVehicleDirectLine.
-
-describe('tickVehicle — NavGrid stuck detection (issue #407 review round 2)', () => {
-  /** Solid rock voxel used to build a small hand-crafted NavGrid below. */
-  function solidVoxel() {
-    return { composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] }, density: 1.0, oreDensities: {}, fractureModifier: 1.0 };
-  }
-
-  it('crosses STUCK_THRESHOLD when no path exists: emits vehicle:stuck once, sets isMoveStuck, and moves the vehicle into waiting', () => {
-    const state = createGame({ seed: VEHICLE_TICK_SEED });
-
-    // A 5×5×5 NavGrid with rock only under (0,0) — every other column stays
-    // void (density 0 everywhere), so a target there is impassable and
-    // findPath returns found:false on every tick, forever.
-    const vg = new VoxelGrid(5, 5, 5);
-    vg.setVoxel(0, 0, 0, solidVoxel());
-    vg.setVoxel(0, 1, 0, solidVoxel());
-    state.navGrid = NavGrid.buildNavGrid(vg, [], []);
-
-    const { vehicle } = purchaseVehicle(state.vehicles, 'rock_digger', 0, 0);
-    vehicle.task = 'moving';
-    vehicle.state = 'moving';
-    vehicle.targetX = 3;
-    vehicle.targetZ = 3; // void column — unreachable
-
-    const emitter = new EventEmitter();
-    const stuckEvents: number[] = [];
-    emitter.on('vehicle:stuck', ({ vehicleId }) => stuckEvents.push(vehicleId));
-
-    for (let i = 0; i < STUCK_THRESHOLD; i++) {
-      tickVehicle(state, vehicle, emitter);
-    }
-
-    expect(vehicle.isMoveStuck).toBe(true);
-    expect(vehicle.moveConsecutiveFailures).toBe(STUCK_THRESHOLD);
-    expect(stuckEvents).toEqual([vehicle.id]); // fired exactly once, on the crossing tick
-    expect(vehicle.x).toBe(0); // never moved — no path ever resolved
-    expect(vehicle.z).toBe(0);
-    expect(vehicle.state).toBe('waiting');
-    expect(vehicle.waitingTicks).toBe(STUCK_THRESHOLD);
-
-    // One more failed tick past the threshold — still stuck, but the event
-    // does not re-fire on every subsequent tick, only on the falling edge.
-    tickVehicle(state, vehicle, emitter);
-    expect(stuckEvents).toEqual([vehicle.id]);
-    expect(vehicle.isMoveStuck).toBe(true);
-    expect(vehicle.waitingTicks).toBe(STUCK_THRESHOLD + 1);
-  });
-});
-
-// ── Task 2.8: Vehicle.waitingTicks tracking ──────────────────────────────────
-
-describe('tickVehicle — waitingTicks (Task 2.8)', () => {
-  it('increments waitingTicks by 1 on each tick the vehicle remains in waiting state', () => {
-    const state = createGame({ seed: VEHICLE_TICK_SEED });
-    const { vehicle: blocker } = purchaseVehicle(state.vehicles, 'rock_digger', 0, 0);
-    const { vehicle: waiting } = purchaseVehicle(state.vehicles, 'debris_hauler', 2, 0);
-
-    // Both vehicles head for the same cell (1, 0)
-    blocker.task = 'moving'; blocker.state = 'moving';
-    blocker.targetX = 1;     blocker.targetZ = 0;
-
-    waiting.task = 'moving'; waiting.state = 'moving';
-    waiting.targetX = 1;     waiting.targetZ = 0;
-
-    // Tick 1 — blocker arrives at (1,0); debris_hauler is blocked → waiting
-    tickVehicle(state, blocker);
-    tickVehicle(state, waiting);
-    expect(waiting.state).toBe('waiting');
-    expect(waiting.waitingTicks).toBe(1);
-
-    // Tick 2 — blocker is idle at (1,0), still blocking; waitingTicks → 2
-    tickVehicle(state, blocker); // no-op (task = 'idle')
-    tickVehicle(state, waiting);
-    expect(waiting.waitingTicks).toBe(2);
-
-    // Tick 3 — same situation; waitingTicks → 3
-    tickVehicle(state, blocker);
-    tickVehicle(state, waiting);
-    expect(waiting.waitingTicks).toBe(3);
-  });
-
-  it('resets waitingTicks to 0 when the vehicle transitions from waiting to moving', () => {
-    const state = createGame({ seed: VEHICLE_TICK_SEED });
-    const { vehicle: blocker } = purchaseVehicle(state.vehicles, 'rock_digger', 0, 0);
-    const { vehicle: waiting } = purchaseVehicle(state.vehicles, 'debris_hauler', 2, 0);
-
-    blocker.task = 'moving'; blocker.state = 'moving';
-    blocker.targetX = 1;     blocker.targetZ = 0;
-
-    waiting.task = 'moving'; waiting.state = 'moving';
-    waiting.targetX = 1;     waiting.targetZ = 0;
-
-    // Build up waitingTicks
-    tickVehicle(state, blocker);
-    tickVehicle(state, waiting);
-    expect(waiting.state).toBe('waiting');
-    expect(waiting.waitingTicks).toBe(1);
-
-    tickVehicle(state, blocker); // no-op
-    tickVehicle(state, waiting);
-    expect(waiting.waitingTicks).toBe(2);
-
-    // Teleport the blocker away so cell (1,0) is free
-    blocker.x = 99;
-    blocker.z = 99;
-
-    // Next tickVehicle — waiting vehicle finally moves; waitingTicks must reset
-    tickVehicle(state, waiting);
-    expect(waiting.state).not.toBe('waiting');
-    expect(waiting.waitingTicks).toBe(0);
-  });
-
-  it('resets waitingTicks to 0 when the vehicle reaches its target and becomes idle', () => {
-    const state = createGame({ seed: VEHICLE_TICK_SEED });
-    const { vehicle: v } = purchaseVehicle(state.vehicles, 'debris_hauler', 0, 0);
-
-    // Manually prime waitingTicks to a non-zero value (simulates prior waiting)
-    v.waitingTicks = 5;
-
-    // Vehicle moves straight to its target — no blocking
-    v.task = 'moving'; v.state = 'moving';
-    v.targetX = 1;     v.targetZ = 0;
-
-    tickVehicle(state, v);
-
-    // Vehicle reached target → idle; waitingTicks must be 0
-    expect(v.state).toBe('idle');
-    expect(v.waitingTicks).toBe(0);
   });
 });
 
@@ -2565,110 +2338,5 @@ describe('tickGeneralRestCompletion', () => {
     expect(result.completed).toEqual([{ employeeId: employee.id, needKey: 'hunger' }]);
     expect(employee.restTicksRemaining).toBeNull();
     expect(employee.activeActionId).toBeNull();
-  });
-});
-
-// ── tickEmployeeMovement (issue #407) ────────────────────────────────────────
-
-describe('tickEmployeeMovement', () => {
-  const SEED = 42;
-
-  /** Solid rock voxel used to build small hand-crafted NavGrids below. */
-  function solidVoxel() {
-    return { composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] }, density: 1.0, oreDensities: {}, fractureModifier: 1.0 };
-  }
-
-  it('is a no-op for an employee with no destination set', () => {
-    const state = createGame({ seed: SEED });
-    const rng = new Random(SEED);
-    const { employee } = hireEmployee(state.employees, 'driller', rng);
-    employee.x = 5;
-    employee.z = 7;
-    employee.destinationX = null;
-    employee.destinationZ = null;
-
-    const result = tickEmployeeMovement(state);
-
-    expect(employee.x).toBe(5);
-    expect(employee.z).toBe(7);
-    expect(employee.destinationX).toBeNull();
-    expect(employee.destinationZ).toBeNull();
-    expect(result).toEqual({ moved: [], arrived: [], stuck: [] });
-  });
-
-  it('falls back to a direct line toward the destination when no NavGrid has been built yet, without crashing', () => {
-    const state = createGame({ seed: SEED });
-    expect(state.navGrid).toBeNull();
-    const rng = new Random(SEED);
-    const { employee } = hireEmployee(state.employees, 'driller', rng);
-    employee.x = 0;
-    employee.z = 0;
-    employee.destinationX = 10;
-    employee.destinationZ = 0;
-
-    let result;
-    expect(() => { result = tickEmployeeMovement(state); }).not.toThrow();
-
-    // AGENT_WALK_SPEED cells covered this tick, straight toward (10, 0) — not yet arrived.
-    expect(employee.x).toBeCloseTo(AGENT_WALK_SPEED, 5);
-    expect(employee.z).toBe(0);
-    expect(employee.destinationX).toBe(10);
-    expect(result!.moved).toEqual([employee.id]);
-    expect(result!.arrived).toEqual([]);
-  });
-
-  it('reaches its destination in one tick when already within walking speed — position exact, destination cleared', () => {
-    const state = createGame({ seed: SEED });
-    const rng = new Random(SEED);
-    const { employee } = hireEmployee(state.employees, 'driller', rng);
-    employee.x = 0;
-    employee.z = 0;
-    employee.destinationX = 1; // 1 cell away, well within AGENT_WALK_SPEED
-    employee.destinationZ = 0;
-
-    const result = tickEmployeeMovement(state);
-
-    expect(employee.x).toBe(1);
-    expect(employee.z).toBe(0);
-    expect(employee.destinationX).toBeNull();
-    expect(employee.destinationZ).toBeNull();
-    expect(result.arrived).toEqual([employee.id]);
-  });
-
-  it('crosses STUCK_THRESHOLD when no path exists: emits agent:stuck once, sets isMoveStuck, applies the morale penalty', () => {
-    const state = createGame({ seed: SEED });
-    const rng = new Random(SEED);
-    const { employee } = hireEmployee(state.employees, 'driller', rng);
-
-    // A 5×5×5 NavGrid with rock only under (0,0) — every other column stays
-    // void (density 0 everywhere), so a destination there is impassable and
-    // findPath returns found:false on every tick, forever.
-    const vg = new VoxelGrid(5, 5, 5);
-    vg.setVoxel(0, 0, 0, solidVoxel());
-    vg.setVoxel(0, 1, 0, solidVoxel());
-    state.navGrid = NavGrid.buildNavGrid(vg, [], []);
-
-    employee.x = 0;
-    employee.z = 0;
-    employee.destinationX = 3;
-    employee.destinationZ = 3; // void column — unreachable
-    employee.morale = 60;
-
-    const emitter = new EventEmitter();
-    const stuckEvents: number[] = [];
-    emitter.on('agent:stuck', ({ employeeId }) => stuckEvents.push(employeeId));
-
-    let result;
-    for (let i = 0; i < STUCK_THRESHOLD; i++) {
-      result = tickEmployeeMovement(state, emitter);
-    }
-
-    expect(employee.isMoveStuck).toBe(true);
-    expect(employee.moveConsecutiveFailures).toBe(STUCK_THRESHOLD);
-    expect(stuckEvents).toEqual([employee.id]); // fired exactly once, on the crossing tick
-    expect(result!.stuck).toEqual([employee.id]);
-    expect(employee.x).toBe(0); // never moved — no path ever resolved
-    expect(employee.z).toBe(0);
-    expect(employee.morale).toBe(60 - STUCK_MORALE_PENALTY);
   });
 });

--- a/tests/unit/engine/GameLoop.test.ts
+++ b/tests/unit/engine/GameLoop.test.ts
@@ -32,6 +32,8 @@ import {
   // ── tickTaskProgress: task-duration countdown + tick-driven XP (issue #406) ──
   // Stub as of this branch — the tests below are the Red-phase spec for it.
   tickTaskProgress,
+  // ── tickEmployeeMovement: NavGrid-aware movement (issue #407) ──
+  tickEmployeeMovement,
 } from '../../../src/core/engine/GameLoop.js';
 import { placeBuilding } from '../../../src/core/entities/Building.js';
 import {
@@ -41,11 +43,13 @@ import type { NeedKey } from '../../../src/core/entities/Employee.js';
 import type { PendingAction } from '../../../src/core/state/GameState.js';
 import type { EventContext } from '../../../src/core/events/EventPool.js';
 import type { FiredEvent } from '../../../src/core/events/EventSystem.js';
-import type { EventEmitter } from '../../../src/core/state/EventEmitter.js';
+import { EventEmitter } from '../../../src/core/state/EventEmitter.js';
 import { setupEvents } from '../../../src/core/events/index.js';
 import { clearEvents, registerEvents } from '../../../src/core/events/EventPool.js';
 import { purchaseVehicle } from '../../../src/core/entities/Vehicle.js';
 import { getLivingQuartersWellbeingMultiplier } from '../../../src/core/entities/BuildingWellbeing.js';
+import { NavGrid } from '../../../src/core/nav/NavGrid.js';
+import { VoxelGrid } from '../../../src/core/world/VoxelGrid.js';
 import {
   NEED_REST_DURATIONS,
   NEED_REST_BUILDING_TYPES,
@@ -59,6 +63,9 @@ import {
   NEED_REST_NO_BUILDING_DURATION_MULTIPLIER,
   BASE_TASK_DURATION_TICKS,
   XP_THRESHOLDS,
+  AGENT_WALK_SPEED,
+  STUCK_THRESHOLD,
+  STUCK_MORALE_PENALTY,
 } from '../../../src/core/config/balance.js';
 
 function buildContext(state: GameState): EventContext {
@@ -2504,5 +2511,110 @@ describe('tickGeneralRestCompletion', () => {
     expect(result.completed).toEqual([{ employeeId: employee.id, needKey: 'hunger' }]);
     expect(employee.restTicksRemaining).toBeNull();
     expect(employee.activeActionId).toBeNull();
+  });
+});
+
+// ── tickEmployeeMovement (issue #407) ────────────────────────────────────────
+
+describe('tickEmployeeMovement', () => {
+  const SEED = 42;
+
+  /** Solid rock voxel used to build small hand-crafted NavGrids below. */
+  function solidVoxel() {
+    return { composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] }, density: 1.0, oreDensities: {}, fractureModifier: 1.0 };
+  }
+
+  it('is a no-op for an employee with no destination set', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.x = 5;
+    employee.z = 7;
+    employee.destinationX = null;
+    employee.destinationZ = null;
+
+    const result = tickEmployeeMovement(state);
+
+    expect(employee.x).toBe(5);
+    expect(employee.z).toBe(7);
+    expect(employee.destinationX).toBeNull();
+    expect(employee.destinationZ).toBeNull();
+    expect(result).toEqual({ moved: [], arrived: [], stuck: [] });
+  });
+
+  it('falls back to a direct line toward the destination when no NavGrid has been built yet, without crashing', () => {
+    const state = createGame({ seed: SEED });
+    expect(state.navGrid).toBeNull();
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.x = 0;
+    employee.z = 0;
+    employee.destinationX = 10;
+    employee.destinationZ = 0;
+
+    let result;
+    expect(() => { result = tickEmployeeMovement(state); }).not.toThrow();
+
+    // AGENT_WALK_SPEED cells covered this tick, straight toward (10, 0) — not yet arrived.
+    expect(employee.x).toBeCloseTo(AGENT_WALK_SPEED, 5);
+    expect(employee.z).toBe(0);
+    expect(employee.destinationX).toBe(10);
+    expect(result!.moved).toEqual([employee.id]);
+    expect(result!.arrived).toEqual([]);
+  });
+
+  it('reaches its destination in one tick when already within walking speed — position exact, destination cleared', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.x = 0;
+    employee.z = 0;
+    employee.destinationX = 1; // 1 cell away, well within AGENT_WALK_SPEED
+    employee.destinationZ = 0;
+
+    const result = tickEmployeeMovement(state);
+
+    expect(employee.x).toBe(1);
+    expect(employee.z).toBe(0);
+    expect(employee.destinationX).toBeNull();
+    expect(employee.destinationZ).toBeNull();
+    expect(result.arrived).toEqual([employee.id]);
+  });
+
+  it('crosses STUCK_THRESHOLD when no path exists: emits agent:stuck once, sets isMoveStuck, applies the morale penalty', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+
+    // A 5×5×5 NavGrid with rock only under (0,0) — every other column stays
+    // void (density 0 everywhere), so a destination there is impassable and
+    // findPath returns found:false on every tick, forever.
+    const vg = new VoxelGrid(5, 5, 5);
+    vg.setVoxel(0, 0, 0, solidVoxel());
+    vg.setVoxel(0, 1, 0, solidVoxel());
+    state.navGrid = NavGrid.buildNavGrid(vg, [], []);
+
+    employee.x = 0;
+    employee.z = 0;
+    employee.destinationX = 3;
+    employee.destinationZ = 3; // void column — unreachable
+    employee.morale = 60;
+
+    const emitter = new EventEmitter();
+    const stuckEvents: number[] = [];
+    emitter.on('agent:stuck', ({ employeeId }) => stuckEvents.push(employeeId));
+
+    let result;
+    for (let i = 0; i < STUCK_THRESHOLD; i++) {
+      result = tickEmployeeMovement(state, emitter);
+    }
+
+    expect(employee.isMoveStuck).toBe(true);
+    expect(employee.moveConsecutiveFailures).toBe(STUCK_THRESHOLD);
+    expect(stuckEvents).toEqual([employee.id]); // fired exactly once, on the crossing tick
+    expect(result!.stuck).toEqual([employee.id]);
+    expect(employee.x).toBe(0); // never moved — no path ever resolved
+    expect(employee.z).toBe(0);
+    expect(employee.morale).toBe(60 - STUCK_MORALE_PENALTY);
   });
 });

--- a/tests/unit/engine/GameLoop.test.ts
+++ b/tests/unit/engine/GameLoop.test.ts
@@ -267,6 +267,60 @@ describe('tickVehicle (Task 2.7)', () => {
   });
 });
 
+// ── tickVehicle — NavGrid stuck detection (issue #407 review round 2) ────────
+// Mirrors the tickEmployeeMovement stuck-threshold test below: the
+// tickVehicleOnNavGrid stuck branch (findPath fails every tick) previously had
+// zero test coverage — every tickVehicle test above runs with state.navGrid
+// null, which only ever exercises tickVehicleDirectLine.
+
+describe('tickVehicle — NavGrid stuck detection (issue #407 review round 2)', () => {
+  /** Solid rock voxel used to build a small hand-crafted NavGrid below. */
+  function solidVoxel() {
+    return { composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] }, density: 1.0, oreDensities: {}, fractureModifier: 1.0 };
+  }
+
+  it('crosses STUCK_THRESHOLD when no path exists: emits vehicle:stuck once, sets isMoveStuck, and moves the vehicle into waiting', () => {
+    const state = createGame({ seed: VEHICLE_TICK_SEED });
+
+    // A 5×5×5 NavGrid with rock only under (0,0) — every other column stays
+    // void (density 0 everywhere), so a target there is impassable and
+    // findPath returns found:false on every tick, forever.
+    const vg = new VoxelGrid(5, 5, 5);
+    vg.setVoxel(0, 0, 0, solidVoxel());
+    vg.setVoxel(0, 1, 0, solidVoxel());
+    state.navGrid = NavGrid.buildNavGrid(vg, [], []);
+
+    const { vehicle } = purchaseVehicle(state.vehicles, 'rock_digger', 0, 0);
+    vehicle.task = 'moving';
+    vehicle.state = 'moving';
+    vehicle.targetX = 3;
+    vehicle.targetZ = 3; // void column — unreachable
+
+    const emitter = new EventEmitter();
+    const stuckEvents: number[] = [];
+    emitter.on('vehicle:stuck', ({ vehicleId }) => stuckEvents.push(vehicleId));
+
+    for (let i = 0; i < STUCK_THRESHOLD; i++) {
+      tickVehicle(state, vehicle, emitter);
+    }
+
+    expect(vehicle.isMoveStuck).toBe(true);
+    expect(vehicle.moveConsecutiveFailures).toBe(STUCK_THRESHOLD);
+    expect(stuckEvents).toEqual([vehicle.id]); // fired exactly once, on the crossing tick
+    expect(vehicle.x).toBe(0); // never moved — no path ever resolved
+    expect(vehicle.z).toBe(0);
+    expect(vehicle.state).toBe('waiting');
+    expect(vehicle.waitingTicks).toBe(STUCK_THRESHOLD);
+
+    // One more failed tick past the threshold — still stuck, but the event
+    // does not re-fire on every subsequent tick, only on the falling edge.
+    tickVehicle(state, vehicle, emitter);
+    expect(stuckEvents).toEqual([vehicle.id]);
+    expect(vehicle.isMoveStuck).toBe(true);
+    expect(vehicle.waitingTicks).toBe(STUCK_THRESHOLD + 1);
+  });
+});
+
 // ── Task 2.8: Vehicle.waitingTicks tracking ──────────────────────────────────
 
 describe('tickVehicle — waitingTicks (Task 2.8)', () => {

--- a/tests/unit/mining/Ramp.test.ts
+++ b/tests/unit/mining/Ramp.test.ts
@@ -9,6 +9,39 @@ function fillGrid(grid: VoxelGrid) {
         grid.setVoxel(x, y, z, { composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] }, density: 1.0, oreDensities: {}, fractureModifier: 1.0 });
 }
 
+/**
+ * Scan a column top-down for the highest voxel with density >= 0.5 — same rule as
+ * NavGrid.computeSurfaceY, kept independent here so the assertion below tests
+ * observable behaviour (does the physical terrain change?) rather than reaching
+ * into Ramp.ts's own (not-yet-implemented) computeColumnSurfaceY helper.
+ */
+function localSurfaceY(grid: VoxelGrid, x: number, z: number): number {
+  for (let y = grid.sizeY - 1; y >= 0; y--) {
+    const voxel = grid.getVoxel(x, y, z);
+    if (voxel && voxel.density >= 0.5) return y;
+  }
+  return -1;
+}
+
+/**
+ * Realistic (non-flat-from-0) terrain: solid rock from y=0 up to a surface well
+ * above the ramp's carved depth range, mirroring real game terrain (surface ~y=23)
+ * rather than the thin fillGrid() helper above, which happens to hide the
+ * absolute-vs-relative-depth bug because its surface sits right where the ramp
+ * carves anyway.
+ */
+function makeElevatedGrid(sizeX: number, sizeY: number, sizeZ: number, surfaceY: number): VoxelGrid {
+  const grid = new VoxelGrid(sizeX, sizeY, sizeZ);
+  for (let z = 0; z < sizeZ; z++) {
+    for (let x = 0; x < sizeX; x++) {
+      for (let y = 0; y <= surfaceY; y++) {
+        grid.setVoxel(x, y, z, { composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] }, density: 1.0, oreDensities: {}, fractureModifier: 1.0 });
+      }
+    }
+  }
+  return grid;
+}
+
 describe('Ramp building', () => {
   it('buildRamp modifies voxel grid to create a sloped passage', () => {
     const grid = new VoxelGrid(20, 15, 20);
@@ -65,5 +98,52 @@ describe('Ramp building', () => {
 
     expect(result.success).toBe(false);
     expect(result.cost).toBe(0);
+  });
+
+  it('lowers the local surface height along the path on realistic (elevated) terrain', () => {
+    // Surface at y=22 — not flat-from-0 — matching a real game map's terrain height,
+    // where the buggy absolute-Y carving lands deep underground and never touches
+    // the topmost solid voxel, so the column's surface never visibly drops.
+    const grid = makeElevatedGrid(20, 30, 30, 22);
+
+    const originSurfaceBefore = localSurfaceY(grid, 10, 10);
+    expect(originSurfaceBefore).toBe(22);
+
+    const length = 15;
+    const targetDepth = 8;
+    const result = buildRamp(grid, {
+      originX: 10, originZ: 10, direction: 'south', length, targetDepth,
+    }, 50000);
+
+    expect(result.success).toBe(true);
+
+    // Origin column (start of ramp, step 0) — should be measurably lower than
+    // the untouched surface once the ramp is actually an open cut, not buried rock.
+    const originSurfaceAfter = localSurfaceY(grid, 10, 10);
+    const originDrop = originSurfaceBefore - originSurfaceAfter;
+    expect(originDrop).toBeGreaterThan(0);
+    expect(originDrop).toBeLessThanOrEqual(targetDepth);
+
+    // End column (last carved step, z = originZ + length - 1) — should have
+    // dropped substantially further than the origin, consistent with targetDepth.
+    const endZ = 10 + length - 1;
+    const endSurfaceAfter = localSurfaceY(grid, 10, endZ);
+    const endDrop = originSurfaceBefore - endSurfaceAfter;
+    expect(endDrop).toBeGreaterThan(originDrop);
+    expect(endDrop).toBeGreaterThanOrEqual(targetDepth - 3);
+    expect(endDrop).toBeLessThanOrEqual(targetDepth + 1);
+  });
+
+  it('does not affect surface height of columns far outside the ramp path', () => {
+    const grid = makeElevatedGrid(20, 30, 30, 22);
+    const farSurfaceBefore = localSurfaceY(grid, 2, 2);
+
+    const result = buildRamp(grid, {
+      originX: 10, originZ: 10, direction: 'south', length: 10, targetDepth: 8,
+    }, 50000);
+
+    expect(result.success).toBe(true);
+    const farSurfaceAfter = localSurfaceY(grid, 2, 2);
+    expect(farSurfaceAfter).toBe(farSurfaceBefore);
   });
 });

--- a/tests/unit/mining/Ramp.test.ts
+++ b/tests/unit/mining/Ramp.test.ts
@@ -47,6 +47,10 @@ describe('Ramp building', () => {
     const grid = new VoxelGrid(20, 15, 20);
     fillGrid(grid);
 
+    // fillGrid fills the column solid from y=0 to the grid's top, so the column's
+    // actual surface (not y=0) is where carving starts (step 0 → currentDepth 0).
+    const surfaceY = localSurfaceY(grid, 10, 10);
+
     const result = buildRamp(grid, {
       originX: 10, originZ: 10, direction: 'south', length: 10, targetDepth: 8,
     }, 50000);
@@ -54,8 +58,8 @@ describe('Ramp building', () => {
     expect(result.success).toBe(true);
     expect(result.voxelsCleared).toBeGreaterThan(0);
 
-    // Check that voxels along the ramp path are cleared
-    const startVoxel = grid.getVoxel(10, 0, 10);
+    // Check that voxels along the ramp path are cleared, at the column's real surface.
+    const startVoxel = grid.getVoxel(10, surfaceY, 10);
     expect(startVoxel?.density).toBe(0);
   });
 
@@ -63,14 +67,18 @@ describe('Ramp building', () => {
     const grid = new VoxelGrid(20, 15, 30);
     fillGrid(grid);
 
+    // fillGrid fills the column solid from y=0 to the grid's top, so the origin
+    // column's real surface (not y=0) is where carving starts (step 0 → currentDepth 0).
+    const originSurfaceY = localSurfaceY(grid, 10, 5);
+
     const result = buildRamp(grid, {
       originX: 10, originZ: 5, direction: 'south', length: 15, targetDepth: 10,
     }, 50000);
 
     expect(result.success).toBe(true);
 
-    // At the start (step 0): should be cleared at y=0
-    expect(grid.getVoxel(10, 0, 5)?.density).toBe(0);
+    // At the start (step 0): should be cleared at the column's real surface.
+    expect(grid.getVoxel(10, originSurfaceY, 5)?.density).toBe(0);
 
     // At the end (step 14): should be cleared at y≈9 (depth 10 * 14/15 ≈ 9.3 → floor=9)
     expect(grid.getVoxel(10, 9, 19)?.density).toBe(0);

--- a/tests/unit/mining/Ramp.test.ts
+++ b/tests/unit/mining/Ramp.test.ts
@@ -13,7 +13,7 @@ function fillGrid(grid: VoxelGrid) {
  * Scan a column top-down for the highest voxel with density >= 0.5 — same rule as
  * NavGrid.computeSurfaceY, kept independent here so the assertion below tests
  * observable behaviour (does the physical terrain change?) rather than reaching
- * into Ramp.ts's own (not-yet-implemented) computeColumnSurfaceY helper.
+ * into Ramp.ts's own computeColumnSurfaceY helper.
  */
 function localSurfaceY(grid: VoxelGrid, x: number, z: number): number {
   for (let y = grid.sizeY - 1; y >= 0; y--) {

--- a/tests/unit/nav/AgentAdvance.test.ts
+++ b/tests/unit/nav/AgentAdvance.test.ts
@@ -1,0 +1,95 @@
+// BlastSimulator2026 — Unit tests: advanceAlongPath (shared find-path/stuck/advance skeleton)
+// Extracted from GameLoop.ts's tickVehicleOnNavGrid and tickEmployeeMovement, which
+// duplicated this sequence end to end (#407 review round 2).
+
+import { describe, it, expect } from 'vitest';
+import { advanceAlongPath, type AdvanceAlongPathInput } from '../../../src/core/nav/AgentAdvance.js';
+import { AGENT_WALK_SPEED, STUCK_THRESHOLD } from '../../../src/core/config/balance.js';
+
+function baseInput(overrides?: Partial<AdvanceAlongPathInput>): AdvanceAlongPathInput {
+  return {
+    x: 0,
+    z: 0,
+    walkSpeed: AGENT_WALK_SPEED,
+    destinationX: 10,
+    destinationZ: 0,
+    consecutiveFailures: 0,
+    isStuck: false,
+    path: { found: true, waypoints: [{ x: 10, z: 0 }] },
+    ...overrides,
+  };
+}
+
+describe('advanceAlongPath', () => {
+  it('advances toward the next waypoint on a found path', () => {
+    const result = advanceAlongPath(baseInput());
+
+    expect(result.pathFound).toBe(true);
+    expect(result.x).toBeCloseTo(AGENT_WALK_SPEED, 5);
+    expect(result.z).toBe(0);
+    expect(result.isPathComplete).toBe(false);
+    expect(result.consecutiveFailures).toBe(0);
+    expect(result.isStuck).toBe(false);
+    expect(result.becameStuck).toBe(false);
+  });
+
+  it('reaches the destination in one tick when within walking speed', () => {
+    const result = advanceAlongPath(baseInput({
+      destinationX: 1,
+      path: { found: true, waypoints: [{ x: 1, z: 0 }] },
+    }));
+
+    expect(result.isPathComplete).toBe(true);
+    expect(result.x).toBe(1);
+    expect(result.z).toBe(0);
+  });
+
+  it('resets stuck-tracking fields when a path is found after prior failures', () => {
+    const result = advanceAlongPath(baseInput({
+      consecutiveFailures: STUCK_THRESHOLD - 1,
+      isStuck: false,
+    }));
+
+    expect(result.consecutiveFailures).toBe(0);
+    expect(result.isStuck).toBe(false);
+  });
+
+  it('records a failed attempt and reports no movement when no path was found', () => {
+    const result = advanceAlongPath(baseInput({
+      x: 5,
+      z: 5,
+      path: { found: false, waypoints: [] },
+    }));
+
+    expect(result.pathFound).toBe(false);
+    expect(result.x).toBe(5);
+    expect(result.z).toBe(5);
+    expect(result.consecutiveFailures).toBe(1);
+    expect(result.isStuck).toBe(false);
+    expect(result.becameStuck).toBe(false);
+    expect(result.isPathComplete).toBe(false);
+  });
+
+  it('crosses STUCK_THRESHOLD and reports becameStuck exactly on the falling edge', () => {
+    let consecutiveFailures = 0;
+    let isStuck = false;
+    const becameStuckTicks: boolean[] = [];
+
+    for (let i = 0; i < STUCK_THRESHOLD + 2; i++) {
+      const result = advanceAlongPath(baseInput({
+        consecutiveFailures,
+        isStuck,
+        path: { found: false, waypoints: [] },
+      }));
+      consecutiveFailures = result.consecutiveFailures;
+      isStuck = result.isStuck;
+      becameStuckTicks.push(result.becameStuck);
+    }
+
+    expect(consecutiveFailures).toBe(STUCK_THRESHOLD + 2);
+    expect(isStuck).toBe(true);
+    // becameStuck true exactly once — on the tick consecutiveFailures first reaches STUCK_THRESHOLD.
+    expect(becameStuckTicks.filter(Boolean)).toHaveLength(1);
+    expect(becameStuckTicks[STUCK_THRESHOLD - 1]).toBe(true);
+  });
+});

--- a/tests/unit/nav/AgentAdvance.test.ts
+++ b/tests/unit/nav/AgentAdvance.test.ts
@@ -1,5 +1,5 @@
 // BlastSimulator2026 — Unit tests: advanceAlongPath (shared find-path/stuck/advance skeleton)
-// Extracted from GameLoop.ts's tickVehicleOnNavGrid and tickEmployeeMovement, which
+// Extracted from EntityMovementTick.ts's tickVehicleOnNavGrid and tickEmployeeMovement, which
 // duplicated this sequence end to end (#407 review round 2).
 
 import { describe, it, expect } from 'vitest';

--- a/tests/unit/nav/NavGrid.test.ts
+++ b/tests/unit/nav/NavGrid.test.ts
@@ -19,6 +19,7 @@ import { addHole } from '../../../src/core/mining/DrillPlan.js';
 import { batchCharge } from '../../../src/core/mining/ChargePlan.js';
 import { autoVPattern } from '../../../src/core/mining/Sequence.js';
 import { assembleBlastPlan } from '../../../src/core/mining/BlastPlan.js';
+import { buildRamp } from '../../../src/core/mining/Ramp.js';
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Helpers
@@ -461,6 +462,44 @@ describe('NavGrid.buildNavGrid — ramp detection', () => {
     for (let z = 0; z < 5; z++) {
       expect(nav.cells[z]![0]!.type).toBe('walkable');
     }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 2c: buildNavGrid — ramp detection after a real Ramp.buildRamp() carve on
+// realistic (elevated) terrain. Regression coverage for issue #407: buildRamp
+// treating depth as an absolute world Y meant it never changed a column's
+// surface height, so this classification path never fired outside hand-crafted
+// NavCell fixtures.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('NavGrid.buildNavGrid — ramp detection after buildRamp() on elevated terrain', () => {
+  it('produces at least one ramp-typed cell along a freshly carved ramp path', () => {
+    // Flat plateau at surface Y=22 (not flat-from-0) — every column starts on the
+    // same bench, so before carving there is no natural elevation cliff anywhere.
+    const grid = makeSolidGrid(20, 30, 30, 22);
+    const beforeNav = NavGrid.buildNavGrid(grid, [], []);
+    // Sanity: uniformly flat terrain has no ramp cells yet.
+    for (let z = 0; z < 30; z++) {
+      for (let x = 0; x < 20; x++) {
+        expect(beforeNav.cells[z]![x]!.type).not.toBe('ramp');
+      }
+    }
+
+    const rampResult = buildRamp(grid, {
+      originX: 10, originZ: 5, direction: 'south', length: 12, targetDepth: 10,
+    }, 100000);
+    expect(rampResult.success).toBe(true);
+
+    const afterNav = NavGrid.buildNavGrid(grid, [], []);
+    let rampCellCount = 0;
+    for (let z = 0; z < 30; z++) {
+      for (let x = 0; x < 20; x++) {
+        if (afterNav.cells[z]![x]!.type === 'ramp') rampCellCount++;
+      }
+    }
+    // The fix must make at least one carved column register as a ramp-typed cell.
+    expect(rampCellCount).toBeGreaterThan(0);
   });
 });
 

--- a/tests/unit/ui/KeyboardShortcuts.test.ts
+++ b/tests/unit/ui/KeyboardShortcuts.test.ts
@@ -17,6 +17,7 @@ describe('KeyboardShortcuts (12.7)', () => {
     togglePanel: ReturnType<typeof vi.fn>;
     quickSave: ReturnType<typeof vi.fn>;
     openSettings: ReturnType<typeof vi.fn>;
+    onToggleNavGrid: ReturnType<typeof vi.fn>;
   };
   let ks: KeyboardShortcuts;
 
@@ -27,6 +28,7 @@ describe('KeyboardShortcuts (12.7)', () => {
       togglePanel: vi.fn(),
       quickSave: vi.fn(),
       openSettings: vi.fn(),
+      onToggleNavGrid: vi.fn(),
     };
     ks = new KeyboardShortcuts(callbacks);
   });
@@ -71,6 +73,25 @@ describe('KeyboardShortcuts (12.7)', () => {
     fireKey('KeyC');
     expect(callbacks.togglePanel).toHaveBeenCalledWith('contracts');
     ks.dispose();
+  });
+
+  it('KeyN triggers onToggleNavGrid', () => {
+    fireKey('KeyN');
+    expect(callbacks.onToggleNavGrid).toHaveBeenCalledOnce();
+    ks.dispose();
+  });
+
+  it('KeyN is a no-op when onToggleNavGrid is not provided', () => {
+    const partialCallbacks = {
+      togglePause: vi.fn(),
+      setSpeed: vi.fn(),
+      togglePanel: vi.fn(),
+      quickSave: vi.fn(),
+      openSettings: vi.fn(),
+    };
+    const partialKs = new KeyboardShortcuts(partialCallbacks);
+    expect(() => fireKey('KeyN')).not.toThrow();
+    partialKs.dispose();
   });
 
   it('Escape opens settings', () => {

--- a/tests/unit/ui/UIManager.test.ts
+++ b/tests/unit/ui/UIManager.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+// BlastSimulator2026 — UIManager NavGrid overlay wiring (issue #407)
+//
+// Regression coverage: UIManager never fed the live NavGrid into the MiniMap,
+// and toggleNavGridOverlay() was an empty stub, so there was no player-facing
+// way to see the nav-grid overlay even though MiniMap's drawing code was correct.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { UIManager } from '../../../src/ui/UIManager.js';
+import { MiniMap } from '../../../src/ui/MiniMap.js';
+import { createGame } from '../../../src/core/state/GameState.js';
+import { NavGrid } from '../../../src/core/nav/NavGrid.js';
+import { VoxelGrid } from '../../../src/core/world/VoxelGrid.js';
+
+function makeState() {
+  const state = createGame({ seed: 1, mineType: 'desert' });
+  // Give the state a real, non-null NavGrid so the assertion below verifies
+  // actual object pass-through, not just a null default.
+  const grid = new VoxelGrid(4, 4, 4);
+  for (let z = 0; z < 4; z++)
+    for (let x = 0; x < 4; x++)
+      grid.setVoxel(x, 0, z, { composition: { rocks: [{ rockId: 'cruite', coefficient: 1.0 }] }, density: 1.0, oreDensities: {}, fractureModifier: 1.0 });
+  state.navGrid = NavGrid.buildNavGrid(grid, [], []);
+  return state;
+}
+
+describe('UIManager — NavGrid overlay wiring', () => {
+  let container: HTMLElement;
+  let uiManager: UIManager | null;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    uiManager = null;
+  });
+
+  afterEach(() => {
+    uiManager?.dispose();
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it('update() feeds the current GameState.navGrid into the MiniMap', () => {
+    // jsdom has no real canvas backend, so MiniMap.update()'s canvas drawing
+    // would throw regardless of this fix — stub it out and verify only the
+    // navGrid-feeding wiring under test.
+    vi.spyOn(MiniMap.prototype, 'update').mockImplementation(() => {});
+    const setNavGridSpy = vi.spyOn(MiniMap.prototype, 'setNavGrid');
+    uiManager = new UIManager(container);
+    const state = makeState();
+
+    uiManager.update(state);
+
+    expect(setNavGridSpy).toHaveBeenCalledWith(state.navGrid);
+  });
+
+  it('update() re-feeds the NavGrid on every call', () => {
+    vi.spyOn(MiniMap.prototype, 'update').mockImplementation(() => {});
+    const setNavGridSpy = vi.spyOn(MiniMap.prototype, 'setNavGrid');
+    uiManager = new UIManager(container);
+    const state = makeState();
+
+    uiManager.update(state);
+    uiManager.update(state);
+    uiManager.update(state);
+
+    expect(setNavGridSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('toggleNavGridOverlay() turns the overlay on from its default-off state', () => {
+    const setVisibleSpy = vi.spyOn(MiniMap.prototype, 'setNavGridVisible');
+    uiManager = new UIManager(container);
+
+    uiManager.toggleNavGridOverlay();
+
+    expect(setVisibleSpy).toHaveBeenCalledWith(true);
+  });
+
+  it('toggleNavGridOverlay() flips back off on a second call', () => {
+    const setVisibleSpy = vi.spyOn(MiniMap.prototype, 'setNavGridVisible');
+    uiManager = new UIManager(container);
+
+    uiManager.toggleNavGridOverlay();
+    uiManager.toggleNavGridOverlay();
+
+    expect(setVisibleSpy).toHaveBeenNthCalledWith(1, true);
+    expect(setVisibleSpy).toHaveBeenNthCalledWith(2, false);
+  });
+
+  it('toggleNavGridOverlay() alternates on repeated calls', () => {
+    const setVisibleSpy = vi.spyOn(MiniMap.prototype, 'setNavGridVisible');
+    uiManager = new UIManager(container);
+
+    uiManager.toggleNavGridOverlay();
+    uiManager.toggleNavGridOverlay();
+    uiManager.toggleNavGridOverlay();
+
+    expect(setVisibleSpy).toHaveBeenNthCalledWith(3, true);
+  });
+});


### PR DESCRIPTION
Closes #407

## Summary

Issue #407 asked to verify visual coherence of the 7 `nav-*-visual.json` scenarios and fix every mismatch found. Investigation found the true root causes went deeper than the renderer:

1. **`src/core/mining/Ramp.ts`** — `buildRamp()` carved terrain at an *absolute* world Y instead of relative to each column's actual surface height. On real terrain (surface ~y=23), the carved band landed buried under solid rock — invisible, unreachable, and never registered as a `ramp` NavCell. Fixed to carve relative to each column's live surface (new shared `computeVoxelColumnSurfaceY` in `src/core/world/VoxelGrid.ts`, used by both `Ramp.ts` and `NavGrid.ts`).
2. **Vehicles and employees never moved during simulation ticks at all.** `tickVehicle` (naive stepper) and the entire `AgentMovement`/pathfinding module existed, fully unit-tested, but were never invoked from the tick loop — `tickCommand()` never advanced any entity's position. This is exactly the "agent not following path" incoherence the issue's own checklist names. Wired real NavGrid-aware A* movement (`Pathfinding.findPath` + shared `advanceAlongPath` helper in new `src/core/nav/AgentAdvance.ts`) into both vehicles and employees via a new `src/core/engine/EntityMovementTick.ts` module, with stuck-detection (`isMoveStuck`, `agent:stuck`/`vehicle:stuck` events).
3. **MiniMap NavGrid overlay was fully implemented but never fed data or reachable by a player.** Wired `UIManager.update()` to feed `state.navGrid` into `MiniMap` every tick, added a `KeyN` shortcut (with help-panel entry, i18n keys) to toggle the overlay.

All 7 `nav-*-visual.json` scenarios were re-run and re-inspected through 3 rounds of screenshot verification; every incoherence found was fixed or the scenario corrected to describe actual behavior truthfully. Scenario coverage extended to cover: ramp routing, path-following stuck/resume (genuine block via a 3-building L-wall), pathfinding around obstacles, dynamic updates (blast + vehicle park/depart), move-cost differentiation, minimap integration, and cell-type classification.

## Decisions taken

Per `agentic-decision-autonomy`:

- **What was open:** the issue's own checklist implies "agent not following path" should be fixed as part of visual coherence, but the actual defect (dead tick-movement wiring) is a core simulation gap far beyond the issue's "visual" framing — every vehicle and employee in the entire game has silently never moved on any tick, in any scenario, ever, until this PR.
  **Chosen:** fix it properly — wire the existing, already-tested `AgentMovement`/`Pathfinding` primitives into the tick loop for both entity types, rather than attempt any renderer-side workaround for geometry that genuinely never changes.
  **Why:** `agentic-decision-autonomy`'s "Scope beyond the issue's framing is not a blocker" — a correct fix outside the framing beats an incorrect one inside it, and the issue explicitly names this exact symptom.
  **If reversed:** revert `src/core/engine/EntityMovementTick.ts`'s wiring calls in `src/console/commands/events.ts`'s `tickCommand()`; the dormant primitives remain in `AgentMovement.ts`/`Pathfinding.ts` untouched.
  **Flagging for human review:** this is a large, previously-dormant gameplay change (not a narrow default) — filing a `decision-review` issue per the skill's "material to gameplay" trigger.

- **What was open:** `NavCellType.void` has no console-reachable way to be produced (no dig/excavate-to-bedrock command exists).
  **Chosen:** scope `nav-cell-types-visual.json`'s claim down to the 4 reachable types (`walkable`, `blocked`, `drill_hole`, `ramp`); did not add a new console command solely to manufacture a `void` column for a screenshot.
  **Why:** inventing a debug-only command purely to satisfy one test risks its own untested surface; `void` legitimately belongs to world-generation, outside this issue's/skill's scope.
  **If reversed:** add a `terrain clear_column` (or similar) console command, then restore the step.

- **What was open:** `nav-ramp-routing-visual.json`'s original design intent (written during this PR's own TDD/visual-loop cycle) was to show "no route before ramp, route after" — but seed:42 terrain turned out to be a single flat bench everywhere, and `buildRamp` can only carve existing solid voxels, never bridge a true void gap. The "gated" premise is architecturally impossible with current terrain gen + console commands.
  **Chosen:** corrected the scenario's own description to state what it actually demonstrates (real A*-routed, cost-aware, tick-by-tick vehicle *and* employee movement, plus ramp construction running cleanly alongside it) rather than assert a false blocked-then-connected story.
  **Why:** matches the same limitation already accepted for the integration-test equivalent earlier in this same pipeline run; a truthful scenario beats a scenario that "passes" while asserting something false.
  **If reversed:** would need either a world-gen change (multi-bench seed) or a new void-carving console command — both larger changes than this issue's scope.

- **What was open:** vehicle movement (`vehicle move` console command) has no player-reachable UI control at all — confirmed by the playability check below.
  **Chosen:** did not add a "send vehicle" UI button in this PR — out of scope for a navmesh-visual-coherence issue.
  **Why:** this is a pre-existing gap (vehicle movement was never player-triggerable before this PR either); this PR only improved the *backend* logic behind an already-console-only feature, it introduces no regression.
  **If reversed:** add a destination-picker control to `VehiclePanel.ts` calling the same `moveVehicle`/dispatch path already wired for console use.

## Verification channels run

- **static** (`npm run typecheck`): PASS, 0 errors.
- **logic** (`npx vitest run`): PASS, 196 files / 5722 tests, 0 failures.
- **scenario** (`npm run scenarios`): PASS, 101/101.
- **visual** (`npm run scenario -- --mode interaction --screenshots`, all 7 `nav-*-visual` scenarios): PASS after 3 rounds of screenshot inspection — every flagged incoherence fixed and re-verified (ramp terrain now visibly carved, minimap overlay renders and toggles via `KeyN`, agents/vehicles now visibly move tick-over-tick, path-following genuinely blocks then resumes, blast crater fires correctly).
- **playability** (`npm run playtest`): PASS, 28/28 beats (`tutorial` + `training`). Employee movement verified end-to-end through a real UI click path (tutorial beat 04, visually confirmed via screenshot). Vehicle movement gives no playability signal — no player-reachable control moves a vehicle today (pre-existing gap, noted above, not this PR's to fix).
- **`npm run validate`**: PASS (typecheck → coverage → integration [351 tests] → scenario defs [2202 tests] → build).
- Code review: 3 rounds, 5 parallel specialist reviewers (security, quality, i18n, duplication, semantic) — all APPROVE, 0 criticals/warnings outstanding in the final round.

5722 tests — all passing

READY TO MERGE