### PR TITLE
feat: fix vehicle-fleet visual incoherence across 7 scenarios (#411)

### DIFF
--- a/scripts/scenario-defs/vehicle-driver-assignment-visual.json
+++ b/scripts/scenario-defs/vehicle-driver-assignment-visual.json
@@ -50,10 +50,15 @@
     },
     {
       "command": "vehicle list",
+      "description": "Opens the Vehicles panel via a real UI click so the after-qualified/after-unqualified shots capture the .bs-vehicle-driver-name indicator instead of a 3D orbit — the panel stays open for every later step once opened here (#411).",
       "interaction": [
         {
           "type": "command",
           "command": "vehicle list"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-toolbar [data-panel=\"vehicles\"]"
         }
       ]
     },

--- a/scripts/scenario-defs/vehicle-purchase-tier-ui-visual.json
+++ b/scripts/scenario-defs/vehicle-purchase-tier-ui-visual.json
@@ -49,6 +49,48 @@
       ]
     },
     {
+      "command": "vehicle buy debris_hauler tier:2",
+      "description": "Tier-2 purchase via the new `tier:` arg (#411), dual-played identically in both modes through the console.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle buy debris_hauler tier:2"
+        }
+      ]
+    },
+    {
+      "command": "vehicle buy drill_rig tier:3",
+      "description": "Tier-3 purchase via the new `tier:` arg (#411), dual-played identically in both modes through the console.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle buy drill_rig tier:3"
+        }
+      ]
+    },
+    {
+      "command": "vehicle list",
+      "description": "Command mode only lists the fleet; interaction mode additionally opens the Vehicles panel and clicks the real tier-2 buy button for rock_fragmenter — a genuine UI click on the new tier selector, not a replayed console command — proving the tier buttons are reachable and enabled, not just that `vehicle buy ... tier:N` works headlessly.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle list"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-toolbar [data-panel=\"vehicles\"]"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": "#bs-vehicle-panel [data-vtype=\"rock_fragmenter\"][data-tier=\"2\"]"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-vehicle-panel [data-vtype=\"rock_fragmenter\"][data-tier=\"2\"]"
+        }
+      ]
+    },
+    {
       "command": "vehicle list",
       "interaction": [
         {

--- a/scripts/scenario-defs/vehicle-purchase-tier-ui-visual.json
+++ b/scripts/scenario-defs/vehicle-purchase-tier-ui-visual.json
@@ -3,21 +3,13 @@
   "description": "Visual check: vehicle purchase menu shows all roles with cost stats and purchase buttons for tier comparison",
   "steps": [
     {
-      "command": "new_game seed:42",
+      "command": "new_game seed:42 cash:100000",
       "timeout": 10,
+      "description": "$100k starting cash (not the dusty_hollow campaign level's $50k) so the fleet has headroom for the tier-2/3 purchases below plus the real tier-2 rock_fragmenter click ($64k) further down — dusty_hollow's cash alone is less than that one click's cost, and other campaign levels with more cash start locked (#411).",
       "interaction": [
         {
           "type": "command",
-          "command": "new_game seed:42"
-        }
-      ]
-    },
-    {
-      "command": "campaign start level:dusty_hollow",
-      "interaction": [
-        {
-          "type": "command",
-          "command": "campaign start level:dusty_hollow"
+          "command": "new_game seed:42 cash:100000"
         }
       ]
     },
@@ -36,6 +28,28 @@
         {
           "type": "command",
           "command": "vehicle buy debris_hauler"
+        }
+      ]
+    },
+    {
+      "command": "vehicle list",
+      "description": "Command mode only lists the fleet; interaction mode additionally opens the Vehicles panel and clicks the real tier-2 buy button for rock_fragmenter — a genuine UI click on the new tier selector, not a replayed console command — proving the tier buttons are reachable and enabled, not just that `vehicle buy ... tier:N` works headlessly. Run now, while only the one cheap debris_hauler purchase above has been spent, so cash ($75k) stays comfortably above this button's $64k cost — later steps' command-mode tier:2/tier:3 purchases (which push cash negative, harmless for command mode) happen only after this click (#411).",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle list"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-toolbar [data-panel=\"vehicles\"]"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": "#bs-vehicle-panel [data-vtype=\"rock_fragmenter\"][data-tier=\"2\"]"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-vehicle-panel [data-vtype=\"rock_fragmenter\"][data-tier=\"2\"]"
         }
       ]
     },
@@ -65,28 +79,6 @@
         {
           "type": "command",
           "command": "vehicle buy drill_rig tier:3"
-        }
-      ]
-    },
-    {
-      "command": "vehicle list",
-      "description": "Command mode only lists the fleet; interaction mode additionally opens the Vehicles panel and clicks the real tier-2 buy button for rock_fragmenter — a genuine UI click on the new tier selector, not a replayed console command — proving the tier buttons are reachable and enabled, not just that `vehicle buy ... tier:N` works headlessly.",
-      "interaction": [
-        {
-          "type": "command",
-          "command": "vehicle list"
-        },
-        {
-          "type": "clickSelector",
-          "selector": "#bs-toolbar [data-panel=\"vehicles\"]"
-        },
-        {
-          "type": "waitForSelector",
-          "selector": "#bs-vehicle-panel [data-vtype=\"rock_fragmenter\"][data-tier=\"2\"]"
-        },
-        {
-          "type": "clickSelector",
-          "selector": "#bs-vehicle-panel [data-vtype=\"rock_fragmenter\"][data-tier=\"2\"]"
         }
       ]
     },

--- a/scripts/scenario-defs/vehicle-roles-panel-visual.json
+++ b/scripts/scenario-defs/vehicle-roles-panel-visual.json
@@ -77,10 +77,15 @@
     },
     {
       "command": "vehicle list",
+      "description": "Opens the Vehicles panel via a real UI click so the roles-panel shot captures the actual panel (tier names + costs) instead of a 3D orbit angle — uiState.panels['bs-vehicle-panel'].visible stayed false the whole scenario before this (#411).",
       "interaction": [
         {
           "type": "command",
           "command": "vehicle list"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-toolbar [data-panel=\"vehicles\"]"
         }
       ]
     },

--- a/scripts/scenario-defs/vehicle-task-states-visual.json
+++ b/scripts/scenario-defs/vehicle-task-states-visual.json
@@ -40,11 +40,12 @@
       ]
     },
     {
-      "command": "vehicle move 1 to:25,25",
+      "command": "vehicle move 1 to:2,2",
+      "description": "Target far enough from spawn that tick 5 below (speed 3/tick = 15 cells) doesn't cover the whole distance in one batch — the old to:25,25 target was close enough that the vehicle arrived and reset to idle within the same tick command, so the moving-state shot never captured the blue in-transit marker (#411).",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle move 1 to:25,25"
+          "command": "vehicle move 1 to:2,2"
         }
       ]
     },

--- a/scripts/scenario-defs/vehicle-traffic-routing-visual.json
+++ b/scripts/scenario-defs/vehicle-traffic-routing-visual.json
@@ -103,30 +103,30 @@
       ]
     },
     {
-      "command": "vehicle move 1 to:36,32",
-      "description": "Stagger hauler targets around a shared cluster near spawn so paths cross and vehicles queue behind each other — a TrafficJamEvent (#411) never fires against parked vehicles.",
+      "command": "vehicle move 1 to:37,33",
+      "description": "All 4 haulers converge on the same target cell — detectTrafficJam groups waiting vehicles by shared targetX/targetZ (#411), so a common destination is what actually lets TRAFFIC_JAM_MIN_VEHICLES be reached, not just visually adjacent-but-different targets. Spawns are staggered (issue 1's fix) so the 4 approach from distinct tiles and queue behind whichever one claims the cell first, instead of spawning fused.",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle move 1 to:36,32"
+          "command": "vehicle move 1 to:37,33"
         }
       ]
     },
     {
-      "command": "vehicle move 2 to:36,33",
+      "command": "vehicle move 2 to:37,33",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle move 2 to:36,33"
+          "command": "vehicle move 2 to:37,33"
         }
       ]
     },
     {
-      "command": "vehicle move 3 to:37,32",
+      "command": "vehicle move 3 to:37,33",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle move 3 to:37,32"
+          "command": "vehicle move 3 to:37,33"
         }
       ]
     },
@@ -140,11 +140,30 @@
       ]
     },
     {
-      "command": "tick 20",
+      "command": "tick 6",
+      "description": "Split from a single tick 20 into smaller batches so a screenshot lands mid-route, before every vehicle has arrived and gone idle — TRAFFIC_JAM_MIN_TICKS=10 needs at least that many ticks of contention, so the congestion shot is captured around cumulative tick 12, not tick 20+ (#411).",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 20"
+          "command": "tick 6"
+        }
+      ]
+    },
+    {
+      "command": "vehicle list",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle list"
+        }
+      ]
+    },
+    {
+      "command": "tick 6",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 6"
         }
       ]
     },

--- a/scripts/scenario-defs/vehicle-traffic-routing-visual.json
+++ b/scripts/scenario-defs/vehicle-traffic-routing-visual.json
@@ -103,6 +103,43 @@
       ]
     },
     {
+      "command": "vehicle move 1 to:36,32",
+      "description": "Stagger hauler targets around a shared cluster near spawn so paths cross and vehicles queue behind each other — a TrafficJamEvent (#411) never fires against parked vehicles.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle move 1 to:36,32"
+        }
+      ]
+    },
+    {
+      "command": "vehicle move 2 to:36,33",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle move 2 to:36,33"
+        }
+      ]
+    },
+    {
+      "command": "vehicle move 3 to:37,32",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle move 3 to:37,32"
+        }
+      ]
+    },
+    {
+      "command": "vehicle move 4 to:37,33",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle move 4 to:37,33"
+        }
+      ]
+    },
+    {
       "command": "tick 20",
       "interaction": [
         {

--- a/scripts/scenario-defs/vehicle-traffic-routing-visual.json
+++ b/scripts/scenario-defs/vehicle-traffic-routing-visual.json
@@ -159,11 +159,12 @@
       ]
     },
     {
-      "command": "tick 6",
+      "command": "tick 16",
+      "description": "Extended from tick 6 (#411 round 3, issue B): TRAFFIC_JAM_MIN_TICKS=10 consecutive waiting ticks on top of the ~8-10 ticks it takes the haulers to converge means the jam fires around cumulative tick 20 — this scenario's own stated purpose (demonstrating TrafficJamEvent) was previously unreachable within its 6+6=12 tick budget even after wiring detectTrafficJam into the console tick path. 6+16=22 gives margin past the tick-20 fire point.",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 6"
+          "command": "tick 16"
         }
       ]
     },

--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -20,7 +20,7 @@ import { tickTraining } from '../../core/entities/EmployeeTraining.js';
 import { tickResearch } from '../../core/entities/Building.js';
 import { tickNeedGauges, needsMoraleEffect } from '../../core/entities/EmployeeNeeds.js';
 import type { FiredEvent } from '../../core/events/EventSystem.js';
-import { tickCollapse, autoInsertNeedTasks, processShiftCycle, tickEmployees, tickGeneralRestCompletion, tickTaskProgress, tickVehicle, tickEmployeeMovement } from '../../core/engine/GameLoop.js';
+import { tickCollapse, autoInsertNeedTasks, processShiftCycle, tickEmployees, tickGeneralRestCompletion, tickTaskProgress, tickVehicle, tickVehicleTaskState, tickEmployeeMovement } from '../../core/engine/GameLoop.js';
 import { detectUnqualifiedTask } from '../../core/events/EventEngine.js';
 import { estimateSurveyResult, type SurveyMethod } from '../../core/mining/SurveyCalc.js';
 import { checkDeadlines, generateContracts } from '../../core/economy/Contract.js';
@@ -227,6 +227,7 @@ export function tickCommand(
     // target; nothing advanced x/z toward it before this).
     for (const vehicle of state.vehicles.vehicles) {
       tickVehicle(state, vehicle, emitter);
+      tickVehicleTaskState(vehicle);
     }
 
     // 8g. Employee movement — walk employees with a destination (set by

--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -21,7 +21,7 @@ import { tickResearch } from '../../core/entities/Building.js';
 import { tickNeedGauges, needsMoraleEffect } from '../../core/entities/EmployeeNeeds.js';
 import type { FiredEvent } from '../../core/events/EventSystem.js';
 import { tickCollapse, autoInsertNeedTasks, processShiftCycle, tickEmployees, tickGeneralRestCompletion, tickTaskProgress, tickVehicle, tickVehicleTaskState, tickEmployeeMovement } from '../../core/engine/GameLoop.js';
-import { detectUnqualifiedTask } from '../../core/events/EventEngine.js';
+import { detectUnqualifiedTask, detectTrafficJam } from '../../core/events/EventEngine.js';
 import { estimateSurveyResult, type SurveyMethod } from '../../core/mining/SurveyCalc.js';
 import { checkDeadlines, generateContracts } from '../../core/economy/Contract.js';
 import { updateBankruptcy } from '../../core/campaign/Bankruptcy.js';
@@ -229,6 +229,11 @@ export function tickCommand(
       tickVehicle(state, vehicle, emitter);
       tickVehicleTaskState(vehicle);
     }
+
+    // 8f-2. Traffic jam detection — mirrors GameLoop.processFrame's own
+    // post-vehicle-tick check (src/core/engine/GameLoop.ts), reachable here so
+    // console/scenario "tick" steps can fire TrafficJamEvent too (#411).
+    fired = fired ?? detectTrafficJam(state.vehicles.vehicles, state.events, state.tickCount);
 
     // 8g. Employee movement — walk employees with a destination (set by
     // tickEmployees/tickCollapse/tickNeedRestoration/forceShiftRestIfNeeded

--- a/src/console/commands/vehicle.ts
+++ b/src/console/commands/vehicle.ts
@@ -10,8 +10,23 @@ import {
   getAllVehicleRoles,
   type VehicleRole,
   type VehicleTask,
+  type VehicleTier,
 } from '../../core/entities/Vehicle.js';
 import { addExpense } from '../../core/economy/Finance.js';
+
+// ── tier arg parsing ──
+
+/**
+ * Parses and validates the `tier:` named arg for `vehicle buy` (default '1';
+ * only 1|2|3 accepted, matching the role-validation branch below). Not yet
+ * wired into the buy case — purchaseVehicle there still defaults tier=1 until
+ * the implementer wires this in (#411), which is what makes Tier 2/3
+ * vehicles unreachable by any player action today.
+ */
+export function parseVehicleTierArg(_named: Record<string, string>): VehicleTier | null {
+  // TODO: implement — default '1', reject values outside 1|2|3.
+  return null;
+}
 
 // ── vehicle command ──
 

--- a/src/console/commands/vehicle.ts
+++ b/src/console/commands/vehicle.ts
@@ -18,11 +18,10 @@ import { SPAWN_RING_SIZE, SPAWN_TILE_SPACING } from '../../core/config/balance.j
 // ── tier arg parsing ──
 
 /**
- * Parses and validates the `tier:` named arg for `vehicle buy` (default '1';
- * only 1|2|3 accepted, matching the role-validation branch below). Not yet
- * wired into the buy case — purchaseVehicle there still defaults tier=1 until
- * the implementer wires this in (#411), which is what makes Tier 2/3
- * vehicles unreachable by any player action today.
+ * Parses and validates the `tier:` named arg for `vehicle buy` (default 1;
+ * only 1|2|3 accepted, matching the role-validation branch below). Returns
+ * the parsed tier, or `null` when the arg is present but not 1|2|3. Called
+ * from the `buy` case below, which threads the result into purchaseVehicle.
  */
 export function parseVehicleTierArg(named: Record<string, string>): VehicleTier | null {
   const raw = named['tier'];

--- a/src/console/commands/vehicle.ts
+++ b/src/console/commands/vehicle.ts
@@ -13,6 +13,7 @@ import {
   type VehicleTier,
 } from '../../core/entities/Vehicle.js';
 import { addExpense } from '../../core/economy/Finance.js';
+import { SPAWN_RING_SIZE, SPAWN_TILE_SPACING } from '../../core/config/balance.js';
 
 // ── tier arg parsing ──
 
@@ -63,9 +64,15 @@ export function vehicleCommand(
       if (tier === null) {
         return { success: false, output: 'Usage: vehicle buy <role> tier:(1|2|3)' };
       }
-      // Spawn near grid centre so vehicles are visible from default camera
-      const spawnX = state.world ? state.world.sizeX / 2 : 32;
-      const spawnZ = state.world ? state.world.sizeZ / 2 : 32;
+      // Spawn near grid centre, staggered per fleet index so newly purchased
+      // vehicles land on distinct tiles instead of stacking on the depot
+      // point — every prior purchase overlapped at one tile, occluding all
+      // but the tallest mesh (#411).
+      const baseX = state.world ? state.world.sizeX / 2 : 32;
+      const baseZ = state.world ? state.world.sizeZ / 2 : 32;
+      const fleetIndex = state.vehicles.vehicles.length;
+      const spawnX = baseX + (fleetIndex % SPAWN_RING_SIZE) * SPAWN_TILE_SPACING;
+      const spawnZ = baseZ + Math.floor(fleetIndex / SPAWN_RING_SIZE) * SPAWN_TILE_SPACING;
       const { vehicle, cost } = purchaseVehicle(state.vehicles, type, spawnX, spawnZ, tier);
       state.cash -= cost;
       addExpense(state.finances, cost, 'equipment', `Buy ${type}`, state.tickCount);

--- a/src/console/commands/vehicle.ts
+++ b/src/console/commands/vehicle.ts
@@ -23,9 +23,12 @@ import { addExpense } from '../../core/economy/Finance.js';
  * the implementer wires this in (#411), which is what makes Tier 2/3
  * vehicles unreachable by any player action today.
  */
-export function parseVehicleTierArg(_named: Record<string, string>): VehicleTier | null {
-  // TODO: implement — default '1', reject values outside 1|2|3.
-  return null;
+export function parseVehicleTierArg(named: Record<string, string>): VehicleTier | null {
+  const raw = named['tier'];
+  if (raw === undefined) return 1;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || (parsed !== 1 && parsed !== 2 && parsed !== 3)) return null;
+  return parsed;
 }
 
 // ── vehicle command ──
@@ -56,10 +59,14 @@ export function vehicleCommand(
       if (!getAllVehicleRoles().includes(type)) {
         return { success: false, output: `Usage: vehicle buy (${getAllVehicleRoles().join('|')})` };
       }
+      const tier = parseVehicleTierArg(named);
+      if (tier === null) {
+        return { success: false, output: 'Usage: vehicle buy <role> tier:(1|2|3)' };
+      }
       // Spawn near grid centre so vehicles are visible from default camera
       const spawnX = state.world ? state.world.sizeX / 2 : 32;
       const spawnZ = state.world ? state.world.sizeZ / 2 : 32;
-      const { vehicle, cost } = purchaseVehicle(state.vehicles, type, spawnX, spawnZ);
+      const { vehicle, cost } = purchaseVehicle(state.vehicles, type, spawnX, spawnZ, tier);
       state.cash -= cost;
       addExpense(state.finances, cost, 'equipment', `Buy ${type}`, state.tickCount);
       return { success: true, output: `Purchased ${type} #${vehicle.id}. Cost: $${cost}` };

--- a/src/core/config/balance.ts
+++ b/src/core/config/balance.ts
@@ -124,6 +124,20 @@ export const TRAFFIC_JAM_MIN_VEHICLES = 3;
 /** Minimum consecutive waiting ticks per vehicle before it counts toward a traffic jam. */
 export const TRAFFIC_JAM_MIN_TICKS = 10;
 
+// ─── Vehicle Spawn Placement ────────────────────────────────────────────────────
+
+/**
+ * `vehicle buy` spreads new arrivals across a ring/grid pattern around the
+ * depot point instead of stacking every purchase on one tile — a shared tile
+ * fully occluded all but the tallest mesh (#411). SPAWN_RING_SIZE columns
+ * before wrapping to the next row; SPAWN_TILE_SPACING tiles between spawns —
+ * wide enough that adjacent vehicle meshes stay visually distinct (1-tile
+ * spacing still let bodies merge, see TRAFFIC_JAM_MIN_TICKS's neighbour
+ * vehicle-traffic-routing-visual fix) while staying near the depot.
+ */
+export const SPAWN_RING_SIZE = 3;
+export const SPAWN_TILE_SPACING = 3;
+
 // ─── Ore Report Events ───────────────────────────────────────────────────────────
 
 /** Yield ratio threshold above which a blast is considered "Lucky Strike" (got more ore than surveyed). */

--- a/src/core/config/balance.ts
+++ b/src/core/config/balance.ts
@@ -138,6 +138,30 @@ export const TRAFFIC_JAM_MIN_TICKS = 10;
 export const SPAWN_RING_SIZE = 3;
 export const SPAWN_TILE_SPACING = 3;
 
+/**
+ * Render-only queue offsets for vehicles in the 'waiting' operational state
+ * that share a contended target cell (#411 round 2). detectTrafficJam groups
+ * waiting vehicles by exact targetX/targetZ, so the simulation intentionally
+ * drives every contending vehicle toward the identical point — that grouping
+ * must not change. Their *rendered* position, however, fanned out to
+ * sub-tile-distance fractional coordinates as each approached along its own
+ * path, fusing 3+ meshes into one blob. VehicleMesh spreads waiting vehicles
+ * that share a target across these slots (world-unit offsets from the shared
+ * target) purely for display — core vehicle.x/z and jam detection are
+ * untouched. Same 3-unit spacing as SPAWN_TILE_SPACING above (debris_hauler's
+ * widest body dimension is 2.5, so anything much under 3 still overlaps).
+ */
+export const WAITING_QUEUE_SLOT_OFFSETS: ReadonlyArray<readonly [number, number]> = [
+  [0, 0],
+  [3, 0],
+  [-3, 0],
+  [0, 3],
+  [0, -3],
+  [3, 3],
+  [-3, -3],
+  [3, -3],
+];
+
 // ─── Ore Report Events ───────────────────────────────────────────────────────────
 
 /** Yield ratio threshold above which a blast is considered "Lucky Strike" (got more ore than surveyed). */

--- a/src/core/config/balance.ts
+++ b/src/core/config/balance.ts
@@ -148,18 +148,21 @@ export const SPAWN_TILE_SPACING = 3;
  * path, fusing 3+ meshes into one blob. VehicleMesh spreads waiting vehicles
  * that share a target across these slots (world-unit offsets from the shared
  * target) purely for display — core vehicle.x/z and jam detection are
- * untouched. Same 3-unit spacing as SPAWN_TILE_SPACING above (debris_hauler's
- * widest body dimension is 2.5, so anything much under 3 still overlaps).
+ * untouched. Reuses SPAWN_TILE_SPACING above rather than its own literal —
+ * both need the same minimum gap (debris_hauler's widest body dimension is
+ * 2.5, so anything much under 3 still overlaps), so one constant enforces it
+ * for both instead of two numbers that could silently drift apart.
  */
+const SPACING = SPAWN_TILE_SPACING;
 export const WAITING_QUEUE_SLOT_OFFSETS: ReadonlyArray<readonly [number, number]> = [
   [0, 0],
-  [3, 0],
-  [-3, 0],
-  [0, 3],
-  [0, -3],
-  [3, 3],
-  [-3, -3],
-  [3, -3],
+  [SPACING, 0],
+  [-SPACING, 0],
+  [0, SPACING],
+  [0, -SPACING],
+  [SPACING, SPACING],
+  [-SPACING, -SPACING],
+  [SPACING, -SPACING],
 ];
 
 // ─── Ore Report Events ───────────────────────────────────────────────────────────

--- a/src/core/engine/EntityMovementTick.ts
+++ b/src/core/engine/EntityMovementTick.ts
@@ -171,6 +171,23 @@ function isCellOccupiedByOtherVehicle(state: GameState, vehicle: Vehicle, x: num
   return state.vehicles.vehicles.some(v => v.id !== vehicle.id && v.x === x && v.z === z);
 }
 
+// ── Vehicle task/work state ──
+
+/**
+ * Transitions vehicle.state to 'working' while vehicle.task is one of the
+ * work tasks ('transport' | 'loading' | 'drilling' | 'clearing'), and back to
+ * 'idle' when task returns to 'idle'. VehicleOperationalState.working was
+ * never assigned anywhere prior to this (#411) — vehicle-task-states-visual's
+ * working-state screenshot was unreachable.
+ *
+ * Not yet wired into the tick pipeline — the implementer calls this per
+ * vehicle alongside tickVehicle in the tick loop (events.ts step 8f).
+ */
+export function tickVehicleTaskState(_vehicle: Vehicle): void {
+  // TODO: implement — task in ('transport'|'loading'|'drilling'|'clearing') → state='working';
+  // task==='idle' → state='idle'.
+}
+
 // ── Employee movement ──
 
 export interface EmployeeMovementResult {

--- a/src/core/engine/EntityMovementTick.ts
+++ b/src/core/engine/EntityMovementTick.ts
@@ -180,8 +180,7 @@ function isCellOccupiedByOtherVehicle(state: GameState, vehicle: Vehicle, x: num
  * never assigned anywhere prior to this (#411) — vehicle-task-states-visual's
  * working-state screenshot was unreachable.
  *
- * Not yet wired into the tick pipeline — the implementer calls this per
- * vehicle alongside tickVehicle in the tick loop (events.ts step 8f).
+ * Called per vehicle alongside tickVehicle in the tick loop (events.ts step 8f).
  */
 const WORK_TASKS: ReadonlySet<Vehicle['task']> = new Set(['transport', 'loading', 'drilling', 'clearing']);
 

--- a/src/core/engine/EntityMovementTick.ts
+++ b/src/core/engine/EntityMovementTick.ts
@@ -183,9 +183,14 @@ function isCellOccupiedByOtherVehicle(state: GameState, vehicle: Vehicle, x: num
  * Not yet wired into the tick pipeline — the implementer calls this per
  * vehicle alongside tickVehicle in the tick loop (events.ts step 8f).
  */
-export function tickVehicleTaskState(_vehicle: Vehicle): void {
-  // TODO: implement — task in ('transport'|'loading'|'drilling'|'clearing') → state='working';
-  // task==='idle' → state='idle'.
+const WORK_TASKS: ReadonlySet<Vehicle['task']> = new Set(['transport', 'loading', 'drilling', 'clearing']);
+
+export function tickVehicleTaskState(vehicle: Vehicle): void {
+  if (WORK_TASKS.has(vehicle.task)) {
+    vehicle.state = 'working';
+  } else if (vehicle.task === 'idle') {
+    vehicle.state = 'idle';
+  }
 }
 
 // ── Employee movement ──

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -14,7 +14,7 @@ import { replenishNeed, getNeedMultiplier } from '../entities/EmployeeNeeds.js';
 import { getLivingQuartersWellbeingMultiplier } from '../entities/BuildingWellbeing.js';
 import type { EventEmitter } from '../state/EventEmitter.js';
 import { addExpense } from '../economy/Finance.js';
-import { tickVehicle, tickEmployeeMovement, type EmployeeMovementResult } from './EntityMovementTick.js';
+import { tickVehicle, tickVehicleTaskState, tickEmployeeMovement, type EmployeeMovementResult } from './EntityMovementTick.js';
 
 // ── Config ──
 
@@ -23,7 +23,7 @@ import { BASE_TICK_MS as _BASE_TICK_MS, VALID_SPEEDS as _VALID_SPEEDS, NEED_REST
 // Vehicle and employee per-tick movement (NavGrid pathing, stuck-tracking) live
 // in EntityMovementTick.ts (#407 refactor) — re-exported here so GameLoop.ts
 // stays the single public surface for tick-orchestration callers.
-export { tickVehicle, tickEmployeeMovement, type EmployeeMovementResult };
+export { tickVehicle, tickVehicleTaskState, tickEmployeeMovement, type EmployeeMovementResult };
 
 /** Milliseconds per base tick at 1x speed. */
 export const BASE_TICK_MS = _BASE_TICK_MS;

--- a/src/renderer/GameRenderer.ts
+++ b/src/renderer/GameRenderer.ts
@@ -106,12 +106,17 @@ export class GameRenderer {
       (x, z) => this.getTerrainSurfaceY(x, z),
     );
 
-    // Place vehicles at terrain surface height (not buried at y=0)
+    // Place vehicles at terrain surface height (not buried at y=0).
+    // Also fold in the waiting-queue render offset (#411 round 2) — this snap
+    // runs on every sync (not just once per frame like update()'s lerp), so
+    // without it every sync would stomp fused 'waiting' vehicles back to
+    // their raw, near-identical GameState x/z.
     if (this.vehicles && this.lastGrid) {
       for (const v of ctx.state.vehicles.vehicles) {
         if (this.renderedVehicleIds.has(v.id)) {
           const surfaceY = this.getTerrainSurfaceY(v.x, v.z);
-          this.vehicles.snapPosition(v.id, v.x, surfaceY, v.z);
+          const [offsetX, offsetZ] = this.vehicles.waitingQueueOffset(v, ctx.state.vehicles.vehicles);
+          this.vehicles.snapPosition(v.id, v.x + offsetX, surfaceY, v.z + offsetZ);
         }
       }
     }

--- a/src/renderer/GameRenderer.ts
+++ b/src/renderer/GameRenderer.ts
@@ -107,16 +107,17 @@ export class GameRenderer {
     );
 
     // Place vehicles at terrain surface height (not buried at y=0).
-    // Also fold in the waiting-queue render offset (#411 round 2) — this snap
-    // runs on every sync (not just once per frame like update()'s lerp), so
-    // without it every sync would stomp fused 'waiting' vehicles back to
-    // their raw, near-identical GameState x/z.
+    // Also fold in the waiting-queue render offset (#411 round 2, anchored to
+    // the shared target point since round 4) — this snap runs on every sync
+    // (not just once per frame like update()'s lerp), so without it every
+    // sync would stomp fused 'waiting' vehicles back to their raw, near-
+    // identical GameState x/z.
     if (this.vehicles && this.lastGrid) {
       for (const v of ctx.state.vehicles.vehicles) {
         if (this.renderedVehicleIds.has(v.id)) {
           const surfaceY = this.getTerrainSurfaceY(v.x, v.z);
-          const [offsetX, offsetZ] = this.vehicles.waitingQueueOffset(v, ctx.state.vehicles.vehicles);
-          this.vehicles.snapPosition(v.id, v.x + offsetX, surfaceY, v.z + offsetZ);
+          const [renderX, renderZ] = this.vehicles.waitingRenderPosition(v, ctx.state.vehicles.vehicles);
+          this.vehicles.snapPosition(v.id, renderX, surfaceY, renderZ);
         }
       }
     }

--- a/src/renderer/VehicleMesh.ts
+++ b/src/renderer/VehicleMesh.ts
@@ -162,8 +162,8 @@ export class VehicleMesh {
     applyTierVariation(group, vehicle.tier);
     applyStateIndicator(group, vehicle.state);
     const pool = [...Array.from(this.vehicles.values(), e => e.vehicle), vehicle];
-    const [offsetX, offsetZ] = this.waitingQueueOffset(vehicle, pool);
-    group.position.set(vehicle.x + offsetX, surfaceY, vehicle.z + offsetZ);
+    const [renderX, renderZ] = this.waitingRenderPosition(vehicle, pool);
+    group.position.set(renderX, surfaceY, renderZ);
     this.scene.add(group);
     this.vehicles.set(vehicle.id, { group, vehicle });
   }
@@ -179,9 +179,7 @@ export class VehicleMesh {
       // Update stored reference
       entry.vehicle = v;
       // Lerp toward target (+ queue offset for fused 'waiting' vehicles, #411 round 2)
-      const [offsetX, offsetZ] = this.waitingQueueOffset(v, vehicles);
-      const targetX = v.x + offsetX;
-      const targetZ = v.z + offsetZ;
+      const [targetX, targetZ] = this.waitingRenderPosition(v, vehicles);
       entry.group.position.x += (targetX - entry.group.position.x) * MOVE_LERP;
       entry.group.position.z += (targetZ - entry.group.position.z) * MOVE_LERP;
       applyStateIndicator(entry.group, v.state);
@@ -210,6 +208,15 @@ export class VehicleMesh {
    * on top of it. The idle vehicle itself is never offset (only 'waiting'
    * vehicles get a non-zero return above), it just reserves slot 0 so the
    * waiting vehicles route around it.
+   *
+   * Round 4 (#411 issue B): the offset alone is not enough — callers must add
+   * it to the *shared target point* (targetX/targetZ), not to the vehicle's
+   * own raw x/z. Multiple vehicles converging on the same jam land at
+   * slightly different raw positions (pathfinding doesn't put them on the
+   * exact identical point), so a fixed offset added to each vehicle's own
+   * base can still leave two of them under the body-width threshold even
+   * though the offsets themselves are correctly spaced apart. Use
+   * waitingRenderPosition() below, which anchors to the common point.
    */
   waitingQueueOffset(vehicle: Vehicle, pool: Vehicle[]): readonly [number, number] {
     if (vehicle.state !== 'waiting') return [0, 0];
@@ -236,6 +243,22 @@ export class VehicleMesh {
 
     const slot = sharingTarget.indexOf(vehicle.id) % WAITING_QUEUE_SLOT_OFFSETS.length;
     return WAITING_QUEUE_SLOT_OFFSETS[slot]!;
+  }
+
+  /**
+   * Render position for a vehicle, folding in the waiting-queue slot offset
+   * (#411 round 4). For a 'waiting' vehicle the offset is anchored to the
+   * shared targetX/targetZ — the common point every contending vehicle is
+   * driving toward — rather than to the vehicle's own raw x/z, which can
+   * differ slightly between vehicles even when they share a target and would
+   * otherwise undermine the slot spacing. Non-waiting vehicles (including the
+   * idle occupant reserving slot 0) get a zero offset and render at their own
+   * x/z, unchanged.
+   */
+  waitingRenderPosition(vehicle: Vehicle, pool: Vehicle[]): readonly [number, number] {
+    if (vehicle.state !== 'waiting') return [vehicle.x, vehicle.z];
+    const [offsetX, offsetZ] = this.waitingQueueOffset(vehicle, pool);
+    return [vehicle.targetX + offsetX, vehicle.targetZ + offsetZ];
   }
 
   /** Snap a vehicle directly to its world position (no lerp — use after teleport or initial placement). */

--- a/src/renderer/VehicleMesh.ts
+++ b/src/renderer/VehicleMesh.ts
@@ -12,7 +12,7 @@
 // Vehicles move smoothly to their target position via lerp each frame.
 
 import * as THREE from 'three';
-import type { Vehicle, VehicleRole, VehicleTier } from '../core/entities/Vehicle.js';
+import type { Vehicle, VehicleRole, VehicleTier, VehicleOperationalState } from '../core/entities/Vehicle.js';
 
 // ---------- Colors ----------
 const YELLOW = 0xf5c518;   // Caterpillar yellow
@@ -252,6 +252,24 @@ function brightenColor(hex: number, shift: number): number {
     (Math.round(g + (0xff - g) * shift) << 8)  |
      Math.round(b + (0xff - b) * shift)
   );
+}
+
+// ---------- State indicator ----------
+
+/**
+ * Marker color per VehicleOperationalState. Empty until the implementer
+ * fills it in (#411) — today waiting/broken/working all render identically
+ * to idle since only position lerps.
+ */
+export const STATE_COLOR_MAP: Partial<Record<VehicleOperationalState, number>> = {};
+
+/**
+ * Adds or updates a small colored marker on a vehicle's group reflecting its
+ * operational state, following the same material-color-manipulation pattern
+ * as applyTierVariation below. Not yet called from addVehicle/update (#411).
+ */
+export function applyStateIndicator(_group: THREE.Group, _state: VehicleOperationalState): void {
+  // TODO: implement — small marker mesh or material tint keyed by STATE_COLOR_MAP[state]
 }
 
 function applyTierVariation(group: THREE.Group, tier: VehicleTier): void {

--- a/src/renderer/VehicleMesh.ts
+++ b/src/renderer/VehicleMesh.ts
@@ -13,6 +13,7 @@
 
 import * as THREE from 'three';
 import type { Vehicle, VehicleRole, VehicleTier, VehicleOperationalState } from '../core/entities/Vehicle.js';
+import { WAITING_QUEUE_SLOT_OFFSETS } from '../core/config/balance.js';
 
 // ---------- Colors ----------
 const YELLOW = 0xf5c518;   // Caterpillar yellow
@@ -160,7 +161,9 @@ export class VehicleMesh {
     const group = builder();
     applyTierVariation(group, vehicle.tier);
     applyStateIndicator(group, vehicle.state);
-    group.position.set(vehicle.x, surfaceY, vehicle.z);
+    const pool = [...Array.from(this.vehicles.values(), e => e.vehicle), vehicle];
+    const [offsetX, offsetZ] = this.waitingQueueOffset(vehicle, pool);
+    group.position.set(vehicle.x + offsetX, surfaceY, vehicle.z + offsetZ);
     this.scene.add(group);
     this.vehicles.set(vehicle.id, { group, vehicle });
   }
@@ -175,11 +178,44 @@ export class VehicleMesh {
       if (!entry) continue;
       // Update stored reference
       entry.vehicle = v;
-      // Lerp toward target
-      entry.group.position.x += (v.x - entry.group.position.x) * MOVE_LERP;
-      entry.group.position.z += (v.z - entry.group.position.z) * MOVE_LERP;
+      // Lerp toward target (+ queue offset for fused 'waiting' vehicles, #411 round 2)
+      const [offsetX, offsetZ] = this.waitingQueueOffset(v, vehicles);
+      const targetX = v.x + offsetX;
+      const targetZ = v.z + offsetZ;
+      entry.group.position.x += (targetX - entry.group.position.x) * MOVE_LERP;
+      entry.group.position.z += (targetZ - entry.group.position.z) * MOVE_LERP;
       applyStateIndicator(entry.group, v.state);
     }
+  }
+
+  /**
+   * Render-only positional offset for a vehicle in the 'waiting' state that
+   * shares its target cell with other waiting vehicles (#411 round 2).
+   * detectTrafficJam (src/core/events/EventEngine.ts) groups waiting vehicles
+   * by exact targetX/targetZ, so the simulation must keep driving every
+   * contending vehicle toward the identical point — this offset never touches
+   * vehicle.x/z or targetX/targetZ, only where the mesh is drawn, so jam
+   * detection is unaffected. Slot assignment is by ascending vehicle id among
+   * vehicles sharing that target, so it stays stable frame to frame.
+   *
+   * Public: GameRenderer's terrain-surface-height correction (syncFromContext)
+   * calls snapPosition with x/z straight from GameState every sync, which
+   * would otherwise stomp this offset back to the fused raw position between
+   * update()'s per-frame lerps — GameRenderer must fold this same offset into
+   * the x/z it passes to snapPosition.
+   */
+  waitingQueueOffset(vehicle: Vehicle, pool: Vehicle[]): readonly [number, number] {
+    if (vehicle.state !== 'waiting') return [0, 0];
+
+    const sharingTarget = pool
+      .filter(v => v.state === 'waiting' && v.targetX === vehicle.targetX && v.targetZ === vehicle.targetZ)
+      .map(v => v.id)
+      .sort((a, b) => a - b);
+
+    if (sharingTarget.length <= 1) return [0, 0];
+
+    const slot = sharingTarget.indexOf(vehicle.id) % WAITING_QUEUE_SLOT_OFFSETS.length;
+    return WAITING_QUEUE_SLOT_OFFSETS[slot]!;
   }
 
   /** Snap a vehicle directly to its world position (no lerp — use after teleport or initial placement). */

--- a/src/renderer/VehicleMesh.ts
+++ b/src/renderer/VehicleMesh.ts
@@ -13,7 +13,7 @@
 
 import * as THREE from 'three';
 import type { Vehicle, VehicleRole, VehicleTier, VehicleOperationalState } from '../core/entities/Vehicle.js';
-import { WAITING_QUEUE_SLOT_OFFSETS } from '../core/config/balance.js';
+import { waitingQueueOffset, waitingRenderPosition } from './VehicleWaitingQueue.js';
 
 // ---------- Colors ----------
 const YELLOW = 0xf5c518;   // Caterpillar yellow
@@ -187,78 +187,20 @@ export class VehicleMesh {
   }
 
   /**
-   * Render-only positional offset for a vehicle in the 'waiting' state that
-   * shares its target cell with other waiting vehicles (#411 round 2).
-   * detectTrafficJam (src/core/events/EventEngine.ts) groups waiting vehicles
-   * by exact targetX/targetZ, so the simulation must keep driving every
-   * contending vehicle toward the identical point — this offset never touches
-   * vehicle.x/z or targetX/targetZ, only where the mesh is drawn, so jam
-   * detection is unaffected. Slot assignment is by ascending vehicle id among
-   * vehicles sharing that target, so it stays stable frame to frame.
-   *
-   * Public: GameRenderer's terrain-surface-height correction (syncFromContext)
-   * calls snapPosition with x/z straight from GameState every sync, which
-   * would otherwise stomp this offset back to the fused raw position between
-   * update()'s per-frame lerps — GameRenderer must fold this same offset into
-   * the x/z it passes to snapPosition.
-   *
-   * Round 3 (#411 issue A): an `idle` vehicle already sitting at that exact
-   * target cell (x/z equal to the target, e.g. it arrived and stopped) also
-   * occupies a slot — otherwise a waiting vehicle's offset could still land
-   * on top of it. The idle vehicle itself is never offset (only 'waiting'
-   * vehicles get a non-zero return above), it just reserves slot 0 so the
-   * waiting vehicles route around it.
-   *
-   * Round 4 (#411 issue B): the offset alone is not enough — callers must add
-   * it to the *shared target point* (targetX/targetZ), not to the vehicle's
-   * own raw x/z. Multiple vehicles converging on the same jam land at
-   * slightly different raw positions (pathfinding doesn't put them on the
-   * exact identical point), so a fixed offset added to each vehicle's own
-   * base can still leave two of them under the body-width threshold even
-   * though the offsets themselves are correctly spaced apart. Use
-   * waitingRenderPosition() below, which anchors to the common point.
+   * Render-only offset for a 'waiting' vehicle sharing its target cell with
+   * others (#411 round 2) — thin delegate to VehicleWaitingQueue.ts, kept as
+   * an instance method so callers/tests don't need a second import.
    */
   waitingQueueOffset(vehicle: Vehicle, pool: Vehicle[]): readonly [number, number] {
-    if (vehicle.state !== 'waiting') return [0, 0];
-
-    const sharesTarget = (v: Vehicle): boolean =>
-      v.targetX === vehicle.targetX && v.targetZ === vehicle.targetZ;
-
-    // Idle vehicles already occupying the target cell claim slot 0 first (in
-    // ascending id order) so waiting vehicles never compute an offset that
-    // lands on an idle occupant.
-    const occupyingIds = pool
-      .filter(v => v.state === 'idle' && v.x === v.targetX && v.z === v.targetZ && sharesTarget(v))
-      .map(v => v.id)
-      .sort((a, b) => a - b);
-
-    const waitingIds = pool
-      .filter(v => v.state === 'waiting' && sharesTarget(v))
-      .map(v => v.id)
-      .sort((a, b) => a - b);
-
-    const sharingTarget = [...occupyingIds, ...waitingIds];
-
-    if (sharingTarget.length <= 1) return [0, 0];
-
-    const slot = sharingTarget.indexOf(vehicle.id) % WAITING_QUEUE_SLOT_OFFSETS.length;
-    return WAITING_QUEUE_SLOT_OFFSETS[slot]!;
+    return waitingQueueOffset(vehicle, pool);
   }
 
   /**
    * Render position for a vehicle, folding in the waiting-queue slot offset
-   * (#411 round 4). For a 'waiting' vehicle the offset is anchored to the
-   * shared targetX/targetZ — the common point every contending vehicle is
-   * driving toward — rather than to the vehicle's own raw x/z, which can
-   * differ slightly between vehicles even when they share a target and would
-   * otherwise undermine the slot spacing. Non-waiting vehicles (including the
-   * idle occupant reserving slot 0) get a zero offset and render at their own
-   * x/z, unchanged.
+   * (#411 round 4) — thin delegate to VehicleWaitingQueue.ts.
    */
   waitingRenderPosition(vehicle: Vehicle, pool: Vehicle[]): readonly [number, number] {
-    if (vehicle.state !== 'waiting') return [vehicle.x, vehicle.z];
-    const [offsetX, offsetZ] = this.waitingQueueOffset(vehicle, pool);
-    return [vehicle.targetX + offsetX, vehicle.targetZ + offsetZ];
+    return waitingRenderPosition(vehicle, pool);
   }
 
   /** Snap a vehicle directly to its world position (no lerp — use after teleport or initial placement). */

--- a/src/renderer/VehicleMesh.ts
+++ b/src/renderer/VehicleMesh.ts
@@ -159,6 +159,7 @@ export class VehicleMesh {
     const builder = VEHICLE_BUILDERS[vehicle.type];
     const group = builder();
     applyTierVariation(group, vehicle.tier);
+    applyStateIndicator(group, vehicle.state);
     group.position.set(vehicle.x, surfaceY, vehicle.z);
     this.scene.add(group);
     this.vehicles.set(vehicle.id, { group, vehicle });
@@ -177,6 +178,7 @@ export class VehicleMesh {
       // Lerp toward target
       entry.group.position.x += (v.x - entry.group.position.x) * MOVE_LERP;
       entry.group.position.z += (v.z - entry.group.position.z) * MOVE_LERP;
+      applyStateIndicator(entry.group, v.state);
     }
   }
 
@@ -256,20 +258,41 @@ function brightenColor(hex: number, shift: number): number {
 
 // ---------- State indicator ----------
 
-/**
- * Marker color per VehicleOperationalState. Empty until the implementer
- * fills it in (#411) — today waiting/broken/working all render identically
- * to idle since only position lerps.
- */
-export const STATE_COLOR_MAP: Partial<Record<VehicleOperationalState, number>> = {};
+/** Marker color per VehicleOperationalState. */
+export const STATE_COLOR_MAP: Record<VehicleOperationalState, number> = {
+  idle: 0x999999,     // grey — not working
+  moving: 0x3399ff,   // blue — en route
+  working: 0x33cc33,  // green — actively working
+  waiting: 0xffcc00,  // amber — blocked/waiting
+  broken: 0xff3333,   // red — broken down
+};
+
+const STATE_INDICATOR_RADIUS = 0.25;
 
 /**
  * Adds or updates a small colored marker on a vehicle's group reflecting its
  * operational state, following the same material-color-manipulation pattern
- * as applyTierVariation below. Not yet called from addVehicle/update (#411).
+ * as applyTierVariation below. Idempotent — reuses the existing marker mesh
+ * (tagged group.userData.isStateIndicator) rather than adding a duplicate.
  */
-export function applyStateIndicator(_group: THREE.Group, _state: VehicleOperationalState): void {
-  // TODO: implement — small marker mesh or material tint keyed by STATE_COLOR_MAP[state]
+export function applyStateIndicator(group: THREE.Group, state: VehicleOperationalState): void {
+  const color = STATE_COLOR_MAP[state];
+  let marker = group.children.find(
+    (child): child is THREE.Mesh => child instanceof THREE.Mesh && child.userData['isStateIndicator'] === true,
+  );
+
+  if (!marker) {
+    marker = new THREE.Mesh(
+      new THREE.SphereGeometry(STATE_INDICATOR_RADIUS, 8, 8),
+      new THREE.MeshPhongMaterial({ color }),
+    );
+    marker.userData['isStateIndicator'] = true;
+    marker.position.set(0, 3.2, 0);
+    group.add(marker);
+    return;
+  }
+
+  (marker.material as THREE.MeshPhongMaterial).color.setHex(color);
 }
 
 function applyTierVariation(group: THREE.Group, tier: VehicleTier): void {

--- a/src/renderer/VehicleMesh.ts
+++ b/src/renderer/VehicleMesh.ts
@@ -203,14 +203,34 @@ export class VehicleMesh {
    * would otherwise stomp this offset back to the fused raw position between
    * update()'s per-frame lerps — GameRenderer must fold this same offset into
    * the x/z it passes to snapPosition.
+   *
+   * Round 3 (#411 issue A): an `idle` vehicle already sitting at that exact
+   * target cell (x/z equal to the target, e.g. it arrived and stopped) also
+   * occupies a slot — otherwise a waiting vehicle's offset could still land
+   * on top of it. The idle vehicle itself is never offset (only 'waiting'
+   * vehicles get a non-zero return above), it just reserves slot 0 so the
+   * waiting vehicles route around it.
    */
   waitingQueueOffset(vehicle: Vehicle, pool: Vehicle[]): readonly [number, number] {
     if (vehicle.state !== 'waiting') return [0, 0];
 
-    const sharingTarget = pool
-      .filter(v => v.state === 'waiting' && v.targetX === vehicle.targetX && v.targetZ === vehicle.targetZ)
+    const sharesTarget = (v: Vehicle): boolean =>
+      v.targetX === vehicle.targetX && v.targetZ === vehicle.targetZ;
+
+    // Idle vehicles already occupying the target cell claim slot 0 first (in
+    // ascending id order) so waiting vehicles never compute an offset that
+    // lands on an idle occupant.
+    const occupyingIds = pool
+      .filter(v => v.state === 'idle' && v.x === v.targetX && v.z === v.targetZ && sharesTarget(v))
       .map(v => v.id)
       .sort((a, b) => a - b);
+
+    const waitingIds = pool
+      .filter(v => v.state === 'waiting' && sharesTarget(v))
+      .map(v => v.id)
+      .sort((a, b) => a - b);
+
+    const sharingTarget = [...occupyingIds, ...waitingIds];
 
     if (sharingTarget.length <= 1) return [0, 0];
 

--- a/src/renderer/VehicleWaitingQueue.ts
+++ b/src/renderer/VehicleWaitingQueue.ts
@@ -1,0 +1,82 @@
+// BlastSimulator2026 — Vehicle Waiting-Queue Render Offsets
+// Extracted from VehicleMesh.ts (#411) to keep that file under the 300-line
+// soft limit. Pure, stateless functions — no `this`, no THREE.js objects —
+// so they're easy to unit-test independent of the mesh/scene machinery.
+
+import type { Vehicle } from '../core/entities/Vehicle.js';
+import { WAITING_QUEUE_SLOT_OFFSETS } from '../core/config/balance.js';
+
+/**
+ * Render-only positional offset for a vehicle in the 'waiting' state that
+ * shares its target cell with other waiting vehicles (#411 round 2).
+ * detectTrafficJam (src/core/events/EventEngine.ts) groups waiting vehicles
+ * by exact targetX/targetZ, so the simulation must keep driving every
+ * contending vehicle toward the identical point — this offset never touches
+ * vehicle.x/z or targetX/targetZ, only where the mesh is drawn, so jam
+ * detection is unaffected. Slot assignment is by ascending vehicle id among
+ * vehicles sharing that target, so it stays stable frame to frame.
+ *
+ * Public: GameRenderer's terrain-surface-height correction (syncFromContext)
+ * calls snapPosition with x/z straight from GameState every sync, which
+ * would otherwise stomp this offset back to the fused raw position between
+ * update()'s per-frame lerps — GameRenderer must fold this same offset into
+ * the x/z it passes to snapPosition.
+ *
+ * Round 3 (#411 issue A): an `idle` vehicle already sitting at that exact
+ * target cell (x/z equal to the target, e.g. it arrived and stopped) also
+ * occupies a slot — otherwise a waiting vehicle's offset could still land
+ * on top of it. The idle vehicle itself is never offset (only 'waiting'
+ * vehicles get a non-zero return above), it just reserves slot 0 so the
+ * waiting vehicles route around it.
+ *
+ * Round 4 (#411 issue B): the offset alone is not enough — callers must add
+ * it to the *shared target point* (targetX/targetZ), not to the vehicle's
+ * own raw x/z. Multiple vehicles converging on the same jam land at
+ * slightly different raw positions (pathfinding doesn't put them on the
+ * exact identical point), so a fixed offset added to each vehicle's own
+ * base can still leave two of them under the body-width threshold even
+ * though the offsets themselves are correctly spaced apart. Use
+ * waitingRenderPosition() below, which anchors to the common point.
+ */
+export function waitingQueueOffset(vehicle: Vehicle, pool: Vehicle[]): readonly [number, number] {
+  if (vehicle.state !== 'waiting') return [0, 0];
+
+  const sharesTarget = (v: Vehicle): boolean =>
+    v.targetX === vehicle.targetX && v.targetZ === vehicle.targetZ;
+
+  // Idle vehicles already occupying the target cell claim slot 0 first (in
+  // ascending id order) so waiting vehicles never compute an offset that
+  // lands on an idle occupant.
+  const occupyingIds = pool
+    .filter(v => v.state === 'idle' && v.x === v.targetX && v.z === v.targetZ && sharesTarget(v))
+    .map(v => v.id)
+    .sort((a, b) => a - b);
+
+  const waitingIds = pool
+    .filter(v => v.state === 'waiting' && sharesTarget(v))
+    .map(v => v.id)
+    .sort((a, b) => a - b);
+
+  const sharingTarget = [...occupyingIds, ...waitingIds];
+
+  if (sharingTarget.length <= 1) return [0, 0];
+
+  const slot = sharingTarget.indexOf(vehicle.id) % WAITING_QUEUE_SLOT_OFFSETS.length;
+  return WAITING_QUEUE_SLOT_OFFSETS[slot]!;
+}
+
+/**
+ * Render position for a vehicle, folding in the waiting-queue slot offset
+ * (#411 round 4). For a 'waiting' vehicle the offset is anchored to the
+ * shared targetX/targetZ — the common point every contending vehicle is
+ * driving toward — rather than to the vehicle's own raw x/z, which can
+ * differ slightly between vehicles even when they share a target and would
+ * otherwise undermine the slot spacing. Non-waiting vehicles (including the
+ * idle occupant reserving slot 0) get a zero offset and render at their own
+ * x/z, unchanged.
+ */
+export function waitingRenderPosition(vehicle: Vehicle, pool: Vehicle[]): readonly [number, number] {
+  if (vehicle.state !== 'waiting') return [vehicle.x, vehicle.z];
+  const [offsetX, offsetZ] = waitingQueueOffset(vehicle, pool);
+  return [vehicle.targetX + offsetX, vehicle.targetZ + offsetZ];
+}

--- a/src/ui/VehiclePanel.ts
+++ b/src/ui/VehiclePanel.ts
@@ -4,7 +4,7 @@
 import { t } from '../core/i18n/I18n.js';
 import type { GameState } from '../core/state/GameState.js';
 import type { Vehicle, VehicleRole, VehicleTier } from '../core/entities/Vehicle.js';
-import { getAllVehicleRoles, getVehicleDef, getVehicleDefByTier, ROLE_LICENCE_REQUIRED } from '../core/entities/Vehicle.js';
+import { getAllVehicleRoles, getVehicleDefByTier, ROLE_LICENCE_REQUIRED } from '../core/entities/Vehicle.js';
 
 const VEHICLE_TIERS: VehicleTier[] = [1, 2, 3];
 
@@ -66,7 +66,6 @@ export class VehiclePanel {
       state.employees.employees.filter(e => e.alive).map(e => `${e.id}:${e.qualifications.length}`).join('|'),
     ].join('#');
     if (signature === this.lastSignature) {
-      this.refreshBuyButtons(state.cash);
       this.refreshTierButtons(state.cash);
       return;
     }
@@ -85,20 +84,10 @@ export class VehiclePanel {
       }
     }
 
-    this.refreshBuyButtons(state.cash);
     this.refreshTierButtons(state.cash);
   }
 
   dispose(): void { this.el.remove(); }
-
-  private refreshBuyButtons(cash: number): void {
-    const buyBtns = this.buySection.querySelectorAll<HTMLButtonElement>('[data-vtype]:not([data-tier])');
-    buyBtns.forEach(btn => {
-      const type = btn.dataset['vtype']!;
-      const def = getVehicleDef(type as any);
-      btn.disabled = cash < def.purchaseCost;
-    });
-  }
 
   private makeVehicleRow(v: Vehicle, state: GameState): HTMLElement {
     const row = document.createElement('div');
@@ -238,7 +227,7 @@ export class VehiclePanel {
 
       const label = document.createElement('div');
       label.style.cssText = 'font-size:11px;color:#d0b090';
-      label.textContent = type;
+      label.textContent = this.vehicleDisplayName(type, 1);
 
       row.append(label, this.buildTierButtons(type));
       this.buySection.appendChild(row);

--- a/src/ui/VehiclePanel.ts
+++ b/src/ui/VehiclePanel.ts
@@ -207,8 +207,7 @@ export class VehiclePanel {
   }
 
   /**
-   * Refreshes tier-button disabled state against current cash — the
-   * per-tier counterpart to refreshBuyButtons.
+   * Refreshes tier-button disabled state against current cash.
    */
   private refreshTierButtons(cash: number): void {
     const tierBtns = this.buySection.querySelectorAll<HTMLButtonElement>('[data-tier]');

--- a/src/ui/VehiclePanel.ts
+++ b/src/ui/VehiclePanel.ts
@@ -3,8 +3,10 @@
 
 import { t } from '../core/i18n/I18n.js';
 import type { GameState } from '../core/state/GameState.js';
-import type { Vehicle, VehicleRole } from '../core/entities/Vehicle.js';
+import type { Vehicle, VehicleRole, VehicleTier } from '../core/entities/Vehicle.js';
 import { getAllVehicleRoles, getVehicleDef, getVehicleDefByTier, ROLE_LICENCE_REQUIRED } from '../core/entities/Vehicle.js';
+
+const VEHICLE_TIERS: VehicleTier[] = [1, 2, 3];
 
 import type { CommandResult } from '../console/ConsoleRunner.js';
 
@@ -46,12 +48,6 @@ export class VehiclePanel {
 
     this.el.append(title, this.listEl, buyHeader, this.buySection, closeBtn);
     container.appendChild(this.el);
-
-    // Stubs not yet wired into render paths (#411) — referenced here only to
-    // satisfy noUnusedLocals until the implementer calls them for real.
-    void this.vehicleDisplayName;
-    void this.buildTierButtons;
-    void this.refreshTierButtons;
   }
 
   setGameConsole(fn: GameConsoleFn): void { this.gameConsole = fn; }
@@ -71,6 +67,7 @@ export class VehiclePanel {
     ].join('#');
     if (signature === this.lastSignature) {
       this.refreshBuyButtons(state.cash);
+      this.refreshTierButtons(state.cash);
       return;
     }
     this.lastSignature = signature;
@@ -89,12 +86,13 @@ export class VehiclePanel {
     }
 
     this.refreshBuyButtons(state.cash);
+    this.refreshTierButtons(state.cash);
   }
 
   dispose(): void { this.el.remove(); }
 
   private refreshBuyButtons(cash: number): void {
-    const buyBtns = this.buySection.querySelectorAll<HTMLButtonElement>('[data-vtype]');
+    const buyBtns = this.buySection.querySelectorAll<HTMLButtonElement>('[data-vtype]:not([data-tier])');
     buyBtns.forEach(btn => {
       const type = btn.dataset['vtype']!;
       const def = getVehicleDef(type as any);
@@ -108,7 +106,7 @@ export class VehiclePanel {
 
     const info = document.createElement('div');
     info.style.cssText = 'flex:1;font-size:11px';
-    info.textContent = `#${v.id} ${v.type}`;
+    info.textContent = `#${v.id} ${this.vehicleDisplayName(v.type, v.tier)}`;
 
     const status = document.createElement('div');
     status.style.cssText = 'font-size:10px;color:#a08060';
@@ -189,53 +187,60 @@ export class VehiclePanel {
   }
 
   /**
-   * Localized display name for a vehicle's current tier def — t(def.nameKey)
-   * instead of the raw role id makeVehicleRow shows today. Not yet wired
-   * into makeVehicleRow (#411).
+   * Localized display name for a role+tier def — t(def.nameKey) instead of
+   * the raw role id. Shared by the buy section and the owned-vehicle rows.
    */
-  private vehicleDisplayName(_v: Vehicle): string {
-    void getVehicleDefByTier;
-    // TODO: implement — t(getVehicleDefByTier(v.type, v.tier).nameKey)
-    return '';
+  private vehicleDisplayName(type: VehicleRole, tier: VehicleTier): string {
+    return t(getVehicleDefByTier(type, tier).nameKey);
   }
 
   /**
    * Tier 1/2/3 buy buttons for one role, each dispatching
-   * `vehicle buy <type> tier:<n>` and labelled with t(def.nameKey). Not yet
-   * wired into buildBuySection (#411) — buildBuySection still renders one
-   * raw-id buy button per role with no tier selector.
+   * `vehicle buy <type> tier:<n>` and labelled with t(def.nameKey) + cost.
    */
-  private buildTierButtons(_type: VehicleRole): HTMLElement {
-    // TODO: implement — one button per tier 1|2|3, label t(def.nameKey)
-    return document.createElement('div');
+  private buildTierButtons(type: VehicleRole): HTMLElement {
+    const wrap = document.createElement('div');
+    wrap.style.cssText = 'display:flex;gap:4px';
+
+    for (const tier of VEHICLE_TIERS) {
+      const def = getVehicleDefByTier(type, tier);
+      const btn = document.createElement('button');
+      btn.className = 'bs-btn bs-btn-primary';
+      btn.style.cssText = 'padding:2px 8px;font-size:10px';
+      btn.textContent = `${this.vehicleDisplayName(type, tier)} ($${def.purchaseCost})`;
+      btn.dataset['vtype'] = type;
+      btn.dataset['tier'] = String(tier);
+      btn.addEventListener('click', () => this.gameConsole?.(`vehicle buy ${type} tier:${tier}`));
+      wrap.appendChild(btn);
+    }
+
+    return wrap;
   }
 
   /**
    * Refreshes tier-button disabled state against current cash — the
-   * per-tier counterpart to refreshBuyButtons. Not yet called (#411).
+   * per-tier counterpart to refreshBuyButtons.
    */
-  private refreshTierButtons(_cash: number): void {
-    // TODO: implement — disable each tier button when cash < that tier's cost
+  private refreshTierButtons(cash: number): void {
+    const tierBtns = this.buySection.querySelectorAll<HTMLButtonElement>('[data-tier]');
+    tierBtns.forEach(btn => {
+      const type = btn.dataset['vtype'] as VehicleRole;
+      const tier = Number(btn.dataset['tier']) as VehicleTier;
+      const def = getVehicleDefByTier(type, tier);
+      btn.disabled = cash < def.purchaseCost;
+    });
   }
 
   private buildBuySection(): void {
     for (const type of getAllVehicleRoles()) {
-      const def = getVehicleDef(type);
       const row = document.createElement('div');
       row.style.cssText = 'display:flex;align-items:center;gap:6px;margin-bottom:4px';
 
       const label = document.createElement('div');
       label.style.cssText = 'flex:1;font-size:11px;color:#d0b090';
-      label.textContent = `${type} ($${def.purchaseCost})`;
+      label.textContent = type;
 
-      const btn = document.createElement('button');
-      btn.className = 'bs-btn bs-btn-primary';
-      btn.style.cssText = 'padding:2px 8px;font-size:10px';
-      btn.textContent = t('ui.vehicles.buy');
-      btn.dataset['vtype'] = type;
-      btn.addEventListener('click', () => this.gameConsole?.(`vehicle buy ${type}`));
-
-      row.append(label, btn);
+      row.append(label, this.buildTierButtons(type));
       this.buySection.appendChild(row);
     }
   }

--- a/src/ui/VehiclePanel.ts
+++ b/src/ui/VehiclePanel.ts
@@ -3,8 +3,8 @@
 
 import { t } from '../core/i18n/I18n.js';
 import type { GameState } from '../core/state/GameState.js';
-import type { Vehicle } from '../core/entities/Vehicle.js';
-import { getAllVehicleRoles, getVehicleDef, ROLE_LICENCE_REQUIRED } from '../core/entities/Vehicle.js';
+import type { Vehicle, VehicleRole } from '../core/entities/Vehicle.js';
+import { getAllVehicleRoles, getVehicleDef, getVehicleDefByTier, ROLE_LICENCE_REQUIRED } from '../core/entities/Vehicle.js';
 
 import type { CommandResult } from '../console/ConsoleRunner.js';
 
@@ -46,6 +46,12 @@ export class VehiclePanel {
 
     this.el.append(title, this.listEl, buyHeader, this.buySection, closeBtn);
     container.appendChild(this.el);
+
+    // Stubs not yet wired into render paths (#411) — referenced here only to
+    // satisfy noUnusedLocals until the implementer calls them for real.
+    void this.vehicleDisplayName;
+    void this.buildTierButtons;
+    void this.refreshTierButtons;
   }
 
   setGameConsole(fn: GameConsoleFn): void { this.gameConsole = fn; }
@@ -180,6 +186,36 @@ export class VehiclePanel {
 
     wrap.append(label, select, assignBtn);
     return wrap;
+  }
+
+  /**
+   * Localized display name for a vehicle's current tier def — t(def.nameKey)
+   * instead of the raw role id makeVehicleRow shows today. Not yet wired
+   * into makeVehicleRow (#411).
+   */
+  private vehicleDisplayName(_v: Vehicle): string {
+    void getVehicleDefByTier;
+    // TODO: implement — t(getVehicleDefByTier(v.type, v.tier).nameKey)
+    return '';
+  }
+
+  /**
+   * Tier 1/2/3 buy buttons for one role, each dispatching
+   * `vehicle buy <type> tier:<n>` and labelled with t(def.nameKey). Not yet
+   * wired into buildBuySection (#411) — buildBuySection still renders one
+   * raw-id buy button per role with no tier selector.
+   */
+  private buildTierButtons(_type: VehicleRole): HTMLElement {
+    // TODO: implement — one button per tier 1|2|3, label t(def.nameKey)
+    return document.createElement('div');
+  }
+
+  /**
+   * Refreshes tier-button disabled state against current cash — the
+   * per-tier counterpart to refreshBuyButtons. Not yet called (#411).
+   */
+  private refreshTierButtons(_cash: number): void {
+    // TODO: implement — disable each tier button when cash < that tier's cost
   }
 
   private buildBuySection(): void {

--- a/src/ui/VehiclePanel.ts
+++ b/src/ui/VehiclePanel.ts
@@ -200,13 +200,13 @@ export class VehiclePanel {
    */
   private buildTierButtons(type: VehicleRole): HTMLElement {
     const wrap = document.createElement('div');
-    wrap.style.cssText = 'display:flex;gap:4px';
+    wrap.style.cssText = 'display:flex;flex-wrap:wrap;gap:4px;width:100%';
 
     for (const tier of VEHICLE_TIERS) {
       const def = getVehicleDefByTier(type, tier);
       const btn = document.createElement('button');
       btn.className = 'bs-btn bs-btn-primary';
-      btn.style.cssText = 'padding:2px 8px;font-size:10px';
+      btn.style.cssText = 'padding:2px 6px;font-size:9px;flex:1 1 auto;min-width:0;white-space:normal;line-height:1.3';
       btn.textContent = `${this.vehicleDisplayName(type, tier)} ($${def.purchaseCost})`;
       btn.dataset['vtype'] = type;
       btn.dataset['tier'] = String(tier);
@@ -234,10 +234,10 @@ export class VehiclePanel {
   private buildBuySection(): void {
     for (const type of getAllVehicleRoles()) {
       const row = document.createElement('div');
-      row.style.cssText = 'display:flex;align-items:center;gap:6px;margin-bottom:4px';
+      row.style.cssText = 'display:flex;flex-direction:column;gap:3px;margin-bottom:6px';
 
       const label = document.createElement('div');
-      label.style.cssText = 'flex:1;font-size:11px;color:#d0b090';
+      label.style.cssText = 'font-size:11px;color:#d0b090';
       label.textContent = type;
 
       row.append(label, this.buildTierButtons(type));

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -181,7 +181,7 @@ const CSS = `
 #bs-blast-panel     { top: 52px; left: 10px; width: 240px; max-height: calc(100vh - 62px); overflow-y: auto; }
 #bs-contract-panel  { top: 52px; left: 10px; width: 300px; max-height: calc(100vh - 62px); overflow-y: auto; }
 #bs-build-panel     { top: 52px; left: 10px; width: 270px; max-height: calc(100vh - 62px); overflow-y: auto; }
-#bs-vehicle-panel   { top: 52px; left: 10px; width: 290px; max-height: calc(100vh - 62px); overflow-y: auto; }
+#bs-vehicle-panel   { top: 52px; left: 10px; width: 340px; max-height: calc(100vh - 62px); overflow-y: auto; }
 #bs-employee-panel  { top: 52px; left: 10px; width: 290px; max-height: calc(100vh - 62px); overflow-y: auto; }
 #bs-survey-panel    { top: 52px; left: 10px; width: 240px; max-height: calc(100vh - 62px); overflow-y: auto; }
 #bs-settings-panel  {

--- a/tests/integration/vehicles.integration.test.ts
+++ b/tests/integration/vehicles.integration.test.ts
@@ -23,6 +23,7 @@ import {
 } from '../../src/core/entities/Employee.js';
 import { tickVehicle } from '../../src/core/engine/GameLoop.js';
 import { Random } from '../../src/core/math/Random.js';
+import { TRAFFIC_JAM_MIN_VEHICLES, TRAFFIC_JAM_MIN_TICKS } from '../../src/core/config/balance.js';
 
 // ── Shared helpers ──────────────────────────────────────────────────────────
 
@@ -469,6 +470,55 @@ describe('Vehicle fleet', () => {
         const v = ctx.state!.vehicles.vehicles.find(veh => veh.id === id)!;
         expect(v.state, `task=${task} should drive state to working`).toBe('working');
       }
+    });
+  });
+
+  // ── traffic jam event, driven through the real console tick path (#411) ──
+  // detectTrafficJam is unit-tested by direct call elsewhere; this drives it
+  // through tickCommand (src/console/commands/events.ts step 8f-2) instead —
+  // the real path a console/scenario "tick" step exercises.
+
+  describe('traffic jam event fires via tickCommand (#411)', () => {
+    it('sets pendingEvent to traffic_jam once enough vehicles have waited long enough on a shared target', () => {
+      // Anchor vehicle occupies the contended target cell. It never ticks
+      // (task stays 'idle'), so it just blocks the cell for occupancy checks.
+      vehicleCommand(ctx, ['buy', 'debris_hauler'], {});
+      const anchor = ctx.state!.vehicles.vehicles[0]!;
+      anchor.x = 20;
+      anchor.z = 20;
+      anchor.targetX = 20;
+      anchor.targetZ = 20;
+      anchor.task = 'idle';
+      anchor.state = 'idle';
+
+      // TRAFFIC_JAM_MIN_VEHICLES vehicles, each one grid step from the
+      // anchor's cell (their shared target), already at
+      // TRAFFIC_JAM_MIN_TICKS - 1 waiting ticks — one real tickCommand tick
+      // finds their path blocked by the anchor and pushes waitingTicks over
+      // the threshold, which detectTrafficJam should pick up.
+      const neighborOffsets: Array<[number, number]> = [
+        [-1, 0], [1, 0], [0, -1], [0, 1], [-1, -1], [1, 1], [-1, 1], [1, -1],
+      ];
+      expect(TRAFFIC_JAM_MIN_VEHICLES).toBeLessThanOrEqual(neighborOffsets.length);
+
+      for (let i = 0; i < TRAFFIC_JAM_MIN_VEHICLES; i++) {
+        vehicleCommand(ctx, ['buy', 'debris_hauler'], {});
+        const v = ctx.state!.vehicles.vehicles[ctx.state!.vehicles.vehicles.length - 1]!;
+        const [dx, dz] = neighborOffsets[i]!;
+        v.x = 20 + dx;
+        v.z = 20 + dz;
+        v.targetX = 20;
+        v.targetZ = 20;
+        v.task = 'moving';
+        v.state = 'waiting';
+        v.waitingTicks = TRAFFIC_JAM_MIN_TICKS - 1;
+      }
+
+      const result = tickCommand(ctx, ['1'], {});
+
+      expect(result.success).toBe(true);
+      expect(ctx.state!.events.pendingEvent).not.toBeNull();
+      expect(ctx.state!.events.pendingEvent?.eventId).toBe('traffic_jam');
     });
   });
 });

--- a/tests/integration/vehicles.integration.test.ts
+++ b/tests/integration/vehicles.integration.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { type GameContext, newGameCommand } from '../../src/console/commands/world.js';
 import { vehicleCommand } from '../../src/console/commands/vehicle.js';
 import { employeeCommand } from '../../src/console/commands/entities.js';
+import { tickCommand } from '../../src/console/commands/events.js';
 import { EventEmitter } from '../../src/core/state/EventEmitter.js';
 import {
   createVehicleState,
@@ -12,6 +13,7 @@ import {
   assignDriver,
   destroyVehicle,
   getVehicleDef,
+  getVehicleDefByTier,
   getAllVehicleRoles,
 } from '../../src/core/entities/Vehicle.js';
 import {
@@ -354,5 +356,119 @@ describe('Vehicle fleet', () => {
 
     expect(result.success).toBe(false);
     expect(result.output).toContain('already has a driver');
+  });
+
+  // ── vehicle buy — tier arg (#411) ──
+
+  describe('vehicle buy — tier arg (#411)', () => {
+    it('buy with tier:2 purchases a tier-2 vehicle', () => {
+      const result = vehicleCommand(ctx, ['buy', 'debris_hauler'], { tier: '2' });
+
+      expect(result.success).toBe(true);
+      const v = ctx.state!.vehicles.vehicles[0]!;
+      expect(v.tier).toBe(2);
+    });
+
+    it('buy with tier:2 deducts the tier-2 cost (not tier-1) from cash', () => {
+      const cashBefore = ctx.state!.cash;
+      const tier2Def = getVehicleDefByTier('debris_hauler', 2);
+
+      vehicleCommand(ctx, ['buy', 'debris_hauler'], { tier: '2' });
+
+      expect(ctx.state!.cash).toBe(cashBefore - tier2Def.purchaseCost);
+    });
+
+    it('buy with tier:3 purchases a tier-3 vehicle at tier-3 cost', () => {
+      const cashBefore = ctx.state!.cash;
+      const tier3Def = getVehicleDefByTier('drill_rig', 3);
+
+      const result = vehicleCommand(ctx, ['buy', 'drill_rig'], { tier: '3' });
+
+      expect(result.success).toBe(true);
+      const v = ctx.state!.vehicles.vehicles[0]!;
+      expect(v.tier).toBe(3);
+      expect(ctx.state!.cash).toBe(cashBefore - tier3Def.purchaseCost);
+    });
+
+    it('buy without a tier arg still defaults to tier 1 (backward compatible)', () => {
+      vehicleCommand(ctx, ['buy', 'debris_hauler'], {});
+
+      const v = ctx.state!.vehicles.vehicles[0]!;
+      expect(v.tier).toBe(1);
+    });
+
+    it('rejects tier:0 as out of range and does not add a vehicle', () => {
+      const result = vehicleCommand(ctx, ['buy', 'debris_hauler'], { tier: '0' });
+
+      expect(result.success).toBe(false);
+      expect(ctx.state!.vehicles.vehicles).toHaveLength(0);
+    });
+
+    it('rejects tier:9 as out of range and does not add a vehicle', () => {
+      const result = vehicleCommand(ctx, ['buy', 'debris_hauler'], { tier: '9' });
+
+      expect(result.success).toBe(false);
+      expect(ctx.state!.vehicles.vehicles).toHaveLength(0);
+    });
+
+    it('rejects non-numeric tier:abc and does not add a vehicle', () => {
+      const result = vehicleCommand(ctx, ['buy', 'debris_hauler'], { tier: 'abc' });
+
+      expect(result.success).toBe(false);
+      expect(ctx.state!.vehicles.vehicles).toHaveLength(0);
+    });
+
+    it('does not deduct cash when the tier is rejected', () => {
+      const cashBefore = ctx.state!.cash;
+
+      vehicleCommand(ctx, ['buy', 'debris_hauler'], { tier: '9' });
+
+      expect(ctx.state!.cash).toBe(cashBefore);
+    });
+  });
+
+  // ── vehicle work-task → working operational state, via the real tick loop (#411) ──
+
+  describe('vehicle work-task → working operational state (#411)', () => {
+    it('vehicle.state becomes working after a tick once task is set to a work task', () => {
+      vehicleCommand(ctx, ['buy', 'debris_hauler'], {});
+      const v = ctx.state!.vehicles.vehicles[0]!;
+      expect(v.state).toBe('idle');
+
+      vehicleCommand(ctx, ['assign', '1'], { task: 'transport' });
+      expect(v.state).toBe('idle'); // assign alone does not flip state — only the tick loop does
+
+      tickCommand(ctx, ['1'], {});
+
+      expect(v.state).toBe('working');
+    });
+
+    it('vehicle.state returns to idle after a tick once task returns to idle', () => {
+      vehicleCommand(ctx, ['buy', 'rock_digger'], {});
+      const v = ctx.state!.vehicles.vehicles[0]!;
+
+      vehicleCommand(ctx, ['assign', '1'], { task: 'loading' });
+      tickCommand(ctx, ['1'], {});
+      expect(v.state).toBe('working');
+
+      vehicleCommand(ctx, ['assign', '1'], { task: 'idle' });
+      tickCommand(ctx, ['1'], {});
+
+      expect(v.state).toBe('idle');
+    });
+
+    it('each work task (transport, loading, drilling, clearing) drives state to working via the tick loop', () => {
+      const workTasks = ['transport', 'loading', 'drilling', 'clearing'];
+      for (const task of workTasks) {
+        vehicleCommand(ctx, ['buy', 'debris_hauler'], {});
+        const id = ctx.state!.vehicles.vehicles[ctx.state!.vehicles.vehicles.length - 1]!.id;
+        vehicleCommand(ctx, ['assign', String(id)], { task });
+
+        tickCommand(ctx, ['1'], {});
+
+        const v = ctx.state!.vehicles.vehicles.find(veh => veh.id === id)!;
+        expect(v.state, `task=${task} should drive state to working`).toBe('working');
+      }
+    });
   });
 });

--- a/tests/unit/console/vehicle-tier-arg.test.ts
+++ b/tests/unit/console/vehicle-tier-arg.test.ts
@@ -1,0 +1,49 @@
+// BlastSimulator2026 — unit tests for parseVehicleTierArg (issue #411)
+// Parses/validates the `tier:` named arg for `vehicle buy <role> tier:<1|2|3>`.
+// Backward compatible: omitted tier defaults to 1 so existing callers of
+// `vehicle buy <role>` (no tier arg) keep working unchanged.
+
+import { describe, it, expect } from 'vitest';
+import { parseVehicleTierArg } from '../../../src/console/commands/vehicle.js';
+
+describe('parseVehicleTierArg (#411)', () => {
+  it('parses tier:1 to 1', () => {
+    expect(parseVehicleTierArg({ tier: '1' })).toBe(1);
+  });
+
+  it('parses tier:2 to 2', () => {
+    expect(parseVehicleTierArg({ tier: '2' })).toBe(2);
+  });
+
+  it('parses tier:3 to 3', () => {
+    expect(parseVehicleTierArg({ tier: '3' })).toBe(3);
+  });
+
+  it('defaults to tier 1 when the tier arg is omitted', () => {
+    expect(parseVehicleTierArg({})).toBe(1);
+  });
+
+  it('defaults to tier 1 when other unrelated named args are present but tier is omitted', () => {
+    expect(parseVehicleTierArg({ role: 'debris_hauler', at: '1,2' })).toBe(1);
+  });
+
+  it('rejects tier:0 as out of range', () => {
+    expect(parseVehicleTierArg({ tier: '0' })).toBeNull();
+  });
+
+  it('rejects tier:9 as out of range', () => {
+    expect(parseVehicleTierArg({ tier: '9' })).toBeNull();
+  });
+
+  it('rejects tier:-1 as out of range', () => {
+    expect(parseVehicleTierArg({ tier: '-1' })).toBeNull();
+  });
+
+  it('rejects non-numeric tier:abc', () => {
+    expect(parseVehicleTierArg({ tier: 'abc' })).toBeNull();
+  });
+
+  it('rejects an empty tier string', () => {
+    expect(parseVehicleTierArg({ tier: '' })).toBeNull();
+  });
+});

--- a/tests/unit/engine/EntityMovementTick.test.ts
+++ b/tests/unit/engine/EntityMovementTick.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect } from 'vitest';
 import { createGame } from '../../../src/core/state/GameState.js';
 import { Random } from '../../../src/core/math/Random.js';
-import { tickVehicle, tickEmployeeMovement } from '../../../src/core/engine/EntityMovementTick.js';
+import { tickVehicle, tickEmployeeMovement, tickVehicleTaskState } from '../../../src/core/engine/EntityMovementTick.js';
 import { hireEmployee } from '../../../src/core/entities/Employee.js';
 import { EventEmitter } from '../../../src/core/state/EventEmitter.js';
 import { purchaseVehicle } from '../../../src/core/entities/Vehicle.js';
@@ -229,6 +229,74 @@ describe('tickVehicle — waitingTicks (Task 2.8)', () => {
     // Vehicle reached target → idle; waitingTicks must be 0
     expect(v.state).toBe('idle');
     expect(v.waitingTicks).toBe(0);
+  });
+});
+
+// ── tickVehicleTaskState (issue #411) ────────────────────────────────────────
+// VehicleOperationalState.working was never assigned anywhere prior to this —
+// vehicle-task-states-visual's working-state screenshot was unreachable.
+// tickVehicleTaskState is the pure per-vehicle transform; tick-loop wiring is
+// covered separately in tests/integration/vehicles.integration.test.ts.
+
+describe('tickVehicleTaskState (#411)', () => {
+  const WORK_TASKS = ['transport', 'loading', 'drilling', 'clearing'] as const;
+
+  it.each(WORK_TASKS)('sets state to working when task is %s', (task) => {
+    const state = createGame({ seed: VEHICLE_TICK_SEED });
+    const { vehicle } = purchaseVehicle(state.vehicles, 'debris_hauler', 0, 0);
+    vehicle.task = task;
+    vehicle.state = 'idle';
+
+    tickVehicleTaskState(vehicle);
+
+    expect(vehicle.state).toBe('working');
+  });
+
+  it('returns state to idle when task returns to idle', () => {
+    const state = createGame({ seed: VEHICLE_TICK_SEED });
+    const { vehicle } = purchaseVehicle(state.vehicles, 'rock_digger', 0, 0);
+    vehicle.task = 'loading';
+    vehicle.state = 'working';
+
+    vehicle.task = 'idle';
+    tickVehicleTaskState(vehicle);
+
+    expect(vehicle.state).toBe('idle');
+  });
+
+  it('is idempotent — calling repeatedly with the same work task keeps state working', () => {
+    const state = createGame({ seed: VEHICLE_TICK_SEED });
+    const { vehicle } = purchaseVehicle(state.vehicles, 'drill_rig', 0, 0);
+    vehicle.task = 'drilling';
+    vehicle.state = 'idle';
+
+    tickVehicleTaskState(vehicle);
+    tickVehicleTaskState(vehicle);
+    tickVehicleTaskState(vehicle);
+
+    expect(vehicle.state).toBe('working');
+  });
+
+  it('does not touch state when task is moving — tickVehicle owns moving/waiting transitions', () => {
+    const state = createGame({ seed: VEHICLE_TICK_SEED });
+    const { vehicle } = purchaseVehicle(state.vehicles, 'building_destroyer', 0, 0);
+    vehicle.task = 'moving';
+    vehicle.state = 'moving';
+
+    tickVehicleTaskState(vehicle);
+
+    expect(vehicle.state).toBe('moving');
+  });
+
+  it('does not touch a waiting state when task is moving', () => {
+    const state = createGame({ seed: VEHICLE_TICK_SEED });
+    const { vehicle } = purchaseVehicle(state.vehicles, 'rock_fragmenter', 0, 0);
+    vehicle.task = 'moving';
+    vehicle.state = 'waiting';
+
+    tickVehicleTaskState(vehicle);
+
+    expect(vehicle.state).toBe('waiting');
   });
 });
 

--- a/tests/unit/renderer/VehicleMesh.test.ts
+++ b/tests/unit/renderer/VehicleMesh.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect } from 'vitest';
 import * as THREE from 'three';
 import type { Vehicle, VehicleTier, VehicleOperationalState } from '../../../src/core/entities/Vehicle.js';
 import { VehicleMesh, STATE_COLOR_MAP, applyStateIndicator } from '../../../src/renderer/VehicleMesh.js';
+import { WAITING_QUEUE_SLOT_OFFSETS } from '../../../src/core/config/balance.js';
 
 function makeVehicle(id: number, type: Vehicle['type'], x = 0, z = 0, tier = 1 as VehicleTier): Vehicle {
   return { id, type, x, z, hp: 100, task: 'idle', targetX: x, targetZ: z, tier } as Vehicle;
@@ -232,5 +233,128 @@ describe('applyStateIndicator (#411)', () => {
     applyStateIndicator(group, 'working');
 
     expect(group.children).toContain(body);
+  });
+});
+
+// ── Issue #411: waitingQueueOffset / waitingRenderPosition ─────────────────
+// Rewritten across 3 bug-fix rounds (idle-occupant slot collision, offset
+// anchored to the shared target rather than each vehicle's own raw x/z).
+// These tests lock in the fixed behavior of both rounds.
+
+describe('waitingQueueOffset / waitingRenderPosition (#411)', () => {
+  it('an idle vehicle occupying the exact target cell reserves slot 0 and renders at its own unoffset position', () => {
+    const scene = new THREE.Scene();
+    const vm = new VehicleMesh(scene);
+
+    const idleAtTarget = makeVehicle(1, 'debris_hauler', 10, 10, 1);
+    idleAtTarget.state = 'idle';
+    idleAtTarget.targetX = 10;
+    idleAtTarget.targetZ = 10;
+
+    const waiting = makeVehicle(2, 'debris_hauler', 5, 5, 1);
+    waiting.state = 'waiting';
+    waiting.targetX = 10;
+    waiting.targetZ = 10;
+
+    const pool = [idleAtTarget, waiting];
+
+    // Idle occupant is never offset regardless of slot bookkeeping.
+    expect(vm.waitingQueueOffset(idleAtTarget, pool)).toEqual([0, 0]);
+    expect(vm.waitingRenderPosition(idleAtTarget, pool)).toEqual([10, 10]);
+
+    // Idle occupant claims slot 0 first (ascending id), so the waiting
+    // vehicle must NOT also get the [0, 0] offset — it would render on top.
+    expect(vm.waitingQueueOffset(waiting, pool)).toEqual(WAITING_QUEUE_SLOT_OFFSETS[1]);
+
+    vm.dispose();
+  });
+
+  it('waiting vehicles anchor to the shared target, not their own raw x/z (round 4 regression)', () => {
+    const scene = new THREE.Scene();
+    const vm = new VehicleMesh(scene);
+
+    // Two vehicles converging on the same target from very different raw
+    // positions — the bug this guards against added the offset to each
+    // vehicle's own x/z, scattering them instead of anchoring to the target.
+    const v1 = makeVehicle(1, 'debris_hauler', 1, 1, 1);
+    v1.state = 'waiting';
+    v1.targetX = 20;
+    v1.targetZ = 20;
+
+    const v2 = makeVehicle(2, 'debris_hauler', 40, 45, 1);
+    v2.state = 'waiting';
+    v2.targetX = 20;
+    v2.targetZ = 20;
+
+    const pool = [v1, v2];
+
+    const [o1x, o1z] = WAITING_QUEUE_SLOT_OFFSETS[0]!;
+    const [o2x, o2z] = WAITING_QUEUE_SLOT_OFFSETS[1]!;
+
+    expect(vm.waitingRenderPosition(v1, pool)).toEqual([20 + o1x, 20 + o1z]);
+    expect(vm.waitingRenderPosition(v2, pool)).toEqual([20 + o2x, 20 + o2z]);
+
+    vm.dispose();
+  });
+
+  it('4 waiting vehicles sharing a target get distinct slots at least one slot-spacing apart', () => {
+    const scene = new THREE.Scene();
+    const vm = new VehicleMesh(scene);
+
+    const vehicles = [1, 2, 3, 4].map(id => {
+      const v = makeVehicle(id, 'debris_hauler', id, id, 1);
+      v.state = 'waiting';
+      v.targetX = 50;
+      v.targetZ = 50;
+      return v;
+    });
+
+    const positions = vehicles.map(v => vm.waitingRenderPosition(v, vehicles));
+
+    // sharingTarget is ascending-id order with no idle occupant, so vehicle
+    // at array index i gets WAITING_QUEUE_SLOT_OFFSETS[i] — derive the
+    // expected minimum spacing from the real constant, not a hardcoded value.
+    const usedOffsets = [0, 1, 2, 3].map(i => WAITING_QUEUE_SLOT_OFFSETS[i]!);
+    const pairwiseOffsetDistances = usedOffsets.flatMap((a, i) =>
+      usedOffsets.slice(i + 1).map(b => Math.hypot(a[0] - b[0], a[1] - b[1])),
+    );
+    const minExpectedDistance = Math.min(...pairwiseOffsetDistances);
+    expect(minExpectedDistance).toBeGreaterThan(0);
+
+    for (let i = 0; i < positions.length; i++) {
+      for (let j = i + 1; j < positions.length; j++) {
+        const [ax, az] = positions[i]!;
+        const [bx, bz] = positions[j]!;
+        const dist = Math.hypot(ax - bx, az - bz);
+        expect(dist).toBeGreaterThanOrEqual(minExpectedDistance);
+      }
+    }
+
+    vm.dispose();
+  });
+
+  it('slot index wraps around via modulo when contenders exceed WAITING_QUEUE_SLOT_OFFSETS.length', () => {
+    const scene = new THREE.Scene();
+    const vm = new VehicleMesh(scene);
+
+    // One more contender than there are slots — current implementation is
+    // `sharingTarget.indexOf(id) % WAITING_QUEUE_SLOT_OFFSETS.length`, so the
+    // (length + 1)th vehicle (index === length) wraps back to slot 0.
+    const count = WAITING_QUEUE_SLOT_OFFSETS.length + 1;
+    const vehicles = Array.from({ length: count }, (_, i) => {
+      const v = makeVehicle(i + 1, 'debris_hauler', i, i, 1);
+      v.state = 'waiting';
+      v.targetX = 5;
+      v.targetZ = 5;
+      return v;
+    });
+
+    const firstOffset = vm.waitingQueueOffset(vehicles[0]!, vehicles);
+    const wrappedOffset = vm.waitingQueueOffset(vehicles[vehicles.length - 1]!, vehicles);
+
+    expect(wrappedOffset).toEqual(firstOffset);
+    expect(wrappedOffset).toEqual(WAITING_QUEUE_SLOT_OFFSETS[0]);
+
+    vm.dispose();
   });
 });

--- a/tests/unit/renderer/VehicleMesh.test.ts
+++ b/tests/unit/renderer/VehicleMesh.test.ts
@@ -2,8 +2,8 @@
 
 import { describe, it, expect } from 'vitest';
 import * as THREE from 'three';
-import type { Vehicle, VehicleTier } from '../../../src/core/entities/Vehicle.js';
-import { VehicleMesh } from '../../../src/renderer/VehicleMesh.js';
+import type { Vehicle, VehicleTier, VehicleOperationalState } from '../../../src/core/entities/Vehicle.js';
+import { VehicleMesh, STATE_COLOR_MAP, applyStateIndicator } from '../../../src/renderer/VehicleMesh.js';
 
 function makeVehicle(id: number, type: Vehicle['type'], x = 0, z = 0, tier = 1 as VehicleTier): Vehicle {
   return { id, type, x, z, hp: 100, task: 'idle', targetX: x, targetZ: z, tier } as Vehicle;
@@ -154,5 +154,83 @@ describe('VehicleMesh — tier color brightening', () => {
     const c3 = getBodyColor(3);
     const brighter = c3.r > c2.r || c3.g > c2.g || c3.b > c2.b;
     expect(brighter).toBe(true);
+  });
+});
+
+// ── Issue #411: operational-state visual indicator ─────────────────────────
+// Prior to this, VehicleOperationalState.working (and waiting/broken) all
+// rendered identically to idle since only position lerped — no color/marker
+// distinguished them. STATE_COLOR_MAP and applyStateIndicator close that gap,
+// following the same material-manipulation pattern as applyTierVariation.
+
+describe('STATE_COLOR_MAP (#411)', () => {
+  const ALL_STATES: VehicleOperationalState[] = ['idle', 'moving', 'working', 'waiting', 'broken'];
+
+  it('has a numeric color entry for every VehicleOperationalState', () => {
+    for (const state of ALL_STATES) {
+      expect(STATE_COLOR_MAP[state], `missing color for state "${state}"`).toBeTypeOf('number');
+    }
+  });
+
+  it('assigns a distinct color to each of the 5 states', () => {
+    const colors = ALL_STATES.map(s => STATE_COLOR_MAP[s]);
+    const unique = new Set(colors);
+    expect(unique.size).toBe(ALL_STATES.length);
+  });
+});
+
+describe('applyStateIndicator (#411)', () => {
+  /** Marker mesh contract: a single child tagged userData.isStateIndicator. */
+  function getIndicatorMeshes(group: THREE.Group): THREE.Mesh[] {
+    return group.children.filter(
+      (c): c is THREE.Mesh => c instanceof THREE.Mesh && c.userData?.['isStateIndicator'] === true,
+    );
+  }
+
+  it('adds exactly one state-indicator marker mesh to the group', () => {
+    const group = new THREE.Group();
+    applyStateIndicator(group, 'working');
+
+    expect(getIndicatorMeshes(group)).toHaveLength(1);
+  });
+
+  it("marker material color matches STATE_COLOR_MAP['broken']", () => {
+    const group = new THREE.Group();
+    applyStateIndicator(group, 'broken');
+
+    const marker = getIndicatorMeshes(group)[0]!;
+    const mat = marker.material as THREE.MeshBasicMaterial | THREE.MeshPhongMaterial;
+    expect(mat.color.getHex()).toBe(STATE_COLOR_MAP['broken']);
+  });
+
+  it("marker material color matches STATE_COLOR_MAP['waiting']", () => {
+    const group = new THREE.Group();
+    applyStateIndicator(group, 'waiting');
+
+    const marker = getIndicatorMeshes(group)[0]!;
+    const mat = marker.material as THREE.MeshBasicMaterial | THREE.MeshPhongMaterial;
+    expect(mat.color.getHex()).toBe(STATE_COLOR_MAP['waiting']);
+  });
+
+  it('updates the existing marker in place on repeated calls rather than stacking duplicates', () => {
+    const group = new THREE.Group();
+    applyStateIndicator(group, 'idle');
+    applyStateIndicator(group, 'moving');
+    applyStateIndicator(group, 'working');
+
+    const markers = getIndicatorMeshes(group);
+    expect(markers).toHaveLength(1);
+    const mat = markers[0]!.material as THREE.MeshBasicMaterial | THREE.MeshPhongMaterial;
+    expect(mat.color.getHex()).toBe(STATE_COLOR_MAP['working']);
+  });
+
+  it('does not remove or alter the group\'s existing body meshes', () => {
+    const group = new THREE.Group();
+    const body = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), new THREE.MeshPhongMaterial({ color: 0xf5c518 }));
+    group.add(body);
+
+    applyStateIndicator(group, 'working');
+
+    expect(group.children).toContain(body);
   });
 });

--- a/tests/unit/renderer/VehicleMesh.test.ts
+++ b/tests/unit/renderer/VehicleMesh.test.ts
@@ -7,7 +7,7 @@ import { VehicleMesh, STATE_COLOR_MAP, applyStateIndicator } from '../../../src/
 import { WAITING_QUEUE_SLOT_OFFSETS } from '../../../src/core/config/balance.js';
 
 function makeVehicle(id: number, type: Vehicle['type'], x = 0, z = 0, tier = 1 as VehicleTier): Vehicle {
-  return { id, type, x, z, hp: 100, task: 'idle', targetX: x, targetZ: z, tier } as Vehicle;
+  return { id, type, x, z, hp: 100, task: 'idle', state: 'idle', targetX: x, targetZ: z, tier } as Vehicle;
 }
 
 describe('VehicleMesh', () => {

--- a/tests/unit/ui/VehiclePanel.test.ts
+++ b/tests/unit/ui/VehiclePanel.test.ts
@@ -1,0 +1,170 @@
+// BlastSimulator2026 — VehiclePanel unit tests (issue #411)
+// Covers: localized tier-specific vehicle names (t(def.nameKey), not raw role
+// ids) and the per-tier buy button selector (Tier 1/2/3, each individually
+// affordability-gated). Mirrors the jsdom harness used by EmployeePanel.test.ts.
+
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { VehiclePanel } from '../../../src/ui/VehiclePanel.js';
+import { createGame } from '../../../src/core/state/GameState.js';
+import type { GameState } from '../../../src/core/state/GameState.js';
+import { purchaseVehicle, getVehicleDefByTier, getAllVehicleRoles } from '../../../src/core/entities/Vehicle.js';
+import { t } from '../../../src/core/i18n/I18n.js';
+import type { CommandResult } from '../../../src/console/ConsoleRunner.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeState(cash = 200_000): GameState {
+  const s = createGame({ seed: 42, mineType: 'desert' });
+  s.cash = cash;
+  return s;
+}
+
+function setupPanel(): { container: HTMLDivElement; panel: VehiclePanel } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const panel = new VehiclePanel(container);
+  return { container, panel };
+}
+
+// ── Buy section — per-tier buttons ──────────────────────────────────────────
+
+describe('VehiclePanel — tier buy buttons (#411)', () => {
+  it('renders 3 tier buttons (1, 2, 3) for every vehicle role', () => {
+    const { container, panel } = setupPanel();
+    panel.update(makeState());
+
+    for (const role of getAllVehicleRoles()) {
+      const buttons = container.querySelectorAll(`[data-vtype="${role}"][data-tier]`);
+      expect(buttons.length, `role ${role} should have 3 tier buttons`).toBe(3);
+      const tiers = Array.from(buttons)
+        .map(b => (b as HTMLElement).dataset['tier'])
+        .sort();
+      expect(tiers).toEqual(['1', '2', '3']);
+    }
+  });
+
+  it("tier-2 button label includes the localized tier-2 name (t(def.nameKey))", () => {
+    const { container, panel } = setupPanel();
+    panel.update(makeState());
+
+    const btn2 = container.querySelector('[data-vtype="debris_hauler"][data-tier="2"]') as HTMLElement | null;
+    expect(btn2).not.toBeNull();
+    expect(btn2!.textContent).toContain(t('vehicle.debris_hauler.tier2'));
+  });
+
+  it('tier-3 button label includes that tier\'s cost, not the tier-1 cost', () => {
+    const { container, panel } = setupPanel();
+    panel.update(makeState());
+
+    const tier1Cost = getVehicleDefByTier('debris_hauler', 1).purchaseCost;
+    const tier3Cost = getVehicleDefByTier('debris_hauler', 3).purchaseCost;
+    expect(tier3Cost).not.toBe(tier1Cost);
+
+    const btn3 = container.querySelector('[data-vtype="debris_hauler"][data-tier="3"]') as HTMLElement;
+    expect(btn3.textContent).toContain(String(tier3Cost));
+  });
+
+  it('clicking a tier button dispatches "vehicle buy <role> tier:<n>"', () => {
+    const { container, panel } = setupPanel();
+    panel.update(makeState());
+
+    const commands: string[] = [];
+    panel.setGameConsole((cmd: string): CommandResult => {
+      commands.push(cmd);
+      return { success: true, output: '' };
+    });
+
+    const btn = container.querySelector('[data-vtype="drill_rig"][data-tier="2"]') as HTMLButtonElement;
+    btn.click();
+
+    expect(commands).toContain('vehicle buy drill_rig tier:2');
+  });
+
+  it('clicking the tier-1 button dispatches tier:1 explicitly', () => {
+    const { container, panel } = setupPanel();
+    panel.update(makeState());
+
+    const commands: string[] = [];
+    panel.setGameConsole((cmd: string): CommandResult => {
+      commands.push(cmd);
+      return { success: true, output: '' };
+    });
+
+    const btn = container.querySelector('[data-vtype="rock_digger"][data-tier="1"]') as HTMLButtonElement;
+    btn.click();
+
+    expect(commands).toContain('vehicle buy rock_digger tier:1');
+  });
+
+  it('disables only the tier buttons whose cost exceeds current cash', () => {
+    const { container, panel } = setupPanel();
+    const tier1Cost = getVehicleDefByTier('debris_hauler', 1).purchaseCost;
+    const tier2Cost = getVehicleDefByTier('debris_hauler', 2).purchaseCost;
+    expect(tier2Cost).toBeGreaterThan(tier1Cost); // sanity: tiers strictly cost more
+
+    panel.update(makeState(tier1Cost)); // exactly enough for tier 1, not tier 2/3
+
+    const btn1 = container.querySelector('[data-vtype="debris_hauler"][data-tier="1"]') as HTMLButtonElement;
+    const btn2 = container.querySelector('[data-vtype="debris_hauler"][data-tier="2"]') as HTMLButtonElement;
+    const btn3 = container.querySelector('[data-vtype="debris_hauler"][data-tier="3"]') as HTMLButtonElement;
+
+    expect(btn1.disabled).toBe(false);
+    expect(btn2.disabled).toBe(true);
+    expect(btn3.disabled).toBe(true);
+  });
+
+  it('re-enables a tier button once a later update() reflects enough cash', () => {
+    const { container, panel } = setupPanel();
+    const tier2Cost = getVehicleDefByTier('debris_hauler', 2).purchaseCost;
+
+    panel.update(makeState(0));
+    let btn2 = container.querySelector('[data-vtype="debris_hauler"][data-tier="2"]') as HTMLButtonElement;
+    expect(btn2.disabled).toBe(true);
+
+    panel.update(makeState(tier2Cost));
+    btn2 = container.querySelector('[data-vtype="debris_hauler"][data-tier="2"]') as HTMLButtonElement;
+    expect(btn2.disabled).toBe(false);
+  });
+});
+
+// ── Owned vehicle rows — localized display name ─────────────────────────────
+
+describe('VehiclePanel — owned vehicle rows show localized tier name (#411)', () => {
+  it("shows t(getVehicleDefByTier(v.type, v.tier).nameKey) for a tier-2 vehicle", () => {
+    const { container, panel } = setupPanel();
+    const state = makeState();
+    purchaseVehicle(state.vehicles, 'debris_hauler', 5, 5, 2);
+
+    panel.update(state);
+
+    const row = container.querySelector('.bs-vehicle-row') as HTMLElement;
+    expect(row).not.toBeNull();
+    expect(row.textContent).toContain(t('vehicle.debris_hauler.tier2'));
+  });
+
+  it("shows t(getVehicleDefByTier(v.type, v.tier).nameKey) for a tier-3 vehicle, not the raw role id", () => {
+    const { container, panel } = setupPanel();
+    const state = makeState();
+    purchaseVehicle(state.vehicles, 'rock_digger', 0, 0, 3);
+
+    panel.update(state);
+
+    const row = container.querySelector('.bs-vehicle-row') as HTMLElement;
+    expect(row.textContent).toContain(t('vehicle.rock_digger.tier3'));
+  });
+
+  it('reflects each vehicle\'s own tier when multiple vehicles of the same role are owned', () => {
+    const { container, panel } = setupPanel();
+    const state = makeState();
+    purchaseVehicle(state.vehicles, 'debris_hauler', 0, 0, 1);
+    purchaseVehicle(state.vehicles, 'debris_hauler', 2, 2, 3);
+
+    panel.update(state);
+
+    const rows = container.querySelectorAll('.bs-vehicle-row');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.textContent).toContain(t('vehicle.debris_hauler.tier1'));
+    expect(rows[1]!.textContent).toContain(t('vehicle.debris_hauler.tier3'));
+  });
+});


### PR DESCRIPTION
Closes #411

## Summary

Fix-until-coherent pass over the 7 vehicle-fleet visual scenarios (`vehicle-3d-rendering-visual`, `vehicle-driver-assignment-visual`, `vehicle-purchase-visual`, `vehicle-purchase-tier-ui-visual`, `vehicle-roles-panel-visual`, `vehicle-task-states-visual`, `vehicle-traffic-routing-visual`). Every scenario ran, screenshots were inspected, every incoherence found was fixed, and scenarios were re-run to confirm.

Root causes fixed, not just symptoms:
- `VehicleOperationalState.working` was never assigned anywhere in code — `tickVehicleTaskState` now sets it from the vehicle's active task, wired into both the browser render loop and the console tick path.
- Every `vehicle buy` spawned at the exact same grid cell — all purchases fully occluded each other. Purchases now spread across a spawn ring (`SPAWN_RING_SIZE`/`SPAWN_TILE_SPACING`).
- Tier 2/3 vehicles were unreachable — no command or UI control ever passed a tier argument to `purchaseVehicle`. Added `vehicle buy <role> tier:<1|2|3>` (console) and a 3-tier buy-button selector per role (`VehiclePanel`), both using localized names/costs instead of raw role ids.
- `VehicleMesh` had no visual indicator for operational state — added `STATE_COLOR_MAP`/`applyStateIndicator` (colored marker per state).
- `TrafficJamEvent` could never fire through console/scenario `tick` steps — `detectTrafficJam` was only ever called from the browser's live render loop (`GameLoop.processFrame`), never from `tickCommand`. Now wired into both, so the traffic-routing scenario can actually demonstrate its own premise.
- Waiting vehicles converging on a shared jam target rendered as a fused, interpenetrating mesh blob across several iterations of this fix — final fix anchors each waiting vehicle's render offset to the shared target cell (not its own raw, slightly-different position), extracted into `src/renderer/VehicleWaitingQueue.ts`.
- Two scenario files were missing steps needed to demonstrate their own claims (`vehicle-purchase-tier-ui-visual.json` never actually clicked a tier button while affordable; `vehicle-traffic-routing-visual.json` never gave vehicles a shared destination or enough ticks to congest) — both fixed at the scenario-definition level.
- `vehicle-roles-panel-visual.json` and `vehicle-driver-assignment-visual.json` never opened the Vehicles panel, so their own subject (panel contents) was never actually on screen — added the missing `clickSelector` interaction steps.

## Verification channels run

- **static** (`npm run typecheck`) — PASS, clean.
- **logic** (`npm run test`) — PASS, 203 files / 5881 tests (5 new tests added for previously-untested waiting-queue offset math and console-tick traffic-jam reachability, per this project's regression-test policy).
- **scenario** (`npm run scenarios`) — PASS, 102/102 scenario definitions, including all 7 in-scope files.
- **visual** (`npm run scenario -- --mode interaction --screenshots`, screenshots inspected with vision) — PASS after 5 rounds of iteration. All 7 scenarios' screenshots confirmed visually coherent with their step descriptions.
- **playability** (`npm run playtest`) — PASS, 28/28 beats. Existing `tutorial.json` chapter already exercises the new tier-button UI end-to-end via real clicks (buy → assign driver), screenshot-confirmed; tier-2/3 button clickability additionally proven via the `vehicle-purchase-tier-ui-visual.json` interaction-mode click step. No new playtest chapter added — see Decisions taken.
- `npm run validate` (typecheck → coverage → integration → scenario defs → build) — PASS.

Code review: security, quality, i18n, duplication, and semantic reviewers all ran in two rounds (round 1 found 5 issues — stale skeleton docstrings, dead code, one unlocalized label, two regression-test-policy gaps; round 2 confirmed all fixed, clean). Refactor phase extracted `VehicleWaitingQueue.ts`, derived `WAITING_QUEUE_SLOT_OFFSETS` from `SPAWN_TILE_SPACING` instead of duplicating the literal, and removed a stale docstring reference.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** the issue didn't specify what triggers `VehicleOperationalState.working` (the type existed but nothing ever assigned it).
  **Chosen:** any of the four work tasks (`transport`, `loading`, `drilling`, `clearing`) sets `state = 'working'` immediately on task assignment.
  **Why:** narrowest fix that makes the state model match what the scenario/schema already claim, without building the full haul/drill/dig work-progress economy the issue doesn't ask for.
  **If reversed:** change the state-assignment branch in `tickVehicleTaskState` (`src/core/engine/EntityMovementTick.ts`) to gate on a work-progress counter instead of task membership.

- **What was open:** the issue didn't specify tier-purchase command syntax.
  **Chosen:** `vehicle buy <role> tier:<1|2|3>`, defaulting to tier 1 when omitted; invalid values rejected with a usage message.
  **Why:** keeps every existing `vehicle buy <role>` call (scenario/test/player) passing unchanged; matches the `named[...]` parsing convention already used for `task:`/`to:` in the same file.
  **If reversed:** change the default literal in `parseVehicleTierArg` (`src/console/commands/vehicle.ts`).

- **What was open:** no visual convention existed yet for rendering `VehicleOperationalState` on the 3D mesh.
  **Chosen:** a small colored marker above each vehicle, one color per state, added in `VehicleMesh`.
  **Why:** matches the existing `applyTierVariation` material-manipulation pattern already in the same file, rather than introducing sprites or an HTML overlay.
  **If reversed:** change the `STATE_COLOR_MAP` object literal in `src/renderer/VehicleMesh.ts`.

- **What was open:** whether a new dedicated playtest chapter was needed for the vehicle-fleet UI changes (CLAUDE.md's playability gate names "vehicles" as a trigger).
  **Chosen:** no new playtest chapter — existing `tutorial.json` (buy + assign, real clicks) plus this issue's own `vehicle-purchase-tier-ui-visual.json` interaction-mode click step already prove the changed UI is clickable and reachable end-to-end.
  **Why:** this issue changes how the buy UI renders (per-tier), not whether the flow is reachable; a new chapter would duplicate coverage two existing layers already provide, against the playability skill's own guidance not to widen scope beyond what's needed.
  **If reversed:** add a `scripts/playtests/vehicles.json` chapter exercising tier-2/3 purchase explicitly through the playtest harness.

Two defects were found outside this issue's 7-scenario scope and deliberately left unfixed here, each filed as its own follow-up issue (not a decision-review item — these are separate defects, not defaulted ambiguity):
- `scripts/scenario-defs/vehicle-traffic.json` (not one of the 7 in-scope files) calls `vehicle buy hauler`, which is not a valid `VehicleRole` (`debris_hauler` is) — the purchase silently no-ops and the scenario's `TrafficJamEvent` assertion is unreachable.
- `gameplay-vehicle-fleet` SKILL.md documents `rock_digger` tier 3 as "Voxel Vanquisher"; shipped `en.json` (and its pinned test) has "Rock Reaper" — doc/code name mismatch, not a rendering defect.

## Files changed

`src/core/config/balance.ts`, `src/core/engine/EntityMovementTick.ts`, `src/core/engine/GameLoop.ts`, `src/console/commands/events.ts`, `src/console/commands/vehicle.ts`, `src/renderer/GameRenderer.ts`, `src/renderer/VehicleMesh.ts`, `src/renderer/VehicleWaitingQueue.ts` (new), `src/ui/VehiclePanel.ts`, `src/ui/styles.ts`, plus test files under `tests/unit/`, `tests/integration/`, and scenario definitions under `scripts/scenario-defs/vehicle-*.json`.

READY TO MERGE