### PR TITLE
fix: keep placed-building label readable on 4-button rows (#462)

### DIFF
--- a/src/ui/BuildMenu.ts
+++ b/src/ui/BuildMenu.ts
@@ -350,13 +350,13 @@ export class BuildMenu {
       'border-bottom:1px solid rgba(200,160,60,0.1)';
 
     const info = document.createElement('div');
-    info.style.cssText = 'flex:1;min-width:0;font-size:10px;color:#c0a060;overflow:hidden;text-overflow:ellipsis;white-space:nowrap';
+    info.style.cssText = 'flex:1 1 50%;min-width:0;font-size:10px;color:#c0a060;overflow:hidden;text-overflow:ellipsis;white-space:nowrap';
     info.title = `${b.type} T${b.tier} at (${b.x},${b.z})`;
     info.textContent = `#${b.id} ${t(`building.${b.type}.t${b.tier}.name`)} (${b.x},${b.z})`;
 
     const moveBtn = document.createElement('button');
     moveBtn.className = 'bs-btn bs-build-move-btn';
-    moveBtn.style.cssText = 'padding:1px 5px;font-size:9px';
+    moveBtn.style.cssText = 'padding:1px 5px;font-size:9px;flex:0 1 auto;white-space:normal;min-width:0';
     moveBtn.textContent = t('ui.build.move');
     moveBtn.addEventListener('click', () => {
       this.tileSelect.open({
@@ -378,7 +378,7 @@ export class BuildMenu {
 
     const upgradeBtn = document.createElement('button');
     upgradeBtn.className = 'bs-btn bs-btn-primary bs-build-upgrade-btn';
-    upgradeBtn.style.cssText = 'padding:1px 5px;font-size:9px';
+    upgradeBtn.style.cssText = 'padding:1px 5px;font-size:9px;flex:0 1 auto;white-space:normal;min-width:0';
     upgradeBtn.textContent = t('ui.build.upgrade');
     upgradeBtn.disabled = nextTier === null;
     if (nextTier !== null) {
@@ -396,7 +396,7 @@ export class BuildMenu {
 
     const researchBtn = document.createElement('button');
     researchBtn.className = 'bs-btn bs-build-research-btn';
-    researchBtn.style.cssText = 'padding:1px 5px;font-size:9px';
+    researchBtn.style.cssText = 'padding:1px 5px;font-size:9px;flex:0 1 auto;white-space:normal;min-width:0';
     researchBtn.textContent = t('ui.build.queue_research_button');
     researchBtn.style.display = nextTier !== null && nextLocked && !nextQueued ? '' : 'none';
     researchBtn.addEventListener('click', () => {
@@ -405,7 +405,7 @@ export class BuildMenu {
 
     const demolishBtn = document.createElement('button');
     demolishBtn.className = 'bs-btn bs-build-demolish-btn';
-    demolishBtn.style.cssText = 'padding:1px 5px;font-size:9px;color:#ff6644';
+    demolishBtn.style.cssText = 'padding:1px 5px;font-size:9px;color:#ff6644;flex:0 1 auto;white-space:normal;min-width:0';
     demolishBtn.textContent = t('ui.build.demolish');
     demolishBtn.title = `$${def.demolishCost}`;
     demolishBtn.addEventListener('click', () => {

--- a/tests/unit/ui/BuildMenu.test.ts
+++ b/tests/unit/ui/BuildMenu.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+// BlastSimulator2026 — Placed-buildings list layout (issue #462)
+//
+// Bug: `makePlacedRow()`'s `info` div uses plain `flex:1` (no basis) and its
+// four action buttons (Move/Upgrade/Queue Research/Demolish) have no
+// flex/white-space override. With 4 buttons in a 270px-wide `#bs-build-panel`
+// the `info` column collapses to near-zero width, showing only a stray
+// fragment of the label (e.g. a lone ':') for rows like Research Center that
+// still show the "Queue Research" button. `makeCatalogRow()` already ships
+// the fix for the identical defect (flex:1 1 50% on info, flex:0 1 auto +
+// white-space:normal on buttons) — this file asserts `makePlacedRow()`
+// matches that pattern. jsdom has no layout engine, so assertions check
+// inline style VALUES, not rendered pixel widths.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { BuildMenu } from '../../../src/ui/BuildMenu.js';
+import { createGame } from '../../../src/core/state/GameState.js';
+import type { GameState } from '../../../src/core/state/GameState.js';
+import type { Building } from '../../../src/core/entities/Building.js';
+
+/** Minimal GameState that won't crash the panel update loop. */
+function makeMockState(overrides?: Partial<GameState>): GameState {
+  const s = createGame({ seed: 42, mineType: 'desert' });
+  s.cash = 99999;
+  return { ...s, ...overrides };
+}
+
+function makeBuilding(overrides: Partial<Building> & Pick<Building, 'id' | 'type' | 'tier'>): Building {
+  return {
+    x: 5,
+    z: 5,
+    hp: 100,
+    active: true,
+    ...overrides,
+  };
+}
+
+function setupMenu(): { container: HTMLDivElement; menu: BuildMenu } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const menu = new BuildMenu(container);
+  return { container, menu };
+}
+
+/**
+ * Find a placed-row by building id, scoped to this test's own container.
+ * Deliberately avoids the `#bs-build-placed` id selector: jsdom resolves id
+ * selectors against the whole document rather than the query root, so a
+ * prior test's un-disposed BuildMenu (same id, different container) can
+ * shadow this one. Class + attribute selectors don't have that failure mode.
+ */
+function findPlacedRow(container: HTMLElement, buildingId: number): HTMLElement {
+  const row = container.querySelector<HTMLElement>(
+    `.bs-build-placed-row[data-building-id="${buildingId}"]`,
+  );
+  if (!row) throw new Error(`no placed row found for building id ${buildingId}`);
+  return row;
+}
+
+describe('BuildMenu — placed-row layout does not collapse the label column (issue #462)', () => {
+  let container: HTMLDivElement;
+  let menu: BuildMenu;
+
+  beforeEach(() => {
+    ({ container, menu } = setupMenu());
+  });
+
+  afterEach(() => {
+    menu.dispose();
+    container.remove();
+  });
+
+  it('4-button row (Research Center, tier 2 locked + not queued): info div gets a flex basis and min-width:0, all 4 buttons get flex:0 1 auto + white-space:normal', () => {
+    const researchCenter = makeBuilding({ id: 1, type: 'research_center', tier: 1 });
+    const state = makeMockState();
+    state.buildings.buildings = [researchCenter];
+    // Default unlockedTiers is {} (tier 2 not unlocked) and researchQueue is
+    // empty (nothing queued), so researchBtn is visible — 4 buttons total.
+
+    menu.update(state);
+
+    const row = findPlacedRow(container, 1);
+
+    const info = row.querySelector<HTMLElement>('div');
+    expect(info).not.toBeNull();
+    expect(info!.style.flex).toBe('1 1 50%');
+    expect(info!.style.minWidth).toBe('0px');
+    // Sanity: only CSS changed, label text still complete.
+    expect(info!.textContent).toContain('#1');
+    expect(info!.textContent).toContain('(5,5)');
+
+    const moveBtn = row.querySelector<HTMLButtonElement>('.bs-build-move-btn');
+    const upgradeBtn = row.querySelector<HTMLButtonElement>('.bs-build-upgrade-btn');
+    const researchBtn = row.querySelector<HTMLButtonElement>('.bs-build-research-btn');
+    const demolishBtn = row.querySelector<HTMLButtonElement>('.bs-build-demolish-btn');
+
+    expect(moveBtn).not.toBeNull();
+    expect(upgradeBtn).not.toBeNull();
+    expect(researchBtn).not.toBeNull();
+    expect(demolishBtn).not.toBeNull();
+    // Research Center's own tier 2 must be locked and not queued for the
+    // 4th button to be visible — confirm the fixture actually exercises the
+    // 4-button case before asserting on its buttons.
+    expect(researchBtn!.style.display).not.toBe('none');
+
+    for (const btn of [moveBtn, upgradeBtn, researchBtn, demolishBtn]) {
+      expect(btn!.style.flex).toBe('0 1 auto');
+      expect(btn!.style.whiteSpace).toBe('normal');
+    }
+  });
+
+  it('3-button row (Living Quarters at max tier 3, researchBtn hidden): info div gets a flex basis and min-width:0, all 3 visible buttons get flex:0 1 auto + white-space:normal', () => {
+    const livingQuarters = makeBuilding({ id: 2, type: 'living_quarters', tier: 3 });
+    const state = makeMockState();
+    state.buildings.buildings = [livingQuarters];
+    // Tier 3 is the max tier, so nextTier is null and researchBtn stays
+    // hidden — exactly 3 visible buttons: Move, Upgrade (disabled), Demolish.
+
+    menu.update(state);
+
+    const row = findPlacedRow(container, 2);
+
+    const info = row.querySelector<HTMLElement>('div');
+    expect(info).not.toBeNull();
+    expect(info!.style.flex).toBe('1 1 50%');
+    expect(info!.style.minWidth).toBe('0px');
+    expect(info!.textContent).toContain('#2');
+    expect(info!.textContent).toContain('(5,5)');
+
+    const moveBtn = row.querySelector<HTMLButtonElement>('.bs-build-move-btn');
+    const upgradeBtn = row.querySelector<HTMLButtonElement>('.bs-build-upgrade-btn');
+    const researchBtn = row.querySelector<HTMLButtonElement>('.bs-build-research-btn');
+    const demolishBtn = row.querySelector<HTMLButtonElement>('.bs-build-demolish-btn');
+
+    expect(moveBtn).not.toBeNull();
+    expect(upgradeBtn).not.toBeNull();
+    expect(demolishBtn).not.toBeNull();
+    // Confirm the fixture actually exercises the 3-button case.
+    expect(researchBtn!.style.display).toBe('none');
+
+    for (const btn of [moveBtn, upgradeBtn, demolishBtn]) {
+      expect(btn!.style.flex).toBe('0 1 auto');
+      expect(btn!.style.whiteSpace).toBe('normal');
+    }
+  });
+});


### PR DESCRIPTION
Closes #462

## Summary

Fixes a cosmetic layout bug in the Build panel's "Placed Buildings" list (`src/ui/BuildMenu.ts`, `makePlacedRow()`). A row with 4 action buttons (e.g. a Research Center row: Move/Upgrade/Queue Research/Demolish) squeezed its name/id label down to an unreadable fragment (a stray `:` character), while 3-button rows (e.g. Living Quarters: Move/Upgrade/Demolish) displayed fine.

**Root cause:** the label (`info`) div used bare `flex:1` (shorthand `1 1 0%`) with no shrink floor, so it absorbed all negative flex space before the four content-sized buttons gave up any width, in the fixed 270px `#bs-build-panel`.

**Fix:** mirrors the identical, already-shipped fix in the sibling `makeCatalogRow()` function in the same file:
- `info.style.cssText`: `flex:1` → `flex:1 1 50%` (gives the label a shrink floor)
- `moveBtn`, `upgradeBtn`, `researchBtn`, `demolishBtn`: append `flex:0 1 auto;white-space:normal;min-width:0` (lets multi-word button labels like "Queue Research" wrap onto two lines instead of forcing the name column to zero width)

Cosmetic only — every button remained clickable and functional both before and after; this did not block gameplay.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** the issue's root-cause hint suggested `flex-shrink:0` on a button container or `flex-wrap` on the row; neither matches the actual DOM structure (no button-container wrapper exists — buttons are direct row children).
  **Chosen:** reuse the exact fix pattern already shipped for the identical defect in the sibling `makeCatalogRow()` function (`info: flex:1 1 50%`, buttons: `flex:0 1 auto;white-space:normal;min-width:0`).
  **Why:** `makeCatalogRow` hit and fixed this exact "4th nowrap button collapses the label" bug already (documented inline at `src/ui/BuildMenu.ts` ~line 234-237); reusing the proven pattern is lower-risk than an untested alternative and keeps the two sibling row-rendering functions visually consistent.
  **If reversed:** the five `cssText` literals at `src/ui/BuildMenu.ts` lines ~353, ~359, ~381, ~399, ~408 — revert the appended `flex`/`white-space`/`min-width` fragments.

This decision is a technical implementation choice for a cosmetic fix, not a gameplay/economy/player-facing default — no follow-up `decision-review` issue filed.

## Verification channels run

- **static** (`npm run typecheck`): PASS — 0 errors
- **logic** (`npm run test`): PASS — 214 test files, 6537 tests, including new `tests/unit/ui/BuildMenu.test.ts` (2 tests: 4-button row, 3-button row), confirmed to fail against pre-fix code and pass against the fix
- **integration** (`npm run test:integration`): PASS — 37 files, 425 tests
- **scenario** (`npm run test:scenarios` + `npm run scenarios`): PASS — 2394 scenario-definition tests + 106/106 scenarios in command mode
- **build** (`vite build`): PASS
- **visual** (`npm run playtest -- research-center-gate --screenshots`): PASS — screenshots inspected directly (`screenshots/playtests/research-center-gate/beat-01.png`, `beat-04.png`). Research Center row (4 buttons: Move/Upgrade/Queue Research/Demolish) shows a readable truncated label with all buttons visible and non-overlapping; "Queue Research" wraps onto two lines inside its own button instead of squeezing the label. Living Quarters row (3 buttons) confirmed no regression.
- **playability** (`npm run playtest`): PASS — same run above, 7/7 beats reached, all cash/buildingCount assertions passed
- **a11y** (`npm run a11y`): PASS — all 109 elements meet WCAG AA contrast

Code review: 5/5 reviewers (security, quality, i18n, duplication, semantic) — APPROVE, zero critical/warning findings.

Test count: 6537 unit + 425 integration + 2394 scenario-definition tests, all passing.

READY TO MERGE