### PR TITLE
fix: correct invalid VehicleRole tokens in 5 scenario-def JSON files (#450)

### DIFF
--- a/scripts/scenario-defs/level1-lose-bankruptcy.json
+++ b/scripts/scenario-defs/level1-lose-bankruptcy.json
@@ -102,20 +102,20 @@
       ]
     },
     {
-      "command": "vehicle buy excavator",
+      "command": "vehicle buy rock_digger",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle buy excavator"
+          "command": "vehicle buy rock_digger"
         }
       ]
     },
     {
-      "command": "vehicle buy truck",
+      "command": "vehicle buy debris_hauler",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle buy truck"
+          "command": "vehicle buy debris_hauler"
         }
       ]
     },
@@ -129,11 +129,11 @@
       ]
     },
     {
-      "command": "vehicle buy bulldozer",
+      "command": "vehicle buy building_destroyer",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle buy bulldozer"
+          "command": "vehicle buy building_destroyer"
         }
       ]
     },

--- a/scripts/scenario-defs/level2-playthrough-bankruptcy.json
+++ b/scripts/scenario-defs/level2-playthrough-bankruptcy.json
@@ -129,20 +129,20 @@
       ]
     },
     {
-      "command": "vehicle buy excavator",
+      "command": "vehicle buy rock_digger",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle buy excavator"
+          "command": "vehicle buy rock_digger"
         }
       ]
     },
     {
-      "command": "vehicle buy truck",
+      "command": "vehicle buy debris_hauler",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle buy truck"
+          "command": "vehicle buy debris_hauler"
         }
       ]
     },
@@ -156,20 +156,20 @@
       ]
     },
     {
-      "command": "vehicle buy bulldozer",
+      "command": "vehicle buy building_destroyer",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle buy bulldozer"
+          "command": "vehicle buy building_destroyer"
         }
       ]
     },
     {
-      "command": "vehicle buy hauler",
+      "command": "vehicle buy debris_hauler",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle buy hauler"
+          "command": "vehicle buy debris_hauler"
         }
       ]
     },

--- a/scripts/scenario-defs/level2-playthrough-win.json
+++ b/scripts/scenario-defs/level2-playthrough-win.json
@@ -327,20 +327,20 @@
       ]
     },
     {
-      "command": "vehicle buy excavator",
+      "command": "vehicle buy rock_digger",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle buy excavator"
+          "command": "vehicle buy rock_digger"
         }
       ]
     },
     {
-      "command": "vehicle buy truck",
+      "command": "vehicle buy debris_hauler",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle buy truck"
+          "command": "vehicle buy debris_hauler"
         }
       ]
     },

--- a/scripts/scenario-defs/level3-playthrough-win.json
+++ b/scripts/scenario-defs/level3-playthrough-win.json
@@ -381,20 +381,20 @@
       ]
     },
     {
-      "command": "vehicle buy excavator",
+      "command": "vehicle buy rock_digger",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle buy excavator"
+          "command": "vehicle buy rock_digger"
         }
       ]
     },
     {
-      "command": "vehicle buy truck",
+      "command": "vehicle buy debris_hauler",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle buy truck"
+          "command": "vehicle buy debris_hauler"
         }
       ]
     },
@@ -408,20 +408,20 @@
       ]
     },
     {
-      "command": "vehicle buy bulldozer",
+      "command": "vehicle buy building_destroyer",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle buy bulldozer"
+          "command": "vehicle buy building_destroyer"
         }
       ]
     },
     {
-      "command": "vehicle buy hauler",
+      "command": "vehicle buy debris_hauler",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle buy hauler"
+          "command": "vehicle buy debris_hauler"
         }
       ]
     },

--- a/scripts/scenario-defs/tutorial-playthrough.json
+++ b/scripts/scenario-defs/tutorial-playthrough.json
@@ -222,11 +222,11 @@
       ]
     },
     {
-      "command": "vehicle buy hauler",
+      "command": "vehicle buy debris_hauler",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle buy hauler"
+          "command": "vehicle buy debris_hauler"
         }
       ]
     },

--- a/tests/unit/scenario-defs.test.ts
+++ b/tests/unit/scenario-defs.test.ts
@@ -330,17 +330,18 @@ describe('No steps use unknown commands', () => {
 // role tokens directly against the VehicleRole set instead of relying on
 // runtime command execution. See issue #445.
 //
-// Scoped to vehicle-traffic.json only — issue #445's exact scope. Two
-// other scenario files (level3-playthrough-win.json,
-// level1-lose-bankruptcy.json) were found to also carry invalid
-// VehicleRole tokens while writing this test, but fixing those is out of
-// scope for #445; they are tracked in a separate follow-up issue instead
-// of being folded into this regression test.
+// Widened to every scenario in ALL_SCENARIO_NAMES (see issue #450):
+// level3-playthrough-win.json, level1-lose-bankruptcy.json,
+// level2-playthrough-win.json, level2-playthrough-bankruptcy.json, and
+// tutorial-playthrough.json all still carry invalid legacy VehicleRole
+// tokens (e.g. "excavator", "truck", "bulldozer", "hauler") in their
+// "vehicle buy" steps. This check now covers all of them, not just
+// vehicle-traffic.json.
 // ──────────────────────────────────────────────
 describe('"vehicle buy" steps use a valid VehicleRole', () => {
   const validRoles = getAllVehicleRoles();
 
-  for (const name of ['vehicle-traffic'] as const) {
+  for (const name of ALL_SCENARIO_NAMES) {
     it(`${name} — every "vehicle buy" step's role is a valid VehicleRole`, () => {
       const scenario = loadScenarioDef(name, SCENARIO_DIR);
       const invalidRoleSteps: string[] = [];


### PR DESCRIPTION
Closes #450

## Summary

Corrects legacy/invalid `VehicleRole` tokens (`excavator`, `truck`, `bulldozer`, `hauler`) used in `vehicle buy <role>` scenario steps across five scenario-definition files, same bug class as #445 (`vehicle-traffic.json`, already fixed). An invalid role makes the console command layer return `CommandResult.success:false` without throwing, so `npm run scenarios`' command-mode runner never surfaced the no-op purchase — the vehicle was silently never created.

Mapping applied (driver-qualification pairing in `src/core/entities/Vehicle.ts` ties each legacy name to a real role):

| Legacy token | Correct `VehicleRole` |
|---|---|
| `excavator` | `rock_digger` |
| `truck` | `debris_hauler` |
| `bulldozer` | `building_destroyer` |
| `hauler` | `debris_hauler` |

Files fixed (both the `command` string and its mirrored `interaction[0].command` string on each touched step):

- `scripts/scenario-defs/level3-playthrough-win.json` (steps 42, 43, 45, 46)
- `scripts/scenario-defs/level1-lose-bankruptcy.json` (steps 11, 12, 14)
- `scripts/scenario-defs/level2-playthrough-win.json` (steps 36, 37)
- `scripts/scenario-defs/level2-playthrough-bankruptcy.json` (steps 14, 15, 17, 18)
- `scripts/scenario-defs/tutorial-playthrough.json` (step 24)

Also widened the regression test added in #445 (`tests/unit/scenario-defs.test.ts`, `"vehicle buy" steps use a valid VehicleRole` describe block) from checking only `vehicle-traffic.json` to iterating `ALL_SCENARIO_NAMES`, so this bug class is now caught across every scenario-def file, not just one.

6272 tests — all passing. 102/102 scenarios pass in command mode. Full `npm run validate` gate green (typecheck, coverage, integration, scenario defs, build).

## Decisions taken

Defaulted under `agentic-decision-autonomy`  none blocked this run.

- **What was open:** the issue named only `level3-playthrough-win.json` and `level1-lose-bankruptcy.json` and called the exact role mapping a "best guess," leaving `bulldozer` ambiguous between `rock_digger` and `building_destroyer`.
  **Chosen:** `excavator`→`rock_digger`, `truck`→`debris_hauler`, `bulldozer`→`building_destroyer`, `hauler`→`debris_hauler`.
  **Why:** `src/core/entities/Vehicle.ts`'s driver-qualification pairing ties `debris_hauler`+`building_destroyer` to `driving.truck` and `rock_digger`+`rock_fragmenter` to `driving.excavator` — the game already treats "truck"/"excavator" as legacy names for those pairs. No touched scenario step tasks a purchased vehicle with digging or demolition after the buy (all are followed only by list/finances steps), so no in-scenario evidence disambiguates `bulldozer` further; it defaults to `building_destroyer`, giving each affected file's starter fleet one of each legacy-named role.
  **If reversed:** remap the four tokens in the five JSON files listed above; no code or test-structure changes.

- **What was open:** the issue's own item 5 asked to check all scenario-def files for other invalid `VehicleRole` tokens, not just the two named ones. This surfaced three more affected files (`level2-playthrough-win.json`, `level2-playthrough-bankruptcy.json`, `tutorial-playthrough.json`).
  **Chosen:** fixed all five files in this PR, using the same mapping, and widened the regression test to cover every scenario-def file.
  **Why:** per `agentic-decision-autonomy`'s "scope beyond the issue's framing is not a blocker" — the widened test the issue itself asked for fails against these three additional files otherwise, so the fix they need is in-scope for this issue, not a separate one.
  **If reversed:** narrow the test's scenario coverage back down and revert those three files — not recommended, reintroduces the same silent no-op bug class in scenario files CI already runs.

Both decisions concern scenario-def test/QA fixtures used by `npm run scenarios`, not live player-facing gameplay/economy config — no `decision-review` follow-up issue opened.

## Verification channels

| Channel | Result |
|---|---|
| static (`npm run typecheck`) | PASS — 0 errors |
| logic (`npm run test`) | PASS — 205 files, 6272 tests |
| scenario (`npm run scenarios`) | PASS — 102/102 scenarios |
| combined gate (`npm run validate`) | PASS — typecheck, coverage, integration, scenario defs, build all green |
| visual / playability | N/A — no `src/renderer/`, `src/ui/`, or other `src/` files touched; JSON scenario-def data + test-loop widening only |

Qualimetry (jscpd) on the changed test file shows identical duplication counts before and after this diff (48 lines / 840 tokens, both against `origin/main` and this branch) — no new duplication introduced.

Code review: security, quality, i18n, duplication, and semantic reviewers all reported PASS/Clean (one non-blocking quality suggestion: a comment's tense reads as if the now-fixed files were still broken).

READY TO MERGE