### PR TITLE
fix: repair tutorial hire-step completion false-positive and survey timing stall (#409)

### DIFF
--- a/.claude/skills/dev-testing-strategy/SKILL.md
+++ b/.claude/skills/dev-testing-strategy/SKILL.md
@@ -135,6 +135,8 @@ JSON files in `scripts/scenario-defs/`. Runner captures screenshot + state JSON 
 
 Scenario steps can define an `interaction` array of `InteractionStepAction` objects for UI-level testing. Steps without `interaction` fall back to command execution. Type definitions in `scripts/shared/scenario-types.ts`.
 
+**Async commands need tick padding.** A command that queues async work (e.g. `survey seismic`) must be followed by enough `tick` steps to let it resolve before a dependent step runs, or the dependent step reads stale state. Insert several `tick 10` steps after the async command, matching `survey-then-blast.json`.
+
 ### Feature Scenarios (Ch.1–7 visual regression)
 
 | Scenario File | Chapter | Purpose |

--- a/.github/skills/dev-testing-strategy/SKILL.md
+++ b/.github/skills/dev-testing-strategy/SKILL.md
@@ -135,6 +135,8 @@ JSON files in `scripts/scenario-defs/`. Runner captures screenshot + state JSON 
 
 Scenario steps can define an `interaction` array of `InteractionStepAction` objects for UI-level testing. Steps without `interaction` fall back to command execution. Type definitions in `scripts/shared/scenario-types.ts`.
 
+**Async commands need tick padding.** A command that queues async work (e.g. `survey seismic`) must be followed by enough `tick` steps to let it resolve before a dependent step runs, or the dependent step reads stale state. Insert several `tick 10` steps after the async command, matching `survey-then-blast.json`.
+
 ### Feature Scenarios (Ch.1–7 visual regression)
 
 | Scenario File | Chapter | Purpose |

--- a/.opencode/skills/dev-testing-strategy/SKILL.md
+++ b/.opencode/skills/dev-testing-strategy/SKILL.md
@@ -135,6 +135,8 @@ JSON files in `scripts/scenario-defs/`. Runner captures screenshot + state JSON 
 
 Scenario steps can define an `interaction` array of `InteractionStepAction` objects for UI-level testing. Steps without `interaction` fall back to command execution. Type definitions in `scripts/shared/scenario-types.ts`.
 
+**Async commands need tick padding.** A command that queues async work (e.g. `survey seismic`) must be followed by enough `tick` steps to let it resolve before a dependent step runs, or the dependent step reads stale state. Insert several `tick 10` steps after the async command, matching `survey-then-blast.json`.
+
 ### Feature Scenarios (Ch.1–7 visual regression)
 
 | Scenario File | Chapter | Purpose |

--- a/scripts/scenario-defs/tutorial-steps-visual.json
+++ b/scripts/scenario-defs/tutorial-steps-visual.json
@@ -88,11 +88,55 @@
     {
       "command": "survey seismic x:15 z:15",
       "timeout": 30,
-      "description": "Step 2 complete: run seismic survey → overlay advances to step 3 (hire-driller)",
+      "description": "Step 2: queue seismic survey (async — resolves over ticks, not on command return)",
       "interaction": [
         {
           "type": "command",
           "command": "survey seismic x:15 z:15"
+        }
+      ]
+    },
+    {
+      "command": "tick 10",
+      "timeout": 30,
+      "description": "Let queued survey work run (1/4) — matches WORK_GRACE_TICKS so the overlay resolves the survey before later commands race ahead of it",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 10"
+        }
+      ]
+    },
+    {
+      "command": "tick 10",
+      "timeout": 30,
+      "description": "Let queued survey work run (2/4)",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 10"
+        }
+      ]
+    },
+    {
+      "command": "tick 10",
+      "timeout": 30,
+      "description": "Let queued survey work run (3/4)",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 10"
+        }
+      ]
+    },
+    {
+      "command": "tick 10",
+      "timeout": 30,
+      "description": "Let queued survey work run (4/4): survey resolves → overlay advances to step 3 (hire-driller)",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 10"
         }
       ]
     },

--- a/src/ui/tutorialStepHelpers.ts
+++ b/src/ui/tutorialStepHelpers.ts
@@ -34,9 +34,12 @@ export interface HireStepSnapshot {
 }
 
 /** Collect the ids of employees who already hold `role` at snapshot time. */
-function captureHireStepSnapshot(_state: GameState, _role: EmployeeRole): HireStepSnapshot {
-  // TODO: implement — filter getEmployees(state) by role, map to id.
-  return undefined as unknown as HireStepSnapshot;
+function captureHireStepSnapshot(state: GameState, role: EmployeeRole): HireStepSnapshot {
+  return {
+    prevIdsWithRole: getEmployees(state)
+      .filter(e => e.role === role)
+      .map(e => e.id),
+  };
 }
 
 /**
@@ -45,13 +48,13 @@ function captureHireStepSnapshot(_state: GameState, _role: EmployeeRole): HireSt
  * one that already existed when the step started.
  */
 function isHireStepComplete(
-  _state: GameState,
-  _snapshot: HireStepSnapshot,
-  _role: EmployeeRole,
+  state: GameState,
+  snapshot: HireStepSnapshot,
+  role: EmployeeRole,
 ): boolean {
-  // TODO: implement — some employee with role === role whose id is not in
-  // snapshot.prevIdsWithRole.
-  throw new Error('not implemented');
+  return getEmployees(state).some(
+    e => e.role === role && !snapshot.prevIdsWithRole.includes(e.id),
+  );
 }
 
 /**

--- a/src/ui/tutorialStepHelpers.ts
+++ b/src/ui/tutorialStepHelpers.ts
@@ -22,6 +22,39 @@ export const TOOLBAR_TARGET = {
 } as const;
 
 /**
+ * Snapshot shape for a hire step: ids of the employees who already hold the
+ * target role at capture time. Completion requires an employee with that
+ * role whose id is NOT in this set — plain count-increased + role-exists
+ * checks false-positive when the role was already staffed before the step
+ * opened (e.g. async survey resolution lag) and the player hires someone
+ * else entirely.
+ */
+export interface HireStepSnapshot {
+  prevIdsWithRole: number[];
+}
+
+/** Collect the ids of employees who already hold `role` at snapshot time. */
+function captureHireStepSnapshot(_state: GameState, _role: EmployeeRole): HireStepSnapshot {
+  // TODO: implement — filter getEmployees(state) by role, map to id.
+  return undefined as unknown as HireStepSnapshot;
+}
+
+/**
+ * True only when an employee holds `role` with an id absent from
+ * `snapshot.prevIdsWithRole` — i.e. a genuinely new hire of that role, not
+ * one that already existed when the step started.
+ */
+function isHireStepComplete(
+  _state: GameState,
+  _snapshot: HireStepSnapshot,
+  _role: EmployeeRole,
+): boolean {
+  // TODO: implement — some employee with role === role whose id is not in
+  // snapshot.prevIdsWithRole.
+  throw new Error('not implemented');
+}
+
+/**
  * Helper: create a "hire employee" step that completes when an employee
  * with the given role has been hired (total count increased).
  *
@@ -41,17 +74,10 @@ export function createHireStep(
     textKey,
     commands: [`employee hire role:${role}`],
     ...(highlightTarget ? { highlightTarget } : {}),
-    captureSnapshot: (state: GameState) => ({
-      prevEmployeeCount: getEmployees(state).length,
-    }),
-    isComplete: (state: GameState, snapshot: Record<string, unknown>) => {
-      const prev = snapshot.prevEmployeeCount as number;
-      const employees = getEmployees(state);
-      return (
-        employees.length > prev &&
-        employees.some(e => e.role === role)
-      );
-    },
+    captureSnapshot: (state: GameState) =>
+      captureHireStepSnapshot(state, role) as unknown as Record<string, unknown>,
+    isComplete: (state: GameState, snapshot: Record<string, unknown>) =>
+      isHireStepComplete(state, snapshot as unknown as HireStepSnapshot, role),
   };
 }
 

--- a/src/ui/tutorialSteps.ts
+++ b/src/ui/tutorialSteps.ts
@@ -139,6 +139,12 @@ export const TUTORIAL_STEPS: TutorialStep[] = [
   createHireStep('hire-driver', 'tutorial.step13.title', 'tutorial.step13', 'driver'),
 
   // ── Step 13: vehicle-buy-assign ──
+  // Uses the naive count-increased + existence-check pattern that #409 fixed
+  // for hire steps. Safe here only because the tutorial buys its first-ever
+  // vehicle at this step: there is no pre-existing vehicle for the "assigned"
+  // half of the check to false-positive on, unlike hire steps where a role
+  // could already be staffed before the step opened. Re-evaluate if a future
+  // tutorial revision buys a vehicle earlier or reorders this step.
   {
     id: 'vehicle-buy-assign',
     titleKey: 'tutorial.step14.title',

--- a/tests/unit/ui/tutorialStepHelpers.test.ts
+++ b/tests/unit/ui/tutorialStepHelpers.test.ts
@@ -1,0 +1,137 @@
+// BlastSimulator2026 — tutorialStepHelpers hire-step completion regression tests (#409)
+//
+// Bug: createHireStep used to complete on `employees.length > prevCount &&
+// employees.some(e => e.role === role)`. If an employee of the target role
+// already existed at snapshot time, the very next hire of an UNRELATED role
+// wrongly satisfied both clauses — count went up, and "some employee has this
+// role" was already true before the hire. The fix (captureHireStepSnapshot /
+// isHireStepComplete) must key off employee IDS: complete only when an
+// employee holding `role` has an id that was NOT present at snapshot time.
+//
+// captureHireStepSnapshot / isHireStepComplete are not exported directly;
+// they're exercised through the public `createHireStep` factory, exactly as
+// tutorialSteps.test.ts exercises step-specific completion logic.
+
+import { describe, it, expect } from 'vitest';
+import { createHireStep } from '../../../src/ui/tutorialStepHelpers.js';
+import type { GameState } from '../../../src/core/state/GameState.js';
+import type { EmployeeRole } from '../../../src/core/entities/Employee.js';
+
+/** Minimal employee shape sufficient for getEmployees() in tutorialStepHelpers.ts. */
+interface MinimalEmployee {
+  id: number;
+  role: EmployeeRole;
+}
+
+function stateWithEmployees(employees: MinimalEmployee[]): GameState {
+  return { employees: { employees } } as unknown as GameState;
+}
+
+describe('tutorialStepHelpers — hire step completion (#409 regression)', () => {
+  const step = createHireStep('hire-driller', 'tutorial.hire_driller_title', 'tutorial.hire_driller_text', 'driller');
+
+  // ── 1 — regression case: role already staffed, unrelated hire follows ────
+  it('does not complete when an unrelated role is hired after the target role was already staffed', () => {
+    // Driller already exists when the step opens (e.g. async survey lag left
+    // one on the roster already). Snapshot captures that.
+    const before = stateWithEmployees([{ id: 1, role: 'driller' }]);
+    const snap = step.captureSnapshot!(before);
+
+    // Player hires a surveyor next — count increases, but no NEW driller
+    // appeared. The old buggy check (count up + some driller exists) would
+    // wrongly report complete here.
+    const after = stateWithEmployees([
+      { id: 1, role: 'driller' },
+      { id: 2, role: 'surveyor' },
+    ]);
+
+    expect(step.isComplete(after, snap)).toBe(false);
+  });
+
+  // ── 2 — happy path: genuinely new hire of the target role ────────────────
+  it('completes when a genuinely new employee of the target role is hired', () => {
+    const before = stateWithEmployees([{ id: 1, role: 'surveyor' }]);
+    const snap = step.captureSnapshot!(before);
+
+    const after = stateWithEmployees([
+      { id: 1, role: 'surveyor' },
+      { id: 2, role: 'driller' },
+    ]);
+
+    expect(step.isComplete(after, snap)).toBe(true);
+  });
+
+  // ── 3 — boundary: nothing hired at all ────────────────────────────────────
+  it('does not complete when no employee has been hired since the snapshot', () => {
+    const before = stateWithEmployees([{ id: 1, role: 'surveyor' }]);
+    const snap = step.captureSnapshot!(before);
+
+    // State unchanged — player hasn't acted yet.
+    expect(step.isComplete(before, snap)).toBe(false);
+  });
+
+  it('does not complete from a zero-employee snapshot when nobody is hired', () => {
+    const before = stateWithEmployees([]);
+    const snap = step.captureSnapshot!(before);
+
+    expect(step.isComplete(before, snap)).toBe(false);
+  });
+
+  // ── 4 — boundary: pre-existing id of target role must not count as new ───
+  it('does not falsely flag a pre-existing employee of the target role as a new hire', () => {
+    const before = stateWithEmployees([{ id: 1, role: 'driller' }]);
+    const snap = step.captureSnapshot!(before);
+
+    // Same driller, same id, nothing else changed — not a new hire.
+    const after = stateWithEmployees([{ id: 1, role: 'driller' }]);
+
+    expect(step.isComplete(after, snap)).toBe(false);
+  });
+
+  it('completes when a new-id employee of the target role is hired even though the old one is still present unchanged', () => {
+    const before = stateWithEmployees([{ id: 1, role: 'driller' }]);
+    const snap = step.captureSnapshot!(before);
+
+    // id 1 unchanged AND a genuinely new id 2 of the target role appears.
+    const after = stateWithEmployees([
+      { id: 1, role: 'driller' },
+      { id: 2, role: 'driller' },
+    ]);
+
+    expect(step.isComplete(after, snap)).toBe(true);
+  });
+
+  it('does not complete when the pre-existing employee of the target role is removed and no new one takes its place', () => {
+    const before = stateWithEmployees([{ id: 1, role: 'driller' }]);
+    const snap = step.captureSnapshot!(before);
+
+    // Roster shrinks — the only driller is gone, nobody new hired.
+    const after = stateWithEmployees([]);
+
+    expect(step.isComplete(after, snap)).toBe(false);
+  });
+
+  it('completes when the pre-existing employee of the target role is replaced by a new-id employee of that role', () => {
+    const before = stateWithEmployees([{ id: 1, role: 'driller' }]);
+    const snap = step.captureSnapshot!(before);
+
+    // id 1 (fired) is gone; a distinct new id 2 with the target role is hired.
+    const after = stateWithEmployees([{ id: 2, role: 'driller' }]);
+
+    expect(step.isComplete(after, snap)).toBe(true);
+  });
+
+  // ── captureSnapshot shape ──────────────────────────────────────────────
+  it('captureSnapshot records the ids of employees already holding the target role', () => {
+    const before = stateWithEmployees([
+      { id: 1, role: 'driller' },
+      { id: 2, role: 'surveyor' },
+      { id: 3, role: 'driller' },
+    ]);
+    const snap = step.captureSnapshot!(before) as { prevIdsWithRole: number[] };
+
+    expect(snap.prevIdsWithRole).toEqual(expect.arrayContaining([1, 3]));
+    expect(snap.prevIdsWithRole).not.toContain(2);
+    expect(snap.prevIdsWithRole.length).toBe(2);
+  });
+});

--- a/tests/unit/ui/tutorialSteps.test.ts
+++ b/tests/unit/ui/tutorialSteps.test.ts
@@ -214,7 +214,7 @@ describe('tutorialSteps', () => {
         events: { pendingEvent: { eventId: 'test_evt', firedAtTick: 5 } },
         employees: { employees: [{ role: 'manager' }] },
       } as unknown as GameState;
-      const snap = { prevEmployeeCount: 0 };
+      const snap = { prevIdsWithRole: [] };
       expect(step10.isComplete(state, snap)).toBe(false);
     });
 
@@ -223,7 +223,7 @@ describe('tutorialSteps', () => {
         events: { pendingEvent: null },
         employees: { employees: [{ role: 'manager' }] },
       } as unknown as GameState;
-      const snap = { prevEmployeeCount: 0 };
+      const snap = { prevIdsWithRole: [] };
       expect(step10.isComplete(state, snap)).toBe(true);
     });
   });


### PR DESCRIPTION
Closes #409

## Summary

The tutorial overlay's "hire X role" completion check (`createHireStep` in `src/ui/tutorialStepHelpers.ts`) had a false-positive bug: it completed when the employee count increased AND some employee had the target role, regardless of whether that role-match predated the step becoming active. If a role-matching employee already existed when the step started (which happens whenever the preceding async `survey` action resolves late), the very next hire of a completely unrelated role wrongly satisfied the check.

In the `tutorial-steps-visual.json` scenario this combined with a second issue — the scenario fired an async `survey seismic` command and then ran seven more commands with zero ticks elapsed, so the survey never resolved until long after the driller had already been hired. The result: the tutorial overlay froze at "SURVEY TERRAIN 3/23" through the entire drill/charge/sequence/blast sequence, then froze again at "HIRE DRILLER 4/23" for the rest of the run. 19 of 23 tutorial steps never rendered on screen in any screenshot — the exact visual coherence failure issue #409 was filed to catch and fix.

## Changes

- `src/ui/tutorialStepHelpers.ts` — replaced the count-based snapshot with an id-based `HireStepSnapshot` contract. `captureHireStepSnapshot(state, role)` records employee ids already holding `role` at snapshot time; `isHireStepComplete(state, snapshot, role)` requires a genuinely *new* id holding that role, not merely "role exists somewhere."
- `scripts/scenario-defs/tutorial-steps-visual.json` — inserted four `tick 10` steps after the async `survey seismic` command (matching the existing `survey-then-blast.json` convention and `WORK_GRACE_TICKS`) so the survey resolves before dependent commands run, keeping the tutorial overlay in lockstep with the scenario.
- `src/ui/tutorialSteps.ts` — added an explanatory comment on `vehicle-buy-assign`, which shares the fixed bug's structural shape but is currently safe (see Decisions taken).
- `tests/unit/ui/tutorialStepHelpers.test.ts` (new) — 9 regression/boundary tests for the snapshot contract.
- `tests/unit/ui/tutorialSteps.test.ts` — 2 existing tests updated to the new snapshot shape (assertions unchanged).

## Verification

- **static** — `npm run typecheck`: clean.
- **logic** — `npm run test`: 5752/5752 tests passed (199 files), including `npm run test:coverage` and `npm run test:integration` (351 tests).
- **scenario** — `npm run scenarios`: 101/101 scenarios passed, including `tutorial-steps-visual`. `npm run test:scenarios` (definitions validation): 2202 tests passed.
- **visual** — `npm run scenario -- --scenario tutorial-steps-visual --mode interaction --screenshots`, independently re-run and inspected (not just the implementer's self-report): all 23 tutorial steps now render with correct card text, correct `N/23` progress counter, correct highlight target, and scene geometry consistent with cumulative game state, through to "TUTORIAL COMPLETE! 23/23" and clean dismissal. `npm run a11y`: PASS (99/99 elements meet WCAG AA contrast).
- **playability** — `npm run playtest -- tutorial --screenshots`: 21/21 beats reached, clicking only, no console commands substituted. Beats 02/05/12/14 (hire surveyor/driller/manager/driver) directly exercise the fixed completion logic and all pass.
- `npm run validate` (typecheck → coverage → integration → scenario defs → build): PASS.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** code review flagged that `vehicle-buy-assign` in `src/ui/tutorialSteps.ts` uses the same structurally-unsafe `count-increased + existence-check` pattern as the bug fixed here, and asked whether to harden it too.
  **Chosen:** leave it, with an explanatory comment. No screenshot in this run's visual passes demonstrates it misfiring — the tutorial only ever purchases one vehicle, so the false-positive precondition (a pre-existing driver-assigned vehicle before the step activates) cannot occur today.
  **Why:** `agentic-decision-autonomy` scopes a fix to what the issue's own change exposes; hardening an untriggered latent pattern here is scope creep for a visual-coherence issue.
  **If reversed:** apply the same id-based snapshot pattern used in `isHireStepComplete` to `vehicle-buy-assign`'s inline check in `tutorialSteps.ts` if a future scenario reorders steps and exposes it.

READY TO MERGE