### PR TITLE
fix: align SKILL.md rock_digger tier-3 name with shipped Rock Reaper string (#446)

### DIFF
--- a/.claude/skills/gameplay-vehicle-fleet/SKILL.md
+++ b/.claude/skills/gameplay-vehicle-fleet/SKILL.md
@@ -22,7 +22,7 @@ Five roles, 3 tiers each. All names are fictional, humorous, and i18n-localized.
 | **Building Destroyer** | "Wrecking Rascal" | "Demolition Darling" | "Obliterator Supreme" | Demolishes buildings; required for tier-upgrade workflow |
 | **Debris Hauler** | "Dumpster on Wheels" | "Haul-o-Matic 3000" | "Mega Mover XL" | Hauls fragmented rock from blast zone to Freight Warehouse |
 | **Drill Rig** | "Pokey McPoke" | "Bore Master" | "Helldriller" | Drills blast holes to specified depth and angle |
-| **Rock Digger** | "The Scratch" | "Scoop Sergeant" | "Voxel Vanquisher" | Removes one voxel at a time; used for ramp shaping and access routes |
+| **Rock Digger** | "The Scratch" | "Scoop Sergeant" | "Rock Reaper" | Removes one voxel at a time; used for ramp shaping and access routes |
 | **Rock Fragmenter** | "Cracky" | "Smasher 2000" | "The Atomizer" | Breaks oversized debris boulders into transportable fragments |
 
 ## Tier Stat Multipliers

--- a/.github/skills/gameplay-vehicle-fleet/SKILL.md
+++ b/.github/skills/gameplay-vehicle-fleet/SKILL.md
@@ -22,7 +22,7 @@ Five roles, 3 tiers each. All names are fictional, humorous, and i18n-localized.
 | **Building Destroyer** | "Wrecking Rascal" | "Demolition Darling" | "Obliterator Supreme" | Demolishes buildings; required for tier-upgrade workflow |
 | **Debris Hauler** | "Dumpster on Wheels" | "Haul-o-Matic 3000" | "Mega Mover XL" | Hauls fragmented rock from blast zone to Freight Warehouse |
 | **Drill Rig** | "Pokey McPoke" | "Bore Master" | "Helldriller" | Drills blast holes to specified depth and angle |
-| **Rock Digger** | "The Scratch" | "Scoop Sergeant" | "Voxel Vanquisher" | Removes one voxel at a time; used for ramp shaping and access routes |
+| **Rock Digger** | "The Scratch" | "Scoop Sergeant" | "Rock Reaper" | Removes one voxel at a time; used for ramp shaping and access routes |
 | **Rock Fragmenter** | "Cracky" | "Smasher 2000" | "The Atomizer" | Breaks oversized debris boulders into transportable fragments |
 
 ## Tier Stat Multipliers

--- a/.opencode/skills/gameplay-vehicle-fleet/SKILL.md
+++ b/.opencode/skills/gameplay-vehicle-fleet/SKILL.md
@@ -22,7 +22,7 @@ Five roles, 3 tiers each. All names are fictional, humorous, and i18n-localized.
 | **Building Destroyer** | "Wrecking Rascal" | "Demolition Darling" | "Obliterator Supreme" | Demolishes buildings; required for tier-upgrade workflow |
 | **Debris Hauler** | "Dumpster on Wheels" | "Haul-o-Matic 3000" | "Mega Mover XL" | Hauls fragmented rock from blast zone to Freight Warehouse |
 | **Drill Rig** | "Pokey McPoke" | "Bore Master" | "Helldriller" | Drills blast holes to specified depth and angle |
-| **Rock Digger** | "The Scratch" | "Scoop Sergeant" | "Voxel Vanquisher" | Removes one voxel at a time; used for ramp shaping and access routes |
+| **Rock Digger** | "The Scratch" | "Scoop Sergeant" | "Rock Reaper" | Removes one voxel at a time; used for ramp shaping and access routes |
 | **Rock Fragmenter** | "Cracky" | "Smasher 2000" | "The Atomizer" | Breaks oversized debris boulders into transportable fragments |
 
 ## Tier Stat Multipliers


### PR DESCRIPTION
Closes #446

## Summary

`.claude/skills/gameplay-vehicle-fleet/SKILL.md` (and its `.github/` and `.opencode/` mirrors) documented the `rock_digger` vehicle role's tier-3 name as "Voxel Vanquisher". The shipped locale strings (`src/core/i18n/locales/en.json`, `fr.json`) and the test that pins them (`tests/unit/i18n/VehicleI18n.test.ts`) already correctly said "Rock Reaper" and already passed on `main`. This was a stale-doc-vs-shipped-code mismatch, filed as its own issue while resolving #411 (vehicle-fleet visual coherence), since it's a text mismatch rather than a rendering defect.

Fix: updated all three SKILL.md doc mirrors to say "Rock Reaper", matching the already-correct and already-tested shipped string. No `src/`, locale, or test files touched.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** the issue asked to align either the SKILL.md docs or the shipped locale string, without saying which is canonical.
  **Chosen:** treat "Rock Reaper" as canonical and update the three SKILL.md doc mirrors to match.
  **Why:** `agentic-decision-autonomy` default order 2 (convention in surrounding code) — the shipped `en.json`/`fr.json` strings and the test that pins them already agree with each other, and `fr.json`'s translation ("Le Faucheur de Rocs" = "The Reaper of Rocks") is thematically built around "Reaper", not "Vanquisher". `git log -S` shows the doc's "Voxel Vanquisher" predates the implementation commit (#45) that shipped "Rock Reaper" — the doc drifted from shipped code and three later doc-only commits carried the stale name forward without checking it against shipped strings.
  **If reversed:** edit `src/core/i18n/locales/en.json:2248`, `fr.json:2248` (with a French translation for the new name), and `tests/unit/i18n/VehicleI18n.test.ts:109-110` instead, leaving the three SKILL.md files as-is.

## Verification

- **static** (`npm run typecheck` / `tsc --noEmit`) — PASS, 0 errors
- **logic** (`npm run test`) — PASS, 205 test files / 6171 tests, including `VehicleI18n.test.ts` (unchanged, still pins "Rock Reaper")
- **build** (`vite build`) — PASS
- **scenario / visual / playability** — not applicable: no `src/`, `src/renderer/`, `src/ui/`, or player-facing surface touched; this is a documentation-only change with zero runtime code path reading the edited files
- Code review: security, quality, i18n, duplication, semantic — all PASS (parallel review, no findings)

Verified no other stale "Voxel Vanquisher" reference remains anywhere in the repo (`grep -rn "Voxel Vanquisher" .` → empty), and all three SKILL.md mirrors remain byte-identical to each other per project convention.

READY TO MERGE