### PR TITLE
fix: correct out-of-range boomite charge amounts in overcharge/undercharge scenarios (#431)

### DIFF
--- a/.claude/skills/dev-testing-strategy/SKILL.md
+++ b/.claude/skills/dev-testing-strategy/SKILL.md
@@ -151,8 +151,8 @@ Scenario steps can define an `interaction` array of `InteractionStepAction` obje
 | `building-lifecycle.json` | 1 | Place → research → demolish → rebuild Tier 2 |
 | `vehicle-traffic.json` | 2 | 4 haulers on narrow ramp → TrafficJamEvent |
 | `employee-training.json` | 3 | Hire generalist → train → blast task accepted |
-| `blast-undercharge.json` | 5 | 30% optimal charge → oversized fragments, zero projections |
-| `blast-overcharge.json` | 5 | 500% optimal charge → projections, catastrophic rating |
+| `blast-undercharge.json` | 5 | Minimum viable charge (2kg) → a couple oversized fragments, zero projections |
+| `blast-overcharge.json` | 5 | Maximum valid charge (8kg) → projections appear, rating degrades perfect to mediocre |
 | `collapse-recovery.json` | 7 | Fatigue hits collapse → rest → original task resumes |
 | `contract-negotiation.json` | — | Negotiate 10× → both improved and worsened outcomes |
 | `weather-flood.json` | — | Heavy rain → flooded holes → water-sensitive explosive fails |

--- a/.github/skills/dev-testing-strategy/SKILL.md
+++ b/.github/skills/dev-testing-strategy/SKILL.md
@@ -151,8 +151,8 @@ Scenario steps can define an `interaction` array of `InteractionStepAction` obje
 | `building-lifecycle.json` | 1 | Place → research → demolish → rebuild Tier 2 |
 | `vehicle-traffic.json` | 2 | 4 haulers on narrow ramp → TrafficJamEvent |
 | `employee-training.json` | 3 | Hire generalist → train → blast task accepted |
-| `blast-undercharge.json` | 5 | 30% optimal charge → oversized fragments, zero projections |
-| `blast-overcharge.json` | 5 | 500% optimal charge → projections, catastrophic rating |
+| `blast-undercharge.json` | 5 | Minimum viable charge (2kg) → a couple oversized fragments, zero projections |
+| `blast-overcharge.json` | 5 | Maximum valid charge (8kg) → projections appear, rating degrades perfect to mediocre |
 | `collapse-recovery.json` | 7 | Fatigue hits collapse → rest → original task resumes |
 | `contract-negotiation.json` | — | Negotiate 10× → both improved and worsened outcomes |
 | `weather-flood.json` | — | Heavy rain → flooded holes → water-sensitive explosive fails |

--- a/.opencode/skills/dev-testing-strategy/SKILL.md
+++ b/.opencode/skills/dev-testing-strategy/SKILL.md
@@ -151,8 +151,8 @@ Scenario steps can define an `interaction` array of `InteractionStepAction` obje
 | `building-lifecycle.json` | 1 | Place → research → demolish → rebuild Tier 2 |
 | `vehicle-traffic.json` | 2 | 4 haulers on narrow ramp → TrafficJamEvent |
 | `employee-training.json` | 3 | Hire generalist → train → blast task accepted |
-| `blast-undercharge.json` | 5 | 30% optimal charge → oversized fragments, zero projections |
-| `blast-overcharge.json` | 5 | 500% optimal charge → projections, catastrophic rating |
+| `blast-undercharge.json` | 5 | Minimum viable charge (2kg) → a couple oversized fragments, zero projections |
+| `blast-overcharge.json` | 5 | Maximum valid charge (8kg) → projections appear, rating degrades perfect to mediocre |
 | `collapse-recovery.json` | 7 | Fatigue hits collapse → rest → original task resumes |
 | `contract-negotiation.json` | — | Negotiate 10× → both improved and worsened outcomes |
 | `weather-flood.json` | — | Heavy rain → flooded holes → water-sensitive explosive fails |

--- a/scripts/scenario-defs/blast-overcharge.json
+++ b/scripts/scenario-defs/blast-overcharge.json
@@ -1,6 +1,6 @@
 {
   "name": "blast-overcharge",
-  "description": "Chapter 5: Charge at 500 percent optimal explosive amount to trigger flyrock projections and catastrophic rating",
+  "description": "Chapter 5: Charge at the maximum valid boomite amount (8kg) to trigger flyrock projections and degrade the blast rating from perfect toward mediocre",
   "steps": [
     {
       "command": "new_game seed:42",
@@ -21,11 +21,11 @@
       ]
     },
     {
-      "command": "charge hole:* explosive:boomite amount:25 stemming:2",
+      "command": "charge hole:* explosive:boomite amount:8 stemming:2",
       "interaction": [
         {
           "type": "command",
-          "command": "charge hole:* explosive:boomite amount:25 stemming:2"
+          "command": "charge hole:* explosive:boomite amount:8 stemming:2"
         }
       ]
     },

--- a/scripts/scenario-defs/blast-undercharge.json
+++ b/scripts/scenario-defs/blast-undercharge.json
@@ -1,6 +1,6 @@
 {
   "name": "blast-undercharge",
-  "description": "Chapter 5: Charge at 30 percent optimal explosive amount to produce oversized fragments with zero projections",
+  "description": "Chapter 5: Charge at the minimum viable boomite amount (2kg) to produce a couple of oversized fragments with zero projections",
   "steps": [
     {
       "command": "new_game seed:42",
@@ -21,11 +21,11 @@
       ]
     },
     {
-      "command": "charge hole:* explosive:boomite amount:1 stemming:2",
+      "command": "charge hole:* explosive:boomite amount:2 stemming:2",
       "interaction": [
         {
           "type": "command",
-          "command": "charge hole:* explosive:boomite amount:1 stemming:2"
+          "command": "charge hole:* explosive:boomite amount:2 stemming:2"
         }
       ]
     },

--- a/tests/integration/blast-charge-scenarios-431.integration.test.ts
+++ b/tests/integration/blast-charge-scenarios-431.integration.test.ts
@@ -5,14 +5,24 @@
 // scripts/shared/command-runner.ts) and asserts on the resulting game state,
 // rather than just checking the JSON files parse.
 //
-//   - blast-overcharge: charges boomite at amount:25, out of boomite's
-//     [1,8]kg valid range (src/core/world/ExplosiveCatalog.ts). ChargePlan's
-//     createCharge rejects the charge, chargesByHole stays empty, and the
-//     later blast step fails validateBlastPlan with "Missing charge" for
-//     every hole — the blast never fires.
-//   - blast-undercharge: charges boomite at amount:1, in-range but too weak
-//     for the 2x2 hole grid, so the blast fires but clears nothing
-//     (Cleared voxels: 0 / Fragments: 0).
+// Regression this test guards against (pre-fix, issue #431): the
+// scenario JSONs used to charge boomite at amount:25 for blast-overcharge
+// (out of boomite's [1,8]kg valid range, src/core/world/ExplosiveCatalog.ts)
+// and amount:1 for blast-undercharge. ChargePlan's createCharge rejected the
+// amount:25 charge outright — chargesByHole stayed empty and the later blast
+// step failed validateBlastPlan with "Missing charge" for every hole, so the
+// blast never fired. amount:1 was in-range but too weak for the 2x2 hole
+// grid, so the blast fired but cleared nothing (Cleared voxels: 0 /
+// Fragments: 0).
+//
+// Current (fixed) scenario files: blast-overcharge now charges amount:8
+// (boomite's max valid amount — still an overcharge relative to the hole
+// grid, producing flyrock/projections) and blast-undercharge charges
+// amount:2 (boomite's min viable amount — clears voxels and produces
+// fragments but no projections). Both are within [1,8]kg, so the charge
+// step succeeds for both scenarios. That is why every assertion below
+// expects success (`not.toMatch(/out of range/i)`, `chargeStep.error
+// toBeUndefined()`) rather than the pre-fix rejection.
 //
 // DO NOT implement anything here — only add implementation to src/.
 

--- a/tests/integration/blast-charge-scenarios-431.integration.test.ts
+++ b/tests/integration/blast-charge-scenarios-431.integration.test.ts
@@ -1,0 +1,122 @@
+// BlastSimulator2026 — Scenario-runner integration tests for issue #431
+//
+// Runs blast-overcharge.json and blast-undercharge.json through the
+// command-mode scenario runner (pure Node.js, no browser — see
+// scripts/shared/command-runner.ts) and asserts on the resulting game state,
+// rather than just checking the JSON files parse.
+//
+//   - blast-overcharge: charges boomite at amount:25, out of boomite's
+//     [1,8]kg valid range (src/core/world/ExplosiveCatalog.ts). ChargePlan's
+//     createCharge rejects the charge, chargesByHole stays empty, and the
+//     later blast step fails validateBlastPlan with "Missing charge" for
+//     every hole — the blast never fires.
+//   - blast-undercharge: charges boomite at amount:1, in-range but too weak
+//     for the 2x2 hole grid, so the blast fires but clears nothing
+//     (Cleared voxels: 0 / Fragments: 0).
+//
+// DO NOT implement anything here — only add implementation to src/.
+
+import { describe, it, expect } from 'vitest';
+import { resolve } from 'path';
+import { tmpdir } from 'os';
+import { createGameEngine, runSteps } from '../../scripts/shared/command-runner.js';
+import { loadScenarioDef, SCENARIO_DIR } from '../../scripts/shared/scenario-utils.js';
+import type { StepResult } from '../../scripts/shared/scenario-types.js';
+
+function runScenarioSteps(name: string) {
+  const engine = createGameEngine();
+  const scenario = loadScenarioDef(name, SCENARIO_DIR);
+  const outDir = resolve(tmpdir(), `bs2026-scenario-431-${name}`);
+  const results = runSteps(engine, scenario.steps, outDir);
+  return { engine, results };
+}
+
+/** Find the first result whose command starts with the given prefix. */
+function stepFor(results: StepResult[], commandPrefix: string): StepResult {
+  const found = results.find(r => r.command.startsWith(commandPrefix));
+  if (!found) throw new Error(`No step found for command prefix "${commandPrefix}"`);
+  return found;
+}
+
+interface BlastReportNumbers {
+  clearedVoxels: number;
+  fragments: number;
+  projections: number;
+}
+
+/** Parse the `=== BLAST REPORT ===` block printed by src/console/commands/mining.ts. */
+function parseBlastReport(output: string): BlastReportNumbers {
+  const clearedMatch = output.match(/Cleared voxels: (\d+)/);
+  const fragmentsMatch = output.match(/Fragments: (\d+)/);
+  const projectionsMatch = output.match(/Projections: (\d+)/);
+  if (!clearedMatch || !fragmentsMatch || !projectionsMatch) {
+    throw new Error(`Could not parse BLAST REPORT numbers from output:\n${output}`);
+  }
+  return {
+    clearedVoxels: Number(clearedMatch[1]),
+    fragments: Number(fragmentsMatch[1]),
+    projections: Number(projectionsMatch[1]),
+  };
+}
+
+describe('blast-overcharge — scenario-runner (#431)', () => {
+  it('the charge step succeeds — amount is within boomite\'s valid range', () => {
+    const { results } = runScenarioSteps('blast-overcharge');
+    const chargeStep = stepFor(results, 'charge hole:*');
+    expect(chargeStep.commandOutput).not.toMatch(/out of range/i);
+    expect(chargeStep.error).toBeUndefined();
+  });
+
+  it('the blast step succeeds and does not report "Missing charge" or an invalid plan', () => {
+    const { results } = runScenarioSteps('blast-overcharge');
+    const blastStep = stepFor(results, 'blast');
+    expect(blastStep.error, blastStep.commandOutput).toBeUndefined();
+    expect(blastStep.commandOutput).not.toMatch(/missing charge|invalid plan/i);
+  });
+
+  it('produces cleared voxels, fragments, and projections (flyrock from overcharge)', () => {
+    const { results } = runScenarioSteps('blast-overcharge');
+    const blastStep = stepFor(results, 'blast');
+    const report = parseBlastReport(blastStep.commandOutput);
+    expect(report.clearedVoxels).toBeGreaterThan(0);
+    expect(report.fragments).toBeGreaterThan(0);
+    expect(report.projections).toBeGreaterThan(0);
+  });
+});
+
+describe('blast-undercharge — scenario-runner (#431)', () => {
+  it('the charge step succeeds — amount is within boomite\'s valid range', () => {
+    const { results } = runScenarioSteps('blast-undercharge');
+    const chargeStep = stepFor(results, 'charge hole:*');
+    expect(chargeStep.commandOutput).not.toMatch(/out of range/i);
+    expect(chargeStep.error).toBeUndefined();
+  });
+
+  it('the blast step succeeds and does not report "Missing charge" or an invalid plan', () => {
+    const { results } = runScenarioSteps('blast-undercharge');
+    const blastStep = stepFor(results, 'blast');
+    expect(blastStep.error, blastStep.commandOutput).toBeUndefined();
+    expect(blastStep.commandOutput).not.toMatch(/missing charge|invalid plan/i);
+  });
+
+  it('clears voxels and produces fragments, but zero projections (charge too weak for flyrock)', () => {
+    const { results } = runScenarioSteps('blast-undercharge');
+    const blastStep = stepFor(results, 'blast');
+    const report = parseBlastReport(blastStep.commandOutput);
+    expect(report.clearedVoxels).toBeGreaterThan(0);
+    expect(report.fragments).toBeGreaterThan(0);
+    expect(report.projections).toBe(0);
+  });
+});
+
+describe('blast-overcharge vs blast-undercharge — relative magnitude (#431)', () => {
+  it('overcharge produces strictly more fragments than undercharge', () => {
+    const overResults = runScenarioSteps('blast-overcharge').results;
+    const underResults = runScenarioSteps('blast-undercharge').results;
+
+    const overReport = parseBlastReport(stepFor(overResults, 'blast').commandOutput);
+    const underReport = parseBlastReport(stepFor(underResults, 'blast').commandOutput);
+
+    expect(overReport.fragments).toBeGreaterThan(underReport.fragments);
+  });
+});


### PR DESCRIPTION
Closes #431

## Summary

`scripts/scenario-defs/blast-overcharge.json` charged boomite at `amount:25`, outside boomite's valid `[1,8]kg` range (`src/core/world/ExplosiveCatalog.ts`). `ChargePlan.createCharge` rejected the charge, leaving every hole uncharged, so the subsequent `blast` command failed validation ("Missing charge") — the blast never fired at all. `blast-undercharge.json` charged at `amount:1`, in-range but too weak for its 2x2 hole grid, producing zero cleared voxels / zero fragments. Both scenarios were visually and mechanically inert despite `npm run scenarios` reporting them as passing (no assertion checked fragment/voxel counts — the gap the issue names).

Fix:
- `blast-overcharge.json`: `amount:25` → `amount:8` (boomite's max valid charge), both the `command` and `interaction.command` occurrences. Description updated to describe the achieved outcome (projections/flyrock, rating degrades to mediocre) rather than the unattainable "500% optimal / catastrophic" framing.
- `blast-undercharge.json`: `amount:1` → `amount:2` (min viable charge for this hole grid), same dual-occurrence update. Description updated to describe the achieved outcome (small oversized-fragment count, zero projections).
- `.claude/skills/dev-testing-strategy/SKILL.md` (+ synced `.github`/`.opencode` copies): scenario-inventory rows updated to match the new, verified outcomes.
- New regression test `tests/integration/blast-charge-scenarios-431.integration.test.ts`, replaying both scenario JSONs through the same runner `npm run scenarios` uses, asserting: no "out of range" / "Missing charge" errors, non-zero cleared voxels/fragments for both, non-zero projections for overcharge, zero projections for undercharge, and overcharge's fragment count strictly exceeding undercharge's.

## Decisions taken

Defaulted under `agentic-decision-autonomy`:

- **What was open:** issue suggested either adjusting the charge amount or widening boomite's valid range. **Chosen:** adjust charge amounts only (8kg/2kg); left `ExplosiveCatalog.ts`'s `[1,8]kg` range untouched. **Why:** that range is a shared balance constant used by every other boomite scenario (`blast-basic.json`, `blast-execution-effects.json`, etc.) — widening it for one scenario's cosmetic framing would be an unjustified live balance change, while the data-file fix is fully self-contained. **If reversed:** change the two `amount:` values back, or widen `maxChargeKg` in `src/core/world/ExplosiveCatalog.ts:57`.

- **What was open:** issue's "500%/30% optimal" framing implied a canonical "optimal charge" value that doesn't exist as a named constant. **Chosen:** treated the informally-recurring 5kg boomite charge (used across several other scenario files) as the de facto baseline, picking 8kg (max, ~160% of baseline) for overcharge and 2kg (~40% of baseline, smallest amount that still clears any voxel on this grid) for undercharge. **Why:** matches the narrowest available convention and satisfies the issue's hard requirement of nonzero fragment/voxel counts. **If reversed:** change the two `amount:` values; no other call site depends on them.

- **What was open:** issue's suggested overcharge outcome ("catastrophic rating") is unreachable at any valid boomite charge for this hole grid — 8kg (the ceiling) yields `MEDIOCRE`, not `CATASTROPHIC`. **Chosen:** rewrote the scenario description to state the actually-achieved outcome instead of forcing an unattainable rating label. **Why:** the description is documentation, not a gameplay lever; matching it to verified behavior is more honest than reshaping the drill grid to chase an exact enum value with no acceptance criterion requiring it.

These decisions concern dev-tooling scenario descriptions and test fixtures, not shipped gameplay/economy/player-facing defaults (confirmed non-player-facing: `scripts/scenario-defs/*.json` `description` fields are only read by `scripts/playtest.ts` console logging) — no `decision-review` follow-up issue opened.

## Verification

| Channel | Command | Result |
|---|---|---|
| static | `npm run typecheck` | PASS — 0 errors |
| logic | `npx vitest run` | PASS — 206 files, 6279 tests |
| scenario | `npm run scenarios` | PASS — 102/102 scenario definitions |
| scenario-defs | `npm run test:scenarios` | PASS — 2328/2328 |
| visual | `npm run scenario -- --scenario blast-overcharge/blast-undercharge --mode interaction --screenshots`, inspected with Read tool | PASS — overcharge shows large debris crater (705 cleared voxels, 5885 fragments, balance $50,000→$619,900); undercharge shows small discoloration patch, no rubble pile (51 cleared voxels, 2 fragments, balance $50,000→$51,600); both visibly differ from their pre-blast state, resolving the prior silent no-op |
| build | `npx vite build` | PASS |
| playability | N/A | not required — change is scenario-def test-fixture data + integration test only, no player-facing UI/flow touched |

7/7 new integration tests pass; full suite 6279/6279 pass; qualimetry (`jscpd`) exits 0 (minor non-blocking test-file duplication noted, reviewed as acceptable/suggestion-only by duplication-reviewer).

READY TO MERGE