### PR TITLE
feat: gate survey, rest, vehicle boarding, and hauling on entity arrival (#437)

### DIFF
--- a/.claude/skills/dev-architecture/SKILL.md
+++ b/.claude/skills/dev-architecture/SKILL.md
@@ -37,6 +37,7 @@ description: >
 - **Core purity:** `src/core/` = zero side effects; no DOM, `window`, WebGL, or file I/O. `SaveBackend` interface in core; implementations in `src/persistence/`.
 - **Single serializable GameState:** enables save/load (JSON), console mode, deterministic tests.
 - **Tick loop steps:** (1) advance time, (2) weather, (3) events, (4) vehicles+tasks, (5) physics (blast only), (6) scores, (7) win/lose check, (8) emit state-change events. Renderer runs at 60fps, interpolates between ticks.
+- **Arrival-gated position-dependent actions:** any action requiring an employee or vehicle to physically be somewhere (survey, rest, vehicle boarding, hauling) queues intent on the acting entity (`pendingTaskDuration`, `pendingRestDuration`, `pendingDriverVehicleId`, hauling phase fields) at claim time, and only starts its timer/effect once navmesh arrival is detected. `src/core/engine/ArrivalGate.ts` (`tickArrivalGate`) resolves this once per tick, after movement (`EntityMovementTick.ts`) has advanced. Follow this pattern for any new position-dependent action instead of starting effects at claim time.
 - **Event-driven renderer:** Core emits `terrain:updated`, `blast:started`, `fragment:created`, etc. Renderer subscribes. Dependency one-way: renderer → core, never reverse.
 - **Asset replaceability:** AssetManager maps IDs → geometry/material; placeholders = Three.js primitives. Replace assets by updating AssetManager only.
 
@@ -76,11 +77,13 @@ src/
 ├── main.ts                 # Browser entry: initializes renderer + game
 ├── console.ts              # CLI entry: Node.js playable console mode
 ├── core/                   # PURE TypeScript — NO DOM, NO WebGL, NO side effects
-│   ├── state/              # GameState, GameLoop, SaveLoad, SaveBackend interface
+│   ├── state/              # GameState, SaveLoad, SaveBackend interface
+│   ├── engine/             # GameLoop (tick orchestration), ArrivalGate, EntityMovementTick, TaskDispatch
+│   ├── nav/                # NavGrid, Pathfinding, AgentMovement, BuildingApproach
 │   ├── campaign/           # Level definitions, Campaign progression
 │   ├── world/              # VoxelGrid, TerrainGen, RockCatalog, OreCatalog, MineType
 │   ├── mining/             # Survey, DrillPlan, ChargePlan, Sequence, BlastPlan, BlastCalc
-│   ├── economy/            # Finance, Contract, Market, Corruption
+│   ├── economy/            # Finance, Contract, Market, Corruption, HaulingTask
 │   ├── entities/           # Employee, Vehicle, Building, Fragment
 │   ├── scores/             # ScoreManager, WellBeing, Safety, Ecology, Nuisance
 │   ├── events/             # EventSystem, EventCategory, EventPool, EventResolver

--- a/.claude/skills/gameplay-employee-needs/SKILL.md
+++ b/.claude/skills/gameplay-employee-needs/SKILL.md
@@ -56,6 +56,8 @@ When any gauge hits its collapse threshold:
 
 If no suitable building within 20 cells: employee collapses in place, rest duration doubled.
 
+Rest duration itself only starts counting down once the employee physically arrives at the building (or, resting in place, immediately) — walking there is separate travel time on top of the duration, arrival-gated per `dev-architecture`'s arrival-gated-actions convention.
+
 ## Resting With No Building
 
 An employee whose need has no building to service it — none built, or the nearest beyond 20 cells — rests where they stand. Two penalties apply, and together they keep an empty site strictly worse than a Tier 1 one:

--- a/.claude/skills/gameplay-navmesh/SKILL.md
+++ b/.claude/skills/gameplay-navmesh/SKILL.md
@@ -99,6 +99,17 @@ NavGrid is **incrementally updated** — full rebuild too expensive.
 
 Paths crossing updated region → marked stale, re-requested next tick. Paths outside region remain valid.
 
+## Reachability Helpers
+
+Two `NavGrid` static queries, beyond `findPath`, for picking a destination that isn't already known to be walkable:
+
+- `findNearestTraversableCell(navGrid, x, z)` — nearest walkable/ramp/drill_hole cell to (x, z) by pure distance, searching outward in rings. Can land on a traversable pocket a blast crater walled off from the rest of the map with `void` on every side — distance-only, no connectivity check.
+- `findNearestReachableCell(navGrid, anchorX, anchorZ, targetX, targetZ)` — BFS flood fill (same 8-directional adjacency as `findPath`) from an `anchorX/anchorZ` known to sit in the map's main connected region (a world corner works), returning the cell nearest `targetX/targetZ` that is actually path-connected to it. Use this, not `findNearestTraversableCell`, wherever a mover must be guaranteed to path away from the point afterward — e.g. snapping a new hire's or purchased vehicle's spawn point off a blast-cleared void or isolated pocket.
+
+## Building Approach Cells
+
+A building's entire footprint — including its `entryPoint`/`exitPoint` markers, which are cosmetic door offsets, not a walkability guarantee — classifies `blocked`. `findPath` rejects an impassable goal outright, so nothing can path onto a building's raw (x, z). `findBuildingApproachCell(navGrid, building, def, fromX, fromZ)` (`src/core/nav/BuildingApproach.ts`) finds the nearest walkable ring cell just outside the footprint, closest to the mover. Any destination that targets a building — rest routing, hauling delivery, shift-cycle sleep — resolves through this, never the building's own coordinates.
+
 ## Path Following & Stuck State
 
 Agents move at most `walkSpeed` cells/tick toward next waypoint. Next waypoint becomes `blocked` mid-path → re-request from current position. After **3 consecutive failed re-requests** → `stuck` state:

--- a/.claude/skills/gameplay-survey-system/SKILL.md
+++ b/.claude/skills/gameplay-survey-system/SKILL.md
@@ -21,6 +21,8 @@ Three tools with different cost/accuracy/coverage tradeoffs:
 | Core Sample | Drills narrow extraction core | `survey.core_sample` | 800 | 4 | ±5% ore density | Single column, full depth |
 | Aerial Spectroscopy | Drone scans surface mineral signature | `survey.aerial` | 1,500 | 3 | ±25% ore density | 30-cell radius, surface only (Y=0 to Y=−1) |
 
+The Time (ticks) duration above starts once the assigned surveyor physically arrives at the target site, not when the survey is queued — walking there is separate travel time on top of it, arrival-gated per `dev-architecture`'s arrival-gated-actions convention.
+
 Accuracy improves with surveyor skill level:
 ```
 finalError = baseError * (1 - (skillLevel - 1) * 0.12)

--- a/.claude/skills/gameplay-vehicle-fleet/SKILL.md
+++ b/.claude/skills/gameplay-vehicle-fleet/SKILL.md
@@ -88,6 +88,11 @@ export type VehicleState =
 - Employee without licence for role cannot be assigned to that vehicle
 - One driver per vehicle; one vehicle per driver at a time
 - Driver injured or leaves → vehicle idles until qualified replacement assigned
+- Assigning a driver (`vehicle driver <vehicleId> <employeeId>`) validates licence/availability immediately but only sets intent — the employee must walk to the vehicle's position first, and only becomes its driver on arrival (arrival-gated per `dev-architecture`'s arrival-gated-actions convention)
+
+## Hauling
+
+`vehicle haul <vehicleId> fragment:<fragmentId>` (Debris Hauler only, must already have a driver): sets intent to haul a fragment to the nearest active Freight Warehouse. Resolves in phases, each arrival-gated: drive to fragment → load on arrival → drive to depot → unload on arrival. A destination targeting the depot building resolves through the building-approach-cell lookup (`gameplay-navmesh`), not the building's raw coordinates.
 
 ## Traffic & Routing
 

--- a/.github/skills/dev-architecture/SKILL.md
+++ b/.github/skills/dev-architecture/SKILL.md
@@ -37,6 +37,7 @@ description: >
 - **Core purity:** `src/core/` = zero side effects; no DOM, `window`, WebGL, or file I/O. `SaveBackend` interface in core; implementations in `src/persistence/`.
 - **Single serializable GameState:** enables save/load (JSON), console mode, deterministic tests.
 - **Tick loop steps:** (1) advance time, (2) weather, (3) events, (4) vehicles+tasks, (5) physics (blast only), (6) scores, (7) win/lose check, (8) emit state-change events. Renderer runs at 60fps, interpolates between ticks.
+- **Arrival-gated position-dependent actions:** any action requiring an employee or vehicle to physically be somewhere (survey, rest, vehicle boarding, hauling) queues intent on the acting entity (`pendingTaskDuration`, `pendingRestDuration`, `pendingDriverVehicleId`, hauling phase fields) at claim time, and only starts its timer/effect once navmesh arrival is detected. `src/core/engine/ArrivalGate.ts` (`tickArrivalGate`) resolves this once per tick, after movement (`EntityMovementTick.ts`) has advanced. Follow this pattern for any new position-dependent action instead of starting effects at claim time.
 - **Event-driven renderer:** Core emits `terrain:updated`, `blast:started`, `fragment:created`, etc. Renderer subscribes. Dependency one-way: renderer → core, never reverse.
 - **Asset replaceability:** AssetManager maps IDs → geometry/material; placeholders = Three.js primitives. Replace assets by updating AssetManager only.
 
@@ -76,11 +77,13 @@ src/
 ├── main.ts                 # Browser entry: initializes renderer + game
 ├── console.ts              # CLI entry: Node.js playable console mode
 ├── core/                   # PURE TypeScript — NO DOM, NO WebGL, NO side effects
-│   ├── state/              # GameState, GameLoop, SaveLoad, SaveBackend interface
+│   ├── state/              # GameState, SaveLoad, SaveBackend interface
+│   ├── engine/             # GameLoop (tick orchestration), ArrivalGate, EntityMovementTick, TaskDispatch
+│   ├── nav/                # NavGrid, Pathfinding, AgentMovement, BuildingApproach
 │   ├── campaign/           # Level definitions, Campaign progression
 │   ├── world/              # VoxelGrid, TerrainGen, RockCatalog, OreCatalog, MineType
 │   ├── mining/             # Survey, DrillPlan, ChargePlan, Sequence, BlastPlan, BlastCalc
-│   ├── economy/            # Finance, Contract, Market, Corruption
+│   ├── economy/            # Finance, Contract, Market, Corruption, HaulingTask
 │   ├── entities/           # Employee, Vehicle, Building, Fragment
 │   ├── scores/             # ScoreManager, WellBeing, Safety, Ecology, Nuisance
 │   ├── events/             # EventSystem, EventCategory, EventPool, EventResolver

--- a/.github/skills/gameplay-employee-needs/SKILL.md
+++ b/.github/skills/gameplay-employee-needs/SKILL.md
@@ -56,6 +56,8 @@ When any gauge hits its collapse threshold:
 
 If no suitable building within 20 cells: employee collapses in place, rest duration doubled.
 
+Rest duration itself only starts counting down once the employee physically arrives at the building (or, resting in place, immediately) — walking there is separate travel time on top of the duration, arrival-gated per `dev-architecture`'s arrival-gated-actions convention.
+
 ## Resting With No Building
 
 An employee whose need has no building to service it — none built, or the nearest beyond 20 cells — rests where they stand. Two penalties apply, and together they keep an empty site strictly worse than a Tier 1 one:

--- a/.github/skills/gameplay-navmesh/SKILL.md
+++ b/.github/skills/gameplay-navmesh/SKILL.md
@@ -99,6 +99,17 @@ NavGrid is **incrementally updated** — full rebuild too expensive.
 
 Paths crossing updated region → marked stale, re-requested next tick. Paths outside region remain valid.
 
+## Reachability Helpers
+
+Two `NavGrid` static queries, beyond `findPath`, for picking a destination that isn't already known to be walkable:
+
+- `findNearestTraversableCell(navGrid, x, z)` — nearest walkable/ramp/drill_hole cell to (x, z) by pure distance, searching outward in rings. Can land on a traversable pocket a blast crater walled off from the rest of the map with `void` on every side — distance-only, no connectivity check.
+- `findNearestReachableCell(navGrid, anchorX, anchorZ, targetX, targetZ)` — BFS flood fill (same 8-directional adjacency as `findPath`) from an `anchorX/anchorZ` known to sit in the map's main connected region (a world corner works), returning the cell nearest `targetX/targetZ` that is actually path-connected to it. Use this, not `findNearestTraversableCell`, wherever a mover must be guaranteed to path away from the point afterward — e.g. snapping a new hire's or purchased vehicle's spawn point off a blast-cleared void or isolated pocket.
+
+## Building Approach Cells
+
+A building's entire footprint — including its `entryPoint`/`exitPoint` markers, which are cosmetic door offsets, not a walkability guarantee — classifies `blocked`. `findPath` rejects an impassable goal outright, so nothing can path onto a building's raw (x, z). `findBuildingApproachCell(navGrid, building, def, fromX, fromZ)` (`src/core/nav/BuildingApproach.ts`) finds the nearest walkable ring cell just outside the footprint, closest to the mover. Any destination that targets a building — rest routing, hauling delivery, shift-cycle sleep — resolves through this, never the building's own coordinates.
+
 ## Path Following & Stuck State
 
 Agents move at most `walkSpeed` cells/tick toward next waypoint. Next waypoint becomes `blocked` mid-path → re-request from current position. After **3 consecutive failed re-requests** → `stuck` state:

--- a/.github/skills/gameplay-survey-system/SKILL.md
+++ b/.github/skills/gameplay-survey-system/SKILL.md
@@ -21,6 +21,8 @@ Three tools with different cost/accuracy/coverage tradeoffs:
 | Core Sample | Drills narrow extraction core | `survey.core_sample` | 800 | 4 | ±5% ore density | Single column, full depth |
 | Aerial Spectroscopy | Drone scans surface mineral signature | `survey.aerial` | 1,500 | 3 | ±25% ore density | 30-cell radius, surface only (Y=0 to Y=−1) |
 
+The Time (ticks) duration above starts once the assigned surveyor physically arrives at the target site, not when the survey is queued — walking there is separate travel time on top of it, arrival-gated per `dev-architecture`'s arrival-gated-actions convention.
+
 Accuracy improves with surveyor skill level:
 ```
 finalError = baseError * (1 - (skillLevel - 1) * 0.12)

--- a/.github/skills/gameplay-vehicle-fleet/SKILL.md
+++ b/.github/skills/gameplay-vehicle-fleet/SKILL.md
@@ -88,6 +88,11 @@ export type VehicleState =
 - Employee without licence for role cannot be assigned to that vehicle
 - One driver per vehicle; one vehicle per driver at a time
 - Driver injured or leaves → vehicle idles until qualified replacement assigned
+- Assigning a driver (`vehicle driver <vehicleId> <employeeId>`) validates licence/availability immediately but only sets intent — the employee must walk to the vehicle's position first, and only becomes its driver on arrival (arrival-gated per `dev-architecture`'s arrival-gated-actions convention)
+
+## Hauling
+
+`vehicle haul <vehicleId> fragment:<fragmentId>` (Debris Hauler only, must already have a driver): sets intent to haul a fragment to the nearest active Freight Warehouse. Resolves in phases, each arrival-gated: drive to fragment → load on arrival → drive to depot → unload on arrival. A destination targeting the depot building resolves through the building-approach-cell lookup (`gameplay-navmesh`), not the building's raw coordinates.
 
 ## Traffic & Routing
 

--- a/.opencode/skills/dev-architecture/SKILL.md
+++ b/.opencode/skills/dev-architecture/SKILL.md
@@ -37,6 +37,7 @@ description: >
 - **Core purity:** `src/core/` = zero side effects; no DOM, `window`, WebGL, or file I/O. `SaveBackend` interface in core; implementations in `src/persistence/`.
 - **Single serializable GameState:** enables save/load (JSON), console mode, deterministic tests.
 - **Tick loop steps:** (1) advance time, (2) weather, (3) events, (4) vehicles+tasks, (5) physics (blast only), (6) scores, (7) win/lose check, (8) emit state-change events. Renderer runs at 60fps, interpolates between ticks.
+- **Arrival-gated position-dependent actions:** any action requiring an employee or vehicle to physically be somewhere (survey, rest, vehicle boarding, hauling) queues intent on the acting entity (`pendingTaskDuration`, `pendingRestDuration`, `pendingDriverVehicleId`, hauling phase fields) at claim time, and only starts its timer/effect once navmesh arrival is detected. `src/core/engine/ArrivalGate.ts` (`tickArrivalGate`) resolves this once per tick, after movement (`EntityMovementTick.ts`) has advanced. Follow this pattern for any new position-dependent action instead of starting effects at claim time.
 - **Event-driven renderer:** Core emits `terrain:updated`, `blast:started`, `fragment:created`, etc. Renderer subscribes. Dependency one-way: renderer → core, never reverse.
 - **Asset replaceability:** AssetManager maps IDs → geometry/material; placeholders = Three.js primitives. Replace assets by updating AssetManager only.
 
@@ -76,11 +77,13 @@ src/
 ├── main.ts                 # Browser entry: initializes renderer + game
 ├── console.ts              # CLI entry: Node.js playable console mode
 ├── core/                   # PURE TypeScript — NO DOM, NO WebGL, NO side effects
-│   ├── state/              # GameState, GameLoop, SaveLoad, SaveBackend interface
+│   ├── state/              # GameState, SaveLoad, SaveBackend interface
+│   ├── engine/             # GameLoop (tick orchestration), ArrivalGate, EntityMovementTick, TaskDispatch
+│   ├── nav/                # NavGrid, Pathfinding, AgentMovement, BuildingApproach
 │   ├── campaign/           # Level definitions, Campaign progression
 │   ├── world/              # VoxelGrid, TerrainGen, RockCatalog, OreCatalog, MineType
 │   ├── mining/             # Survey, DrillPlan, ChargePlan, Sequence, BlastPlan, BlastCalc
-│   ├── economy/            # Finance, Contract, Market, Corruption
+│   ├── economy/            # Finance, Contract, Market, Corruption, HaulingTask
 │   ├── entities/           # Employee, Vehicle, Building, Fragment
 │   ├── scores/             # ScoreManager, WellBeing, Safety, Ecology, Nuisance
 │   ├── events/             # EventSystem, EventCategory, EventPool, EventResolver

--- a/.opencode/skills/gameplay-employee-needs/SKILL.md
+++ b/.opencode/skills/gameplay-employee-needs/SKILL.md
@@ -56,6 +56,8 @@ When any gauge hits its collapse threshold:
 
 If no suitable building within 20 cells: employee collapses in place, rest duration doubled.
 
+Rest duration itself only starts counting down once the employee physically arrives at the building (or, resting in place, immediately) — walking there is separate travel time on top of the duration, arrival-gated per `dev-architecture`'s arrival-gated-actions convention.
+
 ## Resting With No Building
 
 An employee whose need has no building to service it — none built, or the nearest beyond 20 cells — rests where they stand. Two penalties apply, and together they keep an empty site strictly worse than a Tier 1 one:

--- a/.opencode/skills/gameplay-navmesh/SKILL.md
+++ b/.opencode/skills/gameplay-navmesh/SKILL.md
@@ -99,6 +99,17 @@ NavGrid is **incrementally updated** — full rebuild too expensive.
 
 Paths crossing updated region → marked stale, re-requested next tick. Paths outside region remain valid.
 
+## Reachability Helpers
+
+Two `NavGrid` static queries, beyond `findPath`, for picking a destination that isn't already known to be walkable:
+
+- `findNearestTraversableCell(navGrid, x, z)` — nearest walkable/ramp/drill_hole cell to (x, z) by pure distance, searching outward in rings. Can land on a traversable pocket a blast crater walled off from the rest of the map with `void` on every side — distance-only, no connectivity check.
+- `findNearestReachableCell(navGrid, anchorX, anchorZ, targetX, targetZ)` — BFS flood fill (same 8-directional adjacency as `findPath`) from an `anchorX/anchorZ` known to sit in the map's main connected region (a world corner works), returning the cell nearest `targetX/targetZ` that is actually path-connected to it. Use this, not `findNearestTraversableCell`, wherever a mover must be guaranteed to path away from the point afterward — e.g. snapping a new hire's or purchased vehicle's spawn point off a blast-cleared void or isolated pocket.
+
+## Building Approach Cells
+
+A building's entire footprint — including its `entryPoint`/`exitPoint` markers, which are cosmetic door offsets, not a walkability guarantee — classifies `blocked`. `findPath` rejects an impassable goal outright, so nothing can path onto a building's raw (x, z). `findBuildingApproachCell(navGrid, building, def, fromX, fromZ)` (`src/core/nav/BuildingApproach.ts`) finds the nearest walkable ring cell just outside the footprint, closest to the mover. Any destination that targets a building — rest routing, hauling delivery, shift-cycle sleep — resolves through this, never the building's own coordinates.
+
 ## Path Following & Stuck State
 
 Agents move at most `walkSpeed` cells/tick toward next waypoint. Next waypoint becomes `blocked` mid-path → re-request from current position. After **3 consecutive failed re-requests** → `stuck` state:

--- a/.opencode/skills/gameplay-survey-system/SKILL.md
+++ b/.opencode/skills/gameplay-survey-system/SKILL.md
@@ -21,6 +21,8 @@ Three tools with different cost/accuracy/coverage tradeoffs:
 | Core Sample | Drills narrow extraction core | `survey.core_sample` | 800 | 4 | ±5% ore density | Single column, full depth |
 | Aerial Spectroscopy | Drone scans surface mineral signature | `survey.aerial` | 1,500 | 3 | ±25% ore density | 30-cell radius, surface only (Y=0 to Y=−1) |
 
+The Time (ticks) duration above starts once the assigned surveyor physically arrives at the target site, not when the survey is queued — walking there is separate travel time on top of it, arrival-gated per `dev-architecture`'s arrival-gated-actions convention.
+
 Accuracy improves with surveyor skill level:
 ```
 finalError = baseError * (1 - (skillLevel - 1) * 0.12)

--- a/.opencode/skills/gameplay-vehicle-fleet/SKILL.md
+++ b/.opencode/skills/gameplay-vehicle-fleet/SKILL.md
@@ -88,6 +88,11 @@ export type VehicleState =
 - Employee without licence for role cannot be assigned to that vehicle
 - One driver per vehicle; one vehicle per driver at a time
 - Driver injured or leaves → vehicle idles until qualified replacement assigned
+- Assigning a driver (`vehicle driver <vehicleId> <employeeId>`) validates licence/availability immediately but only sets intent — the employee must walk to the vehicle's position first, and only becomes its driver on arrival (arrival-gated per `dev-architecture`'s arrival-gated-actions convention)
+
+## Hauling
+
+`vehicle haul <vehicleId> fragment:<fragmentId>` (Debris Hauler only, must already have a driver): sets intent to haul a fragment to the nearest active Freight Warehouse. Resolves in phases, each arrival-gated: drive to fragment → load on arrival → drive to depot → unload on arrival. A destination targeting the depot building resolves through the building-approach-cell lookup (`gameplay-navmesh`), not the building's raw coordinates.
 
 ## Traffic & Routing
 

--- a/scripts/playtests/tutorial.json
+++ b/scripts/playtests/tutorial.json
@@ -288,6 +288,10 @@
         {
           "do": "click",
           "selector": "#bs-vehicle-panel .bs-vehicle-assign-btn"
+        },
+        {
+          "do": "letTimePass",
+          "ticks": 15
         }
       ],
       "expect": {

--- a/scripts/scenario-defs/building-training-visual.json
+++ b/scripts/scenario-defs/building-training-visual.json
@@ -121,11 +121,11 @@
       ]
     },
     {
-      "command": "tick 15",
+      "command": "tick 25",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 15"
+          "command": "tick 25"
         }
       ]
     },

--- a/scripts/scenario-defs/collapse-recovery.json
+++ b/scripts/scenario-defs/collapse-recovery.json
@@ -39,11 +39,12 @@
       ]
     },
     {
-      "command": "build bunkhouse at:5,5",
+      "command": "build living_quarters at:5,5",
+      "description": "'bunkhouse' was never a valid build type (NEED_REST_BUILDING_TYPES maps every need to 'living_quarters' — dedicated canteen/bunkhouse/break_room types don't exist yet), so this command always failed and the scenario ran with no rest building at all: collapse resolved via instant ground-rest in place, never exercising the arrival-gated building-rest path (#437) this scenario is named for.",
       "interaction": [
         {
           "type": "command",
-          "command": "build bunkhouse at:5,5"
+          "command": "build living_quarters at:5,5"
         }
       ]
     },

--- a/scripts/scenario-defs/hauling-gate.json
+++ b/scripts/scenario-defs/hauling-gate.json
@@ -1,0 +1,195 @@
+{
+  "name": "hauling-gate",
+  "description": "Arrival-gated debris hauling (issue #437): a debris_hauler drives to a blast fragment, loads it only on arrival, drives to the nearest freight_warehouse, and delivers it only on arrival — fragment.state and logistics.storedMassKg only change after both travel legs complete. NOTE: the vehicle haul console subcommand does not exist yet (implementer adds it) — this scenario is expected to fail/error at the \"vehicle haul\" step until that lands.",
+  "steps": [
+    {
+      "command": "new_game seed:42 cash:100000",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "new_game seed:42 cash:100000"
+        }
+      ]
+    },
+    {
+      "command": "build freight_warehouse at:5,5",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "build freight_warehouse at:5,5"
+        }
+      ]
+    },
+    {
+      "command": "drill_plan grid rows:2 cols:2 spacing:5 depth:8 start:20,20",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "drill_plan grid rows:2 cols:2 spacing:5 depth:8 start:20,20"
+        }
+      ]
+    },
+    {
+      "command": "charge hole:* explosive:boomite amount:5 stemming:2",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "charge hole:* explosive:boomite amount:5 stemming:2"
+        }
+      ]
+    },
+    {
+      "command": "sequence auto delay_step:25",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "sequence auto delay_step:25"
+        }
+      ]
+    },
+    {
+      "command": "blast",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "blast"
+        }
+      ]
+    },
+    {
+      "command": "fragments",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "fragments"
+        }
+      ]
+    },
+    {
+      "command": "state full",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "state full"
+        }
+      ]
+    },
+    {
+      "command": "vehicle buy debris_hauler",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle buy debris_hauler"
+        }
+      ]
+    },
+    {
+      "command": "employee hire role:driver",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "employee hire role:driver"
+        }
+      ]
+    },
+    {
+      "command": "employee assign_skill 1 skill:driving.truck level:1",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "employee assign_skill 1 skill:driving.truck level:1"
+        }
+      ]
+    },
+    {
+      "command": "vehicle driver 1 1",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle driver 1 1"
+        }
+      ]
+    },
+    {
+      "command": "tick 10",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 10"
+        }
+      ]
+    },
+    {
+      "command": "vehicle list",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle list"
+        }
+      ]
+    },
+    {
+      "command": "vehicle haul 1 fragment:1",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle haul 1 fragment:1"
+        }
+      ]
+    },
+    {
+      "command": "tick 20",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 20"
+        }
+      ]
+    },
+    {
+      "command": "fragments",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "fragments"
+        }
+      ]
+    },
+    {
+      "command": "state full",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "state full"
+        }
+      ]
+    },
+    {
+      "command": "tick 20",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 20"
+        }
+      ]
+    },
+    {
+      "command": "fragments",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "fragments"
+        }
+      ]
+    },
+    {
+      "command": "state full",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "state full"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/scenario-defs/hauling-gate.json
+++ b/scripts/scenario-defs/hauling-gate.json
@@ -1,6 +1,6 @@
 {
   "name": "hauling-gate",
-  "description": "Arrival-gated debris hauling (issue #437): a debris_hauler drives to a blast fragment, loads it only on arrival, drives to the nearest freight_warehouse, and delivers it only on arrival — fragment.state and logistics.storedMassKg only change after both travel legs complete. NOTE: the vehicle haul console subcommand does not exist yet (implementer adds it) — this scenario is expected to fail/error at the \"vehicle haul\" step until that lands.",
+  "description": "Arrival-gated debris hauling (issue #437): 'vehicle haul <id> fragment:<id>' sets hauling intent only — a debris_hauler then drives to the blast fragment, loads it only on arrival, drives to the nearest freight_warehouse, and delivers it only on arrival. Immediately after the haul command (before the first post-command tick block), the fragment must still be on_ground/untransported — the state dump right after 'vehicle haul' proves the task did not start/complete instantly. After the first tick 20 the vehicle should be in transit (fragment picked up, hauling toward the depot) or already delivered; after the following tick 40 the fragment must be state:stored and logistics.storedMassKg increased.",
   "steps": [
     {
       "command": "new_game seed:42 cash:100000",
@@ -138,6 +138,24 @@
       ]
     },
     {
+      "command": "fragments",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "fragments"
+        }
+      ]
+    },
+    {
+      "command": "state full",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "state full"
+        }
+      ]
+    },
+    {
       "command": "tick 20",
       "interaction": [
         {
@@ -165,11 +183,11 @@
       ]
     },
     {
-      "command": "tick 20",
+      "command": "tick 40",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 20"
+          "command": "tick 40"
         }
       ]
     },

--- a/scripts/scenario-defs/needs-cycle.json
+++ b/scripts/scenario-defs/needs-cycle.json
@@ -66,11 +66,11 @@
       ]
     },
     {
-      "command": "tick 20",
+      "command": "tick 40",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 20"
+          "command": "tick 40"
         }
       ]
     },

--- a/scripts/scenario-defs/needs-proactive-queue-visual.json
+++ b/scripts/scenario-defs/needs-proactive-queue-visual.json
@@ -66,11 +66,12 @@
       ]
     },
     {
-      "command": "build living_quarters at:10,10",
+      "command": "build living_quarters at:15,15",
+      "description": "Placed away from the (10,10) dispatch target (#437) — building on top of the employee's own tile made that cell permanently NavGrid-blocked with the employee still standing on it, so every later rest/collapse routing failed to path out and the employee got stuck COLLAPSING at 0/0/0 needs forever instead of demonstrating the queued-rest recovery this scenario is about.",
       "interaction": [
         {
           "type": "command",
-          "command": "build living_quarters at:10,10"
+          "command": "build living_quarters at:15,15"
         }
       ]
     },

--- a/scripts/scenario-defs/needs-shift-cycle-visual.json
+++ b/scripts/scenario-defs/needs-shift-cycle-visual.json
@@ -57,11 +57,12 @@
       ]
     },
     {
-      "command": "employee dispatch 1 x:10 z:10",
+      "command": "employee dispatch 1 x:20 z:20",
+      "description": "Moved off (10,10) — that tile sits inside the living_quarters footprint just built there, which is permanently NavGrid-blocked, so the dispatch could never path to it and the employee got stuck (STUCK log, no arrival, shift-cycle work never counted) instead of demonstrating the work/rest transition (#437).",
       "interaction": [
         {
           "type": "command",
-          "command": "employee dispatch 1 x:10 z:10"
+          "command": "employee dispatch 1 x:20 z:20"
         }
       ]
     },

--- a/scripts/scenario-defs/survey-confidence-display.json
+++ b/scripts/scenario-defs/survey-confidence-display.json
@@ -138,11 +138,11 @@
       ]
     },
     {
-      "command": "tick 8",
+      "command": "tick 53",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 8"
+          "command": "tick 53"
         }
       ]
     },

--- a/scripts/scenario-defs/survey-confidence-overlay.json
+++ b/scripts/scenario-defs/survey-confidence-overlay.json
@@ -2,9 +2,21 @@
   "name": "survey-confidence-overlay",
   "description": "Dedicated scenario for survey confidence overlay: multiple survey methods at the same location showing confidence differences, stale/fresh rendering, and overlay lifecycle. The final screenshot must show colour-coded confidence markers (green = high, red/yellow = low, grey = stale). This scenario FAILS until GameRenderer wires getSurveyOverlay().show() into syncFromContext().",
   "shots": [
-    { "name": "overview", "yaw": 0, "pitch": 45 },
-    { "name": "seismic-focus", "yaw": 90, "pitch": 30 },
-    { "name": "core-sample-focus", "yaw": 180, "pitch": 45 }
+    {
+      "name": "overview",
+      "yaw": 0,
+      "pitch": 45
+    },
+    {
+      "name": "seismic-focus",
+      "yaw": 90,
+      "pitch": 30
+    },
+    {
+      "name": "core-sample-focus",
+      "yaw": 180,
+      "pitch": 45
+    }
   ],
   "steps": [
     {
@@ -143,11 +155,11 @@
       ]
     },
     {
-      "command": "tick 8",
+      "command": "tick 53",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 8"
+          "command": "tick 53"
         }
       ]
     },
@@ -359,11 +371,11 @@
       ]
     },
     {
-      "command": "tick 8",
+      "command": "tick 53",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 8"
+          "command": "tick 53"
         }
       ]
     },

--- a/scripts/scenario-defs/survey-execution.json
+++ b/scripts/scenario-defs/survey-execution.json
@@ -84,11 +84,11 @@
       ]
     },
     {
-      "command": "tick 8",
+      "command": "tick 23",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 8"
+          "command": "tick 23"
         }
       ]
     },
@@ -192,11 +192,11 @@
       ]
     },
     {
-      "command": "tick 8",
+      "command": "tick 23",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 8"
+          "command": "tick 23"
         }
       ]
     },
@@ -300,11 +300,11 @@
       ]
     },
     {
-      "command": "tick 8",
+      "command": "tick 23",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 8"
+          "command": "tick 23"
         }
       ]
     },

--- a/scripts/scenario-defs/survey-method-selection.json
+++ b/scripts/scenario-defs/survey-method-selection.json
@@ -102,11 +102,11 @@
       ]
     },
     {
-      "command": "tick 8",
+      "command": "tick 23",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 8"
+          "command": "tick 23"
         }
       ]
     },
@@ -192,11 +192,11 @@
       ]
     },
     {
-      "command": "tick 8",
+      "command": "tick 23",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 8"
+          "command": "tick 23"
         }
       ]
     },
@@ -282,11 +282,11 @@
       ]
     },
     {
-      "command": "tick 8",
+      "command": "tick 23",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 8"
+          "command": "tick 23"
         }
       ]
     },

--- a/scripts/scenario-defs/survey-ore-vein-visibility.json
+++ b/scripts/scenario-defs/survey-ore-vein-visibility.json
@@ -120,11 +120,11 @@
       ]
     },
     {
-      "command": "tick 8",
+      "command": "tick 53",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 8"
+          "command": "tick 53"
         }
       ]
     },
@@ -237,11 +237,11 @@
       ]
     },
     {
-      "command": "tick 8",
+      "command": "tick 23",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 8"
+          "command": "tick 23"
         }
       ]
     },

--- a/scripts/scenario-defs/survey-overlay-lifecycle.json
+++ b/scripts/scenario-defs/survey-overlay-lifecycle.json
@@ -2,9 +2,21 @@
   "name": "survey-overlay-lifecycle",
   "description": "Survey confidence overlay lifecycle: fresh survey rendering → tick past stale threshold → new survey refreshes overlay → blast terrain remesh preserves overlay. FAILS until GameRenderer wires getSurveyOverlay().show() in syncFromContext().",
   "shots": [
-    { "name": "overview", "yaw": 0, "pitch": 45 },
-    { "name": "survey-fresh", "yaw": 90, "pitch": 30 },
-    { "name": "post-blast", "yaw": 180, "pitch": 45 }
+    {
+      "name": "overview",
+      "yaw": 0,
+      "pitch": 45
+    },
+    {
+      "name": "survey-fresh",
+      "yaw": 90,
+      "pitch": 30
+    },
+    {
+      "name": "post-blast",
+      "yaw": 180,
+      "pitch": 45
+    }
   ],
   "steps": [
     {
@@ -125,11 +137,11 @@
       ]
     },
     {
-      "command": "tick 10",
+      "command": "tick 40",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 10"
+          "command": "tick 40"
         }
       ]
     },
@@ -242,11 +254,11 @@
       ]
     },
     {
-      "command": "tick 10",
+      "command": "tick 25",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 10"
+          "command": "tick 25"
         }
       ]
     },

--- a/scripts/scenario-defs/survey-post-blast-ore-report.json
+++ b/scripts/scenario-defs/survey-post-blast-ore-report.json
@@ -93,11 +93,11 @@
       ]
     },
     {
-      "command": "tick 8",
+      "command": "tick 23",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 8"
+          "command": "tick 23"
         }
       ]
     },
@@ -210,11 +210,11 @@
       ]
     },
     {
-      "command": "tick 8",
+      "command": "tick 23",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 8"
+          "command": "tick 23"
         }
       ]
     },

--- a/scripts/scenario-defs/survey-result-visualization.json
+++ b/scripts/scenario-defs/survey-result-visualization.json
@@ -93,11 +93,11 @@
       ]
     },
     {
-      "command": "tick 8",
+      "command": "tick 23",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 8"
+          "command": "tick 23"
         }
       ]
     },
@@ -210,11 +210,11 @@
       ]
     },
     {
-      "command": "tick 8",
+      "command": "tick 23",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 8"
+          "command": "tick 23"
         }
       ]
     },
@@ -327,11 +327,11 @@
       ]
     },
     {
-      "command": "tick 8",
+      "command": "tick 23",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 8"
+          "command": "tick 23"
         }
       ]
     },

--- a/scripts/scenario-defs/survey-seismic-side-effects.json
+++ b/scripts/scenario-defs/survey-seismic-side-effects.json
@@ -120,11 +120,11 @@
       ]
     },
     {
-      "command": "tick 4",
+      "command": "tick 19",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 4"
+          "command": "tick 19"
         }
       ]
     },

--- a/scripts/scenario-defs/survey-stale-handling.json
+++ b/scripts/scenario-defs/survey-stale-handling.json
@@ -93,11 +93,11 @@
       ]
     },
     {
-      "command": "tick 10",
+      "command": "tick 25",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 10"
+          "command": "tick 25"
         }
       ]
     },
@@ -300,11 +300,11 @@
       ]
     },
     {
-      "command": "tick 8",
+      "command": "tick 23",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 8"
+          "command": "tick 23"
         }
       ]
     },

--- a/scripts/scenario-defs/survey-then-blast-playthrough.json
+++ b/scripts/scenario-defs/survey-then-blast-playthrough.json
@@ -138,11 +138,11 @@
       ]
     },
     {
-      "command": "tick 10",
+      "command": "tick 40",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 10"
+          "command": "tick 40"
         }
       ]
     },

--- a/scripts/scenario-defs/survey-then-blast.json
+++ b/scripts/scenario-defs/survey-then-blast.json
@@ -102,11 +102,11 @@
       ]
     },
     {
-      "command": "tick 10",
+      "command": "tick 25",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 10"
+          "command": "tick 25"
         }
       ]
     },
@@ -210,11 +210,11 @@
       ]
     },
     {
-      "command": "tick 8",
+      "command": "tick 23",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 8"
+          "command": "tick 23"
         }
       ]
     },

--- a/scripts/scenario-defs/vehicle-driver-assignment-visual.json
+++ b/scripts/scenario-defs/vehicle-driver-assignment-visual.json
@@ -72,6 +72,15 @@
       ]
     },
     {
+      "command": "tick 5",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 5"
+        }
+      ]
+    },
+    {
       "command": "vehicle list",
       "interaction": [
         {
@@ -95,6 +104,15 @@
         {
           "type": "command",
           "command": "vehicle driver 1 2"
+        }
+      ]
+    },
+    {
+      "command": "tick 5",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 5"
         }
       ]
     },

--- a/src/console/commands/employees.ts
+++ b/src/console/commands/employees.ts
@@ -21,6 +21,7 @@ import { addExpense } from '../../core/economy/Finance.js';
 import { dispatchPendingAction } from '../../core/engine/TaskDispatch.js';
 import { Random } from '../../core/math/Random.js';
 import { requireGame, NO_EMPLOYEES_MSG } from './commandUtils.js';
+import { NavGrid } from '../../core/nav/NavGrid.js';
 
 const VALID_SKILL_CATEGORIES: SkillCategory[] = [
   'driving.truck', 'driving.excavator', 'driving.drill_rig',
@@ -59,8 +60,17 @@ export function employeeCommand(
       if (!validRoles.includes(role)) {
         return { success: false, output: `Usage: employee hire role:(${validRoles.join('|')})` };
       }
-      const empX = state.world ? state.world.sizeX / 2 + (state.employees.employees.length % 5) * 2 : 32;
-      const empZ = state.world ? state.world.sizeZ / 2 : 32;
+      const rawEmpX = state.world ? state.world.sizeX / 2 + (state.employees.employees.length % 5) * 2 : 32;
+      const rawEmpZ = state.world ? state.world.sizeZ / 2 : 32;
+      // Same void/isolated-pocket hazard as vehicle purchase spawn (#437): a
+      // blast can clear the grid centre where new hires spawn down to a
+      // floorless column. A hire whose own start tile is impassable can never
+      // path anywhere afterwards — findPath rejects an impassable start
+      // outright — so snap to the nearest tile actually connected to the
+      // map's main region before placing them.
+      const { x: empX, z: empZ } = state.navGrid
+        ? NavGrid.findNearestReachableCell(state.navGrid, 0, 0, rawEmpX, rawEmpZ)
+        : { x: rawEmpX, z: rawEmpZ };
       const { employee, hiringCost } = hireEmployee(state.employees, role, rng, empX, empZ);
       state.cash -= hiringCost;
       addExpense(state.finances, hiringCost, 'salaries', `Hire ${role}: ${employee.name}`, state.tickCount);

--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -20,7 +20,7 @@ import { tickTraining } from '../../core/entities/EmployeeTraining.js';
 import { tickResearch } from '../../core/entities/Building.js';
 import { tickNeedGauges, needsMoraleEffect } from '../../core/entities/EmployeeNeeds.js';
 import type { FiredEvent } from '../../core/events/EventSystem.js';
-import { tickCollapse, autoInsertNeedTasks, processShiftCycle, tickEmployees, tickGeneralRestCompletion, tickTaskProgress, tickVehicle, tickVehicleTaskState, tickEmployeeMovement } from '../../core/engine/GameLoop.js';
+import { tickCollapse, autoInsertNeedTasks, processShiftCycle, tickEmployees, tickGeneralRestCompletion, tickTaskProgress, tickVehicle, tickVehicleTaskState, tickEmployeeMovement, tickArrivalGate } from '../../core/engine/GameLoop.js';
 import { detectUnqualifiedTask, detectTrafficJam } from '../../core/events/EventEngine.js';
 import { estimateSurveyResult, applySeismicSurveyDamage, type SurveyMethod } from '../../core/mining/SurveyCalc.js';
 import { checkDeadlines, generateContracts } from '../../core/economy/Contract.js';
@@ -159,41 +159,6 @@ export function tickCommand(
       lines.push(`[tick ${state.tickCount}] NEED: ${fe.eventId}`);
     }
 
-    // 8b. Process survey pending actions — match surveyors and generate results.
-    //     Surveys complete instantly (duration system TBD); this ensures the
-    //     confidence overlay appears after queuing a survey + advancing time.
-    const surveyActions = state.pendingActions.filter(a => a.type === 'survey');
-    state.pendingActions = state.pendingActions.filter(a => a.type !== 'survey');
-    for (const action of surveyActions) {
-      // Find an idle qualified surveyor
-      const method = action.payload['method'] as SurveyMethod;
-      const surveyor = state.employees.employees.find(
-        emp => emp.alive && !emp.injured && emp.activeActionId === null &&
-               emp.qualifications.some(q => q.category === 'geology'),
-      );
-      if (surveyor && ctx.grid) {
-        const skillLevel = surveyor.qualifications.find(q => q.category === 'geology')?.proficiencyLevel ?? 1;
-        const surveyResult = estimateSurveyResult(ctx.grid, {
-          id: action.id,
-          method,
-          centerX: action.targetX,
-          centerZ: action.targetZ,
-          surveyorId: surveyor.id,
-          skillLevel,
-          completedTick: state.tickCount,
-        }, new Random(state.seed + state.tickCount + action.id));
-        state.surveyResults.push(surveyResult);
-        if (method === 'seismic') {
-          const seismicAccidents = applySeismicSurveyDamage(state.buildings, action.targetX, action.targetZ, state.tickCount);
-          state.damage.accidents.push(...seismicAccidents);
-        }
-        lines.push(`[tick ${state.tickCount}] ${method} survey complete at (${action.targetX}, ${action.targetZ}).`);
-      } else if (!surveyor) {
-        // No eligible surveyor available — keep the action in queue
-        state.pendingActions.push(action);
-      }
-    }
-
     // 8c. Training courses — advance and report completions. Without this the
     //     course never ends: the fee is charged and the qualification never
     //     arrives, which made every skill no role is hired with unobtainable.
@@ -213,13 +178,40 @@ export function tickCommand(
     const dispatchResult = tickEmployees(state);
     fired = fired ?? detectUnqualifiedTask(dispatchResult.unqualified, state.events, state.tickCount);
 
-    // 8e. Task duration progress + XP/level-up reporting.
+    // 8e. Task duration progress + XP/level-up reporting. taskTicksRemaining
+    // only counts down once ArrivalGate (8h below) has promoted it from
+    // pendingTaskDuration on a prior tick — see tickEmployees (#437).
     for (const emp of state.employees.employees) {
       if (!emp.alive) continue;
       const progress = tickTaskProgress(state, emp, emitter);
       if (!progress) continue;
       if (progress.completed) {
         lines.push(`[tick ${state.tickCount}] TASK: ${emp.name} completed task.`);
+
+        // A completed 'survey' task resolves here — after the surveyor has
+        // actually walked to and worked the site, not the instant it was
+        // claimed (#437).
+        if (progress.actionType === 'survey' && progress.actionPayload && ctx.grid) {
+          const method = progress.actionPayload['method'] as SurveyMethod;
+          const centerX = progress.actionPayload['centerX'] as number;
+          const centerZ = progress.actionPayload['centerZ'] as number;
+          const skillLevel = emp.qualifications.find(q => q.category === 'geology')?.proficiencyLevel ?? 1;
+          const surveyResult = estimateSurveyResult(ctx.grid, {
+            id: state.nextSurveyId++,
+            method,
+            centerX,
+            centerZ,
+            surveyorId: emp.id,
+            skillLevel,
+            completedTick: state.tickCount,
+          }, new Random(state.seed + state.tickCount + emp.id));
+          state.surveyResults.push(surveyResult);
+          if (method === 'seismic') {
+            const seismicAccidents = applySeismicSurveyDamage(state.buildings, centerX, centerZ, state.tickCount);
+            state.damage.accidents.push(...seismicAccidents);
+          }
+          lines.push(`[tick ${state.tickCount}] ${method} survey complete at (${centerX}, ${centerZ}).`);
+        }
       }
       if (progress.leveledUp) {
         lines.push(`[tick ${state.tickCount}] LEVELUP: ${emp.name} reached level ${progress.newLevel} in ${progress.skill}.`);
@@ -228,8 +220,11 @@ export function tickCommand(
 
     // 8f. Vehicle movement — advance every vehicle currently task='moving' one
     // step toward its target (moveVehicle/vehicle-move-command only set the
-    // target; nothing advanced x/z toward it before this).
+    // target; nothing advanced x/z toward it before this). Hauling vehicles
+    // are driven entirely by tickArrivalGate/tickHaulingProgress instead (8h)
+    // — ticking them here too would move them twice in the same tick (#437).
     for (const vehicle of state.vehicles.vehicles) {
+      if (vehicle.haulingPhase !== null) continue;
       tickVehicle(state, vehicle, emitter);
       tickVehicleTaskState(vehicle);
     }
@@ -246,6 +241,17 @@ export function tickCommand(
     for (const empId of movementResult.stuck) {
       const emp = state.employees.employees.find(e => e.id === empId);
       lines.push(`[tick ${state.tickCount}] STUCK: ${emp?.name ?? `employee #${empId}`} can't find a path — waiting.`);
+    }
+
+    // 8h. Arrival gate — must run after employee/vehicle movement above:
+    // promotes rest/task/vehicle-boarding intents queued this tick or a prior
+    // one into their active timers/effects once the entity has actually
+    // arrived, and drives hauling vehicles (move → load → move → unload) end
+    // to end (#437).
+    const arrivalResult = tickArrivalGate(state, emitter);
+    for (const cancelled of arrivalResult.boardingCancelled) {
+      const emp = state.employees.employees.find(e => e.id === cancelled.employeeId);
+      lines.push(`[tick ${state.tickCount}] BOARDING CANCELLED: ${emp?.name ?? `employee #${cancelled.employeeId}`} (${cancelled.reason}).`);
     }
 
     // 9. Level stats snapshot + campaign profit check

--- a/src/console/commands/vehicle.ts
+++ b/src/console/commands/vehicle.ts
@@ -15,6 +15,7 @@ import { requestBoardVehicle } from '../../core/entities/VehicleBoarding.js';
 import { requestHaulFragment } from '../../core/economy/HaulingTask.js';
 import { addExpense } from '../../core/economy/Finance.js';
 import { SPAWN_RING_SIZE, SPAWN_TILE_SPACING } from '../../core/config/balance.js';
+import { NavGrid } from '../../core/nav/NavGrid.js';
 
 // ── tier arg parsing ──
 
@@ -71,8 +72,19 @@ export function vehicleCommand(
       const baseX = state.world ? state.world.sizeX / 2 : 32;
       const baseZ = state.world ? state.world.sizeZ / 2 : 32;
       const fleetIndex = state.vehicles.vehicles.length;
-      const spawnX = baseX + (fleetIndex % SPAWN_RING_SIZE) * SPAWN_TILE_SPACING;
-      const spawnZ = baseZ + Math.floor(fleetIndex / SPAWN_RING_SIZE) * SPAWN_TILE_SPACING;
+      const rawSpawnX = baseX + (fleetIndex % SPAWN_RING_SIZE) * SPAWN_TILE_SPACING;
+      const rawSpawnZ = baseZ + Math.floor(fleetIndex / SPAWN_RING_SIZE) * SPAWN_TILE_SPACING;
+      // A blast can clear the grid centre down to a floorless 'void' column,
+      // or wall off a pocket of "nearest" traversable tiles from the rest of
+      // the map entirely — #437 regression: driver boarding now walks to the
+      // vehicle instead of assigning instantly, and nothing can path onto an
+      // unreachable tile. Snap the spawn point to the nearest NavGrid cell
+      // that is actually path-connected to the map's main region (anchored
+      // at a corner, since blast sites are never placed on the map edge) so
+      // a freshly bought vehicle is always reachable on foot.
+      const { x: spawnX, z: spawnZ } = state.navGrid
+        ? NavGrid.findNearestReachableCell(state.navGrid, 0, 0, rawSpawnX, rawSpawnZ)
+        : { x: rawSpawnX, z: rawSpawnZ };
       const { vehicle, cost } = purchaseVehicle(state.vehicles, type, spawnX, spawnZ, tier);
       state.cash -= cost;
       addExpense(state.finances, cost, 'equipment', `Buy ${type}`, state.tickCount);

--- a/src/console/commands/vehicle.ts
+++ b/src/console/commands/vehicle.ts
@@ -5,13 +5,13 @@ import type { GameContext } from './world.js';
 import {
   purchaseVehicle,
   assignVehicle,
-  assignDriver,
   moveVehicle,
   getAllVehicleRoles,
   type VehicleRole,
   type VehicleTask,
   type VehicleTier,
 } from '../../core/entities/Vehicle.js';
+import { requestBoardVehicle } from '../../core/entities/VehicleBoarding.js';
 import { addExpense } from '../../core/economy/Finance.js';
 import { SPAWN_RING_SIZE, SPAWN_TILE_SPACING } from '../../core/config/balance.js';
 
@@ -109,11 +109,14 @@ export function vehicleCommand(
       if (!state.vehicles.vehicles.find(v => v.id === vehicleId)) {
         return { success: false, output: `Vehicle #${vehicleId} not found.` };
       }
-      const result = assignDriver(state.vehicles, state.employees, vehicleId, employeeId);
+      // Validates licence/availability now, but the employee must physically
+      // walk to the vehicle before they actually become its driver — resolved
+      // by ArrivalGate.tickArrivalGate once they arrive (#437).
+      const result = requestBoardVehicle(state, vehicleId, employeeId);
       if (!result.success) {
         return { success: false, output: result.error! };
       }
-      return { success: true, output: `Driver #${employeeId} assigned to vehicle #${vehicleId}.` };
+      return { success: true, output: `Driver #${employeeId} walking to vehicle #${vehicleId} to board.` };
     }
     default:
       return { success: false, output: 'Usage: vehicle (list|buy|assign|move|driver)' };

--- a/src/console/commands/vehicle.ts
+++ b/src/console/commands/vehicle.ts
@@ -12,6 +12,7 @@ import {
   type VehicleTier,
 } from '../../core/entities/Vehicle.js';
 import { requestBoardVehicle } from '../../core/entities/VehicleBoarding.js';
+import { requestHaulFragment } from '../../core/economy/HaulingTask.js';
 import { addExpense } from '../../core/economy/Finance.js';
 import { SPAWN_RING_SIZE, SPAWN_TILE_SPACING } from '../../core/config/balance.js';
 
@@ -118,7 +119,22 @@ export function vehicleCommand(
       }
       return { success: true, output: `Driver #${employeeId} walking to vehicle #${vehicleId} to board.` };
     }
+    case 'haul': {
+      const vehicleId = parseInt(args[1] ?? '', 10);
+      const fragmentId = parseInt(named['fragment'] ?? '', 10);
+      if (isNaN(vehicleId) || isNaN(fragmentId)) {
+        return { success: false, output: 'Usage: vehicle haul <vehicleId> fragment:<fragmentId>' };
+      }
+      // Sets intent only — the vehicle must physically drive to the fragment
+      // before loading it, then to the depot before unloading — resolved by
+      // ArrivalGate.tickArrivalGate/tickHaulingProgress each tick (#437).
+      const result = requestHaulFragment(state, vehicleId, fragmentId);
+      if (!result.success) {
+        return { success: false, output: result.error! };
+      }
+      return { success: true, output: `Vehicle #${vehicleId} hauling fragment #${fragmentId}.` };
+    }
     default:
-      return { success: false, output: 'Usage: vehicle (list|buy|assign|move|driver)' };
+      return { success: false, output: 'Usage: vehicle (list|buy|assign|move|driver|haul)' };
   }
 }

--- a/src/console/createRunner.ts
+++ b/src/console/createRunner.ts
@@ -168,7 +168,7 @@ export function createRunner(): RunnerWithContext {
   runner.register('build', 'Place/manage buildings (list|destroy|move|<type> at:x,z)', (args, named) =>
     buildCommand(ctx, args, named),
   );
-  runner.register('vehicle', 'Manage vehicles (list|buy|assign|move)', (args, named) =>
+  runner.register('vehicle', 'Manage vehicles (list|buy|assign|move|driver|haul)', (args, named) =>
     vehicleCommand(ctx, args, named),
   );
   runner.register('employee', 'Manage employees (list|hire|raise|fire|assign_skill|dispatch|train)', (args, named) =>

--- a/src/core/economy/HaulingTask.ts
+++ b/src/core/economy/HaulingTask.ts
@@ -6,6 +6,10 @@
 
 import type { GameState } from '../state/GameState.js';
 import type { Vehicle } from '../entities/Vehicle.js';
+import { findNearestActiveBuildingOfType, getBuildingDef } from '../entities/Building.js';
+import { findBuildingApproachCell } from '../nav/BuildingApproach.js';
+import { tickVehicle, tickVehicleTaskState } from '../engine/EntityMovementTick.js';
+import { pickupFragment, deliverToDepot } from './Logistics.js';
 
 /**
  * Request that a debris_hauler vehicle haul a fragment to the nearest active
@@ -14,11 +18,30 @@ import type { Vehicle } from '../entities/Vehicle.js';
  * ArrivalGate.tickArrivalGate and tickHaulingProgress drive the phases.
  */
 export function requestHaulFragment(
-  _state: GameState,
-  _vehicleId: number,
-  _fragmentId: number,
+  state: GameState,
+  vehicleId: number,
+  fragmentId: number,
 ): { success: boolean; error?: string } {
-  throw new Error('not implemented: requestHaulFragment');
+  const vehicle = state.vehicles.vehicles.find(v => v.id === vehicleId);
+  if (!vehicle) return { success: false, error: 'Vehicle not found' };
+  if (vehicle.type !== 'debris_hauler') return { success: false, error: 'Vehicle is not a debris hauler' };
+  if (vehicle.haulingPhase !== null) return { success: false, error: 'Vehicle is already hauling' };
+
+  const tracked = state.logistics.fragments.find(
+    f => f.fragment.id === fragmentId && f.state === 'on_ground',
+  );
+  if (!tracked) return { success: false, error: 'Fragment not found or not on the ground' };
+
+  const depot = findNearestActiveBuildingOfType(state.buildings, 'freight_warehouse', vehicle.x, vehicle.z);
+  if (!depot) return { success: false, error: 'No active freight warehouse available' };
+
+  // Intent only — the vehicle does not move or load until tickHaulingProgress
+  // (driven from ArrivalGate.tickArrivalGate) walks it to the fragment first.
+  vehicle.haulingFragmentId = fragmentId;
+  vehicle.haulingPhase = 'to_fragment';
+  vehicle.haulingDepotBuildingId = depot.id;
+
+  return { success: true };
 }
 
 /**
@@ -26,6 +49,73 @@ export function requestHaulFragment(
  * toward its current phase target, and on arrival transitions
  * 'to_fragment' -> load -> 'to_depot' -> deliver -> idle.
  */
-export function tickHaulingProgress(_state: GameState, _vehicle: Vehicle): void {
-  throw new Error('not implemented: tickHaulingProgress');
+export function tickHaulingProgress(state: GameState, vehicle: Vehicle): void {
+  if (vehicle.haulingPhase === null) return;
+
+  if (vehicle.haulingPhase === 'to_fragment') {
+    const tracked = state.logistics.fragments.find(
+      f => f.fragment.id === vehicle.haulingFragmentId && f.state === 'on_ground',
+    );
+    if (!tracked) {
+      // Fragment gone (picked up/removed elsewhere) — abandon this haul.
+      abortHaul(vehicle);
+      return;
+    }
+
+    vehicle.task = 'moving';
+    vehicle.targetX = Math.round(tracked.fragment.position.x);
+    vehicle.targetZ = Math.round(tracked.fragment.position.z);
+    tickVehicle(state, vehicle);
+
+    if (vehicle.x === vehicle.targetX && vehicle.z === vehicle.targetZ) {
+      const loaded = pickupFragment(state.logistics, vehicle.haulingFragmentId!, String(vehicle.id));
+      if (loaded) {
+        vehicle.payloadKg = tracked.fragment.mass;
+        vehicle.haulingPhase = 'to_depot';
+        vehicle.task = 'transport';
+      } else {
+        // Storage full or fragment claimed by another vehicle this tick.
+        abortHaul(vehicle);
+      }
+    }
+    tickVehicleTaskState(vehicle);
+    return;
+  }
+
+  // vehicle.haulingPhase === 'to_depot'
+  const building = state.buildings.buildings.find(
+    b => b.id === vehicle.haulingDepotBuildingId && b.active,
+  );
+  if (!building) {
+    abortHaul(vehicle);
+    return;
+  }
+
+  // A building's raw (x, z) is always NavGrid-blocked (see
+  // findBuildingApproachCell's doc) — target the nearest walkable ring cell
+  // around the depot instead (#437).
+  const approach = findBuildingApproachCell(state.navGrid, building, getBuildingDef(building.type, building.tier), vehicle.x, vehicle.z);
+  vehicle.task = 'moving';
+  vehicle.targetX = approach.x;
+  vehicle.targetZ = approach.z;
+  tickVehicle(state, vehicle);
+
+  if (vehicle.x === vehicle.targetX && vehicle.z === vehicle.targetZ) {
+    deliverToDepot(state.logistics, vehicle.haulingFragmentId!, state.collectedOre);
+    vehicle.payloadKg = 0;
+    vehicle.haulingFragmentId = null;
+    vehicle.haulingPhase = null;
+    vehicle.haulingDepotBuildingId = null;
+    vehicle.task = 'idle';
+  }
+  tickVehicleTaskState(vehicle);
+}
+
+/** Cancel an in-progress haul and return the vehicle to idle. */
+function abortHaul(vehicle: Vehicle): void {
+  vehicle.haulingFragmentId = null;
+  vehicle.haulingPhase = null;
+  vehicle.haulingDepotBuildingId = null;
+  vehicle.payloadKg = 0;
+  vehicle.task = 'idle';
 }

--- a/src/core/economy/HaulingTask.ts
+++ b/src/core/economy/HaulingTask.ts
@@ -6,7 +6,7 @@
 
 import type { GameState } from '../state/GameState.js';
 import type { Vehicle } from '../entities/Vehicle.js';
-import { findNearestActiveBuildingOfType, getBuildingDef } from '../entities/Building.js';
+import { findNearestActiveBuildingOfType, getBuildingDef, type Building } from '../entities/Building.js';
 import { findBuildingApproachCell } from '../nav/BuildingApproach.js';
 import { tickVehicle, tickVehicleTaskState } from '../engine/EntityMovementTick.js';
 import { pickupFragment, deliverToDepot } from './Logistics.js';
@@ -83,13 +83,7 @@ export function tickHaulingProgress(state: GameState, vehicle: Vehicle): void {
           b => b.id === vehicle.haulingDepotBuildingId && b.active,
         );
         if (depotBuilding) {
-          const approach = findBuildingApproachCell(
-            state.navGrid,
-            depotBuilding,
-            getBuildingDef(depotBuilding.type, depotBuilding.tier),
-            vehicle.x,
-            vehicle.z,
-          );
+          const approach = resolveDepotApproach(state, depotBuilding, vehicle);
           vehicle.targetX = approach.x;
           vehicle.targetZ = approach.z;
         }
@@ -111,10 +105,7 @@ export function tickHaulingProgress(state: GameState, vehicle: Vehicle): void {
     return;
   }
 
-  // A building's raw (x, z) is always NavGrid-blocked (see
-  // findBuildingApproachCell's doc) — target the nearest walkable ring cell
-  // around the depot instead (#437).
-  const approach = findBuildingApproachCell(state.navGrid, building, getBuildingDef(building.type, building.tier), vehicle.x, vehicle.z);
+  const approach = resolveDepotApproach(state, building, vehicle);
   vehicle.task = 'moving';
   vehicle.targetX = approach.x;
   vehicle.targetZ = approach.z;
@@ -129,6 +120,16 @@ export function tickHaulingProgress(state: GameState, vehicle: Vehicle): void {
     vehicle.task = 'idle';
   }
   tickVehicleTaskState(vehicle);
+}
+
+/**
+ * Resolve the nearest walkable NavGrid cell on the ring around a depot
+ * building, closest to the vehicle. A building's raw (x, z) is always
+ * NavGrid-blocked (see findBuildingApproachCell's doc), so both hauling
+ * legs that target a depot go through this instead (#437).
+ */
+function resolveDepotApproach(state: GameState, building: Building, vehicle: Vehicle): { x: number; z: number } {
+  return findBuildingApproachCell(state.navGrid, building, getBuildingDef(building.type, building.tier), vehicle.x, vehicle.z);
 }
 
 /** Cancel an in-progress haul and return the vehicle to idle. */

--- a/src/core/economy/HaulingTask.ts
+++ b/src/core/economy/HaulingTask.ts
@@ -1,0 +1,31 @@
+// BlastSimulator2026 — Hauling task
+//
+// Position-gated debris hauling: a debris_hauler vehicle is dispatched to a
+// fragment, loads it only on arrival, then drives to a depot building and
+// delivers it only on arrival. ArrivalGate.ts drives the phase transitions.
+
+import type { GameState } from '../state/GameState.js';
+import type { Vehicle } from '../entities/Vehicle.js';
+
+/**
+ * Request that a debris_hauler vehicle haul a fragment to the nearest active
+ * depot/warehouse building. Sets the vehicle's hauling intent (fragmentId,
+ * phase, destination depot) without moving or loading it immediately —
+ * ArrivalGate.tickArrivalGate and tickHaulingProgress drive the phases.
+ */
+export function requestHaulFragment(
+  _state: GameState,
+  _vehicleId: number,
+  _fragmentId: number,
+): { success: boolean; error?: string } {
+  throw new Error('not implemented: requestHaulFragment');
+}
+
+/**
+ * Advance a single vehicle's in-progress hauling task by one tick: moves it
+ * toward its current phase target, and on arrival transitions
+ * 'to_fragment' -> load -> 'to_depot' -> deliver -> idle.
+ */
+export function tickHaulingProgress(_state: GameState, _vehicle: Vehicle): void {
+  throw new Error('not implemented: tickHaulingProgress');
+}

--- a/src/core/economy/HaulingTask.ts
+++ b/src/core/economy/HaulingTask.ts
@@ -25,6 +25,7 @@ export function requestHaulFragment(
   const vehicle = state.vehicles.vehicles.find(v => v.id === vehicleId);
   if (!vehicle) return { success: false, error: 'Vehicle not found' };
   if (vehicle.type !== 'debris_hauler') return { success: false, error: 'Vehicle is not a debris hauler' };
+  if (vehicle.driverId === null) return { success: false, error: 'Vehicle has no driver' };
   if (vehicle.haulingPhase !== null) return { success: false, error: 'Vehicle is already hauling' };
 
   const tracked = state.logistics.fragments.find(
@@ -35,11 +36,14 @@ export function requestHaulFragment(
   const depot = findNearestActiveBuildingOfType(state.buildings, 'freight_warehouse', vehicle.x, vehicle.z);
   if (!depot) return { success: false, error: 'No active freight warehouse available' };
 
-  // Intent only — the vehicle does not move or load until tickHaulingProgress
-  // (driven from ArrivalGate.tickArrivalGate) walks it to the fragment first.
+  // Intent only — the vehicle does not load until tickHaulingProgress (driven
+  // from ArrivalGate.tickArrivalGate) detects arrival. The movement target is
+  // set immediately so tickVehicle has somewhere to drive toward each tick.
   vehicle.haulingFragmentId = fragmentId;
   vehicle.haulingPhase = 'to_fragment';
   vehicle.haulingDepotBuildingId = depot.id;
+  vehicle.targetX = Math.round(tracked.fragment.position.x);
+  vehicle.targetZ = Math.round(tracked.fragment.position.z);
 
   return { success: true };
 }
@@ -73,6 +77,22 @@ export function tickHaulingProgress(state: GameState, vehicle: Vehicle): void {
         vehicle.payloadKg = tracked.fragment.mass;
         vehicle.haulingPhase = 'to_depot';
         vehicle.task = 'transport';
+        // Re-target toward the depot immediately so the vehicle has somewhere
+        // to drive on its next movement tick.
+        const depotBuilding = state.buildings.buildings.find(
+          b => b.id === vehicle.haulingDepotBuildingId && b.active,
+        );
+        if (depotBuilding) {
+          const approach = findBuildingApproachCell(
+            state.navGrid,
+            depotBuilding,
+            getBuildingDef(depotBuilding.type, depotBuilding.tier),
+            vehicle.x,
+            vehicle.z,
+          );
+          vehicle.targetX = approach.x;
+          vehicle.targetZ = approach.z;
+        }
       } else {
         // Storage full or fragment claimed by another vehicle this tick.
         abortHaul(vehicle);

--- a/src/core/engine/ArrivalGate.ts
+++ b/src/core/engine/ArrivalGate.ts
@@ -6,7 +6,10 @@
 // loop, after entity movement has been advanced.
 
 import type { GameState } from '../state/GameState.js';
+import type { Employee } from '../entities/Employee.js';
 import type { EventEmitter } from '../state/EventEmitter.js';
+import { assignDriver } from '../entities/Vehicle.js';
+import { tickHaulingProgress } from '../economy/HaulingTask.js';
 
 /** Summary of what the arrival gate started/cancelled on this tick. */
 export interface ArrivalGateResult {
@@ -25,7 +28,110 @@ export interface ArrivalGateResult {
  * pending position-dependent action, check whether they have arrived at
  * their destination and, if so, start the corresponding timer/effect (or
  * cancel it if the precondition no longer holds).
+ *
+ * Must run after tickEmployeeMovement/tickVehicle have advanced positions for
+ * this tick — arrival is read off their result (destinationX/Z nulled by
+ * tickEmployeeMovement on arrival is the same signal EntityMovementTick.ts
+ * already uses; this module reuses it rather than tracking arrival a second
+ * way).
  */
-export function tickArrivalGate(_state: GameState, _emitter?: EventEmitter): ArrivalGateResult {
-  throw new Error('not implemented: tickArrivalGate');
+export function tickArrivalGate(state: GameState, emitter?: EventEmitter): ArrivalGateResult {
+  const result: ArrivalGateResult = {
+    restStarted: [],
+    taskStarted: [],
+    driversBoarded: [],
+    boardingCancelled: [],
+  };
+
+  for (const emp of state.employees.employees) {
+    if (!emp.alive) continue;
+
+    // tickEmployeeMovement clears destinationX/Z the instant x/z reaches it
+    // (and never sets it at all when the employee started already on target)
+    // — null on both axes is exactly "nothing left to walk toward this tick".
+    const arrived = emp.destinationX === null && emp.destinationZ === null;
+    if (!arrived) continue;
+
+    if (emp.pendingRestDuration !== null) {
+      emp.restTicksRemaining = emp.pendingRestDuration;
+      emp.restNeedKey = emp.pendingRestNeedKey;
+      emp.pendingRestDuration = null;
+      emp.pendingRestNeedKey = null;
+      result.restStarted.push(emp.id);
+    }
+
+    if (emp.pendingTaskDuration !== null) {
+      emp.taskTicksRemaining = emp.pendingTaskDuration;
+      emp.pendingTaskDuration = null;
+      result.taskStarted.push(emp.id);
+    }
+
+    if (emp.pendingDriverVehicleId !== null) {
+      resolveBoarding(state, emp, result, emitter);
+    }
+  }
+
+  for (const vehicle of state.vehicles.vehicles) {
+    if (vehicle.haulingPhase === null) continue;
+
+    const prevPhase = vehicle.haulingPhase;
+    const prevFragmentId = vehicle.haulingFragmentId;
+
+    tickHaulingProgress(state, vehicle);
+
+    if (prevPhase === 'to_fragment' && vehicle.haulingPhase === 'to_depot' && prevFragmentId !== null) {
+      emitter?.emit('vehicle:haul_loaded', { vehicleId: vehicle.id, fragmentId: prevFragmentId });
+    } else if (prevPhase === 'to_depot' && vehicle.haulingPhase === null && prevFragmentId !== null) {
+      const tracked = state.logistics.fragments.find(f => f.fragment.id === prevFragmentId);
+      if (tracked?.state === 'stored') {
+        emitter?.emit('vehicle:haul_delivered', { vehicleId: vehicle.id, fragmentId: prevFragmentId });
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Resolve a pending driver-boarding request for an employee who has just
+ * arrived at the vehicle's position (or cancel it if the vehicle is no
+ * longer boardable).
+ */
+function resolveBoarding(
+  state: GameState,
+  emp: Employee,
+  result: ArrivalGateResult,
+  emitter?: EventEmitter,
+): void {
+  const vehicleId = emp.pendingDriverVehicleId!;
+  const vehicle = state.vehicles.vehicles.find(v => v.id === vehicleId);
+
+  if (!vehicle) {
+    emp.pendingDriverVehicleId = null;
+    result.boardingCancelled.push({ employeeId: emp.id, reason: 'vehicle_gone' });
+    return;
+  }
+
+  if (vehicle.driverId !== null && vehicle.driverId !== emp.id) {
+    emp.pendingDriverVehicleId = null;
+    result.boardingCancelled.push({ employeeId: emp.id, reason: 'vehicle_taken' });
+    return;
+  }
+
+  if (emp.x !== vehicle.x || emp.z !== vehicle.z) {
+    // The employee reached where the vehicle used to be, but it has since
+    // moved elsewhere — cancel rather than chase it silently.
+    emp.pendingDriverVehicleId = null;
+    result.boardingCancelled.push({ employeeId: emp.id, reason: 'vehicle_moved' });
+    return;
+  }
+
+  const boarded = assignDriver(state.vehicles, state.employees, vehicle.id, emp.id);
+  emp.pendingDriverVehicleId = null;
+  if (boarded.success) {
+    result.driversBoarded.push(emp.id);
+    emitter?.emit('vehicle:driver_boarded', { employeeId: emp.id, vehicleId: vehicle.id });
+  } else {
+    result.boardingCancelled.push({ employeeId: emp.id, reason: boarded.error ?? 'unknown' });
+  }
 }

--- a/src/core/engine/ArrivalGate.ts
+++ b/src/core/engine/ArrivalGate.ts
@@ -63,6 +63,11 @@ export function tickArrivalGate(state: GameState, emitter?: EventEmitter): Arriv
     if (emp.pendingTaskDuration !== null) {
       emp.taskTicksRemaining = emp.pendingTaskDuration;
       emp.pendingTaskDuration = null;
+      // pendingActionType/pendingActionPayload deliberately survive arrival —
+      // tickTaskProgress (GameLoop.ts) reads them at actual task completion
+      // to know what work just finished (e.g. resolving a survey) and clears
+      // them itself. Clearing them here would make every task's completion
+      // handler blind to what it just did (see survey.integration.test.ts).
       result.taskStarted.push(emp.id);
     }
 

--- a/src/core/engine/ArrivalGate.ts
+++ b/src/core/engine/ArrivalGate.ts
@@ -1,0 +1,31 @@
+// BlastSimulator2026 — Arrival gate
+//
+// Gates position-dependent entity actions (survey, rest/eating, vehicle
+// boarding, hauling) on actual navmesh arrival instead of starting
+// timers/effects at claim time. Ticked once per game tick from the game
+// loop, after entity movement has been advanced.
+
+import type { GameState } from '../state/GameState.js';
+import type { EventEmitter } from '../state/EventEmitter.js';
+
+/** Summary of what the arrival gate started/cancelled on this tick. */
+export interface ArrivalGateResult {
+  /** Employee IDs whose rest timer was started this tick because they arrived. */
+  restStarted: number[];
+  /** Employee IDs whose task timer was started this tick because they arrived. */
+  taskStarted: number[];
+  /** Employee IDs who successfully boarded a vehicle this tick because they arrived. */
+  driversBoarded: number[];
+  /** Employee IDs whose pending boarding was cancelled this tick, with a reason. */
+  boardingCancelled: Array<{ employeeId: number; reason: 'vehicle_gone' | 'vehicle_taken' | 'vehicle_moved' | string }>;
+}
+
+/**
+ * Advance the arrival gate by one tick: for every employee/vehicle with a
+ * pending position-dependent action, check whether they have arrived at
+ * their destination and, if so, start the corresponding timer/effect (or
+ * cancel it if the precondition no longer holds).
+ */
+export function tickArrivalGate(_state: GameState, _emitter?: EventEmitter): ArrivalGateResult {
+  throw new Error('not implemented: tickArrivalGate');
+}

--- a/src/core/engine/EntityMovementTick.ts
+++ b/src/core/engine/EntityMovementTick.ts
@@ -156,9 +156,14 @@ function markVehicleWaiting(vehicle: Vehicle): void {
 }
 
 function canTickVehicle(vehicle: Vehicle): boolean {
-  // moveVehicle() sets task='moving'; vehicle state may still be 'idle' on the very first tick.
+  // moveVehicle() sets task='moving'; vehicle state may still be 'idle' on the very first
+  // tick, or 'working' when a caller just switched task off a work task (e.g. HaulingTask's
+  // to_fragment->pickup->to_depot transition leaves state='working' from the tick it loaded —
+  // #437). task is the sole authority on whether a vehicle should move; state is a derived
+  // display value tickVehicleTaskState/tickVehicle themselves update, so it must never block
+  // a 'moving' task from actually ticking.
   return vehicle.task === 'moving' &&
-    (vehicle.state === 'idle' || vehicle.state === 'moving' || vehicle.state === 'waiting');
+    (vehicle.state === 'idle' || vehicle.state === 'moving' || vehicle.state === 'waiting' || vehicle.state === 'working');
 }
 
 function setVehicleIdle(vehicle: Vehicle): void {

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -297,10 +297,7 @@ export function tickNeedRestoration(state: GameState): NeedRestorationResult {
       continue;
     }
 
-    // Every footprint cell of a building — including its raw (x, z) origin —
-    // is 'blocked' on the NavGrid, so that alone can never be pathfound to.
-    // Walk to the nearest walkable cell on the ring around it instead (#437).
-    const approach = findBuildingApproachCell(state.navGrid, building, getBuildingDef(building.type, building.tier), emp.x, emp.z);
+    const approach = resolveBuildingApproach(state, building, emp.x, emp.z);
 
     const restAction = createRestPendingAction(state, {
       targetX: approach.x,
@@ -367,10 +364,7 @@ export function tickCollapse(state: GameState, _firedEvents?: FiredEvent[], _emi
     if (building) {
       const distSq = (building.x - emp.x) ** 2 + (building.z - emp.z) ** 2;
       if (distSq <= NEED_REST_SEARCH_RADIUS ** 2) {
-        // See findBuildingApproachCell's doc — a building's raw (x, z) is
-        // always NavGrid-blocked; walk to the nearest walkable ring cell
-        // around it instead (#437).
-        const approach = findBuildingApproachCell(state.navGrid, building, getBuildingDef(building.type, building.tier), emp.x, emp.z);
+        const approach = resolveBuildingApproach(state, building, emp.x, emp.z);
         targetX = approach.x;
         targetZ = approach.z;
         buildingId = building.id;
@@ -481,11 +475,7 @@ export function autoInsertNeedTasks(state: GameState, _firedEvents?: FiredEvent[
     const buildingType = NEED_REST_BUILDING_TYPES[primaryGauge];
     const building = findNearestBuildingOfType(state, buildingType, emp.x, emp.z);
 
-    // See findBuildingApproachCell's doc — a building's raw (x, z) is always
-    // NavGrid-blocked, so target the nearest walkable ring cell instead (#437).
-    const approach = building
-      ? findBuildingApproachCell(state.navGrid, building, getBuildingDef(building.type, building.tier), emp.x, emp.z)
-      : null;
+    const approach = building ? resolveBuildingApproach(state, building, emp.x, emp.z) : null;
     const targetX = approach?.x ?? emp.x;
     const targetZ = approach?.z ?? emp.z;
     // With nowhere to go the employee rests in place, which takes longer and
@@ -555,6 +545,21 @@ function findNearestLivingQuarters(
   empZ: number,
 ): Building | null {
   return findNearestBuildingOfType(state, 'living_quarters', empX, empZ);
+}
+
+/**
+ * Resolve the nearest walkable NavGrid cell on the ring around a building,
+ * closest to (empX, empZ). See findBuildingApproachCell's doc for why a
+ * building's raw (x, z) can never be targeted directly (#437) — every
+ * rest-routing call site below needs this same resolution.
+ */
+function resolveBuildingApproach(
+  state: GameState,
+  building: Building,
+  empX: number,
+  empZ: number,
+): { x: number; z: number } {
+  return findBuildingApproachCell(state.navGrid, building, getBuildingDef(building.type, building.tier), empX, empZ);
 }
 
 /**
@@ -868,10 +873,7 @@ function forceShiftRestIfNeeded(
   let buildingId: number | undefined;
 
   if (building) {
-    // See findBuildingApproachCell's doc — a building's raw footprint
-    // (including its center) is always NavGrid-blocked; walk to the nearest
-    // walkable ring cell around it instead (#437).
-    const approach = findBuildingApproachCell(state.navGrid, building, getBuildingDef(building.type, building.tier), emp.x, emp.z);
+    const approach = resolveBuildingApproach(state, building, emp.x, emp.z);
     targetX = approach.x;
     targetZ = approach.z;
     buildingId = building.id;

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -2,8 +2,9 @@
 // Manages tick processing with variable speed (1x, 2x, 4x, 8x) and pause.
 // Pure logic: no timers, no DOM. The caller drives the loop.
 
-import type { GameState, PendingAction } from '../state/GameState.js';
-import { getBuildingDef, getDefSize, type Building, type BuildingType } from '../entities/Building.js';
+import type { GameState, PendingAction, ActionType } from '../state/GameState.js';
+import { getBuildingDef, findNearestActiveBuildingOfType, type Building, type BuildingType } from '../entities/Building.js';
+import { findBuildingApproachCell } from '../nav/BuildingApproach.js';
 import type { Random } from '../math/Random.js';
 import type { EventContext } from '../events/EventPool.js';
 import { tickEventSystem, type FiredEvent } from '../events/EventSystem.js';
@@ -15,6 +16,7 @@ import { getLivingQuartersWellbeingMultiplier } from '../entities/BuildingWellbe
 import type { EventEmitter } from '../state/EventEmitter.js';
 import { addExpense } from '../economy/Finance.js';
 import { tickVehicle, tickVehicleTaskState, tickEmployeeMovement, type EmployeeMovementResult } from './EntityMovementTick.js';
+import { tickArrivalGate, type ArrivalGateResult } from './ArrivalGate.js';
 
 // ── Config ──
 
@@ -24,6 +26,11 @@ import { BASE_TICK_MS as _BASE_TICK_MS, VALID_SPEEDS as _VALID_SPEEDS, NEED_REST
 // in EntityMovementTick.ts (#407 refactor) — re-exported here so GameLoop.ts
 // stays the single public surface for tick-orchestration callers.
 export { tickVehicle, tickVehicleTaskState, tickEmployeeMovement, type EmployeeMovementResult };
+
+// Arrival-gated position-dependent actions (survey, rest/eating, vehicle
+// boarding, hauling) live in ArrivalGate.ts (#437) — re-exported here for the
+// same reason as the movement functions above.
+export { tickArrivalGate, type ArrivalGateResult };
 
 /** Milliseconds per base tick at 1x speed. */
 export const BASE_TICK_MS = _BASE_TICK_MS;
@@ -189,34 +196,53 @@ export function tickEmployees(state: GameState): TickEmployeesResult {
     const ghostIdx = state.ghostPreviews.findIndex(g => g.id === action.id);
     if (ghostIdx !== -1) state.ghostPreviews.splice(ghostIdx, 1);
 
-    // tickCollapse/tickNeedRestoration self-claim (see above) and start the rest
-    // timer immediately, so they never reach this path. autoInsertNeedTasks
-    // pushes 'rest' actions unclaimed (busy-employee case), so this is the
-    // first point an idle employee actually starts resting — start the timer
-    // here. Bunkhouse Tier 2+ shift-cycle rest (forceShiftRestIfNeeded) also
-    // self-claims and carries no 'needKey' payload, so resolveRestNeedKey
-    // returns null for it and this block is a no-op.
-    if (action.type === 'rest' && idleMatch.restTicksRemaining === null) {
+    // tickCollapse/tickNeedRestoration self-claim (see above) and, like this
+    // branch, only ever *queue* the rest via pendingRestDuration/
+    // pendingRestNeedKey — ArrivalGate.tickArrivalGate promotes it into
+    // restTicksRemaining once the employee physically reaches the rest
+    // building (#437). autoInsertNeedTasks pushes 'rest' actions unclaimed
+    // (busy-employee case), so this is the first point an idle employee
+    // actually starts walking to rest. Bunkhouse Tier 2+ shift-cycle rest
+    // (forceShiftRestIfNeeded) also self-claims and carries no 'needKey'
+    // payload, so resolveRestNeedKey returns null for it and this block is a
+    // no-op there.
+    if (action.type === 'rest' && idleMatch.restTicksRemaining === null && idleMatch.pendingRestDuration === null) {
       const needKey = resolveRestNeedKey(action.payload);
       if (needKey !== null) {
         const restDuration = typeof action.payload['restDuration'] === 'number'
           ? action.payload['restDuration'] as number
           : NEED_REST_DURATIONS[needKey];
-        idleMatch.restTicksRemaining = restDuration;
-        idleMatch.restNeedKey = needKey;
+        idleMatch.pendingRestDuration = restDuration;
+        idleMatch.pendingRestNeedKey = needKey;
       }
     }
 
-    // Non-rest actions requiring a skill start their task-duration countdown
-    // here — the claimed employee is guaranteed (via allWithSkill above) to
-    // hold requiredSkill, so proficiency lookup below always succeeds.
+    // Non-rest actions requiring a skill queue their task duration here — the
+    // claimed employee is guaranteed (via allWithSkill above) to hold
+    // requiredSkill, so proficiency lookup below always succeeds. The
+    // countdown itself (taskTicksRemaining) does not start until
+    // ArrivalGate.tickArrivalGate confirms the employee has physically
+    // reached targetX/targetZ (#437) — a survey used to resolve the instant
+    // it was claimed, regardless of how far the surveyor still had to walk.
+    // pendingActionType/pendingActionPayload stay set through to completion
+    // (tickTaskProgress clears them) so completion handling (e.g. survey
+    // resolution) still knows what work just finished.
     if (action.type !== 'rest' && action.requiredSkill !== null) {
       const qual = idleMatch.qualifications.find(q => q.category === action.requiredSkill);
       const level = qual?.proficiencyLevel ?? 1;
       const needMult = getNeedMultiplier(idleMatch);
       const lqMult = getLivingQuartersWellbeingMultiplier(state.buildings, state.employees.employees.length);
-      idleMatch.taskTicksRemaining = computeTaskDuration(BASE_TASK_DURATION_TICKS, level, needMult, lqMult, 1);
+      // A survey's own durationTicks (SURVEY_DURATION_TICKS[method], set by
+      // runSurvey) overrides the generic proficiency-scaled duration, mirroring
+      // the 'rest' branch's restDuration override above — otherwise every
+      // survey silently took BASE_TASK_DURATION_TICKS instead of its method's
+      // own duration.
+      idleMatch.pendingTaskDuration = typeof action.payload['durationTicks'] === 'number'
+        ? action.payload['durationTicks'] as number
+        : computeTaskDuration(BASE_TASK_DURATION_TICKS, level, needMult, lqMult, 1);
       idleMatch.activeTaskSkill = action.requiredSkill;
+      idleMatch.pendingActionType = action.type;
+      idleMatch.pendingActionPayload = action.payload;
     }
   }
 
@@ -271,20 +297,27 @@ export function tickNeedRestoration(state: GameState): NeedRestorationResult {
       continue;
     }
 
+    // Every footprint cell of a building — including its raw (x, z) origin —
+    // is 'blocked' on the NavGrid, so that alone can never be pathfound to.
+    // Walk to the nearest walkable cell on the ring around it instead (#437).
+    const approach = findBuildingApproachCell(state.navGrid, building, getBuildingDef(building.type, building.tier), emp.x, emp.z);
+
     const restAction = createRestPendingAction(state, {
-      targetX: building.x,
-      targetZ: building.z,
+      targetX: approach.x,
+      targetZ: approach.z,
       targetEmployeeId: emp.id,
       payload: { buildingId: building.id, needKey, restDuration },
     });
 
     state.pendingActions.push(restAction);
     emp.activeActionId = restAction.id;
-    // Immediately claimed (unlike autoInsertNeedTasks) — start the rest timer now.
-    emp.restTicksRemaining = restDuration;
-    emp.restNeedKey = needKey;
-    emp.destinationX = building.x;
-    emp.destinationZ = building.z;
+    // Immediately claimed (unlike autoInsertNeedTasks) — but the rest timer
+    // itself does not start until ArrivalGate.tickArrivalGate confirms the
+    // employee has walked to the building (#437).
+    emp.pendingRestDuration = restDuration;
+    emp.pendingRestNeedKey = needKey;
+    emp.destinationX = approach.x;
+    emp.destinationZ = approach.z;
     result.routed.push(emp.id);
   }
 
@@ -334,8 +367,12 @@ export function tickCollapse(state: GameState, _firedEvents?: FiredEvent[], _emi
     if (building) {
       const distSq = (building.x - emp.x) ** 2 + (building.z - emp.z) ** 2;
       if (distSq <= NEED_REST_SEARCH_RADIUS ** 2) {
-        targetX = building.x;
-        targetZ = building.z;
+        // See findBuildingApproachCell's doc — a building's raw (x, z) is
+        // always NavGrid-blocked; walk to the nearest walkable ring cell
+        // around it instead (#437).
+        const approach = findBuildingApproachCell(state.navGrid, building, getBuildingDef(building.type, building.tier), emp.x, emp.z);
+        targetX = approach.x;
+        targetZ = approach.z;
         buildingId = building.id;
       } else {
         // Building exists but too far — the employee rests in place
@@ -364,9 +401,12 @@ export function tickCollapse(state: GameState, _firedEvents?: FiredEvent[], _emi
 
     state.pendingActions.push(restAction);
     emp.activeActionId = restAction.id;
-    // Immediately claimed — start the rest timer now (mirrors tickNeedRestoration).
-    emp.restTicksRemaining = restDuration;
-    emp.restNeedKey = collapsedGauge;
+    // Immediately claimed — but the rest timer itself does not start until
+    // ArrivalGate.tickArrivalGate confirms arrival (mirrors tickNeedRestoration, #437).
+    // When resting in place (targetX/Z === emp.x/z, the two no-building branches
+    // above) the employee is already "arrived" and the gate resolves next tick.
+    emp.pendingRestDuration = restDuration;
+    emp.pendingRestNeedKey = collapsedGauge;
     emp.destinationX = targetX;
     emp.destinationZ = targetZ;
   }
@@ -393,15 +433,17 @@ export function autoInsertNeedTasks(state: GameState, _firedEvents?: FiredEvent[
     // Skip dead, injured, or collapsing employees
     if (!emp.alive || emp.injured || emp.collapsing) continue;
 
-    // Skip employees already mid-rest. Their gauge is still below its warning
-    // threshold — the replenishment only lands when the rest completes — so
-    // without this check a second rest is queued every cycle, claimed the
-    // instant the first one ends, and charged again: one wasted rest and one
-    // extra NEED_REST_COSTS payment per dip below the threshold. Rests created
-    // by tickCollapse/tickNeedRestoration stay in pendingActions and are caught
-    // by the hasRestAction check below; a rest claimed through tickEmployees is
-    // consumed from the queue, so only restTicksRemaining still marks it.
-    if (emp.restTicksRemaining !== null) continue;
+    // Skip employees already mid-rest — resting, or (#437) still walking to
+    // rest with the timer not yet started. Their gauge is still below its
+    // warning threshold — the replenishment only lands when the rest
+    // completes — so without this check a second rest is queued every cycle,
+    // claimed the instant the first one ends, and charged again: one wasted
+    // rest and one extra NEED_REST_COSTS payment per dip below the threshold.
+    // Rests created by tickCollapse/tickNeedRestoration stay in pendingActions
+    // and are caught by the hasRestAction check below; a rest claimed through
+    // tickEmployees is consumed from the queue, so only restTicksRemaining/
+    // pendingRestDuration still mark it.
+    if (emp.restTicksRemaining !== null || emp.pendingRestDuration !== null) continue;
 
     // Determine which gauges are below warning thresholds
     const triggeredGauges: NeedKey[] = [];
@@ -439,8 +481,13 @@ export function autoInsertNeedTasks(state: GameState, _firedEvents?: FiredEvent[
     const buildingType = NEED_REST_BUILDING_TYPES[primaryGauge];
     const building = findNearestBuildingOfType(state, buildingType, emp.x, emp.z);
 
-    const targetX = building?.x ?? emp.x;
-    const targetZ = building?.z ?? emp.z;
+    // See findBuildingApproachCell's doc — a building's raw (x, z) is always
+    // NavGrid-blocked, so target the nearest walkable ring cell instead (#437).
+    const approach = building
+      ? findBuildingApproachCell(state.navGrid, building, getBuildingDef(building.type, building.tier), emp.x, emp.z)
+      : null;
+    const targetX = approach?.x ?? emp.x;
+    const targetZ = approach?.z ?? emp.z;
     // With nowhere to go the employee rests in place, which takes longer and
     // (in completeRestForEmployee) tops the gauge out at NEED_REST_NO_BUILDING_CAP.
     const restDuration = building
@@ -499,17 +546,7 @@ function findNearestBuildingOfType(
   empX: number,
   empZ: number,
 ): Building | null {
-  let nearest: Building | null = null;
-  let bestDistSq = Infinity;
-  for (const b of state.buildings.buildings) {
-    if (!b.active || b.type !== buildingType) continue;
-    const distSq = (b.x - empX) ** 2 + (b.z - empZ) ** 2;
-    if (distSq < bestDistSq) {
-      bestDistSq = distSq;
-      nearest = b;
-    }
-  }
-  return nearest;
+  return findNearestActiveBuildingOfType(state.buildings, buildingType, empX, empZ);
 }
 
 function findNearestLivingQuarters(
@@ -691,6 +728,10 @@ export interface TaskProgressResult {
   skill: SkillCategory | null;
   oldLevel?: 1 | 2 | 3 | 4 | 5;
   newLevel?: 1 | 2 | 3 | 4 | 5;
+  /** Action type of the task that just completed — only present when `completed` is true. */
+  actionType?: ActionType;
+  /** Payload of the task that just completed — only present when `completed` is true. */
+  actionPayload?: Record<string, unknown>;
 }
 
 /**
@@ -726,11 +767,20 @@ export function tickTaskProgress(state: GameState, emp: Employee, emitter?: Even
   }
 
   let completed = false;
+  let completedActionType: ActionType | undefined;
+  let completedActionPayload: Record<string, unknown> | undefined;
   if (emp.taskTicksRemaining <= 0) {
     completed = true;
+    // pendingActionType/pendingActionPayload were left set by tickEmployees at
+    // claim time (#437) specifically so completion handling — e.g. resolving
+    // a completed survey — still knows what work this was.
+    completedActionType = emp.pendingActionType ?? undefined;
+    completedActionPayload = emp.pendingActionPayload ?? undefined;
     emp.activeActionId = null;
     emp.taskTicksRemaining = null;
     emp.activeTaskSkill = null;
+    emp.pendingActionType = null;
+    emp.pendingActionPayload = null;
   }
 
   return {
@@ -738,6 +788,8 @@ export function tickTaskProgress(state: GameState, emp: Employee, emitter?: Even
     leveledUp,
     skill,
     ...(levelUpLevels ? { oldLevel: levelUpLevels.oldLevel, newLevel: levelUpLevels.newLevel } : {}),
+    ...(completedActionType !== undefined ? { actionType: completedActionType } : {}),
+    ...(completedActionPayload !== undefined ? { actionPayload: completedActionPayload } : {}),
   };
 }
 
@@ -775,6 +827,10 @@ function incrementWorkTick(
 ): void {
   if (emp.activeActionId === null) return;
   if (emp.restTicksRemaining !== null) return;
+  // Walking to a rest whose timer hasn't started yet is not work either
+  // (#437) — without this, a claimed-but-not-yet-arrived rest still counted
+  // toward the shift-cycle work quota for every tick of the walk.
+  if (emp.pendingRestDuration !== null) return;
 
   // Skip if employee already has a pending rest action (voluntary rest)
   const hasRestAction = state.pendingActions.some(
@@ -797,6 +853,11 @@ function forceShiftRestIfNeeded(
   _emitter?: EventEmitter,
 ): void {
   if (emp.restTicksRemaining !== null) return;
+  // Already walking to a shift rest queued on a prior tick — without this,
+  // ticksWorked stays >= WORK_DURATION_TICKS for the whole walk (it's only
+  // reset on rest completion) and this would requeue a duplicate rest action
+  // every tick until arrival (#437).
+  if (emp.pendingRestDuration !== null) return;
   if (emp.activeActionId === null) return;
   if (emp.ticksWorked < WORK_DURATION_TICKS) return;
 
@@ -807,13 +868,18 @@ function forceShiftRestIfNeeded(
   let buildingId: number | undefined;
 
   if (building) {
-    const center = getBuildingCenter(building);
-    targetX = center.x;
-    targetZ = center.z;
+    // See findBuildingApproachCell's doc — a building's raw footprint
+    // (including its center) is always NavGrid-blocked; walk to the nearest
+    // walkable ring cell around it instead (#437).
+    const approach = findBuildingApproachCell(state.navGrid, building, getBuildingDef(building.type, building.tier), emp.x, emp.z);
+    targetX = approach.x;
+    targetZ = approach.z;
     buildingId = building.id;
   }
 
-  emp.restTicksRemaining = SHIFT_SLEEP_DURATION_TICKS;
+  // The rest timer itself does not start until ArrivalGate.tickArrivalGate
+  // confirms the employee has walked to the bunkhouse (#437).
+  emp.pendingRestDuration = SHIFT_SLEEP_DURATION_TICKS;
 
   const restAction = createRestPendingAction(state, {
     targetX,
@@ -829,13 +895,4 @@ function forceShiftRestIfNeeded(
   shiftRested.push(emp.id);
   firedEvents.push({ eventId: 'employee_shift_change', firedAtTick: state.tickCount });
   _emitter?.emit('employee:shift_change', { employeeId: emp.id });
-}
-
-/**
- * Compute the centre position of a building based on its definition size.
- */
-function getBuildingCenter(building: Building): { x: number; z: number } {
-  const def = getBuildingDef(building.type, building.tier);
-  const { sizeX, sizeZ } = getDefSize(def);
-  return { x: building.x + sizeX / 2, z: building.z + sizeZ / 2 };
 }

--- a/src/core/entities/Building.ts
+++ b/src/core/entities/Building.ts
@@ -312,12 +312,22 @@ export function getBuildingScoreEffects(state: BuildingState): Record<ScoreId, n
  * of that type exists.
  */
 export function findNearestActiveBuildingOfType(
-  _buildings: BuildingState,
-  _type: BuildingType,
-  _x: number,
-  _z: number,
+  buildings: BuildingState,
+  type: BuildingType,
+  x: number,
+  z: number,
 ): Building | null {
-  throw new Error('not implemented: findNearestActiveBuildingOfType');
+  let nearest: Building | null = null;
+  let bestDistSq = Infinity;
+  for (const b of buildings.buildings) {
+    if (!b.active || b.type !== type) continue;
+    const distSq = (b.x - x) ** 2 + (b.z - z) ** 2;
+    if (distSq < bestDistSq) {
+      bestDistSq = distSq;
+      nearest = b;
+    }
+  }
+  return nearest;
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────

--- a/src/core/entities/Building.ts
+++ b/src/core/entities/Building.ts
@@ -306,6 +306,20 @@ export function getBuildingScoreEffects(state: BuildingState): Record<ScoreId, n
   return effects;
 }
 
+/**
+ * Find the nearest active building of a given type to a grid position, by
+ * straight-line distance from (x, z). Returns null when no active building
+ * of that type exists.
+ */
+export function findNearestActiveBuildingOfType(
+  _buildings: BuildingState,
+  _type: BuildingType,
+  _x: number,
+  _z: number,
+): Building | null {
+  throw new Error('not implemented: findNearestActiveBuildingOfType');
+}
+
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 function isOccupied(

--- a/src/core/entities/Employee.ts
+++ b/src/core/entities/Employee.ts
@@ -3,6 +3,7 @@
 
 import { Random } from '../math/Random.js';
 import type { NeedKey } from './EmployeeNeeds.js';
+import type { ActionType } from '../state/GameState.js';
 import { HIRING_COSTS as _HIRING_COSTS, BASE_SALARIES as _BASE_SALARIES, PAY_CYCLE_TICKS as _PAY_CYCLE_TICKS, QUALIFICATION_SALARY_BONUS } from '../config/balance.js';
 
 // ── Roles ──
@@ -132,6 +133,39 @@ export interface Employee {
   moveConsecutiveFailures: number;
   /** True once moveConsecutiveFailures reaches STUCK_THRESHOLD — idle, morale −2/tick until the path clears. */
   isMoveStuck: boolean;
+  /**
+   * Rest duration (ticks) to start once the employee arrives at the rest
+   * destination, or null when no rest arrival is pending. Set alongside
+   * destinationX/destinationZ by the claim step; consumed by
+   * ArrivalGate.tickArrivalGate on arrival, which moves it into
+   * restTicksRemaining.
+   */
+  pendingRestDuration: number | null;
+  /** Need gauge the pending rest (above) will restore, or null. */
+  pendingRestNeedKey: NeedKey | null;
+  /**
+   * Task duration (ticks) to start once the employee arrives at the task
+   * destination, or null when no task arrival is pending. Consumed by
+   * ArrivalGate.tickArrivalGate on arrival, which moves it into
+   * taskTicksRemaining.
+   */
+  pendingTaskDuration: number | null;
+  /** Action type of the pending task-on-arrival (above), or null. */
+  pendingActionType: ActionType | null;
+  /** Free-form payload for the pending task-on-arrival (above), or null. */
+  pendingActionPayload: Record<string, unknown> | null;
+  /**
+   * Vehicle ID the employee has requested to board once they arrive at its
+   * position, or null when no boarding is pending. Consumed by
+   * ArrivalGate.tickArrivalGate on arrival.
+   */
+  pendingDriverVehicleId: number | null;
+  /**
+   * Training course details to start once the employee arrives at the
+   * training building, or null when no training arrival is pending.
+   * Consumed by ArrivalGate.tickArrivalGate on arrival.
+   */
+  pendingTrainingStart: { buildingId: number; skill: string; ticksRemaining: number; fee: number } | null;
 }
 
 // ── Employee state ──
@@ -195,6 +229,13 @@ export function hireEmployee(
     destinationZ: null,
     moveConsecutiveFailures: 0,
     isMoveStuck: false,
+    pendingRestDuration: null,
+    pendingRestNeedKey: null,
+    pendingTaskDuration: null,
+    pendingActionType: null,
+    pendingActionPayload: null,
+    pendingDriverVehicleId: null,
+    pendingTrainingStart: null,
   };
   // Keep the stored salary consistent with the qualification just granted —
   // calculateSalary() sums qualification bonuses, so a base-only salary would

--- a/src/core/entities/Employee.ts
+++ b/src/core/entities/Employee.ts
@@ -160,12 +160,6 @@ export interface Employee {
    * ArrivalGate.tickArrivalGate on arrival.
    */
   pendingDriverVehicleId: number | null;
-  /**
-   * Training course details to start once the employee arrives at the
-   * training building, or null when no training arrival is pending.
-   * Consumed by ArrivalGate.tickArrivalGate on arrival.
-   */
-  pendingTrainingStart: { buildingId: number; skill: string; ticksRemaining: number; fee: number } | null;
 }
 
 // ── Employee state ──
@@ -235,7 +229,6 @@ export function hireEmployee(
     pendingActionType: null,
     pendingActionPayload: null,
     pendingDriverVehicleId: null,
-    pendingTrainingStart: null,
   };
   // Keep the stored salary consistent with the qualification just granted —
   // calculateSalary() sums qualification bonuses, so a base-only salary would

--- a/src/core/entities/EmployeeTraining.ts
+++ b/src/core/entities/EmployeeTraining.ts
@@ -121,6 +121,12 @@ export function startTraining(
  * which is what left an enrolled employee's sprite standing in the pit while
  * their qualification changed.
  *
+ * This relocation is an instant teleport, not a queued walk — intentionally
+ * NOT gated on navmesh arrival like survey/rest/boarding/hauling (#437).
+ * That gating would replace this existing, intentional teleport-not-walk
+ * design (#410) with a walk, which is a larger behavioral change than #437
+ * asked for; out of scope here.
+ *
  * Placed one tile outside the footprint, adjacent to the entry point corner
  * (`building.x`/`building.z`), rather than exactly on that corner: the raw
  * origin coordinate sits on the building's own opaque base-box footprint, so

--- a/src/core/entities/Vehicle.ts
+++ b/src/core/entities/Vehicle.ts
@@ -259,13 +259,21 @@ export const ROLE_LICENCE_REQUIRED: Record<VehicleRole, SkillCategory> = {
   drill_rig: 'driving.drill_rig',
 };
 
-/** Assign a driver (employee) to a vehicle, enforcing licence and availability checks. */
-export function assignDriver(
+/**
+ * Validate that an employee may become a vehicle's driver: vehicle exists,
+ * employee exists and is alive, holds the role's required licence, isn't
+ * already driving another vehicle, and the vehicle has no driver yet.
+ * Shared by `assignDriver` (immediate assignment) and
+ * `VehicleBoarding.requestBoardVehicle` (deferred, arrival-gated assignment,
+ * #437) so the two stay in lockstep — same checks, same order, same error
+ * strings — without duplicating the logic itself.
+ */
+export function canAssignDriver(
   vehicleState: VehicleState,
   employeeState: EmployeeState,
   vehicleId: number,
   employeeId: number,
-): { success: boolean; error?: string } {
+): { success: true; vehicle: Vehicle; employee: EmployeeState['employees'][number] } | { success: false; error: string } {
   const vehicle = vehicleState.vehicles.find(v => v.id === vehicleId);
   if (!vehicle) return { success: false, error: 'Vehicle not found' };
 
@@ -281,7 +289,20 @@ export function assignDriver(
 
   if (vehicle.driverId !== null) return { success: false, error: 'Vehicle already has a driver' };
 
-  vehicle.driverId = employeeId;
+  return { success: true, vehicle, employee };
+}
+
+/** Assign a driver (employee) to a vehicle, enforcing licence and availability checks. */
+export function assignDriver(
+  vehicleState: VehicleState,
+  employeeState: EmployeeState,
+  vehicleId: number,
+  employeeId: number,
+): { success: boolean; error?: string } {
+  const check = canAssignDriver(vehicleState, employeeState, vehicleId, employeeId);
+  if (!check.success) return check;
+
+  check.vehicle.driverId = employeeId;
   return { success: true };
 }
 

--- a/src/core/entities/Vehicle.ts
+++ b/src/core/entities/Vehicle.ts
@@ -136,6 +136,15 @@ export interface Vehicle {
   moveConsecutiveFailures: number;
   /** True once moveConsecutiveFailures reaches STUCK_THRESHOLD — idle until the path clears. */
   isMoveStuck: boolean;
+  /** Fragment ID this debris_hauler is currently hauling, or null when not hauling. */
+  haulingFragmentId: number | null;
+  /**
+   * Which leg of the haul the vehicle is on: driving to the fragment to load
+   * it, or driving to the depot to deliver it. Null when not hauling.
+   */
+  haulingPhase: 'to_fragment' | 'to_depot' | null;
+  /** Depot/warehouse building ID the current haul is delivering to, or null. */
+  haulingDepotBuildingId: number | null;
 }
 
 // ── Fleet state ──
@@ -175,6 +184,9 @@ export function purchaseVehicle(
     waitingTicks: 0,
     moveConsecutiveFailures: 0,
     isMoveStuck: false,
+    haulingFragmentId: null,
+    haulingPhase: null,
+    haulingDepotBuildingId: null,
   };
   state.vehicles.push(vehicle);
   return { vehicle, cost: def.purchaseCost };

--- a/src/core/entities/VehicleBoarding.ts
+++ b/src/core/entities/VehicleBoarding.ts
@@ -5,6 +5,7 @@
 // via ArrivalGate.ts. This module only records the request/intent.
 
 import type { GameState } from '../state/GameState.js';
+import { ROLE_LICENCE_REQUIRED } from './Vehicle.js';
 
 /**
  * Request that an employee board a vehicle as its driver. Validates licence
@@ -14,9 +15,35 @@ import type { GameState } from '../state/GameState.js';
  * arrived at the vehicle's position.
  */
 export function requestBoardVehicle(
-  _state: GameState,
-  _vehicleId: number,
-  _employeeId: number,
+  state: GameState,
+  vehicleId: number,
+  employeeId: number,
 ): { success: boolean; error?: string } {
-  throw new Error('not implemented: requestBoardVehicle');
+  const vehicle = state.vehicles.vehicles.find(v => v.id === vehicleId);
+  if (!vehicle) return { success: false, error: 'Vehicle not found' };
+
+  const employee = state.employees.employees.find(e => e.id === employeeId);
+  if (!employee || !employee.alive) return { success: false, error: 'Employee not found' };
+
+  const requiredLicence = ROLE_LICENCE_REQUIRED[vehicle.type];
+  const hasLicence = employee.qualifications.some(q => q.category === requiredLicence);
+  if (!hasLicence) return { success: false, error: 'Employee lacks licence for this role' };
+
+  const alreadyDriving = state.vehicles.vehicles.some(v => v.driverId === employeeId);
+  if (alreadyDriving) return { success: false, error: 'Employee already driving another vehicle' };
+
+  if (vehicle.driverId !== null) return { success: false, error: 'Vehicle already has a driver' };
+
+  if (employee.pendingDriverVehicleId !== null) {
+    return { success: false, error: 'Employee already walking to board a vehicle' };
+  }
+
+  // Defer the actual assignDriver() call (licence/availability re-checked
+  // there too) until ArrivalGate confirms co-location — walking there is
+  // what #437 adds; the checks above only gate *starting* the walk.
+  employee.pendingDriverVehicleId = vehicleId;
+  employee.destinationX = vehicle.x;
+  employee.destinationZ = vehicle.z;
+
+  return { success: true };
 }

--- a/src/core/entities/VehicleBoarding.ts
+++ b/src/core/entities/VehicleBoarding.ts
@@ -1,0 +1,22 @@
+// BlastSimulator2026 — Vehicle boarding request
+//
+// Mirrors `assignDriver` (Vehicle.ts) but defers the actual driver
+// assignment until the employee has physically arrived at the vehicle,
+// via ArrivalGate.ts. This module only records the request/intent.
+
+import type { GameState } from '../state/GameState.js';
+
+/**
+ * Request that an employee board a vehicle as its driver. Validates licence
+ * and availability eagerly (mirroring `assignDriver`), but does not assign
+ * the driver immediately — instead marks the employee's pending boarding
+ * intent, which ArrivalGate.tickArrivalGate resolves once the employee has
+ * arrived at the vehicle's position.
+ */
+export function requestBoardVehicle(
+  _state: GameState,
+  _vehicleId: number,
+  _employeeId: number,
+): { success: boolean; error?: string } {
+  throw new Error('not implemented: requestBoardVehicle');
+}

--- a/src/core/entities/VehicleBoarding.ts
+++ b/src/core/entities/VehicleBoarding.ts
@@ -1,49 +1,38 @@
 // BlastSimulator2026 — Vehicle boarding request
 //
-// Mirrors `assignDriver` (Vehicle.ts) but defers the actual driver
-// assignment until the employee has physically arrived at the vehicle,
-// via ArrivalGate.ts. This module only records the request/intent.
+// Shares its licence/availability validation with `assignDriver` (Vehicle.ts)
+// via `canAssignDriver`, but defers the actual driver assignment until the
+// employee has physically arrived at the vehicle, via ArrivalGate.ts. This
+// module only records the request/intent.
 
 import type { GameState } from '../state/GameState.js';
-import { ROLE_LICENCE_REQUIRED } from './Vehicle.js';
+import { canAssignDriver } from './Vehicle.js';
 
 /**
  * Request that an employee board a vehicle as its driver. Validates licence
- * and availability eagerly (mirroring `assignDriver`), but does not assign
- * the driver immediately — instead marks the employee's pending boarding
- * intent, which ArrivalGate.tickArrivalGate resolves once the employee has
- * arrived at the vehicle's position.
+ * and availability eagerly via `canAssignDriver` (mirroring `assignDriver`),
+ * but does not assign the driver immediately — instead marks the employee's
+ * pending boarding intent, which ArrivalGate.tickArrivalGate resolves once
+ * the employee has arrived at the vehicle's position.
  */
 export function requestBoardVehicle(
   state: GameState,
   vehicleId: number,
   employeeId: number,
 ): { success: boolean; error?: string } {
-  const vehicle = state.vehicles.vehicles.find(v => v.id === vehicleId);
-  if (!vehicle) return { success: false, error: 'Vehicle not found' };
+  const check = canAssignDriver(state.vehicles, state.employees, vehicleId, employeeId);
+  if (!check.success) return check;
 
-  const employee = state.employees.employees.find(e => e.id === employeeId);
-  if (!employee || !employee.alive) return { success: false, error: 'Employee not found' };
-
-  const requiredLicence = ROLE_LICENCE_REQUIRED[vehicle.type];
-  const hasLicence = employee.qualifications.some(q => q.category === requiredLicence);
-  if (!hasLicence) return { success: false, error: 'Employee lacks licence for this role' };
-
-  const alreadyDriving = state.vehicles.vehicles.some(v => v.driverId === employeeId);
-  if (alreadyDriving) return { success: false, error: 'Employee already driving another vehicle' };
-
-  if (vehicle.driverId !== null) return { success: false, error: 'Vehicle already has a driver' };
-
-  if (employee.pendingDriverVehicleId !== null) {
+  if (check.employee.pendingDriverVehicleId !== null) {
     return { success: false, error: 'Employee already walking to board a vehicle' };
   }
 
-  // Defer the actual assignDriver() call (licence/availability re-checked
-  // there too) until ArrivalGate confirms co-location — walking there is
-  // what #437 adds; the checks above only gate *starting* the walk.
-  employee.pendingDriverVehicleId = vehicleId;
-  employee.destinationX = vehicle.x;
-  employee.destinationZ = vehicle.z;
+  // Defer the actual assignDriver() call (which re-runs canAssignDriver) until
+  // ArrivalGate confirms co-location — walking there is what #437 adds; the
+  // checks above only gate *starting* the walk.
+  check.employee.pendingDriverVehicleId = vehicleId;
+  check.employee.destinationX = check.vehicle.x;
+  check.employee.destinationZ = check.vehicle.z;
 
   return { success: true };
 }

--- a/src/core/nav/BuildingApproach.ts
+++ b/src/core/nav/BuildingApproach.ts
@@ -1,0 +1,64 @@
+// BlastSimulator2026 — Walkable approach cell for a building
+//
+// Every footprint cell of a placed building — including its nominal
+// entry/exit corners (BuildingDef.entryPoint/exitPoint, which are cosmetic
+// door-marker offsets, not a walkability guarantee) — is classified
+// 'blocked' by NavGrid.classifyCellType (buildings are solid obstacles).
+// Any destination that resolves to a building's raw (x, z) can therefore
+// never be reached: Pathfinding.findPath rejects an impassable goal outright,
+// before A* even runs. This module finds the nearest *walkable* cell just
+// outside the footprint instead, so arrival-gated actions that need an
+// employee/vehicle to reach a building (rest, hauling delivery, shift-cycle
+// sleep, #437) have an actually reachable target.
+
+import type { NavGrid } from './NavGrid.js';
+import type { Building, BuildingDef } from '../entities/Building.js';
+import { getDefSize } from '../entities/Building.js';
+
+/**
+ * Find the nearest walkable NavGrid cell on the ring immediately surrounding
+ * a building's footprint, closest to (fromX, fromZ).
+ *
+ * Falls back to the building's raw (x, z) when no NavGrid is built yet
+ * (mirrors the rest of the movement pipeline's own no-NavGrid direct-line
+ * fallback) or when nothing on the ring is walkable (fully boxed in) — the
+ * caller's own stuck-detection already handles an unreachable destination.
+ */
+export function findBuildingApproachCell(
+  navGrid: NavGrid | null,
+  building: Building,
+  def: BuildingDef,
+  fromX: number,
+  fromZ: number,
+): { x: number; z: number } {
+  if (!navGrid) return { x: building.x, z: building.z };
+
+  const { sizeX, sizeZ } = getDefSize(def);
+  const minX = building.x - 1;
+  const maxX = building.x + sizeX;
+  const minZ = building.z - 1;
+  const maxZ = building.z + sizeZ;
+
+  let best: { x: number; z: number } | null = null;
+  let bestDistSq = Infinity;
+
+  for (let x = minX; x <= maxX; x++) {
+    for (let z = minZ; z <= maxZ; z++) {
+      // Ring only — skip the footprint interior (handled by the fallback).
+      const onRing = x === minX || x === maxX || z === minZ || z === maxZ;
+      if (!onRing) continue;
+      if (x < 0 || z < 0 || x >= navGrid.width || z >= navGrid.height) continue;
+
+      const cell = navGrid.cells[z]?.[x];
+      if (!cell || cell.type === 'blocked' || cell.type === 'void') continue;
+
+      const distSq = (x - fromX) ** 2 + (z - fromZ) ** 2;
+      if (distSq < bestDistSq) {
+        bestDistSq = distSq;
+        best = { x, z };
+      }
+    }
+  }
+
+  return best ?? { x: building.x, z: building.z };
+}

--- a/src/core/nav/NavGrid.ts
+++ b/src/core/nav/NavGrid.ts
@@ -140,6 +140,112 @@ export class NavGrid {
     }
   }
 
+  /** True when a cell exists, is in bounds, and has finite moveCost (walkable/ramp/drill_hole). */
+  private static isTraversableCell(navGrid: NavGrid, x: number, z: number): boolean {
+    if (x < 0 || z < 0 || x >= navGrid.width || z >= navGrid.height) return false;
+    const cell = navGrid.cells[z]?.[x];
+    return !!cell && cell.type !== 'blocked' && cell.type !== 'void';
+  }
+
+  /**
+   * Find the nearest traversable cell (walkable/ramp/drill_hole — anything
+   * with finite moveCost) to (x, z), searching outward in expanding square
+   * rings. Returns (x, z) unchanged when it is already traversable, or when
+   * nothing traversable turns up within maxRadius.
+   *
+   * Distance-only: does not check that the cell found is actually path-
+   * connected to anywhere else. A blast crater can carve isolated traversable
+   * pockets walled off by 'void' on every side — nearest-by-distance can land
+   * on one of those. Callers that need an actually reachable point should use
+   * findNearestReachableCell instead.
+   */
+  static findNearestTraversableCell(
+    navGrid: NavGrid,
+    x: number,
+    z: number,
+    maxRadius: number = Math.max(navGrid.width, navGrid.height),
+  ): { x: number; z: number } {
+    if (NavGrid.isTraversableCell(navGrid, x, z)) return { x, z };
+
+    for (let r = 1; r <= maxRadius; r++) {
+      let best: { x: number; z: number } | null = null;
+      let bestDistSq = Infinity;
+      for (let dx = -r; dx <= r; dx++) {
+        for (let dz = -r; dz <= r; dz++) {
+          if (Math.max(Math.abs(dx), Math.abs(dz)) !== r) continue; // ring only
+          const cx = x + dx;
+          const cz = z + dz;
+          if (!NavGrid.isTraversableCell(navGrid, cx, cz)) continue;
+          const distSq = dx * dx + dz * dz;
+          if (distSq < bestDistSq) {
+            bestDistSq = distSq;
+            best = { x: cx, z: cz };
+          }
+        }
+      }
+      if (best) return best;
+    }
+
+    return { x, z };
+  }
+
+  /**
+   * Find the nearest cell to (targetX, targetZ) that is actually 8-directionally
+   * path-connected to (anchorX, anchorZ) — same adjacency Pathfinding.findPath
+   * walks, so a cell this returns is guaranteed reachable from the anchor,
+   * unlike findNearestTraversableCell's plain distance search.
+   *
+   * Exists because a spawn/destination point picked without checking the
+   * NavGrid — e.g. a vehicle purchase or employee hire landing at the world's
+   * geometric centre — can resolve to a blast-cleared 'void' column, or to an
+   * isolated traversable pocket a blast crater walled off from the rest of the
+   * map with no floor at all, which arrival-gated actions (#437) can never
+   * actually path to even after nudging to the "nearest" traversable cell.
+   *
+   * anchorX/anchorZ should be a point known to sit in the map's main
+   * connected region (callers typically use a world corner). Falls back to
+   * (targetX, targetZ) unchanged if the anchor itself resolves to no
+   * traversable cell, or if the connected component containing it is empty.
+   */
+  static findNearestReachableCell(
+    navGrid: NavGrid,
+    anchorX: number,
+    anchorZ: number,
+    targetX: number,
+    targetZ: number,
+  ): { x: number; z: number } {
+    const anchor = NavGrid.findNearestTraversableCell(navGrid, anchorX, anchorZ);
+    if (!NavGrid.isTraversableCell(navGrid, anchor.x, anchor.z)) return { x: targetX, z: targetZ };
+
+    // 8-directional flood fill from the anchor — same adjacency A* uses —
+    // over the whole grid. Grids here are small (dozens of tiles per side),
+    // so an O(width*height) BFS per call is negligible.
+    const visited = new Set<string>();
+    const queue: Array<{ x: number; z: number }> = [anchor];
+    visited.add(`${anchor.x},${anchor.z}`);
+    let best = anchor;
+    let bestDistSq = (anchor.x - targetX) ** 2 + (anchor.z - targetZ) ** 2;
+
+    for (let head = 0; head < queue.length; head++) {
+      const { x, z } = queue[head]!;
+      const distSq = (x - targetX) ** 2 + (z - targetZ) ** 2;
+      if (distSq < bestDistSq) {
+        bestDistSq = distSq;
+        best = { x, z };
+      }
+      for (const [dx, dz] of [[0, -1], [0, 1], [-1, 0], [1, 0], [-1, -1], [1, -1], [-1, 1], [1, 1]] as const) {
+        const nx = x + dx;
+        const nz = z + dz;
+        const key = `${nx},${nz}`;
+        if (visited.has(key) || !NavGrid.isTraversableCell(navGrid, nx, nz)) continue;
+        visited.add(key);
+        queue.push({ x: nx, z: nz });
+      }
+    }
+
+    return best;
+  }
+
   /**
    * Classify a single NavGrid cell based on column solidity, drill holes, buildings, and ramps.
    * Priority order (highest to lowest): void > drill_hole > blocked > ramp > walkable.

--- a/src/core/state/EventEmitter.ts
+++ b/src/core/state/EventEmitter.ts
@@ -31,6 +31,11 @@ export interface GameEventMap {
   // Phase 9 — Navmesh path-following
   'agent:stuck': { employeeId: number };
   'vehicle:stuck': { vehicleId: number };
+
+  // Arrival-gated vehicle actions
+  'vehicle:driver_boarded': { employeeId: number; vehicleId: number };
+  'vehicle:haul_loaded': { vehicleId: number; fragmentId: number };
+  'vehicle:haul_delivered': { vehicleId: number; fragmentId: number };
 }
 
 type EventHandler<T> = (data: T) => void;

--- a/tests/integration/needs.integration.test.ts
+++ b/tests/integration/needs.integration.test.ts
@@ -16,7 +16,7 @@ import {
   getNeedMultiplier,
 } from '../../src/core/entities/EmployeeNeeds.js';
 import type { Employee } from '../../src/core/entities/Employee.js';
-import { NEED_WARNING_THRESHOLDS } from '../../src/core/config/balance.js';
+import { NEED_WARNING_THRESHOLDS, NEED_REST_DURATIONS, AGENT_WALK_SPEED } from '../../src/core/config/balance.js';
 
 // ── Shared helpers ──────────────────────────────────────────────────────────
 
@@ -333,8 +333,16 @@ describe('tick command — a single threshold dip triggers a single rest', () =>
     emp.fatigue = 100;
     emp.breakNeed = 100;
 
-    // Long enough for the rest to be queued, claimed, and completed.
-    for (let i = 0; i < 8; i++) tickCommand(ctx, ['1'], {});
+    // The employee is routed toward the living_quarters on the very first
+    // tick, but (issue #437) the rest timer must not start until they have
+    // actually walked there — routing alone is not resolution.
+    tickCommand(ctx, ['1'], {});
+    expect(emp.destinationX).not.toBeNull();
+    expect(emp.destinationZ).not.toBeNull();
+    expect(emp.restTicksRemaining).toBeNull();
+
+    // Long enough for the walk to (5,5) plus the full rest duration, with slack.
+    for (let i = 0; i < 20; i++) tickCommand(ctx, ['1'], {});
 
     const restCharges = state.finances.transactions.filter(t => t.category === 'needs');
     expect(restCharges).toHaveLength(1);
@@ -343,5 +351,47 @@ describe('tick command — a single threshold dip triggers a single rest', () =>
     expect(emp.activeActionId).toBeNull();
     expect(emp.hunger).toBeGreaterThan(NEED_WARNING_THRESHOLDS.hunger);
     expect(state.pendingActions.filter(a => a.type === 'rest')).toHaveLength(0);
+  });
+
+  // ── New (issue #437): rest must not tick down while still travelling ──────
+
+  it('does not decrement restTicksRemaining while the employee is still travelling to the living_quarters', () => {
+    const ctx = makeCtx();
+    const empId = hireOne(ctx, 'driller');
+    const state = ctx.state!;
+    const emp = getEmployee(ctx, empId);
+
+    const build = buildCommand(ctx, ['living_quarters'], { at: '20,20', tier: '1' });
+    expect(build.success).toBe(true);
+
+    state.cash = 100_000;
+    emp.x = 0;
+    emp.z = 0;
+    emp.hunger = 20; // below warning threshold — triggers routing
+    emp.fatigue = 100;
+    emp.breakNeed = 100;
+
+    tickCommand(ctx, ['1'], {});
+
+    // Routed but not yet arrived: destination set, rest not started.
+    expect(emp.destinationX).not.toBeNull();
+    expect(emp.destinationZ).not.toBeNull();
+    expect(emp.restTicksRemaining).toBeNull();
+
+    // A few more ticks — still travelling (distance from (0,0) to the
+    // building is well beyond a few ticks at AGENT_WALK_SPEED), rest still
+    // has not started.
+    for (let i = 0; i < 3; i++) tickCommand(ctx, ['1'], {});
+    expect(emp.x === 20 && emp.z === 20).toBe(false);
+    expect(emp.restTicksRemaining).toBeNull();
+
+    // Enough ticks to arrive (distance (0,0)→(20,20) ≈ 28.3 cells / AGENT_WALK_SPEED)
+    // and finish the rest (NEED_REST_DURATIONS.hunger ticks of work once
+    // arrival gates the timer open), with slack.
+    const travelTicks = Math.ceil(Math.hypot(20, 20) / AGENT_WALK_SPEED);
+    for (let i = 0; i < travelTicks + NEED_REST_DURATIONS.hunger + 10; i++) tickCommand(ctx, ['1'], {});
+
+    expect(emp.restTicksRemaining).toBeNull(); // completed and cleared
+    expect(emp.hunger).toBeGreaterThan(NEED_WARNING_THRESHOLDS.hunger);
   });
 });

--- a/tests/integration/needs.integration.test.ts
+++ b/tests/integration/needs.integration.test.ts
@@ -341,8 +341,12 @@ describe('tick command — a single threshold dip triggers a single rest', () =>
     expect(emp.destinationZ).not.toBeNull();
     expect(emp.restTicksRemaining).toBeNull();
 
-    // Long enough for the walk to (5,5) plus the full rest duration, with slack.
-    for (let i = 0; i < 20; i++) tickCommand(ctx, ['1'], {});
+    // Long enough for the walk to (5,5) plus the full rest duration, with slack,
+    // but short of the ~14-tick idle hunger decay (NEED_DRAIN_RATES.hunger.idle)
+    // that would otherwise dip the gauge below the warning threshold a second
+    // time and start an unrelated second rest cycle — this test is only about
+    // the first, deliberately-triggered dip.
+    for (let i = 0; i < 12; i++) tickCommand(ctx, ['1'], {});
 
     const restCharges = state.finances.transactions.filter(t => t.category === 'needs');
     expect(restCharges).toHaveLength(1);

--- a/tests/integration/skills.integration.test.ts
+++ b/tests/integration/skills.integration.test.ts
@@ -38,6 +38,20 @@ function hireOne(ctx: GameContext, role = 'blaster'): number {
   return ctx.state!.employees.employees[0]!.id;
 }
 
+/**
+ * Tick until taskTicksRemaining is seeded on the given employee (dispatch
+ * claims the action immediately, but the countdown itself does not start
+ * until ArrivalGate confirms the employee has walked to the dispatch target —
+ * #437). Caps at 30 ticks so a genuine regression fails fast instead of
+ * hanging.
+ */
+function tickUntilTaskSeeded(ctx: GameContext, empId: number): void {
+  const emp = () => ctx.state!.employees.employees.find(e => e.id === empId)!;
+  for (let i = 0; i < 30 && emp().taskTicksRemaining === null; i++) {
+    tickCommand(ctx, ['1'], {});
+  }
+}
+
 // ── Employee skills ──────────────────────────────────────────────────────────
 
 describe('Employee skills', () => {
@@ -397,9 +411,13 @@ describe('Tick-driven task/XP pipeline (dispatch + tick command, issue #406)', (
 
     const emp = () => ctx.state!.employees.employees.find(e => e.id === empId)!;
 
-    // One tick lets tickEmployees claim + seed the task.
+    // One tick lets tickEmployees claim the task (activeActionId set
+    // immediately); the countdown itself only starts once ArrivalGate
+    // confirms the employee has walked to (5,5) (#437).
     tickCommand(ctx, ['1'], {});
     expect(emp().activeActionId).not.toBeNull();
+
+    tickUntilTaskSeeded(ctx, empId);
     expect(emp().taskTicksRemaining).not.toBeNull();
 
     const seeded = emp().taskTicksRemaining!;
@@ -429,14 +447,17 @@ describe('Tick-driven task/XP pipeline (dispatch + tick command, issue #406)', (
     const ctxRookie = makeCtx();
     const rookieId = hireOne(ctxRookie, 'blaster');
     employeeCommand(ctxRookie, ['dispatch', String(rookieId)], { x: '5', z: '5', skill: 'blasting' });
-    tickCommand(ctxRookie, ['1'], {});
+    // The countdown itself only starts once ArrivalGate confirms the
+    // employee has walked to (5,5) (#437) — both hires walk the identical
+    // route, so this doesn't affect the rookie-vs-master comparison below.
+    tickUntilTaskSeeded(ctxRookie, rookieId);
     const rookieSeeded = ctxRookie.state!.employees.employees.find(e => e.id === rookieId)!.taskTicksRemaining!;
 
     const ctxMaster = makeCtx();
     const masterId = hireOne(ctxMaster, 'blaster');
     employeeCommand(ctxMaster, ['assign_skill', String(masterId)], { skill: 'blasting', level: '5' });
     employeeCommand(ctxMaster, ['dispatch', String(masterId)], { x: '5', z: '5', skill: 'blasting' });
-    tickCommand(ctxMaster, ['1'], {});
+    tickUntilTaskSeeded(ctxMaster, masterId);
     const masterSeeded = ctxMaster.state!.employees.employees.find(e => e.id === masterId)!.taskTicksRemaining!;
 
     expect(rookieSeeded).toBeGreaterThan(0);

--- a/tests/integration/survey.integration.test.ts
+++ b/tests/integration/survey.integration.test.ts
@@ -21,7 +21,7 @@ import { computeBlastOreReport } from '../../src/core/mining/BlastOreReport.js';
 import { VoxelGrid } from '../../src/core/world/VoxelGrid.js';
 import { Random } from '../../src/core/math/Random.js';
 import { createGame } from '../../src/core/state/GameState.js';
-import { SURVEY_STALE_TICKS, SURVEY_COSTS, STARTING_CASH } from '../../src/core/config/balance.js';
+import { SURVEY_STALE_TICKS, SURVEY_COSTS, STARTING_CASH, SURVEY_DURATION_TICKS, AGENT_WALK_SPEED } from '../../src/core/config/balance.js';
 import { hireEmployee, assignSkill } from '../../src/core/entities/Employee.js';
 import type { FragmentData } from '../../src/core/mining/BlastExecution.js';
 
@@ -209,9 +209,16 @@ describe('Survey system', () => {
     expect(ctx.state!.ghostPreviews[0]!.type).toBe('survey');
   });
 
-  // ── 6b. Pending survey resolves into surveyResults when ticked ────────────
+  // ── 6b. Pending survey resolves into surveyResults only after arrival + duration (issue #437) ──
+  //
+  // Previously surveys resolved INSTANTLY on the very next tick regardless of
+  // where the surveyor stood (src/console/commands/events.ts step "8b"). The
+  // arrival-gated pipeline requires the claimed surveyor to actually walk to
+  // the survey center (here: zero distance, since the surveyor spawns exactly
+  // on top of it) and then spend SURVEY_DURATION_TICKS[method] ticks working —
+  // a single tick is no longer enough even with zero travel distance.
 
-  it('tickCommand resolves a pending survey action into state.surveyResults', () => {
+  it('tickCommand resolves a pending survey action into state.surveyResults only once duration ticks elapse', () => {
     const empId = hireEmployeeByRole(ctx, 'surveyor');
     employeeCommand(ctx, ['assign_skill', String(empId)], { skill: 'geology', level: '3' });
 
@@ -219,14 +226,56 @@ describe('Survey system', () => {
     expect(ctx.state!.pendingActions.filter(a => a.type === 'survey')).toHaveLength(1);
     expect(ctx.state!.surveyResults).toHaveLength(0);
 
+    // One tick is not enough — SURVEY_DURATION_TICKS.core_sample ticks of work
+    // remain even though the surveyor starts right on top of the target.
     const result = tickCommand(ctx, ['1'], {});
     expect(result.success).toBe(true);
+    expect(ctx.state!.surveyResults).toHaveLength(0);
+
+    // Padding: no travel needed here (surveyor spawns on the survey center),
+    // just the full duration plus slack.
+    for (let i = 0; i < SURVEY_DURATION_TICKS.core_sample + 5; i++) {
+      tickCommand(ctx, ['1'], {});
+    }
 
     // The pending survey action is consumed and a result is produced.
     expect(ctx.state!.pendingActions.filter(a => a.type === 'survey')).toHaveLength(0);
     expect(ctx.state!.surveyResults).toHaveLength(1);
     expect(ctx.state!.surveyResults[0]!.method).toBe('core_sample');
-    expect(result.output).toContain('core_sample survey complete');
+  });
+
+  // ── 6c. Claiming a survey far from the surveyor stays pending through travel (issue #437) ──
+
+  it('a survey far from the surveyor produces no result immediately, and only resolves after travel + duration ticks', () => {
+    const empId = hireEmployeeByRole(ctx, 'surveyor');
+    employeeCommand(ctx, ['assign_skill', String(empId)], { skill: 'geology', level: '3' });
+    const emp = ctx.state!.employees.employees.find(e => e.id === empId)!;
+    // First-hired employee spawns at (world.sizeX/2, world.sizeZ/2) = (16, 16)
+    // for this 32×32 test world.
+    expect(emp.x).toBe(16);
+    expect(emp.z).toBe(16);
+
+    surveyCommand(ctx as any, ['seismic'], { x: '2', z: '2' });
+    expect(ctx.state!.surveyResults).toHaveLength(0);
+
+    const afterOneTick = tickCommand(ctx, ['1'], {});
+    expect(afterOneTick.success).toBe(true);
+    // Not resolved yet — the surveyor has only just started walking there.
+    expect(ctx.state!.surveyResults).toHaveLength(0);
+    expect(emp.destinationX).not.toBeNull();
+    expect(emp.destinationZ).not.toBeNull();
+    expect(emp.x === 2 && emp.z === 2).toBe(false);
+
+    // Enough ticks for the walk (Euclidean distance / AGENT_WALK_SPEED) plus
+    // the full seismic survey duration, with slack.
+    const travelTicks = Math.ceil(Math.hypot(16 - 2, 16 - 2) / AGENT_WALK_SPEED);
+    for (let i = 0; i < travelTicks + SURVEY_DURATION_TICKS.seismic + 5; i++) {
+      tickCommand(ctx, ['1'], {});
+    }
+
+    expect(ctx.state!.pendingActions.filter(a => a.type === 'survey')).toHaveLength(0);
+    expect(ctx.state!.surveyResults).toHaveLength(1);
+    expect(ctx.state!.surveyResults[0]!.method).toBe('seismic');
   });
 
   it('surveyCommand rejects and queues nothing when no qualified surveyor is available', () => {
@@ -435,9 +484,17 @@ describe('Survey system — seismic building side effects', () => {
     employeeCommand(ctx, ['assign_skill', String(empId)], { skill: 'geology', level: String(level) });
   }
 
-  /** Resolve queued survey pending-actions by advancing one tick. */
-  function resolveTick(): void {
-    tickCommand(ctx, ['1'], {});
+  /**
+   * Resolve queued survey pending-actions by advancing enough ticks for the
+   * surveyor to walk to the survey center and complete the full survey
+   * duration (issue #437 — surveys no longer resolve on the very next tick
+   * regardless of distance). 30 ticks comfortably covers every distance/method
+   * combination used in this describe block (worst case here: ~16 travel
+   * ticks + 8 duration ticks for a seismic survey at (5,5) from a surveyor
+   * spawned at (16,16)).
+   */
+  function resolveTick(ticks = 30): void {
+    for (let i = 0; i < ticks; i++) tickCommand(ctx, ['1'], {});
   }
 
   function findBuilding(id: number) {

--- a/tests/integration/survey.integration.test.ts
+++ b/tests/integration/survey.integration.test.ts
@@ -557,7 +557,12 @@ describe('Survey system — seismic building side effects', () => {
 
   it('damages every building within 5 cells when multiple are in range', () => {
     hireSurveyor();
-    const b1Result = buildCommand(ctx, ['living_quarters'], { at: '19,20' });
+    // living_quarters T1 is a 3x3 footprint; at (19,20) it would cover
+    // (20,20) — the survey's own target cell, which the surveyor must now be
+    // able to walk to and stand on (#437). Placed at (17,20) instead: still
+    // within the 5-cell damage radius (footprint centre (18.5,21.5), distance
+    // ≈2.1 from (20,20)), but no longer overlapping the survey centre.
+    const b1Result = buildCommand(ctx, ['living_quarters'], { at: '17,20' });
     const b2Result = buildCommand(ctx, ['management_office'], { at: '21,17' });
     expect(b1Result.success).toBe(true);
     expect(b2Result.success).toBe(true);

--- a/tests/integration/vehicles.integration.test.ts
+++ b/tests/integration/vehicles.integration.test.ts
@@ -95,7 +95,7 @@ describe('Vehicle fleet', () => {
 
   // ── Driver assignment ──
 
-  it('assign driver with driving skill succeeds', () => {
+  it('assign driver with driving skill succeeds — driverId sets only after a tick resolves arrival (issue #437)', () => {
     vehicleCommand(ctx, ['buy', 'debris_hauler'], {});
     const eid = hireOne(ctx, 'driver');
     employeeCommand(ctx, ['assign_skill', String(eid)], { skill: 'driving.truck', level: '1' });
@@ -103,7 +103,13 @@ describe('Vehicle fleet', () => {
     const result = vehicleCommand(ctx, ['driver', '1', String(eid)], {});
 
     expect(result.success).toBe(true);
-    expect(result.output).toBe(`Driver #${eid} assigned to vehicle #1.`);
+    // The request succeeds immediately, but boarding is deferred to arrival —
+    // driverId must not be set synchronously (previously it was, unconditionally).
+    expect(ctx.state!.vehicles.vehicles[0]!.driverId).toBeNull();
+
+    // The employee (hired at the same spawn point as the vehicle here) needs
+    // one tick to resolve the arrival gate before driverId is actually set.
+    tickCommand(ctx, ['1'], {});
     expect(ctx.state!.vehicles.vehicles[0]!.driverId).toBe(eid);
   });
 
@@ -117,6 +123,34 @@ describe('Vehicle fleet', () => {
     expect(result.success).toBe(false);
     expect(result.output).toContain('lacks licence');
     expect(ctx.state!.vehicles.vehicles[0]!.driverId).toBeNull();
+
+    // Rejected at request time — a tick later, still no driver.
+    tickCommand(ctx, ['1'], {});
+    expect(ctx.state!.vehicles.vehicles[0]!.driverId).toBeNull();
+  });
+
+  // ── New (issue #437): driverId stays null until the arrival gate resolves ──
+
+  it('driverId is null immediately after "vehicle driver" and only set once the employee has walked to the vehicle', () => {
+    vehicleCommand(ctx, ['buy', 'debris_hauler'], {});
+    const v = ctx.state!.vehicles.vehicles[0]!;
+    // Vehicle spawns at (16, 16) for a 32×32 world (see "move vehicle" test below).
+    expect(v.x).toBe(16);
+    expect(v.z).toBe(16);
+
+    const eid = hireOne(ctx, 'driver');
+    employeeCommand(ctx, ['assign_skill', String(eid)], { skill: 'driving.truck', level: '1' });
+    const emp = ctx.state!.employees.employees.find(e => e.id === eid)!;
+    // First-hired employee also spawns at (16, 16) — co-located with the vehicle.
+    expect(emp.x).toBe(16);
+    expect(emp.z).toBe(16);
+
+    const result = vehicleCommand(ctx, ['driver', '1', String(eid)], {});
+    expect(result.success).toBe(true);
+    expect(v.driverId).toBeNull();
+
+    tickCommand(ctx, ['1'], {});
+    expect(v.driverId).toBe(eid);
   });
 
   // ── Movement ──
@@ -201,6 +235,8 @@ describe('Vehicle fleet', () => {
     const eid = hireOne(ctx, 'driver');
     employeeCommand(ctx, ['assign_skill', String(eid)], { skill: 'driving.truck', level: '1' });
     vehicleCommand(ctx, ['driver', '1', String(eid)], {});
+    // Issue #437: driverId is only set once the arrival gate resolves.
+    tickCommand(ctx, ['1'], {});
 
     const result = vehicleCommand(ctx, ['list'], {});
 
@@ -346,6 +382,11 @@ describe('Vehicle fleet', () => {
     const eid1 = hireOne(ctx, 'driver');
     employeeCommand(ctx, ['assign_skill', String(eid1)], { skill: 'driving.truck', level: '1' });
     vehicleCommand(ctx, ['driver', '1', String(eid1)], {});
+    // Issue #437: driverId is only set once the arrival gate resolves — the
+    // first driver must actually board before the "already has a driver"
+    // rule can fire for a second request.
+    tickCommand(ctx, ['1'], {});
+    expect(ctx.state!.vehicles.vehicles[0]!.driverId).toBe(eid1);
 
     // Hire a second employee
     const rng = new Random(99);

--- a/tests/integration/vehicles.integration.test.ts
+++ b/tests/integration/vehicles.integration.test.ts
@@ -103,6 +103,7 @@ describe('Vehicle fleet', () => {
     const result = vehicleCommand(ctx, ['driver', '1', String(eid)], {});
 
     expect(result.success).toBe(true);
+    expect(result.output).toBe(`Driver #${eid} walking to vehicle #1 to board.`);
     // The request succeeds immediately, but boarding is deferred to arrival —
     // driverId must not be set synchronously (previously it was, unconditionally).
     expect(ctx.state!.vehicles.vehicles[0]!.driverId).toBeNull();
@@ -236,6 +237,8 @@ describe('Vehicle fleet', () => {
     employeeCommand(ctx, ['assign_skill', String(eid)], { skill: 'driving.truck', level: '1' });
     vehicleCommand(ctx, ['driver', '1', String(eid)], {});
     // Issue #437: driverId is only set once the arrival gate resolves.
+    // Boarding is arrival-gated (#437) — employee and vehicle both spawn at
+    // (16,16), so one tick resolves the walk (they're already co-located).
     tickCommand(ctx, ['1'], {});
 
     const result = vehicleCommand(ctx, ['list'], {});

--- a/tests/unit/console/vehicle-commands.test.ts
+++ b/tests/unit/console/vehicle-commands.test.ts
@@ -304,7 +304,8 @@ describe('vehicle driver — domain validation errors', () => {
     const firstDriverId = addTruckDriver(ctx);
     const secondDriverId = addTruckDriver(ctx);
 
-    // Assign first driver successfully
+    // Assign first driver successfully — resolve the walk so driverId is
+    // actually set before the second request is evaluated (#437).
     vehicleCommand(ctx, ['driver', String(vehicleId), String(firstDriverId)], {});
     // Issue #437: driverId is only set once the arrival gate resolves — the
     // first driver must actually board before the second request can see the
@@ -328,7 +329,8 @@ describe('vehicle driver — domain validation errors', () => {
     const secondVehicleId = addTruckVehicle(ctx);
     const employeeId = addTruckDriver(ctx);
 
-    // Assign driver to first vehicle successfully
+    // Assign driver to first vehicle successfully — resolve the walk so
+    // driverId is actually set before the second request is evaluated (#437).
     vehicleCommand(ctx, ['driver', String(firstVehicleId), String(employeeId)], {});
     // Issue #437: driverId is only set once the arrival gate resolves.
     tickCommand(ctx, ['1'], {});

--- a/tests/unit/console/vehicle-commands.test.ts
+++ b/tests/unit/console/vehicle-commands.test.ts
@@ -77,7 +77,6 @@ function employeeMovementDefaults(): Omit<
     pendingActionType: null,
     pendingActionPayload: null,
     pendingDriverVehicleId: null,
-    pendingTrainingStart: null,
   };
 }
 

--- a/tests/unit/console/vehicle-commands.test.ts
+++ b/tests/unit/console/vehicle-commands.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { EventEmitter } from '../../../src/core/state/EventEmitter.js';
 import { newGameCommand } from '../../../src/console/commands/world.js';
 import { vehicleCommand } from '../../../src/console/commands/vehicle.js';
+import { tickCommand } from '../../../src/console/commands/events.js';
 import type { MiningContext } from '../../../src/console/commands/mining.js';
 import { createTubingState } from '../../../src/core/mining/Tubing.js';
 import { purchaseVehicle } from '../../../src/core/entities/Vehicle.js';
@@ -42,6 +43,45 @@ function addDrillRig(ctx: MiningContext): number {
 }
 
 /**
+ * Fields every Employee needs beyond the identity/role/qualification basics —
+ * factored out so the three fixture builders below stay in sync with the
+ * Employee interface (issue #437 added several "pending" and "destination"
+ * fields; a fixture missing them isn't a type error in test files — tests
+ * aren't typechecked — but tickCommand's movement/arrival-gate pipeline reads
+ * them directly and crashes on `undefined` rather than failing a clean
+ * assertion).
+ */
+function employeeMovementDefaults(): Omit<
+  Employee,
+  'id' | 'name' | 'role' | 'salary' | 'morale' | 'unionized' | 'injured' | 'alive' | 'x' | 'z' | 'qualifications' | 'trainingState'
+> {
+  return {
+    activeActionId: null,
+    hunger: 100,
+    fatigue: 100,
+    breakNeed: 100,
+    collapsing: false,
+    interruptedActionPayload: null,
+    ticksWorked: 0,
+    restTicksRemaining: null,
+    taskTicksRemaining: null,
+    activeTaskSkill: null,
+    restNeedKey: null,
+    destinationX: null,
+    destinationZ: null,
+    moveConsecutiveFailures: 0,
+    isMoveStuck: false,
+    pendingRestDuration: null,
+    pendingRestNeedKey: null,
+    pendingTaskDuration: null,
+    pendingActionType: null,
+    pendingActionPayload: null,
+    pendingDriverVehicleId: null,
+    pendingTrainingStart: null,
+  };
+}
+
+/**
  * Push a qualified truck driver (driving.truck licence) directly into employee state.
  * Returns the new employee's ID.
  */
@@ -59,6 +99,7 @@ function addTruckDriver(ctx: MiningContext): number {
     z: 0,
     qualifications: [{ category: 'driving.truck', proficiencyLevel: 1, xp: 0 }],
     trainingState: null,
+    ...employeeMovementDefaults(),
   };
   ctx.state!.employees.employees.push(emp);
   return emp.id;
@@ -82,6 +123,7 @@ function addDrillRigDriver(ctx: MiningContext): number {
     z: 0,
     qualifications: [{ category: 'driving.drill_rig', proficiencyLevel: 1, xp: 0 }],
     trainingState: null,
+    ...employeeMovementDefaults(),
   };
   ctx.state!.employees.employees.push(emp);
   return emp.id;
@@ -105,6 +147,7 @@ function addUnqualifiedEmployee(ctx: MiningContext): number {
     z: 0,
     qualifications: [],
     trainingState: null,
+    ...employeeMovementDefaults(),
   };
   ctx.state!.employees.employees.push(emp);
   return emp.id;
@@ -113,6 +156,13 @@ function addUnqualifiedEmployee(ctx: MiningContext): number {
 // ── vehicle driver — happy path ──
 
 describe('vehicle driver — successful assignment', () => {
+  // Issue #437: "vehicle driver" now only *requests* boarding — the licence
+  // and availability checks still happen eagerly (so the command still
+  // reports success/failure immediately), but the actual driverId assignment
+  // is deferred to ArrivalGate.tickArrivalGate, once the employee has walked
+  // to the vehicle. Every fixture employee here spawns at the same (0,0) as
+  // the fixture vehicle, so a single tick is enough to resolve arrival.
+
   it('returns success when a qualified driver is assigned to a matching vehicle', () => {
     const ctx = makeCtx();
     const vehicleId = addTruckVehicle(ctx);
@@ -143,18 +193,22 @@ describe('vehicle driver — successful assignment', () => {
     expect(result.output).toContain(String(employeeId));
   });
 
-  it('sets driverId on the vehicle after assignment', () => {
+  it('does NOT set driverId synchronously — driverId stays null until a tick resolves arrival', () => {
     const ctx = makeCtx();
     const vehicleId = addTruckVehicle(ctx);
     const employeeId = addTruckDriver(ctx);
 
-    vehicleCommand(ctx, ['driver', String(vehicleId), String(employeeId)], {});
+    const result = vehicleCommand(ctx, ['driver', String(vehicleId), String(employeeId)], {});
+    expect(result.success).toBe(true);
 
     const vehicle = ctx.state!.vehicles.vehicles.find(v => v.id === vehicleId);
+    expect(vehicle!.driverId).toBeNull();
+
+    tickCommand(ctx, ['1'], {});
     expect(vehicle!.driverId).toBe(employeeId);
   });
 
-  it('assigns a drill_rig driver with the driving.drill_rig licence', () => {
+  it('assigns a drill_rig driver with the driving.drill_rig licence, once a tick resolves arrival', () => {
     const ctx = makeCtx();
     const vehicleId = addDrillRig(ctx);
     const employeeId = addDrillRigDriver(ctx);
@@ -163,6 +217,9 @@ describe('vehicle driver — successful assignment', () => {
 
     expect(result.success).toBe(true);
     const vehicle = ctx.state!.vehicles.vehicles.find(v => v.id === vehicleId);
+    expect(vehicle!.driverId).toBeNull();
+
+    tickCommand(ctx, ['1'], {});
     expect(vehicle!.driverId).toBe(employeeId);
   });
 });
@@ -249,6 +306,10 @@ describe('vehicle driver — domain validation errors', () => {
 
     // Assign first driver successfully
     vehicleCommand(ctx, ['driver', String(vehicleId), String(firstDriverId)], {});
+    // Issue #437: driverId is only set once the arrival gate resolves — the
+    // first driver must actually board before the second request can see the
+    // vehicle as taken.
+    tickCommand(ctx, ['1'], {});
 
     // Attempt to assign a second driver to the same vehicle
     const result = vehicleCommand(
@@ -269,6 +330,8 @@ describe('vehicle driver — domain validation errors', () => {
 
     // Assign driver to first vehicle successfully
     vehicleCommand(ctx, ['driver', String(firstVehicleId), String(employeeId)], {});
+    // Issue #437: driverId is only set once the arrival gate resolves.
+    tickCommand(ctx, ['1'], {});
 
     // Attempt to assign same driver to second vehicle
     const result = vehicleCommand(

--- a/tests/unit/console/vehicle-list.test.ts
+++ b/tests/unit/console/vehicle-list.test.ts
@@ -9,6 +9,44 @@ import type { MiningContext } from '../../../src/console/commands/mining.js';
 import { createTubingState } from '../../../src/core/mining/Tubing.js';
 import { purchaseVehicle } from '../../../src/core/entities/Vehicle.js';
 import type { Employee } from '../../../src/core/entities/Employee.js';
+import { tickEmployeeMovement } from '../../../src/core/engine/EntityMovementTick.js';
+import { tickArrivalGate } from '../../../src/core/engine/ArrivalGate.js';
+
+/** Default fields for hand-built Employee test fixtures below (mirrors hireEmployee's defaults). */
+const EMPLOYEE_DEFAULTS = {
+  activeActionId: null,
+  hunger: 100,
+  fatigue: 100,
+  breakNeed: 100,
+  collapsing: false,
+  interruptedActionPayload: null,
+  ticksWorked: 0,
+  restTicksRemaining: null,
+  restNeedKey: null,
+  taskTicksRemaining: null,
+  activeTaskSkill: null,
+  destinationX: null,
+  destinationZ: null,
+  moveConsecutiveFailures: 0,
+  isMoveStuck: false,
+  pendingRestDuration: null,
+  pendingRestNeedKey: null,
+  pendingTaskDuration: null,
+  pendingActionType: null,
+  pendingActionPayload: null,
+  pendingDriverVehicleId: null,
+  pendingTrainingStart: null,
+} as const;
+
+/**
+ * Boarding is arrival-gated (#437): `vehicle driver` only queues the walk.
+ * These fixtures spawn both vehicle and employee at (0,0), so a single
+ * movement + arrival-gate tick resolves it (the employee is already there).
+ */
+function resolveDriverBoarding(ctx: MiningContext): void {
+  tickEmployeeMovement(ctx.state!, ctx.emitter);
+  tickArrivalGate(ctx.state!, ctx.emitter);
+}
 
 // ── Test context factory ──
 
@@ -43,6 +81,7 @@ function addTruckDriver(ctx: MiningContext): number {
     z: 0,
     qualifications: [{ category: 'driving.truck', proficiencyLevel: 1, xp: 0 }],
     trainingState: null,
+    ...EMPLOYEE_DEFAULTS,
   };
   ctx.state!.employees.employees.push(emp);
   return emp.id;
@@ -66,6 +105,7 @@ describe('vehicle list — driver display', () => {
     const vehicleId = addTruckVehicle(ctx);
     const employeeId = addTruckDriver(ctx);
     vehicleCommand(ctx, ['driver', String(vehicleId), String(employeeId)], {});
+    resolveDriverBoarding(ctx);
 
     const result = vehicleCommand(ctx, ['list'], {});
 
@@ -79,6 +119,7 @@ describe('vehicle list — driver display', () => {
     const undrivenVehicleId = addTruckVehicle(ctx);
     const employeeId = addTruckDriver(ctx);
     vehicleCommand(ctx, ['driver', String(drivenVehicleId), String(employeeId)], {});
+    resolveDriverBoarding(ctx);
 
     const result = vehicleCommand(ctx, ['list'], {});
 
@@ -94,6 +135,7 @@ describe('vehicle list — driver display', () => {
     const vehicleId = addTruckVehicle(ctx);
     const employeeId = addTruckDriver(ctx);
     vehicleCommand(ctx, ['driver', String(vehicleId), String(employeeId)], {});
+    resolveDriverBoarding(ctx);
 
     const result = vehicleCommand(ctx, ['list'], {});
 

--- a/tests/unit/console/vehicle-list.test.ts
+++ b/tests/unit/console/vehicle-list.test.ts
@@ -35,7 +35,6 @@ const EMPLOYEE_DEFAULTS = {
   pendingActionType: null,
   pendingActionPayload: null,
   pendingDriverVehicleId: null,
-  pendingTrainingStart: null,
 } as const;
 
 /**

--- a/tests/unit/economy/HaulingTask.test.ts
+++ b/tests/unit/economy/HaulingTask.test.ts
@@ -4,10 +4,6 @@
 // without loading it immediately; tickHaulingProgress advances the vehicle
 // through to_fragment -> pickup -> to_depot -> deliver -> idle, only acting
 // on arrival (never mid-transit).
-//
-// RED PHASE: src/core/economy/HaulingTask.ts's requestHaulFragment and
-// tickHaulingProgress both always throw 'not implemented'. Every test below
-// fails until the implementer fills in the real logic.
 
 import { describe, it, expect } from 'vitest';
 import { createGame } from '../../../src/core/state/GameState.js';

--- a/tests/unit/economy/HaulingTask.test.ts
+++ b/tests/unit/economy/HaulingTask.test.ts
@@ -1,0 +1,265 @@
+// BlastSimulator2026 — Tests for HaulingTask (issue #437)
+//
+// requestHaulFragment dispatches a debris_hauler toward a ground fragment
+// without loading it immediately; tickHaulingProgress advances the vehicle
+// through to_fragment -> pickup -> to_depot -> deliver -> idle, only acting
+// on arrival (never mid-transit).
+//
+// RED PHASE: src/core/economy/HaulingTask.ts's requestHaulFragment and
+// tickHaulingProgress both always throw 'not implemented'. Every test below
+// fails until the implementer fills in the real logic.
+
+import { describe, it, expect } from 'vitest';
+import { createGame } from '../../../src/core/state/GameState.js';
+import { purchaseVehicle } from '../../../src/core/entities/Vehicle.js';
+import { hireEmployee, assignSkill } from '../../../src/core/entities/Employee.js';
+import { Random } from '../../../src/core/math/Random.js';
+import { placeBuilding } from '../../../src/core/entities/Building.js';
+import { addBlastFragments } from '../../../src/core/economy/Logistics.js';
+import type { FragmentData } from '../../../src/core/mining/BlastExecution.js';
+import { requestHaulFragment, tickHaulingProgress } from '../../../src/core/economy/HaulingTask.js';
+
+const SEED = 42;
+const GRID = 64;
+
+function makeFragment(id: number, x: number, z: number, mass = 1000): FragmentData {
+  return {
+    id,
+    position: { x, y: 0, z },
+    volume: 1.0,
+    mass,
+    rockId: 'cruite',
+    oreDensities: {},
+    initialVelocity: { x: 0, y: 0, z: 0 },
+    isProjection: false,
+  };
+}
+
+/** A driverless debris_hauler with no active haul. */
+function makeIdleHauler(state: ReturnType<typeof createGame>, x = 0, z = 0) {
+  return purchaseVehicle(state.vehicles, 'debris_hauler', x, z).vehicle;
+}
+
+/** A debris_hauler with a licensed driver already boarded (driverId set). */
+function makeDrivenHauler(state: ReturnType<typeof createGame>, x = 0, z = 0) {
+  const vehicle = makeIdleHauler(state, x, z);
+  const rng = new Random(SEED);
+  const { employee } = hireEmployee(state.employees, 'driver', rng);
+  assignSkill(state.employees, employee.id, 'driving.truck', 1);
+  vehicle.driverId = employee.id;
+  return vehicle;
+}
+
+function placeWarehouse(state: ReturnType<typeof createGame>, x: number, z: number) {
+  const result = placeBuilding(state.buildings, 'freight_warehouse', x, z, GRID, GRID);
+  if (!result.success) throw new Error(`Setup: placeBuilding failed — ${result.error}`);
+  return result.building!;
+}
+
+// ── requestHaulFragment — precondition failures ─────────────────────────────
+
+describe('requestHaulFragment — precondition failures', () => {
+  it('rejects a non-debris_hauler vehicle', () => {
+    const state = createGame({ seed: SEED });
+    placeWarehouse(state, 10, 10);
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driver', rng);
+    assignSkill(state.employees, employee.id, 'driving.excavator', 1);
+    const { vehicle } = purchaseVehicle(state.vehicles, 'rock_digger', 0, 0);
+    vehicle.driverId = employee.id;
+    addBlastFragments(state.logistics, [makeFragment(1, 5, 5)]);
+
+    const result = requestHaulFragment(state, vehicle.id, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('rejects a vehicle with no driver', () => {
+    const state = createGame({ seed: SEED });
+    placeWarehouse(state, 10, 10);
+    const vehicle = makeIdleHauler(state);
+    addBlastFragments(state.logistics, [makeFragment(1, 5, 5)]);
+
+    const result = requestHaulFragment(state, vehicle.id, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('rejects a vehicle that is already hauling', () => {
+    const state = createGame({ seed: SEED });
+    placeWarehouse(state, 10, 10);
+    const vehicle = makeDrivenHauler(state);
+    vehicle.haulingFragmentId = 999;
+    vehicle.haulingPhase = 'to_fragment';
+    addBlastFragments(state.logistics, [makeFragment(1, 5, 5)]);
+
+    const result = requestHaulFragment(state, vehicle.id, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('rejects a fragment that is not on_ground (already in_transit)', () => {
+    const state = createGame({ seed: SEED });
+    placeWarehouse(state, 10, 10);
+    const vehicle = makeDrivenHauler(state);
+    addBlastFragments(state.logistics, [makeFragment(1, 5, 5)]);
+    state.logistics.fragments[0]!.state = 'in_transit';
+
+    const result = requestHaulFragment(state, vehicle.id, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('rejects a fragment ID that does not exist', () => {
+    const state = createGame({ seed: SEED });
+    placeWarehouse(state, 10, 10);
+    const vehicle = makeDrivenHauler(state);
+
+    const result = requestHaulFragment(state, vehicle.id, 9999);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('rejects when no active freight_warehouse exists', () => {
+    const state = createGame({ seed: SEED });
+    const vehicle = makeDrivenHauler(state);
+    addBlastFragments(state.logistics, [makeFragment(1, 5, 5)]);
+
+    const result = requestHaulFragment(state, vehicle.id, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('rejects an unknown vehicle ID', () => {
+    const state = createGame({ seed: SEED });
+    placeWarehouse(state, 10, 10);
+    addBlastFragments(state.logistics, [makeFragment(1, 5, 5)]);
+
+    const result = requestHaulFragment(state, 9999, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+});
+
+// ── requestHaulFragment — happy path defers movement/loading ───────────────
+
+describe('requestHaulFragment — happy path', () => {
+  it('sets the vehicle destination toward the fragment and marks the haul pending', () => {
+    const state = createGame({ seed: SEED });
+    const warehouse = placeWarehouse(state, 10, 10);
+    const vehicle = makeDrivenHauler(state, 0, 0);
+    addBlastFragments(state.logistics, [makeFragment(1, 5, 7)]);
+
+    const result = requestHaulFragment(state, vehicle.id, 1);
+
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(vehicle.targetX).toBe(5);
+    expect(vehicle.targetZ).toBe(7);
+    expect(vehicle.haulingFragmentId).toBe(1);
+    expect(vehicle.haulingPhase).toBe('to_fragment');
+    expect(vehicle.haulingDepotBuildingId).toBe(warehouse.id);
+    // The core contract under test: no synchronous pickup.
+    expect(state.logistics.fragments[0]!.state).toBe('on_ground');
+  });
+
+  it('routes to the nearest active freight_warehouse when several exist', () => {
+    const state = createGame({ seed: SEED });
+    placeWarehouse(state, 40, 40); // far
+    const near = placeWarehouse(state, 6, 6); // near
+    const vehicle = makeDrivenHauler(state, 0, 0);
+    addBlastFragments(state.logistics, [makeFragment(1, 5, 5)]);
+
+    const result = requestHaulFragment(state, vehicle.id, 1);
+
+    expect(result.success).toBe(true);
+    expect(vehicle.haulingDepotBuildingId).toBe(near.id);
+  });
+});
+
+// ── tickHaulingProgress — no-op while travelling ────────────────────────────
+
+describe('tickHaulingProgress — travelling', () => {
+  it('does nothing while the vehicle has not yet arrived at the fragment', () => {
+    const state = createGame({ seed: SEED });
+    placeWarehouse(state, 10, 10);
+    const vehicle = makeDrivenHauler(state, 0, 0);
+    addBlastFragments(state.logistics, [makeFragment(1, 5, 5)]);
+    requestHaulFragment(state, vehicle.id, 1);
+
+    // Still en route: task is 'moving' and position has not reached the fragment.
+    vehicle.task = 'moving';
+    vehicle.x = 1;
+    vehicle.z = 1;
+
+    tickHaulingProgress(state, vehicle);
+
+    expect(state.logistics.fragments[0]!.state).toBe('on_ground');
+    expect(vehicle.haulingPhase).toBe('to_fragment');
+  });
+});
+
+// ── tickHaulingProgress — arrival at the fragment ───────────────────────────
+
+describe('tickHaulingProgress — arrival at fragment', () => {
+  it('loads the fragment on arrival and re-targets the vehicle toward the depot', () => {
+    const state = createGame({ seed: SEED });
+    const warehouse = placeWarehouse(state, 10, 10);
+    const vehicle = makeDrivenHauler(state, 0, 0);
+    addBlastFragments(state.logistics, [makeFragment(1, 5, 5)]);
+    requestHaulFragment(state, vehicle.id, 1);
+
+    // Arrived: task idle, position matches the fragment.
+    vehicle.task = 'idle';
+    vehicle.x = 5;
+    vehicle.z = 5;
+
+    tickHaulingProgress(state, vehicle);
+
+    expect(state.logistics.fragments[0]!.state).toBe('in_transit');
+    expect(vehicle.haulingPhase).toBe('to_depot');
+    expect(vehicle.targetX).toBe(warehouse.x);
+    expect(vehicle.targetZ).toBe(warehouse.z);
+  });
+});
+
+// ── tickHaulingProgress — arrival at the depot ──────────────────────────────
+
+describe('tickHaulingProgress — arrival at depot', () => {
+  it('delivers the fragment on arrival, increases stored mass, and clears hauling fields', () => {
+    const state = createGame({ seed: SEED });
+    const warehouse = placeWarehouse(state, 10, 10);
+    const vehicle = makeDrivenHauler(state, 0, 0);
+    addBlastFragments(state.logistics, [makeFragment(1, 5, 5, 1200)]);
+    requestHaulFragment(state, vehicle.id, 1);
+
+    // First leg: arrive at fragment, load it.
+    vehicle.task = 'idle';
+    vehicle.x = 5;
+    vehicle.z = 5;
+    tickHaulingProgress(state, vehicle);
+    expect(state.logistics.fragments[0]!.state).toBe('in_transit');
+
+    const storedBefore = state.logistics.storedMassKg;
+
+    // Second leg: arrive at the depot.
+    vehicle.task = 'idle';
+    vehicle.x = warehouse.x;
+    vehicle.z = warehouse.z;
+    tickHaulingProgress(state, vehicle);
+
+    expect(state.logistics.fragments[0]!.state).toBe('stored');
+    expect(state.logistics.storedMassKg).toBe(storedBefore + 1200);
+    expect(vehicle.haulingFragmentId).toBeNull();
+    expect(vehicle.haulingPhase).toBeNull();
+    expect(vehicle.haulingDepotBuildingId).toBeNull();
+    expect(vehicle.task).toBe('idle');
+  });
+});

--- a/tests/unit/engine/ArrivalGate.test.ts
+++ b/tests/unit/engine/ArrivalGate.test.ts
@@ -9,10 +9,6 @@
 // Training enrollment (enrolInTraining) is deliberately NOT arrival-gated:
 // it relocates the employee to the school instantly rather than queuing a
 // walk — see EmployeeTraining.ts and #410.
-//
-// RED PHASE: src/core/engine/ArrivalGate.ts's tickArrivalGate always throws
-// 'not implemented'. Every test below therefore fails until the implementer
-// fills in the real gating logic.
 
 import { describe, it, expect } from 'vitest';
 import { createGame } from '../../../src/core/state/GameState.js';

--- a/tests/unit/engine/ArrivalGate.test.ts
+++ b/tests/unit/engine/ArrivalGate.test.ts
@@ -1,10 +1,14 @@
 // BlastSimulator2026 — Tests for ArrivalGate.tickArrivalGate (issue #437)
 //
 // ArrivalGate.ts is the single place that promotes pending* fields (set at
-// claim time by tickEmployees / requestBoardVehicle / requestHaulFragment /
-// enrolInTraining) into their live counterparts (restTicksRemaining,
-// taskTicksRemaining, vehicle.driverId) — but only once the employee has
-// actually arrived (destinationX === null && destinationZ === null).
+// claim time by tickEmployees / requestBoardVehicle / requestHaulFragment)
+// into their live counterparts (restTicksRemaining, taskTicksRemaining,
+// vehicle.driverId) — but only once the employee has actually arrived
+// (destinationX === null && destinationZ === null).
+//
+// Training enrollment (enrolInTraining) is deliberately NOT arrival-gated:
+// it relocates the employee to the school instantly rather than queuing a
+// walk — see EmployeeTraining.ts and #410.
 //
 // RED PHASE: src/core/engine/ArrivalGate.ts's tickArrivalGate always throws
 // 'not implemented'. Every test below therefore fails until the implementer

--- a/tests/unit/engine/ArrivalGate.test.ts
+++ b/tests/unit/engine/ArrivalGate.test.ts
@@ -1,0 +1,312 @@
+// BlastSimulator2026 — Tests for ArrivalGate.tickArrivalGate (issue #437)
+//
+// ArrivalGate.ts is the single place that promotes pending* fields (set at
+// claim time by tickEmployees / requestBoardVehicle / requestHaulFragment /
+// enrolInTraining) into their live counterparts (restTicksRemaining,
+// taskTicksRemaining, vehicle.driverId) — but only once the employee has
+// actually arrived (destinationX === null && destinationZ === null).
+//
+// RED PHASE: src/core/engine/ArrivalGate.ts's tickArrivalGate always throws
+// 'not implemented'. Every test below therefore fails until the implementer
+// fills in the real gating logic.
+
+import { describe, it, expect } from 'vitest';
+import { createGame } from '../../../src/core/state/GameState.js';
+import { Random } from '../../../src/core/math/Random.js';
+import { hireEmployee } from '../../../src/core/entities/Employee.js';
+import { purchaseVehicle } from '../../../src/core/entities/Vehicle.js';
+import { EventEmitter } from '../../../src/core/state/EventEmitter.js';
+import { tickArrivalGate } from '../../../src/core/engine/ArrivalGate.js';
+
+const SEED = 42;
+
+describe('tickArrivalGate — mid-transit employees are untouched', () => {
+  it('does not promote a pending rest while the employee is still walking (destinationX/Z non-null)', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.x = 0;
+    employee.z = 0;
+    employee.destinationX = 10;
+    employee.destinationZ = 10;
+    employee.pendingRestDuration = 5;
+    employee.pendingRestNeedKey = 'hunger';
+
+    const result = tickArrivalGate(state);
+
+    expect(employee.restTicksRemaining).toBeNull();
+    expect(employee.restNeedKey).toBeNull();
+    expect(employee.pendingRestDuration).toBe(5);
+    expect(employee.pendingRestNeedKey).toBe('hunger');
+    expect(result.restStarted).toEqual([]);
+  });
+
+  it('does not promote a pending task while only one axis of the destination is still set', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'surveyor', rng);
+    employee.x = 3;
+    employee.z = 3;
+    employee.destinationX = null;
+    employee.destinationZ = 3; // still travelling on Z — not yet arrived
+    employee.pendingTaskDuration = 4;
+    employee.pendingActionType = 'survey';
+    employee.pendingActionPayload = { method: 'core_sample' };
+
+    const result = tickArrivalGate(state);
+
+    expect(employee.taskTicksRemaining).toBeNull();
+    expect(employee.pendingTaskDuration).toBe(4);
+    expect(result.taskStarted).toEqual([]);
+  });
+
+  it('does not board a vehicle while the employee is still travelling toward it', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driver', rng);
+    const { vehicle } = purchaseVehicle(state.vehicles, 'debris_hauler', 5, 5);
+    employee.x = 0;
+    employee.z = 0;
+    employee.destinationX = 5;
+    employee.destinationZ = 5;
+    employee.pendingDriverVehicleId = vehicle.id;
+
+    const result = tickArrivalGate(state);
+
+    expect(vehicle.driverId).toBeNull();
+    expect(employee.pendingDriverVehicleId).toBe(vehicle.id);
+    expect(result.driversBoarded).toEqual([]);
+    expect(result.boardingCancelled).toEqual([]);
+  });
+});
+
+describe('tickArrivalGate — rest arrival', () => {
+  it('promotes pendingRestDuration into restTicksRemaining/restNeedKey on arrival, clearing the pending fields', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.x = 8;
+    employee.z = 8;
+    employee.destinationX = null;
+    employee.destinationZ = null;
+    employee.pendingRestDuration = 6;
+    employee.pendingRestNeedKey = 'fatigue';
+
+    const result = tickArrivalGate(state);
+
+    expect(employee.restTicksRemaining).toBe(6);
+    expect(employee.restNeedKey).toBe('fatigue');
+    expect(employee.pendingRestDuration).toBeNull();
+    expect(employee.pendingRestNeedKey).toBeNull();
+    expect(result.restStarted).toEqual([employee.id]);
+  });
+
+  it('is a no-op for an arrived employee with no pending rest', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.x = 8;
+    employee.z = 8;
+    employee.destinationX = null;
+    employee.destinationZ = null;
+
+    const result = tickArrivalGate(state);
+
+    expect(employee.restTicksRemaining).toBeNull();
+    expect(result.restStarted).toEqual([]);
+  });
+});
+
+describe('tickArrivalGate — task arrival', () => {
+  it('promotes pendingTaskDuration into taskTicksRemaining on arrival, clearing pending fields', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'surveyor', rng);
+    employee.x = 16;
+    employee.z = 16;
+    employee.destinationX = null;
+    employee.destinationZ = null;
+    employee.pendingTaskDuration = 4;
+    employee.pendingActionType = 'survey';
+    employee.pendingActionPayload = { method: 'core_sample', centerX: 16, centerZ: 16 };
+
+    const result = tickArrivalGate(state);
+
+    expect(employee.taskTicksRemaining).toBe(4);
+    expect(employee.pendingTaskDuration).toBeNull();
+    expect(employee.pendingActionType).toBeNull();
+    expect(employee.pendingActionPayload).toBeNull();
+    expect(result.taskStarted).toEqual([employee.id]);
+  });
+
+  it('is a no-op for an arrived employee with no pending task', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'surveyor', rng);
+    employee.x = 16;
+    employee.z = 16;
+    employee.destinationX = null;
+    employee.destinationZ = null;
+
+    const result = tickArrivalGate(state);
+
+    expect(employee.taskTicksRemaining).toBeNull();
+    expect(result.taskStarted).toEqual([]);
+  });
+});
+
+describe('tickArrivalGate — vehicle boarding', () => {
+  it('assigns the driver once the employee has arrived at a still-driverless, still-in-place vehicle', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driver', rng);
+    const { vehicle } = purchaseVehicle(state.vehicles, 'debris_hauler', 5, 5);
+    employee.x = 5;
+    employee.z = 5;
+    employee.destinationX = null;
+    employee.destinationZ = null;
+    employee.pendingDriverVehicleId = vehicle.id;
+
+    const emitter = new EventEmitter();
+    const boardedEvents: Array<{ employeeId: number; vehicleId: number }> = [];
+    emitter.on('vehicle:driver_boarded', (data) => boardedEvents.push(data));
+
+    const result = tickArrivalGate(state, emitter);
+
+    expect(vehicle.driverId).toBe(employee.id);
+    expect(employee.pendingDriverVehicleId).toBeNull();
+    expect(result.driversBoarded).toEqual([employee.id]);
+    expect(boardedEvents).toEqual([{ employeeId: employee.id, vehicleId: vehicle.id }]);
+  });
+
+  it('cancels the boarding with reason "vehicle_gone" when the vehicle was destroyed en route', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driver', rng);
+    const { vehicle } = purchaseVehicle(state.vehicles, 'debris_hauler', 5, 5);
+    const goneId = vehicle.id;
+    state.vehicles.vehicles = state.vehicles.vehicles.filter(v => v.id !== goneId);
+
+    employee.x = 5;
+    employee.z = 5;
+    employee.destinationX = null;
+    employee.destinationZ = null;
+    employee.pendingDriverVehicleId = goneId;
+
+    const result = tickArrivalGate(state);
+
+    expect(employee.pendingDriverVehicleId).toBeNull();
+    expect(result.driversBoarded).toEqual([]);
+    expect(result.boardingCancelled).toEqual([{ employeeId: employee.id, reason: 'vehicle_gone' }]);
+  });
+
+  it('cancels the boarding with reason "vehicle_taken" when another driver claimed the vehicle first', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driver', rng);
+    const { employee: otherDriver } = hireEmployee(state.employees, 'driver', new Random(SEED + 1));
+    const { vehicle } = purchaseVehicle(state.vehicles, 'debris_hauler', 5, 5);
+    vehicle.driverId = otherDriver.id;
+
+    employee.x = 5;
+    employee.z = 5;
+    employee.destinationX = null;
+    employee.destinationZ = null;
+    employee.pendingDriverVehicleId = vehicle.id;
+
+    const result = tickArrivalGate(state);
+
+    expect(vehicle.driverId).toBe(otherDriver.id);
+    expect(employee.pendingDriverVehicleId).toBeNull();
+    expect(result.driversBoarded).toEqual([]);
+    expect(result.boardingCancelled).toEqual([{ employeeId: employee.id, reason: 'vehicle_taken' }]);
+  });
+
+  it('cancels the boarding with reason "vehicle_moved" when the vehicle is no longer where the employee arrived', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driver', rng);
+    const { vehicle } = purchaseVehicle(state.vehicles, 'debris_hauler', 5, 5);
+    // Vehicle drove off before the employee finished walking to its old spot.
+    vehicle.x = 40;
+    vehicle.z = 40;
+
+    employee.x = 5;
+    employee.z = 5;
+    employee.destinationX = null;
+    employee.destinationZ = null;
+    employee.pendingDriverVehicleId = vehicle.id;
+
+    const result = tickArrivalGate(state);
+
+    expect(vehicle.driverId).toBeNull();
+    expect(employee.pendingDriverVehicleId).toBeNull();
+    expect(result.driversBoarded).toEqual([]);
+    expect(result.boardingCancelled).toEqual([{ employeeId: employee.id, reason: 'vehicle_moved' }]);
+  });
+});
+
+describe('tickArrivalGate — dead employees are skipped entirely', () => {
+  it('does nothing for a dead employee even with pending rest/task/boarding set', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driver', rng);
+    const { vehicle } = purchaseVehicle(state.vehicles, 'debris_hauler', 5, 5);
+    employee.alive = false;
+    employee.x = 5;
+    employee.z = 5;
+    employee.destinationX = null;
+    employee.destinationZ = null;
+    employee.pendingRestDuration = 3;
+    employee.pendingRestNeedKey = 'hunger';
+    employee.pendingTaskDuration = 4;
+    employee.pendingDriverVehicleId = vehicle.id;
+
+    const result = tickArrivalGate(state);
+
+    expect(employee.restTicksRemaining).toBeNull();
+    expect(employee.taskTicksRemaining).toBeNull();
+    expect(vehicle.driverId).toBeNull();
+    expect(employee.pendingRestDuration).toBe(3);
+    expect(employee.pendingTaskDuration).toBe(4);
+    expect(employee.pendingDriverVehicleId).toBe(vehicle.id);
+    expect(result.restStarted).toEqual([]);
+    expect(result.taskStarted).toEqual([]);
+    expect(result.driversBoarded).toEqual([]);
+    expect(result.boardingCancelled).toEqual([]);
+  });
+});
+
+describe('tickArrivalGate — combined multi-employee tick', () => {
+  it('processes rest, task, and boarding promotions for different employees in the same tick', () => {
+    const state = createGame({ seed: SEED });
+    const { employee: resting } = hireEmployee(state.employees, 'driller', new Random(SEED));
+    const { employee: tasked } = hireEmployee(state.employees, 'surveyor', new Random(SEED + 1));
+    const { employee: driver } = hireEmployee(state.employees, 'driver', new Random(SEED + 2));
+    const { vehicle } = purchaseVehicle(state.vehicles, 'debris_hauler', 9, 9);
+
+    resting.x = 1; resting.z = 1;
+    resting.destinationX = null; resting.destinationZ = null;
+    resting.pendingRestDuration = 2;
+    resting.pendingRestNeedKey = 'hunger';
+
+    tasked.x = 2; tasked.z = 2;
+    tasked.destinationX = null; tasked.destinationZ = null;
+    tasked.pendingTaskDuration = 3;
+    tasked.pendingActionType = 'survey';
+    tasked.pendingActionPayload = { method: 'aerial' };
+
+    driver.x = 9; driver.z = 9;
+    driver.destinationX = null; driver.destinationZ = null;
+    driver.pendingDriverVehicleId = vehicle.id;
+
+    const result = tickArrivalGate(state);
+
+    expect(result.restStarted).toEqual([resting.id]);
+    expect(result.taskStarted).toEqual([tasked.id]);
+    expect(result.driversBoarded).toEqual([driver.id]);
+    expect(resting.restTicksRemaining).toBe(2);
+    expect(tasked.taskTicksRemaining).toBe(3);
+    expect(vehicle.driverId).toBe(driver.id);
+  });
+});

--- a/tests/unit/engine/ArrivalGate.test.ts
+++ b/tests/unit/engine/ArrivalGate.test.ts
@@ -118,7 +118,7 @@ describe('tickArrivalGate — rest arrival', () => {
 });
 
 describe('tickArrivalGate — task arrival', () => {
-  it('promotes pendingTaskDuration into taskTicksRemaining on arrival, clearing pending fields', () => {
+  it('promotes pendingTaskDuration into taskTicksRemaining on arrival, clearing pendingTaskDuration but leaving pendingActionType/Payload for tickTaskProgress to consume at completion', () => {
     const state = createGame({ seed: SEED });
     const rng = new Random(SEED);
     const { employee } = hireEmployee(state.employees, 'surveyor', rng);
@@ -134,8 +134,11 @@ describe('tickArrivalGate — task arrival', () => {
 
     expect(employee.taskTicksRemaining).toBe(4);
     expect(employee.pendingTaskDuration).toBeNull();
-    expect(employee.pendingActionType).toBeNull();
-    expect(employee.pendingActionPayload).toBeNull();
+    // pendingActionType/pendingActionPayload are consumed by tickTaskProgress
+    // at actual completion (GameLoop.ts), not here — see survey resolution,
+    // which needs to know what kind of task just finished.
+    expect(employee.pendingActionType).toBe('survey');
+    expect(employee.pendingActionPayload).toEqual({ method: 'core_sample', centerX: 16, centerZ: 16 });
     expect(result.taskStarted).toEqual([employee.id]);
   });
 

--- a/tests/unit/engine/GameLoop.test.ts
+++ b/tests/unit/engine/GameLoop.test.ts
@@ -31,7 +31,11 @@ import {
   // ── tickTaskProgress: task-duration countdown + tick-driven XP (issue #406) ──
   // Stub as of this branch — the tests below are the Red-phase spec for it.
   tickTaskProgress,
+  // ── ArrivalGate (#437): claim only queues pendingRestDuration/pendingTaskDuration —
+  // the timer itself starts once the employee has arrived at targetX/targetZ.
+  tickArrivalGate,
 } from '../../../src/core/engine/GameLoop.js';
+import { tickEmployeeMovement } from '../../../src/core/engine/EntityMovementTick.js';
 import { placeBuilding } from '../../../src/core/entities/Building.js';
 import {
   hireEmployee, assignSkill, checkCollapse, getNeedMultiplier, computeTaskDuration,
@@ -58,6 +62,19 @@ import {
   BASE_TASK_DURATION_TICKS,
   XP_THRESHOLDS,
 } from '../../../src/core/config/balance.js';
+
+/**
+ * Rest/task timers are arrival-gated (#437): tickEmployees only queues
+ * pendingRestDuration/pendingTaskDuration; ArrivalGate.tickArrivalGate
+ * promotes them into restTicksRemaining/taskTicksRemaining once the
+ * employee has actually walked to targetX/targetZ. Call after tickEmployees
+ * in tests that build fixtures already co-located with their target (the
+ * common case below, both at (0,0)) to resolve that walk in one step.
+ */
+function resolveArrival(state: GameState): void {
+  tickEmployeeMovement(state);
+  tickArrivalGate(state);
+}
 
 function buildContext(state: GameState): EventContext {
   return {
@@ -438,6 +455,7 @@ describe('tickEmployees — task duration seeding on claim (Ch.3 skill progressi
 
     state.pendingActions.push(makeSkillAction({ id: 1, targetEmployeeId: employee.id }));
     tickEmployees(state);
+    resolveArrival(state);
 
     expect(employee.activeActionId).toBe(1);
     const needMult = getNeedMultiplier(employee);
@@ -458,6 +476,7 @@ describe('tickEmployees — task duration seeding on claim (Ch.3 skill progressi
     state.pendingActions.push(makeSkillAction({ id: 1, targetEmployeeId: rookie.id }));
     state.pendingActions.push(makeSkillAction({ id: 2, targetEmployeeId: master.id }));
     tickEmployees(state);
+    resolveArrival(state);
 
     expect(rookie.taskTicksRemaining).not.toBeNull();
     expect(master.taskTicksRemaining).not.toBeNull();
@@ -480,6 +499,7 @@ describe('tickEmployees — task duration seeding on claim (Ch.3 skill progressi
     state.pendingActions.push(makeSkillAction({ id: 1, targetEmployeeId: fed.id }));
     state.pendingActions.push(makeSkillAction({ id: 2, targetEmployeeId: hungry.id }));
     tickEmployees(state);
+    resolveArrival(state);
 
     expect(fed.taskTicksRemaining).not.toBeNull();
     expect(hungry.taskTicksRemaining).not.toBeNull();
@@ -498,6 +518,7 @@ describe('tickEmployees — task duration seeding on claim (Ch.3 skill progressi
       targetEmployeeId: employee.id,
     });
     tickEmployees(state);
+    resolveArrival(state);
 
     expect(employee.restTicksRemaining).toBe(5);
     expect(employee.taskTicksRemaining).toBeNull();
@@ -507,13 +528,19 @@ describe('tickEmployees — task duration seeding on claim (Ch.3 skill progressi
 describe('tickTaskProgress — per-tick countdown, incremental XP, and completion (Ch.3 skill progression, issue #406)', () => {
   const SEED = 42;
 
-  /** Dispatch a 'blasting'-required task to `employeeId` and let tickEmployees claim + seed it. */
+  /**
+   * Dispatch a 'blasting'-required task to `employeeId` and let tickEmployees
+   * claim + seed it. targetX/Z (0,0) matches every hireEmployee call in this
+   * describe block (defaults to (0,0)), so resolveArrival's single movement
+   * pass resolves arrival immediately and taskTicksRemaining is seeded (#437).
+   */
   function dispatchAndClaim(state: GameState, employeeId: number, actionId: number): void {
     state.pendingActions.push({
       id: actionId, type: 'general_work', requiredSkill: 'blasting', requiredVehicleRole: null,
       targetX: 0, targetZ: 0, targetY: 0, payload: {}, targetEmployeeId: employeeId,
     });
     tickEmployees(state);
+    resolveArrival(state);
   }
 
   it('decrements taskTicksRemaining by exactly 1 per call', () => {
@@ -1175,7 +1202,10 @@ describe('tickCollapse (7.6)', () => {
     );
     expect(restActions).toHaveLength(1);
     expect(restActions[0]!.id).toBe(employee.activeActionId);
-    expect(employee.restNeedKey).toBe('fatigue');
+    // The rest timer itself does not start until ArrivalGate confirms the
+    // employee has walked to the building — restNeedKey stays queued as
+    // pendingRestNeedKey until then (#437).
+    expect(employee.pendingRestNeedKey).toBe('fatigue');
   });
 
 });
@@ -2041,7 +2071,10 @@ describe('processShiftCycle (7.9)', () => {
     const result = processShiftCycle(state, firedEvents);
 
     expect(result.shiftRested).toContain(employee.id);
-    expect(employee.restTicksRemaining).toBe(SHIFT_SLEEP_DURATION_TICKS);
+    // The rest timer itself does not start until ArrivalGate confirms the
+    // employee has walked to the bunkhouse — queued as pendingRestDuration
+    // until then (#437).
+    expect(employee.pendingRestDuration).toBe(SHIFT_SLEEP_DURATION_TICKS);
     // Employee should be claimed by a rest action (activeActionId changed)
     expect(employee.activeActionId).not.toBe(ORIGINAL_ACTION_ID);
     expect(employee.activeActionId).not.toBeNull();
@@ -2201,8 +2234,9 @@ describe('processShiftCycle (7.9)', () => {
     expect(result.shiftRested).toContain(emp1.id);
     expect(result.shiftRested).not.toContain(emp2.id);
 
-    // emp1's rest timer starts
-    expect(emp1.restTicksRemaining).toBe(SHIFT_SLEEP_DURATION_TICKS);
+    // emp1's rest timer is queued — it starts once ArrivalGate confirms
+    // arrival at the bunkhouse (#437).
+    expect(emp1.pendingRestDuration).toBe(SHIFT_SLEEP_DURATION_TICKS);
 
     // emp2 continues working
     expect(emp2.ticksWorked).toBe(3);

--- a/tests/unit/entities/Building.test.ts
+++ b/tests/unit/entities/Building.test.ts
@@ -12,6 +12,7 @@ import {
   queueResearchTask,
   tickResearch,
   isTierUnlocked,
+  findNearestActiveBuildingOfType,
 } from '../../../src/core/entities/Building.js';
 
 describe('Building system', () => {
@@ -215,5 +216,95 @@ describe('placeBuilding — research gating', () => {
 
     const result = placeBuilding(state, 'living_quarters', 0, 0, 64, 64, 3);
     expect(result.success).toBe(false);
+  });
+});
+
+// ── findNearestActiveBuildingOfType (issue #437 — arrival-gated actions) ────
+//
+// RED PHASE: the function currently always throws 'not implemented'. Every
+// test below fails until the implementer fills in the real nearest-search.
+
+describe('findNearestActiveBuildingOfType', () => {
+  it('returns null when no building of that type exists at all', () => {
+    const state = createBuildingState();
+    placeBuilding(state, 'management_office', 0, 0, 64, 64);
+
+    const result = findNearestActiveBuildingOfType(state, 'living_quarters', 5, 5);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when a building of that type exists but is inactive', () => {
+    const state = createBuildingState();
+    placeBuilding(state, 'living_quarters', 0, 0, 64, 64);
+    state.buildings[0]!.active = false;
+
+    const result = findNearestActiveBuildingOfType(state, 'living_quarters', 1, 1);
+    expect(result).toBeNull();
+  });
+
+  it('returns the sole matching active building when only one exists', () => {
+    const state = createBuildingState();
+    placeBuilding(state, 'living_quarters', 10, 10, 64, 64);
+    const building = state.buildings[0]!;
+
+    const result = findNearestActiveBuildingOfType(state, 'living_quarters', 0, 0);
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe(building.id);
+  });
+
+  it('returns the nearest of several matching buildings by Euclidean distance from (x, z)', () => {
+    const state = createBuildingState();
+    placeBuilding(state, 'living_quarters', 0, 0, 64, 64);   // distance from (20,20) ≈ 28.28
+    placeBuilding(state, 'living_quarters', 18, 18, 64, 64); // distance from (20,20) ≈ 2.83 — nearest
+    placeBuilding(state, 'living_quarters', 40, 40, 64, 64); // distance from (20,20) ≈ 28.28
+
+    const nearest = state.buildings[1]!;
+    const result = findNearestActiveBuildingOfType(state, 'living_quarters', 20, 20);
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe(nearest.id);
+  });
+
+  it('ignores buildings of a different type even when closer', () => {
+    const state = createBuildingState();
+    placeBuilding(state, 'management_office', 1, 1, 64, 64); // closest, wrong type
+    placeBuilding(state, 'living_quarters', 30, 30, 64, 64); // only correct-type match
+
+    const target = state.buildings[1]!;
+    const result = findNearestActiveBuildingOfType(state, 'living_quarters', 0, 0);
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe(target.id);
+  });
+
+  it('ignores inactive buildings even when they are the nearest of the correct type', () => {
+    const state = createBuildingState();
+    placeBuilding(state, 'living_quarters', 1, 1, 64, 64);
+    state.buildings[0]!.active = false; // nearest, but inactive
+    placeBuilding(state, 'living_quarters', 30, 30, 64, 64); // farther, but active
+
+    const active = state.buildings[1]!;
+    const result = findNearestActiveBuildingOfType(state, 'living_quarters', 0, 0);
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe(active.id);
+  });
+
+  it('a building exactly at the query position has distance 0 and is returned', () => {
+    const state = createBuildingState();
+    placeBuilding(state, 'freight_warehouse', 5, 5, 64, 64);
+    placeBuilding(state, 'freight_warehouse', 20, 20, 64, 64);
+
+    const exact = state.buildings[0]!;
+    const result = findNearestActiveBuildingOfType(state, 'freight_warehouse', 5, 5);
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe(exact.id);
+  });
+
+  it('returns null against an empty building state', () => {
+    const state = createBuildingState();
+    const result = findNearestActiveBuildingOfType(state, 'freight_warehouse', 0, 0);
+    expect(result).toBeNull();
   });
 });

--- a/tests/unit/entities/Building.test.ts
+++ b/tests/unit/entities/Building.test.ts
@@ -220,9 +220,6 @@ describe('placeBuilding — research gating', () => {
 });
 
 // ── findNearestActiveBuildingOfType (issue #437 — arrival-gated actions) ────
-//
-// RED PHASE: the function currently always throws 'not implemented'. Every
-// test below fails until the implementer fills in the real nearest-search.
 
 describe('findNearestActiveBuildingOfType', () => {
   it('returns null when no building of that type exists at all', () => {

--- a/tests/unit/entities/VehicleBoarding.test.ts
+++ b/tests/unit/entities/VehicleBoarding.test.ts
@@ -1,0 +1,172 @@
+// BlastSimulator2026 — Tests for requestBoardVehicle (issue #437)
+//
+// requestBoardVehicle mirrors assignDriver's eager licence/availability
+// validation, but on success only records the employee's *intent* to board
+// (destinationX/Z + pendingDriverVehicleId) — it never sets vehicle.driverId
+// synchronously. ArrivalGate.tickArrivalGate is the only place driverId gets
+// set, once the employee has actually walked to the vehicle.
+//
+// RED PHASE: src/core/entities/VehicleBoarding.ts's requestBoardVehicle always
+// throws 'not implemented'. Every test below fails until the implementer
+// fills in the real request logic.
+
+import { describe, it, expect } from 'vitest';
+import { hireEmployee, assignSkill } from '../../../src/core/entities/Employee.js';
+import { createVehicleState, purchaseVehicle } from '../../../src/core/entities/Vehicle.js';
+import { createGame } from '../../../src/core/state/GameState.js';
+import { Random } from '../../../src/core/math/Random.js';
+import { requestBoardVehicle } from '../../../src/core/entities/VehicleBoarding.js';
+
+const SEED = 42;
+
+describe('requestBoardVehicle — licence validation', () => {
+  it('rejects an employee without the licence the vehicle role requires', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'blaster', rng); // no driving licence
+    const { vehicle } = purchaseVehicle(state.vehicles, 'debris_hauler', 5, 5);
+
+    const result = requestBoardVehicle(state, vehicle.id, employee.id);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(employee.pendingDriverVehicleId).toBeNull();
+    expect(employee.destinationX).toBeNull();
+    expect(employee.destinationZ).toBeNull();
+  });
+
+  it('rejects when the vehicle does not exist', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driver', rng);
+
+    const result = requestBoardVehicle(state, 9999, employee.id);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('rejects when the employee does not exist', () => {
+    const state = createGame({ seed: SEED });
+    const { vehicle } = purchaseVehicle(state.vehicles, 'debris_hauler', 5, 5);
+
+    const result = requestBoardVehicle(state, vehicle.id, 9999);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+});
+
+describe('requestBoardVehicle — availability validation', () => {
+  it('rejects when the vehicle already has a driver', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driver', rng);
+    const { employee: other } = hireEmployee(state.employees, 'driver', new Random(SEED + 1));
+    const { vehicle } = purchaseVehicle(state.vehicles, 'debris_hauler', 5, 5);
+    vehicle.driverId = other.id;
+
+    const result = requestBoardVehicle(state, vehicle.id, employee.id);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('driver');
+    expect(employee.pendingDriverVehicleId).toBeNull();
+  });
+
+  it('rejects when the employee is already driving another vehicle', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driver', rng);
+    const { vehicle: alreadyDriving } = purchaseVehicle(state.vehicles, 'drill_rig', 1, 1);
+    alreadyDriving.driverId = employee.id;
+    const { vehicle: target } = purchaseVehicle(state.vehicles, 'debris_hauler', 5, 5);
+
+    const result = requestBoardVehicle(state, target.id, employee.id);
+
+    expect(result.success).toBe(false);
+    expect(employee.pendingDriverVehicleId).toBeNull();
+  });
+
+  it('rejects a dead employee', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driver', rng);
+    employee.alive = false;
+    const { vehicle } = purchaseVehicle(state.vehicles, 'debris_hauler', 5, 5);
+
+    const result = requestBoardVehicle(state, vehicle.id, employee.id);
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('requestBoardVehicle — happy path defers the actual assignment', () => {
+  it('returns success and sets destination + pendingDriverVehicleId, without touching vehicle.driverId', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driver', rng);
+    const { vehicle } = purchaseVehicle(state.vehicles, 'debris_hauler', 5, 5);
+    employee.x = 0;
+    employee.z = 0;
+
+    const result = requestBoardVehicle(state, vehicle.id, employee.id);
+
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(employee.destinationX).toBe(vehicle.x);
+    expect(employee.destinationZ).toBe(vehicle.z);
+    expect(employee.pendingDriverVehicleId).toBe(vehicle.id);
+    // The core contract under test: no synchronous assignment.
+    expect(vehicle.driverId).toBeNull();
+  });
+
+  it('a higher proficiency level still qualifies the employee to request boarding', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driver', rng);
+    assignSkill(state.employees, employee.id, 'driving.truck', 4);
+    const { vehicle } = purchaseVehicle(state.vehicles, 'debris_hauler', 8, 2);
+
+    const result = requestBoardVehicle(state, vehicle.id, employee.id);
+
+    expect(result.success).toBe(true);
+    expect(employee.destinationX).toBe(8);
+    expect(employee.destinationZ).toBe(2);
+  });
+
+  it('drill_rig role requires driving.drill_rig licence', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driver', rng); // holds driving.truck only
+    const { vehicle } = purchaseVehicle(state.vehicles, 'drill_rig', 3, 3);
+
+    const result = requestBoardVehicle(state, vehicle.id, employee.id);
+
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── Same validations reachable via bare EmployeeState/VehicleState (no GameState) ──
+// requestBoardVehicle's signature takes a GameState per the skeleton, but the
+// underlying employee/vehicle collections it reads/writes are exactly
+// state.employees / state.vehicles — covered implicitly above via createGame().
+// This block re-confirms the module is usable standalone with a minimal state
+// shape built the same way the other entity modules are unit-tested.
+describe('requestBoardVehicle — fixture consistency with core state factories', () => {
+  it('works against a freshly created employee/vehicle pair with no other state mutations', () => {
+    const state = createGame({ seed: SEED });
+    expect(state.employees).toBeDefined();
+    expect(state.vehicles).toBeDefined();
+
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driver', rng);
+    const { vehicle } = purchaseVehicle(state.vehicles, 'debris_hauler', 5, 5);
+
+    const before = { cash: state.cash };
+    const result = requestBoardVehicle(state, vehicle.id, employee.id);
+
+    expect(result.success).toBe(true);
+    // No cash side effect from a boarding request.
+    expect(state.cash).toBe(before.cash);
+  });
+});

--- a/tests/unit/entities/VehicleBoarding.test.ts
+++ b/tests/unit/entities/VehicleBoarding.test.ts
@@ -5,10 +5,6 @@
 // (destinationX/Z + pendingDriverVehicleId) — it never sets vehicle.driverId
 // synchronously. ArrivalGate.tickArrivalGate is the only place driverId gets
 // set, once the employee has actually walked to the vehicle.
-//
-// RED PHASE: src/core/entities/VehicleBoarding.ts's requestBoardVehicle always
-// throws 'not implemented'. Every test below fails until the implementer
-// fills in the real request logic.
 
 import { describe, it, expect } from 'vitest';
 import { hireEmployee, assignSkill } from '../../../src/core/entities/Employee.js';

--- a/tests/unit/nav/NavGrid.test.ts
+++ b/tests/unit/nav/NavGrid.test.ts
@@ -8,7 +8,7 @@
 //   BlastResult      (§15):    clearedRegion returned by executeBlast
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { NavGrid, type NavCellType } from '../../../src/core/nav/NavGrid.js';
+import { NavGrid, type NavCellType, type NavCell } from '../../../src/core/nav/NavGrid.js';
 import { VoxelGrid, type VoxelData } from '../../../src/core/world/VoxelGrid.js';
 import type { Building } from '../../../src/core/entities/Building.js';
 import type { DrillHole } from '../../../src/core/mining/DrillPlan.js';
@@ -977,5 +977,109 @@ describe('executeBlast — clearedRegion', () => {
     expect(result!.clearedRegion.maxX).toBeDefined();
     expect(result!.clearedRegion.minZ).toBeDefined();
     expect(result!.clearedRegion.maxZ).toBeDefined();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 4: findNearestTraversableCell / findNearestReachableCell (#437 fix —
+// spawn placement for `vehicle buy` / `employee hire` so new hires/vehicles
+// don't land inside a blast-crater void).
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/** Build a hand-crafted NavGrid directly from a type grid, rows[z][x]. Bypasses VoxelGrid entirely for precise control over which cells are walkable/blocked. */
+function makeNavGridFromTypes(rows: NavCellType[][]): NavGrid {
+  const height = rows.length;
+  const width = rows[0]!.length;
+  const cells = rows.map(row => row.map((type): NavCell => {
+    const moveCost = type === 'walkable' ? 1.0 : type === 'ramp' ? 1.8 : type === 'drill_hole' ? 5.0 : Infinity;
+    return { type, moveCost, benchLevel: 0, vehicleOccupied: false };
+  }));
+  return new NavGrid(width, height, cells, 0);
+}
+
+describe('NavGrid.findNearestTraversableCell', () => {
+  it('returns the point unchanged when it is already traversable', () => {
+    const nav = makeNavGridFromTypes([
+      ['walkable', 'walkable', 'walkable'],
+      ['walkable', 'walkable', 'walkable'],
+      ['walkable', 'walkable', 'walkable'],
+    ]);
+    const result = NavGrid.findNearestTraversableCell(nav, 1, 1);
+    expect(result).toEqual({ x: 1, z: 1 });
+  });
+
+  it('searches outward in expanding rings to find the nearest traversable cell', () => {
+    // 5×5 grid, entirely blocked except a single walkable cell at (4,4).
+    const rows: NavCellType[][] = Array.from({ length: 5 }, () =>
+      Array.from({ length: 5 }, (): NavCellType => 'blocked'));
+    rows[4]![4] = 'walkable';
+    const nav = makeNavGridFromTypes(rows);
+
+    const result = NavGrid.findNearestTraversableCell(nav, 0, 0);
+    expect(result).toEqual({ x: 4, z: 4 });
+  });
+
+  it('returns the original point unchanged when nothing traversable exists within maxRadius', () => {
+    // Same grid as above, but the walkable cell at (4,4) is farther than the
+    // search bound allows.
+    const rows: NavCellType[][] = Array.from({ length: 5 }, () =>
+      Array.from({ length: 5 }, (): NavCellType => 'blocked'));
+    rows[4]![4] = 'walkable';
+    const nav = makeNavGridFromTypes(rows);
+
+    const result = NavGrid.findNearestTraversableCell(nav, 0, 0, 2);
+    expect(result).toEqual({ x: 0, z: 0 });
+  });
+});
+
+describe('NavGrid.findNearestReachableCell', () => {
+  it('returns the target unchanged when it is already traversable and path-connected to the anchor', () => {
+    const rows: NavCellType[][] = Array.from({ length: 5 }, () =>
+      Array.from({ length: 5 }, (): NavCellType => 'walkable'));
+    const nav = makeNavGridFromTypes(rows);
+
+    const result = NavGrid.findNearestReachableCell(nav, 0, 0, 4, 4);
+    expect(result).toEqual({ x: 4, z: 4 });
+  });
+
+  it('falls back to the target unchanged when the anchor itself resolves to no traversable cell', () => {
+    const rows: NavCellType[][] = Array.from({ length: 5 }, () =>
+      Array.from({ length: 5 }, (): NavCellType => 'blocked'));
+    const nav = makeNavGridFromTypes(rows);
+
+    const result = NavGrid.findNearestReachableCell(nav, 0, 0, 2, 2);
+    expect(result).toEqual({ x: 2, z: 2 });
+  });
+
+  it('skips a cell that is nearest by raw distance but walled off from the anchor, in favor of an actually reachable cell', () => {
+    // 7×7 grid: a walkable pocket at (3,3) is fully surrounded on all 8 sides
+    // by blocked cells, isolating it from the rest of the (otherwise entirely
+    // walkable) grid, which anchor (0,0) sits in. findNearestTraversableCell
+    // on (3,3) would return (3,3) unchanged (it IS traversable) — but nothing
+    // can actually path there, which is exactly the bug this function fixes.
+    const rows: NavCellType[][] = Array.from({ length: 7 }, () =>
+      Array.from({ length: 7 }, (): NavCellType => 'walkable'));
+    for (const [x, z] of [[2, 2], [3, 2], [4, 2], [2, 3], [4, 3], [2, 4], [3, 4], [4, 4]] as const) {
+      rows[z]![x] = 'blocked';
+    }
+    const nav = makeNavGridFromTypes(rows);
+
+    // Sanity: the pocket itself is traversable, and pure-distance search
+    // (findNearestTraversableCell) on it returns itself unchanged — it does
+    // not know the cell is unreachable.
+    expect(NavGrid.findNearestTraversableCell(nav, 3, 3)).toEqual({ x: 3, z: 3 });
+
+    const result = NavGrid.findNearestReachableCell(nav, 0, 0, 3, 3);
+
+    // Must not be the isolated pocket itself.
+    expect(result).not.toEqual({ x: 3, z: 3 });
+    // Must be an actually walkable, reachable cell.
+    expect(nav.cells[result.z]![result.x]!.type).toBe('walkable');
+    // The 8 ring cells immediately surrounding the pocket are all blocked, so
+    // the true nearest reachable cell sits one ring farther out — distance²
+    // 4 (e.g. (1,3), (5,3), (3,1), (3,5)) — never distance² 1 or 2, which
+    // would mean it picked one of the (blocked) ring cells or the pocket.
+    const distSq = (result.x - 3) ** 2 + (result.z - 3) ** 2;
+    expect(distSq).toBe(4);
   });
 });

--- a/tests/unit/scenario-defs.test.ts
+++ b/tests/unit/scenario-defs.test.ts
@@ -61,6 +61,7 @@ const FEATURE_SCENARIO_NAMES = [
   'level1-lose-revolt',
   'level1-win-conservative',
   'level1-win-efficient',
+  'hauling-gate',
 ] as const;
 
 const VISUAL_SCENARIO_NAMES = [


### PR DESCRIPTION
Closes #437

## Summary

Every entity action that requires being at a location now gates its effect/timer start on the acting entity's actual navmesh arrival, instead of starting at claim time:

- **Survey** — employee must physically reach the survey `(x, z)` before `taskTicksRemaining` starts (`src/core/mining/Survey.ts` path, wired via `src/console/commands/events.ts`).
- **Eating/resting** (canteen, bunkhouse, break room) — `restTicksRemaining` no longer starts until the employee is at the building's approach cell (`src/core/engine/GameLoop.ts`: `tickNeedRestoration`, `tickCollapse`, `autoInsertNeedTasks`, `forceShiftRestIfNeeded`).
- **Vehicle boarding** — `vehicle driver`/`assignDriver` now requires the employee to walk to the vehicle first; boarding is no longer instant regardless of distance (`src/core/entities/VehicleBoarding.ts`, shares validation with `Vehicle.assignDriver` via a new `canAssignDriver` predicate).
- **Hauling** (new minimal mechanic) — a hauler moves to a rock/debris fragment, loads it, moves to a container building, then unloads (`src/core/economy/HaulingTask.ts`, new `vehicle haul <vehicleId> fragment:<fragmentId>` console command).

All four gate through one shared mechanism, `src/core/engine/ArrivalGate.ts`, reused rather than duplicated per action type as the issue required. `src/core/nav/BuildingApproach.ts` is new — building footprints are NavGrid-blocked, so any arrival-gated destination at `building.x/z` was previously unreachable; it finds the nearest walkable approach cell instead.

**Broader audit fix:** exercising the real multi-tick flows (not just unit tests) surfaced that `employee hire`/`vehicle buy` spawn new entities at the raw world-centre point with no regard to terrain — the tutorial's own drill grid blasts a crater through that exact point, landing new hires/vehicles on an unreachable void tile with no path out. Fixed via a new `NavGrid.findNearestReachableCell` (BFS flood fill from a known-good anchor, unlike a distance-only ring search which can return an isolated pocket). This is what tutorial beat 15 was actually hitting once vehicle boarding became arrival-gated.

**Scenario coverage:** all 12 survey defs, needs/rest defs, and vehicle defs listed in the issue were audited; those that didn't already exercise a real travel phase were fixed (building/dispatch coordinate collisions that silently made rest/boarding instant, wrong building type in `collapse-recovery.json`). New `scripts/scenario-defs/hauling-gate.json` added for the new mechanic. Full 103-scenario suite re-audited for other instant-resolution assumptions; none found beyond the fixed set.

## Decisions taken

Defaulted under `agentic-decision-autonomy`:

- **What was open:** the issue's audit ("apply the same gate... the four cases above are illustrative, not exhaustive") could be read to include `EmployeeTraining.enrolInTraining`'s instant relocate-to-school teleport, which is also a claim-time, position-dependent effect.
  **Chosen:** left it un-gated. `enrolInTraining`'s teleport is an existing, intentional design from #410 (schools relocate the employee instantly rather than making them walk). Gating it would replace that design, which is a larger behavioral change than this issue's four named cases ask for.
  **Why:** the issue's explicit scope is survey/rest/boarding/hauling; broadening to training reopens a settled, separately-numbered design decision rather than closing this one.
  **If reversed:** wire `EmployeeTraining.enrolInTraining` through `ArrivalGate` the same way `VehicleBoarding.requestBoardVehicle` is (queue a destination + pending state, let `tickArrivalGate` promote it on arrival). No other call site changes.

- **What was open:** the issue asked for "the minimal hauling mechanic needed to enforce the movement gate," with no console-facing surface specified.
  **Chosen:** added `vehicle haul <vehicleId> fragment:<fragmentId>` as a thin wrapper over `requestHaulFragment`, matching the existing `vehicle driver` subcommand's pattern.
  **Why:** the issue's own verification section requires a console session to demonstrate the haul gate end to end; without a command, the core `HaulingTask.ts` logic was unreachable from outside a unit test.
  **If reversed:** remove the `haul` case from `src/console/commands/vehicle.ts`; core logic in `HaulingTask.ts` is unaffected.

## Verification

- **static** — `npx tsc --noEmit`: clean.
- **logic** — `npx vitest run`: 209 test files, 6353 tests, all passing.
- **scenario** — `npm run scenarios`: 103/103 passing, including new `hauling-gate` and all issue-listed defs re-verified to exercise a real travel phase (not just pass by coincidence).
- **visual** — scenario screenshots inspected directly (survey, needs, vehicle, hauling scenarios): entities render at correct in-transit positions during travel, no teleporting, no missing geometry, WCAG AA a11y check passing.
- **playability** — `npm run playtest`: training 7/7 beats, tutorial 21/21 beats, including beat 04 (survey) and beat 15 (vehicle assign) which exercise the arrival gate directly.
- **build** — `npx vite build`: succeeds.

READY TO MERGE
