### PR TITLE
fix: correct invalid VehicleRole in vehicle-traffic scenario, reach traffic-jam state (#445)

### DIFF
--- a/scripts/scenario-defs/vehicle-traffic.json
+++ b/scripts/scenario-defs/vehicle-traffic.json
@@ -66,38 +66,101 @@
       ]
     },
     {
-      "command": "vehicle buy hauler",
+      "command": "vehicle buy debris_hauler",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle buy hauler"
+          "command": "vehicle buy debris_hauler"
         }
       ]
     },
     {
-      "command": "vehicle buy hauler",
+      "command": "vehicle buy debris_hauler",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle buy hauler"
+          "command": "vehicle buy debris_hauler"
         }
       ]
     },
     {
-      "command": "vehicle buy hauler",
+      "command": "vehicle buy debris_hauler",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle buy hauler"
+          "command": "vehicle buy debris_hauler"
         }
       ]
     },
     {
-      "command": "vehicle buy hauler",
+      "command": "vehicle buy debris_hauler",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle buy hauler"
+          "command": "vehicle buy debris_hauler"
+        }
+      ]
+    },
+    {
+      "command": "vehicle move 2 to:21,20",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle move 2 to:21,20"
+        }
+      ]
+    },
+    {
+      "command": "vehicle move 3 to:20,21",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle move 3 to:20,21"
+        }
+      ]
+    },
+    {
+      "command": "vehicle move 4 to:19,20",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle move 4 to:19,20"
+        }
+      ]
+    },
+    {
+      "command": "tick 5",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 5"
+        }
+      ]
+    },
+    {
+      "command": "vehicle move 2 to:20,20",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle move 2 to:20,20"
+        }
+      ]
+    },
+    {
+      "command": "vehicle move 3 to:20,20",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle move 3 to:20,20"
+        }
+      ]
+    },
+    {
+      "command": "vehicle move 4 to:20,20",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle move 4 to:20,20"
         }
       ]
     },

--- a/tests/unit/scenario-defs.test.ts
+++ b/tests/unit/scenario-defs.test.ts
@@ -4,6 +4,7 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import type { ScenarioDef, ScenarioStepDef } from '../../scripts/shared/scenario-types.js';
 import { loadScenarioDef, SCENARIO_DIR } from '../../scripts/shared/scenario-utils.js';
+import { getAllVehicleRoles } from '../../src/core/entities/Vehicle.js';
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 
@@ -314,6 +315,43 @@ describe('No steps use unknown commands', () => {
         }
       }
       expect(unknownCommands).toEqual([]);
+    });
+  }
+});
+
+// ──────────────────────────────────────────────
+// 8b. "vehicle buy" steps pass a valid VehicleRole
+// Regression: scripts/scenario-defs/vehicle-traffic.json used to pass
+// "hauler" as the role argument, which is not a member of VehicleRole
+// (the valid id is "debris_hauler"). Because the console command layer
+// rejects the buy with CommandResult.success:false rather than throwing,
+// `npm run scenarios` (command-mode runner) never surfaced the bug — it
+// only fails a step on a thrown exception. This test catches invalid
+// role tokens directly against the VehicleRole set instead of relying on
+// runtime command execution. See issue #445.
+// ──────────────────────────────────────────────
+describe('"vehicle buy" steps use a valid VehicleRole', () => {
+  const validRoles = getAllVehicleRoles();
+
+  for (const name of ALL_SCENARIO_NAMES) {
+    it(`${name} — every "vehicle buy" step's role is a valid VehicleRole`, () => {
+      const scenario = loadScenarioDef(name, SCENARIO_DIR);
+      const invalidRoleSteps: string[] = [];
+      for (let i = 0; i < scenario.steps.length; i++) {
+        const step = scenario.steps[i];
+        const cmdStr = typeof step === 'string' ? step : (step as ScenarioStepDef).command;
+        if (!cmdStr.startsWith('vehicle buy ')) continue;
+        const role = cmdStr.trim().split(/\s+/)[2];
+        if (!validRoles.includes(role as never)) {
+          invalidRoleSteps.push(
+            `step[${i}]: "${cmdStr}" — role "${role}" is not a valid VehicleRole (valid: ${validRoles.join(', ')})`,
+          );
+        }
+      }
+      expect(
+        invalidRoleSteps,
+        `${name}.json has "vehicle buy" steps with invalid roles:\n${invalidRoleSteps.join('\n')}`,
+      ).toEqual([]);
     });
   }
 });

--- a/tests/unit/scenario-defs.test.ts
+++ b/tests/unit/scenario-defs.test.ts
@@ -329,11 +329,18 @@ describe('No steps use unknown commands', () => {
 // only fails a step on a thrown exception. This test catches invalid
 // role tokens directly against the VehicleRole set instead of relying on
 // runtime command execution. See issue #445.
+//
+// Scoped to vehicle-traffic.json only — issue #445's exact scope. Two
+// other scenario files (level3-playthrough-win.json,
+// level1-lose-bankruptcy.json) were found to also carry invalid
+// VehicleRole tokens while writing this test, but fixing those is out of
+// scope for #445; they are tracked in a separate follow-up issue instead
+// of being folded into this regression test.
 // ──────────────────────────────────────────────
 describe('"vehicle buy" steps use a valid VehicleRole', () => {
   const validRoles = getAllVehicleRoles();
 
-  for (const name of ALL_SCENARIO_NAMES) {
+  for (const name of ['vehicle-traffic'] as const) {
     it(`${name} — every "vehicle buy" step's role is a valid VehicleRole`, () => {
       const scenario = loadScenarioDef(name, SCENARIO_DIR);
       const invalidRoleSteps: string[] = [];


### PR DESCRIPTION
Closes #445

## Summary

`scripts/scenario-defs/vehicle-traffic.json` called `vehicle buy hauler`, but `hauler` is not a valid `VehicleRole` (the actual id is `debris_hauler`). The console command layer rejects an invalid role with `CommandResult.success:false` rather than throwing, so `npm run scenarios`' command-mode runner never surfaced the bug — the scenario silently never owned a vehicle, and its `TrafficJamEvent` assertion could never fire.

Fix:
- Corrected all 4 `vehicle buy` steps in `scripts/scenario-defs/vehicle-traffic.json` from `hauler` to `debris_hauler`.
- The role-id fix alone was not sufficient: purchased vehicles spawn idle and never move on their own, so `detectTrafficJam` (which needs vehicles in `state: 'waiting'` with `waitingTicks >= 10` contesting the same cell) could still never fire. Added 6 `vehicle move` steps + 1 `tick 5` step so 3 of the 4 purchased vehicles converge, in two staged hops, onto the 4th vehicle's spawn tile (matching this repo's occupancy-check semantics in `EntityMovementTick.ts`, which only registers `waiting` state against the immediate next waypoint, not a one-hop overshoot onto the final cell).
- Added a regression test (`tests/unit/scenario-defs.test.ts`) asserting `vehicle-traffic.json`'s `vehicle buy` steps use a role id from `getAllVehicleRoles()`. This is necessary because `npm run scenarios` cannot catch this class of bug by itself (see above) — confirmed the test fails on the pre-fix JSON and passes on the fix.

## Decisions taken

Defaulted under `agentic-decision-autonomy`:

- **What was open:** the issue assumed swapping `hauler`→`debris_hauler` alone would let the scenario "demonstrate a jam." Investigation showed purchased vehicles never move without added `vehicle move` steps, so the fix needed to go beyond the issue's literal instruction.
  **Chosen:** added a staged two-hop `vehicle move` sequence for 3 of the 4 purchased vehicles, using the first-purchased vehicle's own spawn position as the blocking anchor — verified empirically to fire `traffic_jam` at tick 15, within the existing `tick 20` budget.
  **Why:** matches this repo's own established pattern for exercising `detectTrafficJam` through the real per-tick movement path (see `tests/integration/vehicles.integration.test.ts`'s existing traffic-jam test), and reaches the scenario's actual stated purpose rather than a literal-but-insufficient reading of the issue.
  **If reversed:** delete the added `vehicle move`/`tick 5` steps; scenario reverts to non-functional buy-only shape.

- **What was open:** while writing the regression test, the same invalid-`VehicleRole` bug was found in two other scenario files (`level3-playthrough-win.json`, `level1-lose-bankruptcy.json`) — outside #445's stated scope (#445 covers `vehicle-traffic.json` only, itself filed as a scope carve-out from #411).
  **Chosen:** scoped the new regression test to `vehicle-traffic.json` only; filed the other two files as a separate follow-up issue (#450) rather than folding them into this PR.
  **Why:** matches the relevance limit in `agentic-decision-autonomy` and the precedent that created #445 itself — fix what this issue's own change exposes, file unrelated pre-existing defects separately.
  **If reversed:** widen the test's scenario loop back to all scenarios (or `ALL_SCENARIO_NAMES`) once #450 is resolved.

## Verification

- `static` — `npm run typecheck`: PASS
- `logic` — `npm run test`: PASS (205 files, 6171 tests, including the new regression test)
- `scenario` — `npm run scenarios`: PASS (102/102). Inspected `vehicle-traffic`'s state dump directly (not just exit code) — final `state full` step shows `pendingEvent: { eventId: "traffic_jam", firedAtTick: 15 }`, vehicles 2/3/4 in `state: "waiting"`, `waitingTicks: 10`.
- `build` — `npx vite build`: PASS
- `visual`/`playability` — not owed: this is a scenario-definition data fix with no `src/renderer/`, `src/ui/`, or player-facing flow change.
- Code review: security PASS, quality PASS (after filing #450 to resolve a comment-accuracy finding), i18n PASS, duplication PASS (jscpd flagged 6 pre-existing clones in the touched test file, confirmed identical on `main` before this diff — unrelated), semantic PASS.

205 test files, 6171 tests — all passing.

READY TO MERGE