### PR TITLE
fix: cancel and refund in-flight research when Research Center is destroyed (#461)

### DIFF
--- a/.claude/skills/gameplay-buildings/SKILL.md
+++ b/.claude/skills/gameplay-buildings/SKILL.md
@@ -96,6 +96,7 @@ Overcapacity (more employees than beds) → well-being penalty for all residents
 - Employees inside → injured
 - Stored contents lost; Explosive Warehouse detonation → secondary blast
 - Well-being, Safety, Ecology score penalties applied
+- Research Center destroyed while its enabling research task is in-flight and no other active Research Center remains → the in-flight task is cancelled and its cost refunded in full; a task still pending behind it in the queue is cancelled/refunded in turn once it reaches the head with no Research Center present. If another active Research Center still exists, the in-flight task is unaffected.
 
 ## Building Effects Summary
 

--- a/.github/skills/gameplay-buildings/SKILL.md
+++ b/.github/skills/gameplay-buildings/SKILL.md
@@ -96,6 +96,7 @@ Overcapacity (more employees than beds) → well-being penalty for all residents
 - Employees inside → injured
 - Stored contents lost; Explosive Warehouse detonation → secondary blast
 - Well-being, Safety, Ecology score penalties applied
+- Research Center destroyed while its enabling research task is in-flight and no other active Research Center remains → the in-flight task is cancelled and its cost refunded in full; a task still pending behind it in the queue is cancelled/refunded in turn once it reaches the head with no Research Center present. If another active Research Center still exists, the in-flight task is unaffected.
 
 ## Building Effects Summary
 

--- a/.opencode/skills/gameplay-buildings/SKILL.md
+++ b/.opencode/skills/gameplay-buildings/SKILL.md
@@ -96,6 +96,7 @@ Overcapacity (more employees than beds) → well-being penalty for all residents
 - Employees inside → injured
 - Stored contents lost; Explosive Warehouse detonation → secondary blast
 - Well-being, Safety, Ecology score penalties applied
+- Research Center destroyed while its enabling research task is in-flight and no other active Research Center remains → the in-flight task is cancelled and its cost refunded in full; a task still pending behind it in the queue is cancelled/refunded in turn once it reaches the head with no Research Center present. If another active Research Center still exists, the in-flight task is unaffected.
 
 ## Building Effects Summary
 

--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -186,7 +186,10 @@ export function tickCommand(
 
     // 8c-2. Research Center queue — advance the head task's progress each tick,
     //       unlocking its target tier when it completes.
-    tickResearch(state.buildings);
+    // TODO: when cancelledResearch is set, refund the cost to cash/finances
+    // and report the cancellation (Research Center destroyed mid-flight).
+    const cancelledResearch = tickResearch(state.buildings);
+    void cancelledResearch;
 
     // 8d. Dispatch remaining pending actions to idle qualified employees.
     // An action requiring a skill nobody on the roster holds is not left to

--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -185,11 +185,17 @@ export function tickCommand(
     }
 
     // 8c-2. Research Center queue — advance the head task's progress each tick,
-    //       unlocking its target tier when it completes.
-    // TODO: when cancelledResearch is set, refund the cost to cash/finances
-    // and report the cancellation (Research Center destroyed mid-flight).
+    //       unlocking its target tier when it completes. If the enabling
+    //       Research Center was destroyed mid-flight, the task is cancelled
+    //       and its cost refunded instead.
     const cancelledResearch = tickResearch(state.buildings);
-    void cancelledResearch;
+    if (cancelledResearch) {
+      state.cash += cancelledResearch.refund;
+      addIncome(state.finances, cancelledResearch.refund, 'refund',
+        `Research cancelled: ${cancelledResearch.targetType} T${cancelledResearch.targetTier} (Research Center destroyed)`,
+        state.tickCount);
+      lines.push(`[tick ${state.tickCount}] Research cancelled: ${cancelledResearch.targetType} tier ${cancelledResearch.targetTier} — Research Center destroyed, $${cancelledResearch.refund} refunded.`);
+    }
 
     // 8d. Dispatch remaining pending actions to idle qualified employees.
     // An action requiring a skill nobody on the roster holds is not left to

--- a/src/core/economy/Finance.ts
+++ b/src/core/economy/Finance.ts
@@ -4,7 +4,7 @@
 
 // ── Categories ──
 
-export type IncomeCategory = 'sales' | 'contracts' | 'bonus';
+export type IncomeCategory = 'sales' | 'contracts' | 'bonus' | 'refund';
 export type ExpenseCategory = 'salaries' | 'equipment' | 'fines' | 'maintenance' | 'fuel' | 'materials' | 'construction' | 'corruption' | 'mafia' | 'needs';
 
 // ── Transaction records ──

--- a/src/core/entities/Building.ts
+++ b/src/core/entities/Building.ts
@@ -361,7 +361,7 @@ export {
 export {
   queueResearchTask, tickResearch, isTierUnlocked, isResearchQueued,
   hasActiveResearchCenter, getUnmetConditions, getQueueBlockCode,
-  type QueueBlockCode,
+  type QueueBlockCode, type CancelledResearch,
 } from './BuildingResearch.js';
 export { getLivingQuartersWellbeingMultiplier } from './BuildingWellbeing.js';
 export {

--- a/src/core/entities/BuildingResearch.ts
+++ b/src/core/entities/BuildingResearch.ts
@@ -114,17 +114,31 @@ export function queueResearchTask(
 }
 
 /**
+ * A research task cancelled mid-flight because the Research Center enabling it
+ * was destroyed (or otherwise no longer active). The queued cost is refunded
+ * to the caller, who is responsible for crediting it back to cash/finances.
+ */
+export interface CancelledResearch {
+  targetType: BuildingType;
+  targetTier: 2 | 3;
+  refund: number;
+}
+
+/**
  * Tick the research queue. Decrements head task's ticksRemaining.
  * When ticksRemaining reaches 0: set unlockedTiers[targetType] = targetTier, remove from queue.
+ * TODO: implement cancellation check — if no active research_center remains,
+ * cancel the head task and return a CancelledResearch describing the refund.
  */
-export function tickResearch(state: BuildingState): void {
+export function tickResearch(state: BuildingState): CancelledResearch | undefined {
   const task = state.researchQueue[0];
-  if (!task) return;
+  if (!task) return undefined;
   task.ticksRemaining -= 1;
   if (task.ticksRemaining <= 0) {
     state.unlockedTiers[task.targetType] = task.targetTier;
     state.researchQueue.shift();
   }
+  return undefined;
 }
 
 /**

--- a/src/core/entities/BuildingResearch.ts
+++ b/src/core/entities/BuildingResearch.ts
@@ -125,14 +125,22 @@ export interface CancelledResearch {
 }
 
 /**
- * Tick the research queue. Decrements head task's ticksRemaining.
- * When ticksRemaining reaches 0: set unlockedTiers[targetType] = targetTier, remove from queue.
- * TODO: implement cancellation check — if no active research_center remains,
- * cancel the head task and return a CancelledResearch describing the refund.
+ * Tick the research queue. If no active Research Center remains for the head
+ * task (the enabling building was destroyed mid-flight, or otherwise
+ * deactivated), the head task is cancelled and removed from the queue, and
+ * its cost is returned for the caller to refund — this check runs every
+ * tick, not just at queue time, so a task loses its enabling building it is
+ * cancelled rather than silently completing. Otherwise, decrement the head
+ * task's ticksRemaining; when it reaches 0, set
+ * unlockedTiers[targetType] = targetTier and remove it from the queue.
  */
 export function tickResearch(state: BuildingState): CancelledResearch | undefined {
   const task = state.researchQueue[0];
   if (!task) return undefined;
+  if (!hasActiveResearchCenter(state)) {
+    state.researchQueue.shift();
+    return { targetType: task.targetType, targetTier: task.targetTier, refund: task.cost };
+  }
   task.ticksRemaining -= 1;
   if (task.ticksRemaining <= 0) {
     state.unlockedTiers[task.targetType] = task.targetTier;

--- a/tests/integration/research.integration.test.ts
+++ b/tests/integration/research.integration.test.ts
@@ -278,6 +278,116 @@ describe('research command — status (#410)', () => {
   });
 });
 
+// ── Research Center — destroyed mid-research cancels + refunds (#461) ────────
+//
+// Reverses the earlier queue-time-only decision (see the removed "research
+// center check is queue-time only" unit-test block): once no active
+// research_center remains, tickResearch cancels the in-flight head task and
+// the tick loop (events.ts tickCommand) must credit the refund to cash and
+// log a 'refund'-category finance transaction.
+
+describe('Research Center — destroyed mid-research cancels + refunds (#461)', () => {
+  it('cancels an in-flight tier-3 task and refunds its exact cost when the sole Research Center is destroyed', () => {
+    const ctx = makeCtx();
+    placeResearchCenter(ctx);
+    const centerId = ctx.state!.buildings.buildings.find((b) => b.type === 'research_center')!.id;
+
+    researchCommand(ctx, ['queue'], { type: 'driving_center', tier: '2' });
+    tickCommand(ctx, ['1'], {}); // completes tier-2 instantly
+
+    researchCommand(ctx, ['queue'], { type: 'driving_center', tier: '3' });
+    const cost = ctx.state!.buildings.researchQueue[0]!.cost;
+    expect(cost).toBeGreaterThan(0);
+
+    tickCommand(ctx, ['5'], {}); // partway through the tier-3 task
+    expect(ctx.state!.buildings.researchQueue).toHaveLength(1);
+    expect(isTierUnlocked(ctx.state!.buildings, 'driving_center', 3)).toBe(false);
+
+    buildCommand(ctx, ['destroy', String(centerId)], {});
+    expect(ctx.state!.buildings.buildings.some((b) => b.type === 'research_center')).toBe(false);
+
+    const cashBefore = ctx.state!.cash;
+    tickCommand(ctx, ['1'], {}); // cancellation tick
+    const cashAfter = ctx.state!.cash;
+
+    expect(ctx.state!.buildings.researchQueue).toHaveLength(0);
+    expect(isTierUnlocked(ctx.state!.buildings, 'driving_center', 3)).toBe(false);
+    expect(cashAfter - cashBefore).toBe(cost);
+
+    const refundTx = ctx.state!.finances.transactions.find((t) => t.category === 'refund');
+    expect(refundTx).toBeDefined();
+    expect(refundTx!.amount).toBe(cost);
+  });
+
+  it('keeps a task progressing to normal completion when one of two Research Centers is destroyed', () => {
+    const ctx = makeCtx();
+    placeResearchCenter(ctx, '10,10');
+    placeResearchCenter(ctx, '50,50');
+    const centerIds = ctx.state!.buildings.buildings
+      .filter((b) => b.type === 'research_center')
+      .map((b) => b.id);
+
+    researchCommand(ctx, ['queue'], { type: 'driving_center', tier: '2' });
+    tickCommand(ctx, ['1'], {});
+    researchCommand(ctx, ['queue'], { type: 'driving_center', tier: '3' });
+
+    buildCommand(ctx, ['destroy', String(centerIds[0])], {});
+    expect(ctx.state!.buildings.buildings.some((b) => b.type === 'research_center')).toBe(true);
+
+    tickCommand(ctx, ['500'], {});
+
+    expect(isTierUnlocked(ctx.state!.buildings, 'driving_center', 3)).toBe(true);
+    expect(ctx.state!.buildings.researchQueue).toHaveLength(0);
+    expect(ctx.state!.finances.transactions.some((t) => t.category === 'refund')).toBe(false);
+  });
+
+  it('cancels and refunds a queued tier-2 (0-tick) task destroyed before the next tick', () => {
+    const ctx = makeCtx();
+    placeResearchCenter(ctx);
+    const centerId = ctx.state!.buildings.buildings.find((b) => b.type === 'research_center')!.id;
+
+    researchCommand(ctx, ['queue'], { type: 'geology_lab', tier: '2' });
+    const cost = ctx.state!.buildings.researchQueue[0]!.cost;
+
+    buildCommand(ctx, ['destroy', String(centerId)], {});
+
+    tickCommand(ctx, ['1'], {});
+
+    expect(ctx.state!.buildings.researchQueue).toHaveLength(0);
+    expect(isTierUnlocked(ctx.state!.buildings, 'geology_lab', 2)).toBe(false);
+
+    const refundTx = ctx.state!.finances.transactions.find((t) => t.category === 'refund');
+    expect(refundTx).toBeDefined();
+    expect(refundTx!.amount).toBe(cost);
+  });
+
+  it('drains multiple queued tasks one cancellation per tick, refunding each, once the center is destroyed', () => {
+    const ctx = makeCtx();
+    placeResearchCenter(ctx);
+    const centerId = ctx.state!.buildings.buildings.find((b) => b.type === 'research_center')!.id;
+
+    researchCommand(ctx, ['queue'], { type: 'driving_center', tier: '2' });
+    const cost1 = ctx.state!.buildings.researchQueue[0]!.cost;
+    researchCommand(ctx, ['queue'], { type: 'blasting_academy', tier: '2' });
+    const cost2 = ctx.state!.buildings.researchQueue[1]!.cost;
+    expect(ctx.state!.buildings.researchQueue).toHaveLength(2);
+
+    buildCommand(ctx, ['destroy', String(centerId)], {});
+
+    const cashBefore = ctx.state!.cash;
+    tickCommand(ctx, ['10'], {});
+    const cashAfter = ctx.state!.cash;
+
+    expect(ctx.state!.buildings.researchQueue).toHaveLength(0);
+    expect(isTierUnlocked(ctx.state!.buildings, 'driving_center', 2)).toBe(false);
+    expect(isTierUnlocked(ctx.state!.buildings, 'blasting_academy', 2)).toBe(false);
+    expect(cashAfter - cashBefore).toBe(cost1 + cost2);
+
+    const refundTxs = ctx.state!.finances.transactions.filter((t) => t.category === 'refund');
+    expect(refundTxs).toHaveLength(2);
+  });
+});
+
 // ── research → tick → unlock end-to-end ───────────────────────────────────────
 
 describe('research → tick → unlock end-to-end (#410, #442)', () => {

--- a/tests/unit/entities/BuildingResearch.test.ts
+++ b/tests/unit/entities/BuildingResearch.test.ts
@@ -452,10 +452,16 @@ describe('getQueueBlockCode', () => {
   });
 });
 
-// ── Section 5: demolished research_center does not interrupt an in-flight task ──
+// ── Section 5: tickResearch — Research Center destroyed mid-research (#461) ──
+//
+// REVERSES the earlier (queue-time-only) decision: an in-flight task is now
+// cancelled — not silently completed — the moment no active research_center
+// remains. `hasActiveResearchCenter` is the live, per-tick source of truth;
+// there is no latch remembering a past destruction (a re-placed center lets
+// the task resume).
 
-describe('queueResearchTask / tickResearch — research center check is queue-time only', () => {
-  it('a task queued while a research_center exists keeps progressing after the center is removed', () => {
+describe('tickResearch — Research Center destroyed mid-research (#461)', () => {
+  it('cancels an in-flight tier-3 task and refunds its exact cost when the sole active research_center is destroyed', () => {
     const state = freshState();
     placeResearchCenter(state);
 
@@ -465,17 +471,126 @@ describe('queueResearchTask / tickResearch — research center check is queue-ti
 
     const t3 = queueResearchTask(state, 'vehicle_depot', 3);
     expect(t3.success, JSON.stringify(t3)).toBe(true);
-    const ticksNeeded = getResearchTaskDef('vehicle_depot', 3).ticks;
-    expect(ticksNeeded).toBeGreaterThan(0);
+    const def = getResearchTaskDef('vehicle_depot', 3);
+    expect(def.ticks).toBeGreaterThan(1);
 
-    // Demolish the research_center entirely — no active center remains.
-    state.buildings.splice(0, state.buildings.length);
+    // Tick partway through — still in-flight.
+    tickResearch(state);
+    expect(state.researchQueue[0]!.ticksRemaining).toBe(def.ticks - 1);
+
+    // Destroy the sole active research_center.
+    const center = state.buildings.find((b) => b.type === 'research_center')!;
+    center.active = false;
     expect(hasActiveResearchCenter(state)).toBe(false);
 
-    // The in-flight task must still progress and complete on schedule.
-    for (let i = 0; i < ticksNeeded; i++) tickResearch(state);
-    expect(isTierUnlocked(state, 'vehicle_depot', 3)).toBe(true);
+    const result = tickResearch(state);
+    expect(result).toEqual({ targetType: 'vehicle_depot', targetTier: 3, refund: def.cost });
     expect(state.researchQueue).toHaveLength(0);
+    expect(isTierUnlocked(state, 'vehicle_depot', 3)).toBe(false);
+  });
+
+  it('does NOT cancel when a second research_center remains active — ticksRemaining decrements normally', () => {
+    const state = freshState();
+    placeResearchCenter(state, 0, 0);
+    placeResearchCenter(state, 20, 20);
+
+    queueResearchTask(state, 'vehicle_depot', 2);
+    tickResearch(state);
+    queueResearchTask(state, 'vehicle_depot', 3);
+    const before = state.researchQueue[0]!.ticksRemaining;
+
+    // Destroy only one of the two active centers.
+    state.buildings[0]!.active = false;
+    expect(hasActiveResearchCenter(state)).toBe(true);
+
+    const result = tickResearch(state);
+    expect(result).toBeUndefined();
+    expect(state.researchQueue[0]!.ticksRemaining).toBe(before - 1);
+  });
+
+  it('is a live per-tick check, not a latch: re-placing a center before the next tick lets the task survive', () => {
+    const state = freshState();
+    placeResearchCenter(state);
+
+    queueResearchTask(state, 'vehicle_depot', 2);
+    tickResearch(state);
+    queueResearchTask(state, 'vehicle_depot', 3);
+    const before = state.researchQueue[0]!.ticksRemaining;
+
+    // Destroy the only active center...
+    state.buildings[0]!.active = false;
+    expect(hasActiveResearchCenter(state)).toBe(false);
+
+    // ...then place a new one before the next tickResearch call.
+    placeResearchCenter(state, 60, 60);
+    expect(hasActiveResearchCenter(state)).toBe(true);
+
+    const result = tickResearch(state);
+    expect(result).toBeUndefined();
+    expect(state.researchQueue[0]!.ticksRemaining).toBe(before - 1);
+  });
+
+  it('cancels a 0-tick tier-2 task before it can silently complete, when the center is destroyed first', () => {
+    const state = freshState();
+    placeResearchCenter(state);
+
+    const q = queueResearchTask(state, 'driving_center', 2);
+    expect(q.success, JSON.stringify(q)).toBe(true);
+    const def = getResearchTaskDef('driving_center', 2);
+    expect(def.ticks).toBe(0);
+
+    // Destroy the center BEFORE the first tickResearch call.
+    state.buildings[0]!.active = false;
+    expect(hasActiveResearchCenter(state)).toBe(false);
+
+    const result = tickResearch(state);
+    expect(result).toEqual({ targetType: 'driving_center', targetTier: 2, refund: def.cost });
+    expect(state.researchQueue).toHaveLength(0);
+    expect(isTierUnlocked(state, 'driving_center', 2)).toBe(false);
+  });
+
+  it('cancels multiple queued tasks one at a time across successive ticks, never both in one call', () => {
+    const state = freshState();
+    placeResearchCenter(state);
+
+    const q1 = queueResearchTask(state, 'driving_center', 2);
+    const q2 = queueResearchTask(state, 'blasting_academy', 2);
+    expect(q1.success, JSON.stringify(q1)).toBe(true);
+    expect(q2.success, JSON.stringify(q2)).toBe(true);
+    expect(state.researchQueue).toHaveLength(2);
+
+    state.buildings[0]!.active = false;
+    expect(hasActiveResearchCenter(state)).toBe(false);
+
+    const r1 = tickResearch(state);
+    expect(r1).toEqual({
+      targetType: 'driving_center',
+      targetTier: 2,
+      refund: getResearchTaskDef('driving_center', 2).cost,
+    });
+    expect(state.researchQueue).toHaveLength(1);
+    expect(state.researchQueue[0]!.targetType).toBe('blasting_academy');
+
+    const r2 = tickResearch(state);
+    expect(r2).toEqual({
+      targetType: 'blasting_academy',
+      targetTier: 2,
+      refund: getResearchTaskDef('blasting_academy', 2).cost,
+    });
+    expect(state.researchQueue).toHaveLength(0);
+
+    // No crash, no phantom refund, once the queue is empty.
+    expect(() => tickResearch(state)).not.toThrow();
+    expect(tickResearch(state)).toBeUndefined();
+  });
+
+  it('returns undefined on an empty queue regardless of whether an active research_center exists', () => {
+    const withCenter = freshState();
+    placeResearchCenter(withCenter);
+    expect(tickResearch(withCenter)).toBeUndefined();
+
+    const withoutCenter = freshState();
+    expect(tickResearch(withoutCenter)).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Closes #461

## Summary

Reverses one of the decisions defaulted by PR #460 (closes #442), per explicit human instruction on issue #461: when the Research Center enabling an in-flight research task is destroyed mid-research, the research is now **cancelled and its cost refunded**. Previously (queue-time-only check), the task kept progressing/completing regardless of demolition.

Other decisions recorded in #461 from PR #460 (flat cost/duration across building types, single `research_completed` condition on tier-3 tasks, synchronous-ish tier-2 completion at `ticksRemaining: 0`) are untouched — explicitly out of scope per the trigger comment ("other chosen decisions are fine at least for now").

## Changes

- `src/core/entities/BuildingResearch.ts` — `tickResearch` now checks `hasActiveResearchCenter(state)` before progressing/completing the head task. If no active Research Center remains, the head task is cancelled (removed from queue, `unlockedTiers` left untouched) and a `CancelledResearch { targetType, targetTier, refund }` descriptor is returned. Stays core-pure — no cash mutation in this module.
- `src/core/entities/Building.ts` — re-exports the new `CancelledResearch` type.
- `src/core/economy/Finance.ts` — adds `'refund'` to `IncomeCategory`.
- `src/console/commands/events.ts` — `tickCommand` wires the cancellation: credits `state.cash`, records a `'refund'`-category `addIncome` transaction, and emits a `[tick N] Research cancelled: ...` diagnostic line.
- `tests/unit/entities/BuildingResearch.test.ts`, `tests/integration/research.integration.test.ts` — replaced the old test asserting the previous "queue-time only" behavior with coverage for: single-center destruction (cancel+refund), second center surviving (task unaffected), live per-tick re-placement (not a latch), 0-tick tier-2 tasks cancelled before completing, multi-task drain (one cancellation per tick, no double refund), and empty-queue safety.
- `.claude/skills/gameplay-buildings/SKILL.md` (+ synced `.github/` and `.opencode/` copies) — documents the corrected destruction-effects behavior.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run; these fill in mechanics the human's instruction didn't spell out.

- **What was open:** exactly when the "active Research Center" check should fire relative to the per-tick decrement, and whether the check applies only to the in-progress (head) task or the whole queue at once.
  **Chosen:** check runs at the top of `tickResearch`, before the head task's `ticksRemaining` decrement, and applies to the head task only each call — pending tasks behind it are cancelled one at a time as each naturally becomes head on a later tick with no center present.
  **Why:** matches the codebase's existing "in progress" vs "pending" distinction, and resolves the 0-tick tier-2 edge case (destroy-then-immediately-complete) for free without a special branch.
  **If reversed:** move the `hasActiveResearchCenter` check in `tickResearch` (`src/core/entities/BuildingResearch.ts`), or extend it to sweep the whole queue in one call.
- **What was open:** how to categorize the refund transaction in the finance ledger — no existing `IncomeCategory` fit a cost reversal.
  **Chosen:** added a new `'refund'` category to `IncomeCategory` in `src/core/economy/Finance.ts`.
  **Why:** reusing `'contracts'` or `'bonus'` would misreport this in financial breakdowns.
  **If reversed:** rename/remove the `'refund'` literal and the one call site in `events.ts`.
- **What was open:** whether destruction should also affect already-completed research (`unlockedTiers`), since the issue only says "the research is cancelled."
  **Chosen:** left `unlockedTiers` untouched — only in-flight/pending queue entries are affected by center destruction.
  **Why:** issue is scoped to work-in-progress; retroactively re-locking completed research isn't part of the ask.
  **If reversed:** no code lever exists today — would need new logic, only add if a human asks for it.

## Verification

- `static`: `npm run typecheck` — clean, 0 errors.
- `logic`: `npm run test` — 214 files, 6578 tests, all passing.
- `scenario`: `npm run scenarios` — 106/106 passing.
- `build`: `npm run build` — succeeds.
- Context validation: `npm run validate:context` — passing (skill doc copies stay in sync).
- `visual`/`playability`: not applicable — change confined to `src/core/` and `src/console/`, no renderer/UI/player-facing flow touched.
- Code review: security, quality, i18n, duplication, semantic reviewers all PASS (0 critical, 0 warning; 3 non-blocking suggestions: a doc-comment typo, an optional `creditIncome` helper for future income-side symmetry, and a pre-existing unrelated file-size overage in `events.ts`).

READY TO MERGE