### PR TITLE
Document Research Center requirements in gameplay-buildings skill

### DIFF
--- a/.claude/skills/gameplay-buildings/SKILL.md
+++ b/.claude/skills/gameplay-buildings/SKILL.md
@@ -13,7 +13,7 @@ Buildings are player's infrastructure layer. Gate actions behind qualified emplo
 
 - **Every action requires qualified employee.** No qualified employee → immediate error, not silent queue.
 - **Training buildings** upskill employees for time + fee. Hiring pre-qualified staff generally cheaper.
-- **Research Center** prerequisite for unlocking higher tiers of all other buildings.
+- **Research Center** prerequisite for unlocking higher tiers of all other buildings — a placed Research Center building is required before any research task can be queued, not just implied by the unlock fiction.
 - **Placement tradeoff:** Far-from-pit reduces projection damage risk but increases travel time (productivity loss).
 
 ## Building Types & Tier Names
@@ -34,11 +34,19 @@ All tier names are fictional and humorous. Localized via i18n (`en.json` + `fr.j
 
 ## Tier System
 
-Tier 1 is available from the start. Higher tiers unlocked by paid Research Center tasks:
-- Research task occupies Research Center for fixed duration + costs money
-- Higher tiers: larger capacity, better performance, larger physical footprint
-- Upgrading: demolish old building → construct new tier on same/adjacent cleared ground
-- Both construction and demolition carry a cost
+Tier 1 is available from the start. Higher tiers unlocked by paid Research Center tasks.
+
+**A placed `research_center` building is a hard prerequisite to queue any research task.** No research center on the map → no research task can be queued, enforced at the point research is queued, not left to the unlock fiction.
+
+Research task shape:
+- **Cost** (money) — every research task has one.
+- **Duration** (ticks occupying the Research Center) — every task beyond the first upgrade has one.
+- **Conditions** (prerequisites already met — e.g. a specific other building already at a given tier, or another research already completed) — every task beyond the first upgrade has these too.
+- **Exception — first upgrade (tier 1 → tier 2) of any building type:** cost only, no duration, no conditions.
+
+Higher tiers: larger capacity, better performance, larger physical footprint.
+Upgrading: demolish old building → construct new tier on same/adjacent cleared ground.
+Both construction and demolition carry a cost.
 
 ## Training Buildings
 

--- a/.github/skills/gameplay-buildings/SKILL.md
+++ b/.github/skills/gameplay-buildings/SKILL.md
@@ -13,7 +13,7 @@ Buildings are player's infrastructure layer. Gate actions behind qualified emplo
 
 - **Every action requires qualified employee.** No qualified employee → immediate error, not silent queue.
 - **Training buildings** upskill employees for time + fee. Hiring pre-qualified staff generally cheaper.
-- **Research Center** prerequisite for unlocking higher tiers of all other buildings.
+- **Research Center** prerequisite for unlocking higher tiers of all other buildings — a placed Research Center building is required before any research task can be queued, not just implied by the unlock fiction.
 - **Placement tradeoff:** Far-from-pit reduces projection damage risk but increases travel time (productivity loss).
 
 ## Building Types & Tier Names
@@ -34,11 +34,19 @@ All tier names are fictional and humorous. Localized via i18n (`en.json` + `fr.j
 
 ## Tier System
 
-Tier 1 is available from the start. Higher tiers unlocked by paid Research Center tasks:
-- Research task occupies Research Center for fixed duration + costs money
-- Higher tiers: larger capacity, better performance, larger physical footprint
-- Upgrading: demolish old building → construct new tier on same/adjacent cleared ground
-- Both construction and demolition carry a cost
+Tier 1 is available from the start. Higher tiers unlocked by paid Research Center tasks.
+
+**A placed `research_center` building is a hard prerequisite to queue any research task.** No research center on the map → no research task can be queued, enforced at the point research is queued, not left to the unlock fiction.
+
+Research task shape:
+- **Cost** (money) — every research task has one.
+- **Duration** (ticks occupying the Research Center) — every task beyond the first upgrade has one.
+- **Conditions** (prerequisites already met — e.g. a specific other building already at a given tier, or another research already completed) — every task beyond the first upgrade has these too.
+- **Exception — first upgrade (tier 1 → tier 2) of any building type:** cost only, no duration, no conditions.
+
+Higher tiers: larger capacity, better performance, larger physical footprint.
+Upgrading: demolish old building → construct new tier on same/adjacent cleared ground.
+Both construction and demolition carry a cost.
 
 ## Training Buildings
 

--- a/.opencode/skills/gameplay-buildings/SKILL.md
+++ b/.opencode/skills/gameplay-buildings/SKILL.md
@@ -13,7 +13,7 @@ Buildings are player's infrastructure layer. Gate actions behind qualified emplo
 
 - **Every action requires qualified employee.** No qualified employee → immediate error, not silent queue.
 - **Training buildings** upskill employees for time + fee. Hiring pre-qualified staff generally cheaper.
-- **Research Center** prerequisite for unlocking higher tiers of all other buildings.
+- **Research Center** prerequisite for unlocking higher tiers of all other buildings — a placed Research Center building is required before any research task can be queued, not just implied by the unlock fiction.
 - **Placement tradeoff:** Far-from-pit reduces projection damage risk but increases travel time (productivity loss).
 
 ## Building Types & Tier Names
@@ -34,11 +34,19 @@ All tier names are fictional and humorous. Localized via i18n (`en.json` + `fr.j
 
 ## Tier System
 
-Tier 1 is available from the start. Higher tiers unlocked by paid Research Center tasks:
-- Research task occupies Research Center for fixed duration + costs money
-- Higher tiers: larger capacity, better performance, larger physical footprint
-- Upgrading: demolish old building → construct new tier on same/adjacent cleared ground
-- Both construction and demolition carry a cost
+Tier 1 is available from the start. Higher tiers unlocked by paid Research Center tasks.
+
+**A placed `research_center` building is a hard prerequisite to queue any research task.** No research center on the map → no research task can be queued, enforced at the point research is queued, not left to the unlock fiction.
+
+Research task shape:
+- **Cost** (money) — every research task has one.
+- **Duration** (ticks occupying the Research Center) — every task beyond the first upgrade has one.
+- **Conditions** (prerequisites already met — e.g. a specific other building already at a given tier, or another research already completed) — every task beyond the first upgrade has these too.
+- **Exception — first upgrade (tier 1 → tier 2) of any building type:** cost only, no duration, no conditions.
+
+Higher tiers: larger capacity, better performance, larger physical footprint.
+Upgrading: demolish old building → construct new tier on same/adjacent cleared ground.
+Both construction and demolition carry a cost.
 
 ## Training Buildings
 


### PR DESCRIPTION
## Summary
- Documents (issue #442 review) that queuing research must require a placed `research_center` building, enforced at the queue entry point rather than left to the unlock fiction.
- Documents the new research task shape: cost + duration + conditions for every task, except a building's first tier upgrade (tier 1 → tier 2), which is cost-only.
- Applied identically across `.claude/skills/gameplay-buildings/SKILL.md`, `.github/skills/gameplay-buildings/SKILL.md`, `.opencode/skills/gameplay-buildings/SKILL.md` per the context-authoring rule (body content must stay byte-identical across runtimes).

This is a context/skill documentation change only — no `src/` code changes. The actual implementation (placement check, conditions system, scenario updates) is scoped in issue #442.

## Test plan
- [x] Verified all three skill copies are byte-identical after edit (`diff` clean)
- [ ] No code changes — `typecheck`/`test`/`scenarios` unaffected, not re-run for this doc-only change


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8zyj2XtVb6KjktwSQVw9M)_