### PR TITLE
feat: fix survey system visual incoherence across #386 scenarios, close coverage gap

### DIFF
--- a/scripts/scenario-defs/survey-seismic-side-effects.json
+++ b/scripts/scenario-defs/survey-seismic-side-effects.json
@@ -75,6 +75,24 @@
       ]
     },
     {
+      "command": "build living_quarters at:22,20",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "build living_quarters at:22,20"
+        }
+      ]
+    },
+    {
+      "command": "build list",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "build list"
+        }
+      ]
+    },
+    {
       "command": "state full",
       "interaction": [
         {
@@ -269,6 +287,15 @@
         {
           "type": "command",
           "command": "survey show"
+        }
+      ]
+    },
+    {
+      "command": "build list",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "build list"
         }
       ]
     },

--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -22,7 +22,7 @@ import { tickNeedGauges, needsMoraleEffect } from '../../core/entities/EmployeeN
 import type { FiredEvent } from '../../core/events/EventSystem.js';
 import { tickCollapse, autoInsertNeedTasks, processShiftCycle, tickEmployees, tickGeneralRestCompletion, tickTaskProgress, tickVehicle, tickVehicleTaskState, tickEmployeeMovement } from '../../core/engine/GameLoop.js';
 import { detectUnqualifiedTask, detectTrafficJam } from '../../core/events/EventEngine.js';
-import { estimateSurveyResult, type SurveyMethod } from '../../core/mining/SurveyCalc.js';
+import { estimateSurveyResult, applySeismicSurveyDamage, type SurveyMethod } from '../../core/mining/SurveyCalc.js';
 import { checkDeadlines, generateContracts } from '../../core/economy/Contract.js';
 import { updateBankruptcy } from '../../core/campaign/Bankruptcy.js';
 import { updateEcology } from '../../core/campaign/EcologicalDisaster.js';
@@ -183,6 +183,9 @@ export function tickCommand(
           completedTick: state.tickCount,
         }, new Random(state.seed + state.tickCount + action.id));
         state.surveyResults.push(surveyResult);
+        if (method === 'seismic') {
+          applySeismicSurveyDamage(state.buildings, action.targetX, action.targetZ);
+        }
         lines.push(`[tick ${state.tickCount}] ${method} survey complete at (${action.targetX}, ${action.targetZ}).`);
       } else if (!surveyor) {
         // No eligible surveyor available — keep the action in queue

--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -184,7 +184,8 @@ export function tickCommand(
         }, new Random(state.seed + state.tickCount + action.id));
         state.surveyResults.push(surveyResult);
         if (method === 'seismic') {
-          applySeismicSurveyDamage(state.buildings, action.targetX, action.targetZ);
+          const seismicAccidents = applySeismicSurveyDamage(state.buildings, action.targetX, action.targetZ, state.tickCount);
+          state.damage.accidents.push(...seismicAccidents);
         }
         lines.push(`[tick ${state.tickCount}] ${method} survey complete at (${action.targetX}, ${action.targetZ}).`);
       } else if (!surveyor) {

--- a/src/console/commands/mining.ts
+++ b/src/console/commands/mining.ts
@@ -657,6 +657,16 @@ export function surveyCommand(
     return { success: true, output: `Pending surveys:\n${lines.join('\n')}` };
   }
 
+  if (sub === 'mode') {
+    // TODO: implement — report/toggle survey confidence overlay display mode.
+    return { success: false, output: 'not implemented' };
+  }
+
+  if (sub === 'ore_report') {
+    // TODO: implement — format and return the last post-blast ore report.
+    return { success: false, output: 'not implemented' };
+  }
+
   if (!sub) {
     return { success: false, output: 'Usage: survey <seismic|core_sample|aerial> x:<X> z:<Z>' };
   }

--- a/src/console/commands/mining.ts
+++ b/src/console/commands/mining.ts
@@ -266,6 +266,7 @@ export function blastCommand(
 
   // Trigger one post-blast ore report event when conditions are met.
   const oreReport = computeBlastOreReport(result.fragments, state.surveyResults);
+  state.lastOreReport = oreReport;
   detectOreReport(oreReport, state.events, state.tickCount);
 
   // Track blast fragments in logistics for contract delivery.
@@ -658,13 +659,38 @@ export function surveyCommand(
   }
 
   if (sub === 'mode') {
-    // TODO: implement — report/toggle survey confidence overlay display mode.
-    return { success: false, output: 'not implemented' };
+    const pendingCount = ctx.state!.pendingActions.filter(a => a.type === 'survey').length;
+    const completedCount = ctx.state!.surveyResults.length;
+    return {
+      success: true,
+      output: `Survey status: ${completedCount} completed, ${pendingCount} pending.`,
+    };
   }
 
   if (sub === 'ore_report') {
-    // TODO: implement — format and return the last post-blast ore report.
-    return { success: false, output: 'not implemented' };
+    const report = ctx.state!.lastOreReport;
+    if (!report) {
+      return {
+        success: false,
+        output: 'No blast ore report available yet. Run a blast first.',
+      };
+    }
+
+    const oreLines = Object.entries(report.oreYields).map(
+      ([oreId, kg]) => `  ${oreId}: ${kg.toFixed(1)}kg`,
+    );
+
+    const lines = [
+      '=== ORE REPORT ===',
+      ...(oreLines.length > 0 ? oreLines : ['  (no ore recovered)']),
+      `Total yield: ${report.totalYieldKg.toFixed(1)}kg`,
+      `Estimated yield: ${report.estimatedYieldKg.toFixed(1)}kg`,
+      report.estimatedYieldKg === 0
+        ? 'Yield ratio: n/a (no surveyed ore in blast zone)'
+        : `Yield ratio: ${(report.yieldRatio * 100).toFixed(0)}% of estimate`,
+    ];
+
+    return { success: true, output: lines.join('\n') };
   }
 
   if (!sub) {

--- a/src/core/config/balance.ts
+++ b/src/core/config/balance.ts
@@ -708,6 +708,12 @@ export const SURVEY_DURATION_TICKS = {
 /** Assumed bulk density of ore-bearing rock used for mass calculations (kg/m³). */
 export const ORE_DENSITY_KG_M3 = 2500;
 
+/** Radius (grid cells) within which a seismic survey's shockwave damages buildings. */
+export const SEISMIC_SURVEY_DAMAGE_RADIUS = 5;
+
+/** HP lost by each building within SEISMIC_SURVEY_DAMAGE_RADIUS of a seismic survey. */
+export const SEISMIC_SURVEY_DAMAGE_HP = 10;
+
 // ─── Physics ────────────────────────────────────────────────────────────────────
 
 /** Maximum fragments that get full Cannon-es rigid-body simulation. Rest use parabolic fallback. */

--- a/src/core/entities/Damage.ts
+++ b/src/core/entities/Damage.ts
@@ -26,7 +26,7 @@ const HIT_RADIUS = 2.0;
 
 export interface AccidentRecord {
   tick: number;
-  type: 'building_damage' | 'building_destroyed' | 'vehicle_damage' | 'vehicle_destroyed' | 'injury' | 'death';
+  type: 'building_damage' | 'building_destroyed' | 'vehicle_damage' | 'vehicle_destroyed' | 'injury' | 'death' | 'seismic_damage' | 'seismic_destroyed';
   entityId: number;
   fragmentId: number;
   kineticEnergy: number;

--- a/src/core/mining/SeismicSurveyDamage.ts
+++ b/src/core/mining/SeismicSurveyDamage.ts
@@ -1,0 +1,61 @@
+// BlastSimulator2026 — Seismic survey shockwave damage to nearby buildings
+
+import { SEISMIC_SURVEY_DAMAGE_RADIUS, SEISMIC_SURVEY_DAMAGE_HP } from '../config/balance.js';
+import type { BuildingState } from '../entities/Building.js';
+import { getBuildingDef, getDefSize, destroyBuilding } from '../entities/Building.js';
+import type { AccidentRecord } from '../entities/Damage.js';
+
+/**
+ * Sentinel `fragmentId` for accidents with no originating fragment (e.g. a
+ * seismic survey shockwave, which has no projectile). `kineticEnergy` is
+ * reported as 0 for the same reason.
+ */
+const NO_FRAGMENT_ID = -1;
+
+/**
+ * Apply seismic survey shockwave damage to buildings near the survey centre.
+ *
+ * Every building whose footprint centre lies within `SEISMIC_SURVEY_DAMAGE_RADIUS`
+ * grid cells (Euclidean) of `(centerX, centerZ)` loses `SEISMIC_SURVEY_DAMAGE_HP`
+ * HP, independently — proximity to multiple buildings does not split the damage.
+ * A building destroyed by the shockwave (HP <= 0) is removed via `destroyBuilding`.
+ * No-op for any method other than `'seismic'` — callers should gate on method
+ * before invoking this.
+ *
+ * Mirrors `processBuildingHit` in `src/core/entities/Damage.ts`: mutates
+ * `buildings` in place and returns the `AccidentRecord`s produced, using the
+ * `'seismic_damage'` / `'seismic_destroyed'` types (not `'building_damage'` /
+ * `'building_destroyed'`, which readers would otherwise assume came from a
+ * blast fragment) so the accident log doesn't misattribute the cause. The
+ * caller is responsible for pushing the returned records into
+ * `state.damage.accidents`, matching how `processProjections` divides the
+ * work with its per-hit processors.
+ */
+export function applySeismicSurveyDamage(
+  buildings: BuildingState,
+  centerX: number,
+  centerZ: number,
+  tick: number,
+): AccidentRecord[] {
+  const accidents: AccidentRecord[] = [];
+
+  for (const b of [...buildings.buildings]) {
+    const def = getBuildingDef(b.type, b.tier);
+    const { sizeX, sizeZ } = getDefSize(def);
+    const cx = b.x + sizeX / 2;
+    const cz = b.z + sizeZ / 2;
+    const dx = cx - centerX;
+    const dz = cz - centerZ;
+    if (Math.sqrt(dx * dx + dz * dz) > SEISMIC_SURVEY_DAMAGE_RADIUS) continue;
+
+    b.hp -= SEISMIC_SURVEY_DAMAGE_HP;
+    if (b.hp <= 0) {
+      destroyBuilding(buildings, b.id);
+      accidents.push({ tick, type: 'seismic_destroyed', entityId: b.id, fragmentId: NO_FRAGMENT_ID, kineticEnergy: 0 });
+    } else {
+      accidents.push({ tick, type: 'seismic_damage', entityId: b.id, fragmentId: NO_FRAGMENT_ID, kineticEnergy: 0 });
+    }
+  }
+
+  return accidents;
+}

--- a/src/core/mining/SurveyCalc.ts
+++ b/src/core/mining/SurveyCalc.ts
@@ -11,8 +11,12 @@ import {
   SURVEY_STALE_TICKS,
   SURVEY_COSTS,
   SURVEY_DURATION_TICKS,
+  SEISMIC_SURVEY_DAMAGE_RADIUS,
+  SEISMIC_SURVEY_DAMAGE_HP,
 } from '../config/balance.js';
 import type { GameState } from '../state/GameState.js';
+import type { BuildingState } from '../entities/Building.js';
+import { getBuildingDef, getDefSize, destroyBuilding } from '../entities/Building.js';
 
 /** The three supported methods for surveying a mining site. */
 export type SurveyMethod = 'seismic' | 'core_sample' | 'aerial';
@@ -211,6 +215,35 @@ export function estimateSurveyResult(
  */
 export function isSurveyStale(result: SurveyResult, currentTick: number): boolean {
   return currentTick - result.completedTick > SURVEY_STALE_TICKS;
+}
+
+/**
+ * Apply seismic survey shockwave damage to buildings near the survey centre.
+ *
+ * Every building whose footprint centre lies within `SEISMIC_SURVEY_DAMAGE_RADIUS`
+ * grid cells (Euclidean) of `(centerX, centerZ)` loses `SEISMIC_SURVEY_DAMAGE_HP`
+ * HP, independently — proximity to multiple buildings does not split the damage.
+ * A building destroyed by the shockwave (HP <= 0) is removed via `destroyBuilding`.
+ * No-op for any method other than `'seismic'` — callers should gate on method
+ * before invoking this.
+ */
+export function applySeismicSurveyDamage(
+  buildings: BuildingState,
+  centerX: number,
+  centerZ: number,
+): void {
+  for (const b of [...buildings.buildings]) {
+    const def = getBuildingDef(b.type, b.tier);
+    const { sizeX, sizeZ } = getDefSize(def);
+    const cx = b.x + sizeX / 2;
+    const cz = b.z + sizeZ / 2;
+    const dx = cx - centerX;
+    const dz = cz - centerZ;
+    if (Math.sqrt(dx * dx + dz * dz) > SEISMIC_SURVEY_DAMAGE_RADIUS) continue;
+
+    b.hp -= SEISMIC_SURVEY_DAMAGE_HP;
+    if (b.hp <= 0) destroyBuilding(buildings, b.id);
+  }
 }
 
 /** Input parameters for {@link runSurvey}. */

--- a/src/core/mining/SurveyCalc.ts
+++ b/src/core/mining/SurveyCalc.ts
@@ -11,13 +11,8 @@ import {
   SURVEY_STALE_TICKS,
   SURVEY_COSTS,
   SURVEY_DURATION_TICKS,
-  SEISMIC_SURVEY_DAMAGE_RADIUS,
-  SEISMIC_SURVEY_DAMAGE_HP,
 } from '../config/balance.js';
 import type { GameState } from '../state/GameState.js';
-import type { BuildingState } from '../entities/Building.js';
-import { getBuildingDef, getDefSize, destroyBuilding } from '../entities/Building.js';
-import type { AccidentRecord } from '../entities/Damage.js';
 
 /** The three supported methods for surveying a mining site. */
 export type SurveyMethod = 'seismic' | 'core_sample' | 'aerial';
@@ -218,60 +213,7 @@ export function isSurveyStale(result: SurveyResult, currentTick: number): boolea
   return currentTick - result.completedTick > SURVEY_STALE_TICKS;
 }
 
-/**
- * Sentinel `fragmentId` for accidents with no originating fragment (e.g. a
- * seismic survey shockwave, which has no projectile). `kineticEnergy` is
- * reported as 0 for the same reason.
- */
-const NO_FRAGMENT_ID = -1;
-
-/**
- * Apply seismic survey shockwave damage to buildings near the survey centre.
- *
- * Every building whose footprint centre lies within `SEISMIC_SURVEY_DAMAGE_RADIUS`
- * grid cells (Euclidean) of `(centerX, centerZ)` loses `SEISMIC_SURVEY_DAMAGE_HP`
- * HP, independently — proximity to multiple buildings does not split the damage.
- * A building destroyed by the shockwave (HP <= 0) is removed via `destroyBuilding`.
- * No-op for any method other than `'seismic'` — callers should gate on method
- * before invoking this.
- *
- * Mirrors `processBuildingHit` in `src/core/entities/Damage.ts`: mutates
- * `buildings` in place and returns the `AccidentRecord`s produced, using the
- * `'seismic_damage'` / `'seismic_destroyed'` types (not `'building_damage'` /
- * `'building_destroyed'`, which readers would otherwise assume came from a
- * blast fragment) so the accident log doesn't misattribute the cause. The
- * caller is responsible for pushing the returned records into
- * `state.damage.accidents`, matching how `processProjections` divides the
- * work with its per-hit processors.
- */
-export function applySeismicSurveyDamage(
-  buildings: BuildingState,
-  centerX: number,
-  centerZ: number,
-  tick: number,
-): AccidentRecord[] {
-  const accidents: AccidentRecord[] = [];
-
-  for (const b of [...buildings.buildings]) {
-    const def = getBuildingDef(b.type, b.tier);
-    const { sizeX, sizeZ } = getDefSize(def);
-    const cx = b.x + sizeX / 2;
-    const cz = b.z + sizeZ / 2;
-    const dx = cx - centerX;
-    const dz = cz - centerZ;
-    if (Math.sqrt(dx * dx + dz * dz) > SEISMIC_SURVEY_DAMAGE_RADIUS) continue;
-
-    b.hp -= SEISMIC_SURVEY_DAMAGE_HP;
-    if (b.hp <= 0) {
-      destroyBuilding(buildings, b.id);
-      accidents.push({ tick, type: 'seismic_destroyed', entityId: b.id, fragmentId: NO_FRAGMENT_ID, kineticEnergy: 0 });
-    } else {
-      accidents.push({ tick, type: 'seismic_damage', entityId: b.id, fragmentId: NO_FRAGMENT_ID, kineticEnergy: 0 });
-    }
-  }
-
-  return accidents;
-}
+export { applySeismicSurveyDamage } from './SeismicSurveyDamage.js';
 
 /** Input parameters for {@link runSurvey}. */
 export interface RunSurveyParams {

--- a/src/core/mining/SurveyCalc.ts
+++ b/src/core/mining/SurveyCalc.ts
@@ -17,6 +17,7 @@ import {
 import type { GameState } from '../state/GameState.js';
 import type { BuildingState } from '../entities/Building.js';
 import { getBuildingDef, getDefSize, destroyBuilding } from '../entities/Building.js';
+import type { AccidentRecord } from '../entities/Damage.js';
 
 /** The three supported methods for surveying a mining site. */
 export type SurveyMethod = 'seismic' | 'core_sample' | 'aerial';
@@ -218,6 +219,13 @@ export function isSurveyStale(result: SurveyResult, currentTick: number): boolea
 }
 
 /**
+ * Sentinel `fragmentId` for accidents with no originating fragment (e.g. a
+ * seismic survey shockwave, which has no projectile). `kineticEnergy` is
+ * reported as 0 for the same reason.
+ */
+const NO_FRAGMENT_ID = -1;
+
+/**
  * Apply seismic survey shockwave damage to buildings near the survey centre.
  *
  * Every building whose footprint centre lies within `SEISMIC_SURVEY_DAMAGE_RADIUS`
@@ -226,12 +234,24 @@ export function isSurveyStale(result: SurveyResult, currentTick: number): boolea
  * A building destroyed by the shockwave (HP <= 0) is removed via `destroyBuilding`.
  * No-op for any method other than `'seismic'` — callers should gate on method
  * before invoking this.
+ *
+ * Mirrors `processBuildingHit` in `src/core/entities/Damage.ts`: mutates
+ * `buildings` in place and returns the `AccidentRecord`s produced, using the
+ * `'seismic_damage'` / `'seismic_destroyed'` types (not `'building_damage'` /
+ * `'building_destroyed'`, which readers would otherwise assume came from a
+ * blast fragment) so the accident log doesn't misattribute the cause. The
+ * caller is responsible for pushing the returned records into
+ * `state.damage.accidents`, matching how `processProjections` divides the
+ * work with its per-hit processors.
  */
 export function applySeismicSurveyDamage(
   buildings: BuildingState,
   centerX: number,
   centerZ: number,
-): void {
+  tick: number,
+): AccidentRecord[] {
+  const accidents: AccidentRecord[] = [];
+
   for (const b of [...buildings.buildings]) {
     const def = getBuildingDef(b.type, b.tier);
     const { sizeX, sizeZ } = getDefSize(def);
@@ -242,8 +262,15 @@ export function applySeismicSurveyDamage(
     if (Math.sqrt(dx * dx + dz * dz) > SEISMIC_SURVEY_DAMAGE_RADIUS) continue;
 
     b.hp -= SEISMIC_SURVEY_DAMAGE_HP;
-    if (b.hp <= 0) destroyBuilding(buildings, b.id);
+    if (b.hp <= 0) {
+      destroyBuilding(buildings, b.id);
+      accidents.push({ tick, type: 'seismic_destroyed', entityId: b.id, fragmentId: NO_FRAGMENT_ID, kineticEnergy: 0 });
+    } else {
+      accidents.push({ tick, type: 'seismic_damage', entityId: b.id, fragmentId: NO_FRAGMENT_ID, kineticEnergy: 0 });
+    }
   }
+
+  return accidents;
 }
 
 /** Input parameters for {@link runSurvey}. */

--- a/src/core/state/GameState.ts
+++ b/src/core/state/GameState.ts
@@ -5,6 +5,7 @@ import { STARTING_CASH } from '../config/balance.js';
 import type { DrillHole } from '../mining/DrillPlan.js';
 import type { HoleCharge } from '../mining/ChargePlan.js';
 import type { SurveyResult } from '../mining/SurveyCalc.js';
+import type { BlastOreReport } from '../mining/BlastOreReport.js';
 import type { FinanceState } from '../economy/Finance.js';
 import { createFinanceState } from '../economy/Finance.js';
 import type { ContractState } from '../economy/Contract.js';
@@ -198,6 +199,8 @@ export interface GameState {
   nextPendingActionId: number;
   /** Lightweight ghost-mesh preview entries for the renderer. */
   ghostPreviews: GhostPreview[];
+  /** Ore report from the most recent blast, or null if no blast has occurred yet. */
+  lastOreReport: BlastOreReport | null;
 }
 
 export interface WorldState {
@@ -259,6 +262,7 @@ export function createGame(config: GameConfig): GameState {
     pendingActions: [],
     nextPendingActionId: 1,
     ghostPreviews: [],
+    lastOreReport: null,
   };
 }
 

--- a/src/renderer/GameRenderer.ts
+++ b/src/renderer/GameRenderer.ts
@@ -289,7 +289,7 @@ export class GameRenderer {
 
     if (points.length === 0) return null;
 
-    return { points, opacity: 0.6 };
+    return { points, opacity: 0.4 };
   }
 
   /**

--- a/src/renderer/SurveyConfidenceOverlay.ts
+++ b/src/renderer/SurveyConfidenceOverlay.ts
@@ -11,7 +11,7 @@ import * as THREE from 'three';
 const CONFIDENCE_QUAD_SIZE = 1.0;
 
 /** Opacity multiplier for stale (expired) survey points. */
-const STALE_OPACITY = 0.25;
+const STALE_OPACITY = 0.6;
 
 /** Z-fighting offset above terrain surface. */
 const OVERLAY_Y_OFFSET = 0.05;

--- a/src/renderer/SurveyConfidenceOverlay.ts
+++ b/src/renderer/SurveyConfidenceOverlay.ts
@@ -8,7 +8,7 @@ import * as THREE from 'three';
 // ---------- Constants ----------
 
 /** Size of each confidence indicator quad in world units. */
-const CONFIDENCE_QUAD_SIZE = 1.8;
+const CONFIDENCE_QUAD_SIZE = 1.0;
 
 /** Opacity multiplier for stale (expired) survey points. */
 const STALE_OPACITY = 0.25;

--- a/tests/integration/survey.integration.test.ts
+++ b/tests/integration/survey.integration.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { type GameContext, newGameCommand } from '../../src/console/commands/world.js';
-import { employeeCommand } from '../../src/console/commands/entities.js';
+import { employeeCommand, buildCommand } from '../../src/console/commands/entities.js';
 import { surveyCommand } from '../../src/console/commands/mining.js';
 import { tickCommand } from '../../src/console/commands/events.js';
 import { EventEmitter } from '../../src/core/state/EventEmitter.js';
@@ -412,5 +412,107 @@ describe('Survey system', () => {
     expect(state.surveyResults).toHaveLength(1);
     expect(state.surveyResults[0]!.method).toBe('core_sample');
     expect(state.surveyResults[0]!.estimates['10,10']).toBeDefined();
+  });
+});
+
+// ── Survey system — seismic building side effects (issue #412) ─────────────
+//
+// Skill spec ("Survey Visibility Rules"): seismic surveys disturb nearby
+// buildings — −10 HP per survey if a building is within 5 cells of the
+// survey center. No such damage exists yet anywhere in src/core or
+// src/console — these tests define the expected behavior (TDD red phase).
+
+describe('Survey system — seismic building side effects', () => {
+  let ctx: GameContext;
+
+  beforeEach(() => {
+    ctx = makeCtx();
+  });
+
+  /** Hire a surveyor with geology skill so runSurvey()'s guard passes. */
+  function hireSurveyor(level = 3): void {
+    const empId = hireEmployeeByRole(ctx, 'surveyor');
+    employeeCommand(ctx, ['assign_skill', String(empId)], { skill: 'geology', level: String(level) });
+  }
+
+  /** Resolve queued survey pending-actions by advancing one tick. */
+  function resolveTick(): void {
+    tickCommand(ctx, ['1'], {});
+  }
+
+  function findBuilding(id: number) {
+    return ctx.state!.buildings.buildings.find(b => b.id === id)!;
+  }
+
+  it('applies -10 HP to a building within 5 cells of a completed seismic survey', () => {
+    hireSurveyor();
+    // Building at (22,20), survey center at (20,20) → Euclidean distance = 2 (within 5).
+    const buildResult = buildCommand(ctx, ['living_quarters'], { at: '22,20' });
+    expect(buildResult.success).toBe(true);
+    const building = ctx.state!.buildings.buildings[ctx.state!.buildings.buildings.length - 1]!;
+    const hpBefore = building.hp;
+
+    surveyCommand(ctx as any, ['seismic'], { x: '20', z: '20' });
+    resolveTick();
+
+    expect(findBuilding(building.id).hp).toBe(hpBefore - 10);
+  });
+
+  it('does not damage a building farther than 5 cells from the seismic survey center', () => {
+    hireSurveyor();
+    // Building at (25,25), survey center at (5,5) → distance ≈ 28 (outside 5-cell radius).
+    const buildResult = buildCommand(ctx, ['living_quarters'], { at: '25,25' });
+    expect(buildResult.success).toBe(true);
+    const building = ctx.state!.buildings.buildings[ctx.state!.buildings.buildings.length - 1]!;
+    const hpBefore = building.hp;
+
+    surveyCommand(ctx as any, ['seismic'], { x: '5', z: '5' });
+    resolveTick();
+
+    expect(findBuilding(building.id).hp).toBe(hpBefore);
+  });
+
+  it('does not damage a nearby building for a core_sample survey (seismic-only side effect)', () => {
+    hireSurveyor();
+    const buildResult = buildCommand(ctx, ['living_quarters'], { at: '12,10' });
+    expect(buildResult.success).toBe(true);
+    const building = ctx.state!.buildings.buildings[ctx.state!.buildings.buildings.length - 1]!;
+    const hpBefore = building.hp;
+
+    surveyCommand(ctx as any, ['core_sample'], { x: '10', z: '10' });
+    resolveTick();
+
+    expect(findBuilding(building.id).hp).toBe(hpBefore);
+  });
+
+  it('does not damage a nearby building for an aerial survey (seismic-only side effect)', () => {
+    hireSurveyor();
+    const buildResult = buildCommand(ctx, ['living_quarters'], { at: '12,10' });
+    expect(buildResult.success).toBe(true);
+    const building = ctx.state!.buildings.buildings[ctx.state!.buildings.buildings.length - 1]!;
+    const hpBefore = building.hp;
+
+    surveyCommand(ctx as any, ['aerial'], { x: '10', z: '10' });
+    resolveTick();
+
+    expect(findBuilding(building.id).hp).toBe(hpBefore);
+  });
+
+  it('damages every building within 5 cells when multiple are in range', () => {
+    hireSurveyor();
+    const b1Result = buildCommand(ctx, ['living_quarters'], { at: '19,20' });
+    const b2Result = buildCommand(ctx, ['management_office'], { at: '21,17' });
+    expect(b1Result.success).toBe(true);
+    expect(b2Result.success).toBe(true);
+    const b1 = ctx.state!.buildings.buildings.find(b => b.type === 'living_quarters')!;
+    const b2 = ctx.state!.buildings.buildings.find(b => b.type === 'management_office')!;
+    const b1HpBefore = b1.hp;
+    const b2HpBefore = b2.hp;
+
+    surveyCommand(ctx as any, ['seismic'], { x: '20', z: '20' });
+    resolveTick();
+
+    expect(findBuilding(b1.id).hp).toBe(b1HpBefore - 10);
+    expect(findBuilding(b2.id).hp).toBe(b2HpBefore - 10);
   });
 });

--- a/tests/unit/console/mining-commands.test.ts
+++ b/tests/unit/console/mining-commands.test.ts
@@ -533,6 +533,142 @@ describe('blastCommand — ore report event wiring', () => {
     expect(detectSpy).toHaveBeenCalledWith(mockedReport, ctx.state!.events, ctx.state!.tickCount);
     expect(ctx.state!.events.pendingEvent?.eventId).toBe('lucky_strike');
   });
+
+  // ── GameState.lastOreReport wiring (issue #412) ───────────────────────────
+
+  it('leaves state.lastOreReport null before any blast has been executed', () => {
+    const ctx = makeMiningContext();
+    expect(ctx.state!.lastOreReport).toBeNull();
+  });
+
+  it('populates state.lastOreReport with the computed BlastOreReport after a blast', () => {
+    const ctx = makeMiningContext();
+
+    drillPlanCommand(ctx, ['grid'], { rows: '1', cols: '1', spacing: '3', depth: '8' });
+    chargeCommand(ctx, [], { hole: 'H1', explosive: 'boomite', amount: '5kg', stemming: '2m' });
+    sequenceCommand(ctx, ['set'], { hole: 'H1', delay: '0ms' });
+
+    const mockedReport = {
+      oreYields: { dirtite: 1300 },
+      totalYieldKg: 1300,
+      estimatedYieldKg: 1000,
+      yieldRatio: 1.3,
+      hasTreranium: false,
+      absurdiumFraction: 0,
+    };
+    vi.spyOn(SurveyCalcModule, 'computeBlastOreReport').mockReturnValue(mockedReport);
+
+    const result = blastCommand(ctx, [], {});
+
+    expect(result.success).toBe(true);
+    expect(ctx.state!.lastOreReport).not.toBeNull();
+    expect(ctx.state!.lastOreReport).toEqual(mockedReport);
+  });
+});
+
+// ── survey mode / ore_report subcommands (issue #412) ──────────────────────
+
+describe('surveyCommand — mode subcommand', () => {
+  it('returns success:true, not the "not implemented" stub placeholder', () => {
+    const ctx = makeMiningContext();
+    const result = surveyCommand(ctx, ['mode'], {});
+    expect(result.success).toBe(true);
+    expect(result.output).not.toBe('not implemented');
+  });
+
+  it('reports zero completed surveys when none have run yet', () => {
+    const ctx = makeMiningContext();
+    const result = surveyCommand(ctx, ['mode'], {});
+    expect(result.success).toBe(true);
+    expect(result.output.toLowerCase()).toMatch(/survey/);
+    expect(result.output).toMatch(/\b0\b/);
+  });
+
+  it('reflects the count of completed surveys in state.surveyResults', () => {
+    const ctx = makeMiningContext();
+    ctx.state!.surveyResults.push({
+      id: 1,
+      method: 'seismic',
+      centerX: 10,
+      centerZ: 10,
+      completedTick: 5,
+      surveyorId: 1,
+      estimates: {},
+      confidence: 0.9,
+    });
+
+    const result = surveyCommand(ctx, ['mode'], {});
+    expect(result.success).toBe(true);
+    expect(result.output).toMatch(/\b1\b/);
+  });
+
+  it('requires a loaded game', () => {
+    const ctx: MiningContext = {
+      state: null, grid: null, softwareTier: 0,
+      tubingState: createTubingState(), emitter: new EventEmitter(),
+    };
+    const result = surveyCommand(ctx, ['mode'], {});
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('No game loaded');
+  });
+});
+
+describe('surveyCommand — ore_report subcommand', () => {
+  it('returns success:false with a clear message when no ore report exists yet', () => {
+    const ctx = makeMiningContext();
+    expect(ctx.state!.lastOreReport).toBeNull();
+
+    const result = surveyCommand(ctx, ['ore_report'], {});
+    expect(result.success).toBe(false);
+    expect(result.output).not.toBe('not implemented');
+    expect(result.output.toLowerCase()).toMatch(/no.*(ore report|blast)/);
+  });
+
+  it('formats yield, estimate, and ratio data from a populated lastOreReport', () => {
+    const ctx = makeMiningContext();
+    ctx.state!.lastOreReport = {
+      oreYields: { dirtite: 1300 },
+      totalYieldKg: 1300,
+      estimatedYieldKg: 1000,
+      yieldRatio: 1.3,
+      hasTreranium: false,
+      absurdiumFraction: 0,
+    };
+
+    const result = surveyCommand(ctx, ['ore_report'], {});
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('dirtite');
+    expect(result.output).toMatch(/1300/);
+    expect(result.output).toMatch(/1000/);
+    // Ratio 1.3 → 130% (or "1.3" / "1.30" depending on format) must appear somewhere
+    expect(result.output).toMatch(/130%|1\.3\b/);
+  });
+
+  it('does not crash or print NaN% when estimatedYieldKg is 0 and yieldRatio is 1.0', () => {
+    const ctx = makeMiningContext();
+    ctx.state!.lastOreReport = {
+      oreYields: {},
+      totalYieldKg: 0,
+      estimatedYieldKg: 0,
+      yieldRatio: 1.0,
+      hasTreranium: false,
+      absurdiumFraction: 0,
+    };
+
+    const result = surveyCommand(ctx, ['ore_report'], {});
+    expect(result.success).toBe(true);
+    expect(result.output).not.toMatch(/NaN/);
+  });
+
+  it('requires a loaded game', () => {
+    const ctx: MiningContext = {
+      state: null, grid: null, softwareTier: 0,
+      tubingState: createTubingState(), emitter: new EventEmitter(),
+    };
+    const result = surveyCommand(ctx, ['ore_report'], {});
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('No game loaded');
+  });
 });
 
 describe('buildRampCommand', () => {

--- a/tests/unit/renderer/TerrainMesh.test.ts
+++ b/tests/unit/renderer/TerrainMesh.test.ts
@@ -432,8 +432,8 @@ describe('SurveyConfidenceOverlay', () => {
     overlay.dispose();
   });
 
-  // ── Stale point opacity (STALE_OPACITY = 0.25) ──
-  it('stale point has opacity multiplied by STALE_OPACITY (0.25)', () => {
+  // ── Stale point opacity (STALE_OPACITY = 0.6) ──
+  it('stale point has opacity multiplied by STALE_OPACITY (0.6)', () => {
     const scene = makeScene();
     const overlay = new SurveyConfidenceOverlay(scene);
     // Fresh point with opacity 0.6 → material opacity = 0.6 * 1.0 = 0.6
@@ -454,11 +454,11 @@ describe('SurveyConfidenceOverlay', () => {
     const staleMesh = group.children[0] as THREE.Mesh;
     const staleMat = staleMesh.material as THREE.MeshBasicMaterial;
 
-    // Stale opacity should be 0.25x the fresh opacity
+    // Stale opacity should be 0.6x the fresh opacity
     // Fresh: 0.6 * 1.0 = 0.6
-    // Stale: 0.6 * 0.25 = 0.15
+    // Stale: 0.6 * 0.6 = 0.36
     expect(freshOpacity).toBeCloseTo(0.6, 2);
-    expect(staleMat.opacity).toBeCloseTo(0.15, 2);
+    expect(staleMat.opacity).toBeCloseTo(0.36, 2);
     overlay.dispose();
   });
 


### PR DESCRIPTION
Closes #412

## Summary

Verified and fixed visual coherence across all 8 scenario files added by PR #386 (survey system: seismic/core-sample/aerial surveys, confidence overlay, stale surveys, ore vein visibility, post-blast ore reporting), per `gameplay-survey-system`.

### Fixes applied

- **Confidence overlay opacity/overlap bug**: adjacent overlay quads on 1-unit grid centers were overlapping and compounding alpha, turning large survey areas into an opaque flat-color plane that hid terrain texture entirely (confirmed via screenshot diff across the ore-vein-visibility scenario). Fixed by shrinking `CONFIDENCE_QUAD_SIZE` (1.8→1.0) and lowering global overlay opacity (0.6→0.4) in `SurveyConfidenceOverlay.ts`/`GameRenderer.ts`.
- **Stale-marker visibility regression** (caught by the visual feedback loop, second iteration): the opacity fix above compounded with the existing `STALE_OPACITY` multiplier, dropping stale survey markers to ~0.10 combined alpha — imperceptible against terrain. Raised `STALE_OPACITY` 0.25→0.6 to restore visibility while keeping stale markers visually duller than fresh ones.
- **Missing console commands**: `survey mode` and `survey ore_report` were unimplemented (`Unknown method`) — both scenarios that call them now get real, formatted output instead of an error.
- **Missing coverage gap — seismic building damage**: `gameplay-survey-system`'s Survey Visibility Rules document that a seismic survey damages buildings within 5 cells (−10 HP), but no implementation existed anywhere in `src/core`. Implemented `applySeismicSurveyDamage` (method-gated to seismic only), wired into the existing `AccidentRecord`/`DamageState` accident-tracking system (new `'seismic_damage'`/`'seismic_destroyed'` accident types) so it surfaces through `recentAccidents` like every other building-damage path. `survey-seismic-side-effects.json` extended with a `build`/`state full` sequence that exercises and proves the HP drop.
- `GameState.lastOreReport` now persists the last blast's ore report so `survey ore_report` has data to format.

### Files changed

- `src/console/commands/mining.ts` — `survey mode`/`survey ore_report` subcommands, `lastOreReport` wiring
- `src/console/commands/events.ts` — seismic damage wired into survey resolution, accident records pushed
- `src/core/mining/SeismicSurveyDamage.ts` (new, extracted during refactor) — seismic building-damage logic
- `src/core/mining/SurveyCalc.ts` — re-exports the above
- `src/core/entities/Damage.ts` — `AccidentRecord.type` extended
- `src/core/config/balance.ts` — `SEISMIC_SURVEY_DAMAGE_RADIUS`, `SEISMIC_SURVEY_DAMAGE_HP`
- `src/core/state/GameState.ts` — `lastOreReport` field
- `src/renderer/SurveyConfidenceOverlay.ts`, `src/renderer/GameRenderer.ts` — overlay constant tuning
- `scripts/scenario-defs/survey-seismic-side-effects.json` — extended scenario
- Tests: `tests/integration/survey.integration.test.ts`, `tests/unit/console/mining-commands.test.ts`, `tests/unit/renderer/TerrainMesh.test.ts`

5896 tests — all passing (203 files). 102/102 scenarios pass in command mode. `npm run validate` green.

## Decisions taken

- **What was open:** exact confidence-overlay opacity/quad-size values weren't specified by the issue or skill — only that overlapping quads produced an opaque flat-color plane that needed fixing.
  **Chosen:** `CONFIDENCE_QUAD_SIZE` 1.8→1.0, overlay `opacity` 0.6→0.4, `STALE_OPACITY` 0.25→0.6.
  **Why:** confirmed correct via screenshot inspection across all 8 scenarios — terrain stays legible under the overlay, confidence color-coding and fresh/stale distinction both remain clear.
  **If reversed:** change the three named constants in `src/renderer/SurveyConfidenceOverlay.ts`/`GameRenderer.ts`; no call sites move.

- **What was open:** `gameplay-survey-system`'s Survey Visibility Rules describe a color-coded ore-density/identity overlay on terrain distinct from the confidence overlay; it doesn't exist, and none of #386's 8 scenarios exercise it.
  **Chosen:** left out of this pass — ore density/identity is already surfaced via `SurveyUI`'s per-ore panel rows (text). Filing a `decision-review` follow-up issue rather than building a new overlay type under a fix-coherence issue.
  **Why:** the issue's own scenario checklist doesn't call for a new overlay type, and the existing text panel satisfies the weaker "surveyed voxels show ore data" reading of the spec.
  **If reversed:** implement a second terrain overlay layer keyed on dominant ore type per surveyed column.

- **What was open:** `AccidentRecord.type` had no category for a shockwave-caused (non-fragment) building hit.
  **Chosen:** added `'seismic_damage'`/`'seismic_destroyed'` rather than reusing `'building_damage'`/`'building_destroyed'`.
  **Why:** keeps the accident log's cause attribution honest for anything reading it later (e.g. lawsuit logic).
  **If reversed:** collapse the two new type strings into the existing pair; nothing else depends on the distinction today.

## Verification channels run

- **static** (`npm run typecheck`): PASS, clean
- **logic** (`npm run test`): PASS, 5896/5896
- **scenario** (`npm run scenarios`): PASS, 102/102 command-mode
- **visual** (`npm run scenario -- --mode interaction --screenshots`, all 8 PR #386 scenarios, screenshots inspected via Read tool across two feedback-loop iterations): PASS — confidence overlay legible over terrain, stale markers distinctly grey after fix, ore vein tint present, seismic wave animation renders, post-blast ore report text well-formed, single-cell surveys still legible at the smaller quad size
- **playability**: not run — this change is a rendering/overlay tune plus a console-command/back-end fix with no new UI panel or altered player-facing flow (survey execution UI itself is unchanged)
- `npm run validate` (typecheck → coverage → integration → scenario defs → build): PASS

READY TO MERGE