### PR TITLE
Stop auto-labelling issues ready — keep label control manual/agent-authored

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -45,7 +45,7 @@ Prefix categories:
 
 ## ▶ Autonomous pipeline sessions
 
-The project takes one human input: a GitHub issue. Filing one starts a run — intake labels it, the queue assigns it, and the run carries it to a merged pull request or to a stated blocker. A run always leaves its issue in a terminal state; an issue left holding `in-progress` stalls every assignment behind it.
+The project takes one human input: a GitHub issue. Filing one does not by itself start a run — label assignment stays with the filer. A run starts once `ready` is on the issue (the issue form's own default, an agent authoring the issue per `agentic-issue-creation`, or a human adding it by hand); the queue then assigns it and carries it to a merged pull request or to a stated blocker. A run always leaves its issue in a terminal state; an issue left holding `in-progress` stalls every assignment behind it.
 
 A session started by the autonomous pipeline — a GitHub Actions run woken by the `@claude` mention in a pipeline assignment comment — is not an ordinary session. Its first action is to hand the task to the `orchestrator` agent, which classifies it and delegates every step to specialists. Never implement a pipeline-assigned task in the main session, and never explore the codebase before the orchestrator has classified it. The `/agentic-run` command carries that mandate; the system around it is described in `agentic-autonomous-pipeline`.
 

--- a/.claude/skills/agentic-autonomous-pipeline/references/github-loop.md
+++ b/.claude/skills/agentic-autonomous-pipeline/references/github-loop.md
@@ -31,7 +31,7 @@ agentic-intake.yml                          auto-assign-next.yml  agentic-watchd
 
 | Entry | Fires on | Covers |
 |-------|----------|--------|
-| `agentic-intake.yml` | `issues: opened, reopened, labeled` | The only human input. A filed issue starts a run by itself; a `ready` label on a previously `blocked` issue is the whole resume procedure |
+| `agentic-intake.yml` | `issues: opened, reopened, labeled` | The only human input, but filing alone does not start a run — `ready` does, whether it arrives with the issue (the form's own `labels:` default, or an agent authoring the issue per `agentic-issue-creation`) or a human adds it later. A `ready` label on a previously `blocked` issue is the whole resume procedure |
 | `auto-assign-next.yml` | `pull_request: opened, synchronize, closed` | Auto-merge on `READY TO MERGE`, then chain from the merge to the next issue |
 | `agentic-watchdog.yml` | hourly schedule | Sweeps stalled runs, then restarts the queue if the pipeline is idle |
 | `agentic-trigger.yml` | manual dispatch | A human forcing the queue forward |
@@ -42,20 +42,20 @@ Events get lost — GitHub keeps one pending run per concurrency group and drops
 
 | Label | Means | Applied by | Cleared by |
 |-------|-------|-----------|-----------|
-| `agent-task` | The pipeline owns this issue | Intake, or the issue form | — |
-| `ready` | Waiting in the assignment queue | Intake, the issue form, or a human unblocking | `agentic-assign`, on assignment |
+| `agent-task` | The pipeline owns this issue | The issue form, or an agent authoring the issue | — |
+| `ready` | Waiting in the assignment queue | The issue form, an agent authoring the issue, or a human adding it by hand | `agentic-assign`, on assignment |
 | `in-progress` | A run owns it. Single flight reads this label | `agentic-assign` | The merged-PR chain, the run itself when its deliverable is not a diff, `agentic-rescue` when the run ended without finishing, or the watchdog |
 | `blocked` | Halted; a human has to answer something | The run, `agentic-rescue`, or the watchdog | A human, by adding `ready` |
 | `done` | Finished | The merged-PR chain, or a run releasing a non-PR deliverable | — |
 | `decision-review` | A default the run chose, revisit at leisure. Carries no `ready`, so it never enters the queue | The run — see `agentic-decision-autonomy` | A human, by adding `ready` |
 
-Intake labels an issue `agent-task` + `ready` only when it carries none of these. A human filing from the web form, from a phone, or through the API produces different labels each way and often none at all, and `agentic-assign` selects on `ready` alone — an unlabelled issue would otherwise be invisible to the pipeline forever.
+Intake never applies `agent-task` or `ready` itself — that would take label assignment out of the hands of whoever files the issue. `agentic-assign` selects on `ready` alone, so an issue only enters the queue once something puts `ready` on it: the "Agent Task" form's own `labels:` default, an agent following `agentic-issue-creation`, or a human adding it by hand — including to resume a `blocked` issue, or to opt a free-form/API-filed issue in. A human filing without the form and without `ready` gets an issue that sits unlabelled and out of the queue until they choose to add it; that is deliberate, not an oversight.
 
 **An issue is released by whoever finishes it.** A run whose deliverable is a pull request is released by the merge. A run whose deliverable is an answer or an executed command releases its own issue — closes it, labels it `done`, drops `in-progress`. Skipping that leaves single flight deferring behind a run that already succeeded, until the watchdog ages it out and reports it as lost.
 
 ## Two rules keep the loop alive
 
-1. **Comments must be posted with `PAT_TOKEN_COPILOT_AUTOMATION`.** A comment created with `GITHUB_TOKEN` triggers no workflow, so the loop stops silently. The same applies to the PR: one opened with `GITHUB_TOKEN` raises no `pull_request` event, leaving `auto-assign-next.yml` dormant. The inverse is also load-bearing: intake labels with `GITHUB_TOKEN` precisely so its own `ready` label raises no event and the workflow cannot retrigger itself. The rule reaches `git push`, where it has to be enforced differently: `git push` reads no token from the environment, so a step that merely sets `GH_TOKEN` pushes with whatever credential the job's git configuration holds — and after the agent step that is the agent's own GitHub App token, which no `permissions:` block can grant `workflows` to, because there is no such key. A branch differing from `main` on a workflow file is then rejected outright. `agentic-rescue` pushes to an explicitly authenticated URL so the PAT is the credential actually used.
+1. **Comments must be posted with `PAT_TOKEN_COPILOT_AUTOMATION`.** A comment created with `GITHUB_TOKEN` triggers no workflow, so the loop stops silently. The same applies to the PR: one opened with `GITHUB_TOKEN` raises no `pull_request` event, leaving `auto-assign-next.yml` dormant. The inverse is also load-bearing: the `label` job's own housekeeping (ensuring the label definitions exist, dropping a stale `done` on reopen) runs under `GITHUB_TOKEN` precisely so it raises no event the workflow could retrigger on — intake itself never applies `ready`, so this only matters for the labels it does still touch. The rule reaches `git push`, where it has to be enforced differently: `git push` reads no token from the environment, so a step that merely sets `GH_TOKEN` pushes with whatever credential the job's git configuration holds — and after the agent step that is the agent's own GitHub App token, which no `permissions:` block can grant `workflows` to, because there is no such key. A branch differing from `main` on a workflow file is then rejected outright. `agentic-rescue` pushes to an explicitly authenticated URL so the PAT is the credential actually used.
 
    **The agent step needs the PAT stated twice.** `claude-code-action` exports its own `github_token` input into the session environment, overriding the step-level `GH_TOKEN` — so that input is the identity `gh pr create` actually runs under. Left as `GITHUB_TOKEN`, the PR is authored by `github-actions[bot]`, and GitHub creates its `pull_request` workflow runs already parked as `action_required`: "N workflows awaiting approval", no CI, no `auto-assign-next.yml`. Both `claude-code-action` steps in `claude-runner.yml` therefore pass `PAT_TOKEN_COPILOT_AUTOMATION` as `github_token`. `opencode-runner.yml` needs no equivalent — opencode reads `GH_TOKEN` from the step environment and overrides nothing.
 

--- a/.claude/skills/agentic-issue-creation/SKILL.md
+++ b/.claude/skills/agentic-issue-creation/SKILL.md
@@ -16,7 +16,7 @@ Two shapes are valid, and they differ in how much of the answer is already known
 | **Intent** | A human filing from the issue form or free-form | Context, Task, Verification, and any Blocked by. The planner derives the files and the tests. |
 | **Complete** | An agent decomposing a feature into atomic tasks | Every section below. The decomposition already knows the file layout, so it states it. |
 
-Both enter the same queue. Intake labels whatever arrives, so a two-line issue typed from a phone is a valid input — where it leaves a choice open, the run defaults it under `agentic-decision-autonomy` rather than bouncing it back.
+Both enter the same queue once `ready` lands on the issue — a two-line issue typed from a phone is still a valid input, and where it leaves a choice open, the run defaults it under `agentic-decision-autonomy` rather than bouncing it back.
 
 ## ▶ PROCEDURE — EXECUTE IN ORDER
 
@@ -24,9 +24,11 @@ Both enter the same queue. Intake labels whatever arrives, so a two-line issue t
 2. Fill every section that shape carries, using the headings below verbatim
 3. Verify the Rules are satisfied
 4. Run through the Checklist
-5. Create the issue with `gh issue create`
+5. Create the issue with `gh issue create`, setting labels yourself:
+   - Human gave no instruction about labels → `--label ready,agent-task`. That is the default, not intake's — a **Complete**-shape issue you authored is ready to run the moment it exists, and intake no longer assigns `ready` on its own.
+   - Human specified labels, or said the issue should wait — `decision-review` for a default to revisit later, or an explicit hold — → follow that instruction instead, and leave `ready` off.
 
-Intake applies `agent-task` and `ready` on its own, and the issue joins the queue in number order. An issue that must **stay out** of the queue is created carrying a lifecycle label of its own — `decision-review` for a default to revisit later — because intake leaves an issue's labels alone once it has one.
+An issue that must **stay out** of the queue is created carrying a lifecycle label of its own instead of `ready` — `decision-review` for a default to revisit later. The issue joins the queue in number order once `ready` is on it, whoever put it there.
 
 ## Issue Body Template
 
@@ -80,3 +82,4 @@ Intake applies `agent-task` and `ready` on its own, and the issue joins the queu
 - [ ] An issue that must stay out of the queue carries its own lifecycle label
 - [ ] Interaction-mode risk assessed → `full-ci` added when the change affects UI, rendering, or interaction
 - [ ] If the issue has `full-ci`, the PR gets `full-ci` when opened
+- [ ] Labels set on creation: `ready,agent-task` unless the human specified otherwise or the issue must stay out of the queue

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,7 +71,7 @@ Five independent channels prove a change works. Each catches what the others mis
 
 ## ▶ Autonomous pipeline sessions
 
-The project takes one human input: a GitHub issue. Filing one starts a run — intake labels it, the queue assigns it, and the run carries it to a merged pull request or to a stated blocker. A run always leaves its issue in a terminal state; an issue left holding `in-progress` stalls every assignment behind it.
+The project takes one human input: a GitHub issue. Filing one does not by itself start a run — label assignment stays with the filer. A run starts once `ready` is on the issue (the issue form's own default, an agent authoring the issue per `agentic-issue-creation`, or a human adding it by hand); the queue then assigns it and carries it to a merged pull request or to a stated blocker. A run always leaves its issue in a terminal state; an issue left holding `in-progress` stalls every assignment behind it.
 
 A session started by the autonomous pipeline — a GitHub Actions run woken by the configured agent mention in a pipeline assignment comment — is not an ordinary session. Its first action is to run as the orchestrator: classify the task, then delegate every step to specialists. Never implement a pipeline-assigned task directly, and never explore the codebase before the task has been classified. The `/agentic-run` command carries that mandate; the system around it is described in `agentic-autonomous-pipeline`.
 

--- a/.github/skills/agentic-autonomous-pipeline/references/github-loop.md
+++ b/.github/skills/agentic-autonomous-pipeline/references/github-loop.md
@@ -31,7 +31,7 @@ agentic-intake.yml                          auto-assign-next.yml  agentic-watchd
 
 | Entry | Fires on | Covers |
 |-------|----------|--------|
-| `agentic-intake.yml` | `issues: opened, reopened, labeled` | The only human input. A filed issue starts a run by itself; a `ready` label on a previously `blocked` issue is the whole resume procedure |
+| `agentic-intake.yml` | `issues: opened, reopened, labeled` | The only human input, but filing alone does not start a run — `ready` does, whether it arrives with the issue (the form's own `labels:` default, or an agent authoring the issue per `agentic-issue-creation`) or a human adds it later. A `ready` label on a previously `blocked` issue is the whole resume procedure |
 | `auto-assign-next.yml` | `pull_request: opened, synchronize, closed` | Auto-merge on `READY TO MERGE`, then chain from the merge to the next issue |
 | `agentic-watchdog.yml` | hourly schedule | Sweeps stalled runs, then restarts the queue if the pipeline is idle |
 | `agentic-trigger.yml` | manual dispatch | A human forcing the queue forward |
@@ -42,20 +42,20 @@ Events get lost — GitHub keeps one pending run per concurrency group and drops
 
 | Label | Means | Applied by | Cleared by |
 |-------|-------|-----------|-----------|
-| `agent-task` | The pipeline owns this issue | Intake, or the issue form | — |
-| `ready` | Waiting in the assignment queue | Intake, the issue form, or a human unblocking | `agentic-assign`, on assignment |
+| `agent-task` | The pipeline owns this issue | The issue form, or an agent authoring the issue | — |
+| `ready` | Waiting in the assignment queue | The issue form, an agent authoring the issue, or a human adding it by hand | `agentic-assign`, on assignment |
 | `in-progress` | A run owns it. Single flight reads this label | `agentic-assign` | The merged-PR chain, the run itself when its deliverable is not a diff, `agentic-rescue` when the run ended without finishing, or the watchdog |
 | `blocked` | Halted; a human has to answer something | The run, `agentic-rescue`, or the watchdog | A human, by adding `ready` |
 | `done` | Finished | The merged-PR chain, or a run releasing a non-PR deliverable | — |
 | `decision-review` | A default the run chose, revisit at leisure. Carries no `ready`, so it never enters the queue | The run — see `agentic-decision-autonomy` | A human, by adding `ready` |
 
-Intake labels an issue `agent-task` + `ready` only when it carries none of these. A human filing from the web form, from a phone, or through the API produces different labels each way and often none at all, and `agentic-assign` selects on `ready` alone — an unlabelled issue would otherwise be invisible to the pipeline forever.
+Intake never applies `agent-task` or `ready` itself — that would take label assignment out of the hands of whoever files the issue. `agentic-assign` selects on `ready` alone, so an issue only enters the queue once something puts `ready` on it: the "Agent Task" form's own `labels:` default, an agent following `agentic-issue-creation`, or a human adding it by hand — including to resume a `blocked` issue, or to opt a free-form/API-filed issue in. A human filing without the form and without `ready` gets an issue that sits unlabelled and out of the queue until they choose to add it; that is deliberate, not an oversight.
 
 **An issue is released by whoever finishes it.** A run whose deliverable is a pull request is released by the merge. A run whose deliverable is an answer or an executed command releases its own issue — closes it, labels it `done`, drops `in-progress`. Skipping that leaves single flight deferring behind a run that already succeeded, until the watchdog ages it out and reports it as lost.
 
 ## Two rules keep the loop alive
 
-1. **Comments must be posted with `PAT_TOKEN_COPILOT_AUTOMATION`.** A comment created with `GITHUB_TOKEN` triggers no workflow, so the loop stops silently. The same applies to the PR: one opened with `GITHUB_TOKEN` raises no `pull_request` event, leaving `auto-assign-next.yml` dormant. The inverse is also load-bearing: intake labels with `GITHUB_TOKEN` precisely so its own `ready` label raises no event and the workflow cannot retrigger itself. The rule reaches `git push`, where it has to be enforced differently: `git push` reads no token from the environment, so a step that merely sets `GH_TOKEN` pushes with whatever credential the job's git configuration holds — and after the agent step that is the agent's own GitHub App token, which no `permissions:` block can grant `workflows` to, because there is no such key. A branch differing from `main` on a workflow file is then rejected outright. `agentic-rescue` pushes to an explicitly authenticated URL so the PAT is the credential actually used.
+1. **Comments must be posted with `PAT_TOKEN_COPILOT_AUTOMATION`.** A comment created with `GITHUB_TOKEN` triggers no workflow, so the loop stops silently. The same applies to the PR: one opened with `GITHUB_TOKEN` raises no `pull_request` event, leaving `auto-assign-next.yml` dormant. The inverse is also load-bearing: the `label` job's own housekeeping (ensuring the label definitions exist, dropping a stale `done` on reopen) runs under `GITHUB_TOKEN` precisely so it raises no event the workflow could retrigger on — intake itself never applies `ready`, so this only matters for the labels it does still touch. The rule reaches `git push`, where it has to be enforced differently: `git push` reads no token from the environment, so a step that merely sets `GH_TOKEN` pushes with whatever credential the job's git configuration holds — and after the agent step that is the agent's own GitHub App token, which no `permissions:` block can grant `workflows` to, because there is no such key. A branch differing from `main` on a workflow file is then rejected outright. `agentic-rescue` pushes to an explicitly authenticated URL so the PAT is the credential actually used.
 
    **The agent step needs the PAT stated twice.** `claude-code-action` exports its own `github_token` input into the session environment, overriding the step-level `GH_TOKEN` — so that input is the identity `gh pr create` actually runs under. Left as `GITHUB_TOKEN`, the PR is authored by `github-actions[bot]`, and GitHub creates its `pull_request` workflow runs already parked as `action_required`: "N workflows awaiting approval", no CI, no `auto-assign-next.yml`. Both `claude-code-action` steps in `claude-runner.yml` therefore pass `PAT_TOKEN_COPILOT_AUTOMATION` as `github_token`. `opencode-runner.yml` needs no equivalent — opencode reads `GH_TOKEN` from the step environment and overrides nothing.
 

--- a/.github/skills/agentic-issue-creation/SKILL.md
+++ b/.github/skills/agentic-issue-creation/SKILL.md
@@ -16,7 +16,7 @@ Two shapes are valid, and they differ in how much of the answer is already known
 | **Intent** | A human filing from the issue form or free-form | Context, Task, Verification, and any Blocked by. The planner derives the files and the tests. |
 | **Complete** | An agent decomposing a feature into atomic tasks | Every section below. The decomposition already knows the file layout, so it states it. |
 
-Both enter the same queue. Intake labels whatever arrives, so a two-line issue typed from a phone is a valid input — where it leaves a choice open, the run defaults it under `agentic-decision-autonomy` rather than bouncing it back.
+Both enter the same queue once `ready` lands on the issue — a two-line issue typed from a phone is still a valid input, and where it leaves a choice open, the run defaults it under `agentic-decision-autonomy` rather than bouncing it back.
 
 ## ▶ PROCEDURE — EXECUTE IN ORDER
 
@@ -24,9 +24,11 @@ Both enter the same queue. Intake labels whatever arrives, so a two-line issue t
 2. Fill every section that shape carries, using the headings below verbatim
 3. Verify the Rules are satisfied
 4. Run through the Checklist
-5. Create the issue with `gh issue create`
+5. Create the issue with `gh issue create`, setting labels yourself:
+   - Human gave no instruction about labels → `--label ready,agent-task`. That is the default, not intake's — a **Complete**-shape issue you authored is ready to run the moment it exists, and intake no longer assigns `ready` on its own.
+   - Human specified labels, or said the issue should wait — `decision-review` for a default to revisit later, or an explicit hold — → follow that instruction instead, and leave `ready` off.
 
-Intake applies `agent-task` and `ready` on its own, and the issue joins the queue in number order. An issue that must **stay out** of the queue is created carrying a lifecycle label of its own — `decision-review` for a default to revisit later — because intake leaves an issue's labels alone once it has one.
+An issue that must **stay out** of the queue is created carrying a lifecycle label of its own instead of `ready` — `decision-review` for a default to revisit later. The issue joins the queue in number order once `ready` is on it, whoever put it there.
 
 ## Issue Body Template
 
@@ -80,3 +82,4 @@ Intake applies `agent-task` and `ready` on its own, and the issue joins the queu
 - [ ] An issue that must stay out of the queue carries its own lifecycle label
 - [ ] Interaction-mode risk assessed → `full-ci` added when the change affects UI, rendering, or interaction
 - [ ] If the issue has `full-ci`, the PR gets `full-ci` when opened
+- [ ] Labels set on creation: `ready,agent-task` unless the human specified otherwise or the issue must stay out of the queue

--- a/.github/workflows/agentic-intake.yml
+++ b/.github/workflows/agentic-intake.yml
@@ -1,10 +1,13 @@
 name: "Pipeline: intake a filed issue"
 
-# The one human input the pipeline takes is a GitHub issue, so filing one must
-# be enough to start a run. Without this workflow the loop had no issue-side
-# entry at all: `auto-assign-next.yml` only fires on a merged pull request and
-# `agentic-trigger.yml` is manual dispatch, so an issue filed while the pipeline
-# sat idle waited for a human to press a button.
+# The one human input the pipeline takes is a GitHub issue, but filing one is
+# not by itself enough to start a run — that would take label assignment out
+# of human hands. A run starts only once `ready` is on the issue: set by a
+# human (by hand, or through the issue form's own `labels:` default) or by an
+# agent authoring the issue per `agentic-issue-creation`. This workflow reacts
+# to that label arriving; `auto-assign-next.yml` only fires on a merged pull
+# request and `agentic-trigger.yml` is manual dispatch, so without this one an
+# issue that already carries `ready` would wait for a human to press a button.
 on:
   issues:
     types: [opened, reopened, labeled]
@@ -13,28 +16,19 @@ permissions:
   issues: write
 
 jobs:
-  # Labelling runs unserialised so it can never be dropped: an issue that fails
-  # to get `ready` is invisible to `agentic-assign` and waits forever.
+  # Filing an issue no longer opts it into the queue by itself — that decision
+  # stays with whoever set `ready`: a human, by hand or through the issue
+  # form's own `labels:` default, or an agent authoring the issue per
+  # `agentic-issue-creation`. This job only tidies stale state and reports
+  # whether `ready` already arrived on the payload; it never applies `ready`.
   label:
-    # `labeled` fires for every label the pipeline applies to an issue —
-    # `in-progress` on assignment, `blocked` on escalation, `done` on merge.
-    # Only `ready` means "this issue wants a run", and it is also how a human
-    # resumes a `blocked` issue: drop `blocked`, add `ready`, and the chain
-    # re-enters here with no workflow to dispatch by hand.
-    if: github.event.action != 'labeled' || github.event.label.name == 'ready'
+    if: github.event.action == 'opened' || github.event.action == 'reopened'
     runs-on: ubuntu-latest
     outputs:
       assignable: ${{ steps.labels.outputs.assignable || 'false' }}
     steps:
-      # A human files an issue from the web form, from a phone, or through the
-      # API, and only the form applies labels. `agentic-assign` selects on
-      # `ready` alone, so an unlabelled issue is invisible to the pipeline
-      # forever. Labelling here is deliberately done with GITHUB_TOKEN: the
-      # label raises no further `issues: labeled` event, so this job cannot
-      # retrigger itself.
       - name: Normalise lifecycle labels
         id: labels
-        if: github.event.action != 'labeled'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -47,47 +41,36 @@ jobs:
               (context.payload.issue.labels || []).map((l) => (typeof l === 'string' ? l : l.name))
             );
 
-            // Any of these means the issue already has a place in the pipeline's
-            // lifecycle and its labels are somebody else's to move. `decision-review`
-            // is the deliberate case: the pipeline files those without `ready` so
-            // they wait in the backlog instead of entering the queue.
-            const LIFECYCLE = ['ready', 'in-progress', 'blocked', 'done', 'decision-review'];
-
+            // Ensures the two label definitions exist so a human picking them
+            // from the GitHub UI finds them there. Never applied automatically.
             const ensureLabel = async (name, color, description) => {
               await github.rest.issues.createLabel({ owner, repo, name, color, description })
                 .catch(() => {});
             };
+            await ensureLabel('agent-task', '0e8a16', 'Atomic task for the autonomous pipeline');
+            await ensureLabel('ready', '1d76db', 'Waiting in the assignment queue');
 
-            const add = [];
-            if (!on.has('agent-task')) add.push('agent-task');
-
-            // Reopening is a human saying the work is not finished after all, so
-            // it re-enters the queue: `done` comes off and `ready` goes on.
+            // Reopening is a human saying the work is not finished after all.
+            // `done` no longer reflects reality, but re-entering the queue is
+            // still their call: they add `ready` back themselves.
             if (reopened && on.has('done')) {
               await github.rest.issues.removeLabel({ owner, repo, issue_number: n, name: 'done' })
                 .catch(() => {});
               on.delete('done');
+              core.info(`#${n}: reopened, dropped stale done. Add ready to re-enter the queue.`);
             }
 
-            const claimed = LIFECYCLE.filter((l) => on.has(l));
-            if (claimed.length === 0) {
-              add.push('ready');
-            } else {
-              core.info(`#${n}: already carries ${claimed.join(', ')} — leaving lifecycle labels alone.`);
-            }
-
-            if (add.length > 0) {
-              await ensureLabel('agent-task', '0e8a16', 'Atomic task for the autonomous pipeline');
-              await ensureLabel('ready', '1d76db', 'Waiting in the assignment queue');
-              await github.rest.issues.addLabels({ owner, repo, issue_number: n, labels: add });
-              core.info(`#${n}: added ${add.join(', ')}.`);
-            }
-
-            core.setOutput('assignable', on.has('ready') || add.includes('ready') ? 'true' : 'false');
+            // `ready` here means it arrived with the issue itself — the "Agent
+            // Task" form's `labels:` default, or an agent that set it at
+            // creation. Nothing in this step ever adds it.
+            core.setOutput('assignable', on.has('ready') ? 'true' : 'false');
 
   assign:
     needs: label
-    if: github.event.action == 'labeled' || needs.label.outputs.assignable == 'true'
+    # The `labeled` branch is deliberately narrow: only the `ready` label
+    # itself may start a run. Matching on `action == 'labeled'` alone used to
+    # fire this job for *any* label added to *any* issue in the repo.
+    if: (github.event.action == 'labeled' && github.event.label.name == 'ready') || needs.label.outputs.assignable == 'true'
     runs-on: ubuntu-latest
     # Filing a batch of issues in one sitting fires one intake per issue, and
     # single flight lives in the assign action rather than in GitHub: parallel

--- a/.opencode/AGENTS.md
+++ b/.opencode/AGENTS.md
@@ -71,7 +71,7 @@ Five independent channels prove a change works. Each catches what the others mis
 
 ## ▶ Autonomous pipeline sessions
 
-The project takes one human input: a GitHub issue. Filing one starts a run — intake labels it, the queue assigns it, and the run carries it to a merged pull request or to a stated blocker. A run always leaves its issue in a terminal state; an issue left holding `in-progress` stalls every assignment behind it.
+The project takes one human input: a GitHub issue. Filing one does not by itself start a run — label assignment stays with the filer. A run starts once `ready` is on the issue (the issue form's own default, an agent authoring the issue per `agentic-issue-creation`, or a human adding it by hand); the queue then assigns it and carries it to a merged pull request or to a stated blocker. A run always leaves its issue in a terminal state; an issue left holding `in-progress` stalls every assignment behind it.
 
 A session started by the autonomous pipeline — a GitHub Actions run woken by the configured agent mention in a pipeline assignment comment — is not an ordinary session. Its first action is to run as the orchestrator: classify the task, then delegate every step to specialists. Never implement a pipeline-assigned task directly, and never explore the codebase before the task has been classified. The `/agentic-run` command carries that mandate; the system around it is described in `agentic-autonomous-pipeline`.
 

--- a/.opencode/skills/agentic-autonomous-pipeline/references/github-loop.md
+++ b/.opencode/skills/agentic-autonomous-pipeline/references/github-loop.md
@@ -31,7 +31,7 @@ agentic-intake.yml                          auto-assign-next.yml  agentic-watchd
 
 | Entry | Fires on | Covers |
 |-------|----------|--------|
-| `agentic-intake.yml` | `issues: opened, reopened, labeled` | The only human input. A filed issue starts a run by itself; a `ready` label on a previously `blocked` issue is the whole resume procedure |
+| `agentic-intake.yml` | `issues: opened, reopened, labeled` | The only human input, but filing alone does not start a run — `ready` does, whether it arrives with the issue (the form's own `labels:` default, or an agent authoring the issue per `agentic-issue-creation`) or a human adds it later. A `ready` label on a previously `blocked` issue is the whole resume procedure |
 | `auto-assign-next.yml` | `pull_request: opened, synchronize, closed` | Auto-merge on `READY TO MERGE`, then chain from the merge to the next issue |
 | `agentic-watchdog.yml` | hourly schedule | Sweeps stalled runs, then restarts the queue if the pipeline is idle |
 | `agentic-trigger.yml` | manual dispatch | A human forcing the queue forward |
@@ -42,20 +42,20 @@ Events get lost — GitHub keeps one pending run per concurrency group and drops
 
 | Label | Means | Applied by | Cleared by |
 |-------|-------|-----------|-----------|
-| `agent-task` | The pipeline owns this issue | Intake, or the issue form | — |
-| `ready` | Waiting in the assignment queue | Intake, the issue form, or a human unblocking | `agentic-assign`, on assignment |
+| `agent-task` | The pipeline owns this issue | The issue form, or an agent authoring the issue | — |
+| `ready` | Waiting in the assignment queue | The issue form, an agent authoring the issue, or a human adding it by hand | `agentic-assign`, on assignment |
 | `in-progress` | A run owns it. Single flight reads this label | `agentic-assign` | The merged-PR chain, the run itself when its deliverable is not a diff, `agentic-rescue` when the run ended without finishing, or the watchdog |
 | `blocked` | Halted; a human has to answer something | The run, `agentic-rescue`, or the watchdog | A human, by adding `ready` |
 | `done` | Finished | The merged-PR chain, or a run releasing a non-PR deliverable | — |
 | `decision-review` | A default the run chose, revisit at leisure. Carries no `ready`, so it never enters the queue | The run — see `agentic-decision-autonomy` | A human, by adding `ready` |
 
-Intake labels an issue `agent-task` + `ready` only when it carries none of these. A human filing from the web form, from a phone, or through the API produces different labels each way and often none at all, and `agentic-assign` selects on `ready` alone — an unlabelled issue would otherwise be invisible to the pipeline forever.
+Intake never applies `agent-task` or `ready` itself — that would take label assignment out of the hands of whoever files the issue. `agentic-assign` selects on `ready` alone, so an issue only enters the queue once something puts `ready` on it: the "Agent Task" form's own `labels:` default, an agent following `agentic-issue-creation`, or a human adding it by hand — including to resume a `blocked` issue, or to opt a free-form/API-filed issue in. A human filing without the form and without `ready` gets an issue that sits unlabelled and out of the queue until they choose to add it; that is deliberate, not an oversight.
 
 **An issue is released by whoever finishes it.** A run whose deliverable is a pull request is released by the merge. A run whose deliverable is an answer or an executed command releases its own issue — closes it, labels it `done`, drops `in-progress`. Skipping that leaves single flight deferring behind a run that already succeeded, until the watchdog ages it out and reports it as lost.
 
 ## Two rules keep the loop alive
 
-1. **Comments must be posted with `PAT_TOKEN_COPILOT_AUTOMATION`.** A comment created with `GITHUB_TOKEN` triggers no workflow, so the loop stops silently. The same applies to the PR: one opened with `GITHUB_TOKEN` raises no `pull_request` event, leaving `auto-assign-next.yml` dormant. The inverse is also load-bearing: intake labels with `GITHUB_TOKEN` precisely so its own `ready` label raises no event and the workflow cannot retrigger itself. The rule reaches `git push`, where it has to be enforced differently: `git push` reads no token from the environment, so a step that merely sets `GH_TOKEN` pushes with whatever credential the job's git configuration holds — and after the agent step that is the agent's own GitHub App token, which no `permissions:` block can grant `workflows` to, because there is no such key. A branch differing from `main` on a workflow file is then rejected outright. `agentic-rescue` pushes to an explicitly authenticated URL so the PAT is the credential actually used.
+1. **Comments must be posted with `PAT_TOKEN_COPILOT_AUTOMATION`.** A comment created with `GITHUB_TOKEN` triggers no workflow, so the loop stops silently. The same applies to the PR: one opened with `GITHUB_TOKEN` raises no `pull_request` event, leaving `auto-assign-next.yml` dormant. The inverse is also load-bearing: the `label` job's own housekeeping (ensuring the label definitions exist, dropping a stale `done` on reopen) runs under `GITHUB_TOKEN` precisely so it raises no event the workflow could retrigger on — intake itself never applies `ready`, so this only matters for the labels it does still touch. The rule reaches `git push`, where it has to be enforced differently: `git push` reads no token from the environment, so a step that merely sets `GH_TOKEN` pushes with whatever credential the job's git configuration holds — and after the agent step that is the agent's own GitHub App token, which no `permissions:` block can grant `workflows` to, because there is no such key. A branch differing from `main` on a workflow file is then rejected outright. `agentic-rescue` pushes to an explicitly authenticated URL so the PAT is the credential actually used.
 
    **The agent step needs the PAT stated twice.** `claude-code-action` exports its own `github_token` input into the session environment, overriding the step-level `GH_TOKEN` — so that input is the identity `gh pr create` actually runs under. Left as `GITHUB_TOKEN`, the PR is authored by `github-actions[bot]`, and GitHub creates its `pull_request` workflow runs already parked as `action_required`: "N workflows awaiting approval", no CI, no `auto-assign-next.yml`. Both `claude-code-action` steps in `claude-runner.yml` therefore pass `PAT_TOKEN_COPILOT_AUTOMATION` as `github_token`. `opencode-runner.yml` needs no equivalent — opencode reads `GH_TOKEN` from the step environment and overrides nothing.
 

--- a/.opencode/skills/agentic-issue-creation/SKILL.md
+++ b/.opencode/skills/agentic-issue-creation/SKILL.md
@@ -16,7 +16,7 @@ Two shapes are valid, and they differ in how much of the answer is already known
 | **Intent** | A human filing from the issue form or free-form | Context, Task, Verification, and any Blocked by. The planner derives the files and the tests. |
 | **Complete** | An agent decomposing a feature into atomic tasks | Every section below. The decomposition already knows the file layout, so it states it. |
 
-Both enter the same queue. Intake labels whatever arrives, so a two-line issue typed from a phone is a valid input — where it leaves a choice open, the run defaults it under `agentic-decision-autonomy` rather than bouncing it back.
+Both enter the same queue once `ready` lands on the issue — a two-line issue typed from a phone is still a valid input, and where it leaves a choice open, the run defaults it under `agentic-decision-autonomy` rather than bouncing it back.
 
 ## ▶ PROCEDURE — EXECUTE IN ORDER
 
@@ -24,9 +24,11 @@ Both enter the same queue. Intake labels whatever arrives, so a two-line issue t
 2. Fill every section that shape carries, using the headings below verbatim
 3. Verify the Rules are satisfied
 4. Run through the Checklist
-5. Create the issue with `gh issue create`
+5. Create the issue with `gh issue create`, setting labels yourself:
+   - Human gave no instruction about labels → `--label ready,agent-task`. That is the default, not intake's — a **Complete**-shape issue you authored is ready to run the moment it exists, and intake no longer assigns `ready` on its own.
+   - Human specified labels, or said the issue should wait — `decision-review` for a default to revisit later, or an explicit hold — → follow that instruction instead, and leave `ready` off.
 
-Intake applies `agent-task` and `ready` on its own, and the issue joins the queue in number order. An issue that must **stay out** of the queue is created carrying a lifecycle label of its own — `decision-review` for a default to revisit later — because intake leaves an issue's labels alone once it has one.
+An issue that must **stay out** of the queue is created carrying a lifecycle label of its own instead of `ready` — `decision-review` for a default to revisit later. The issue joins the queue in number order once `ready` is on it, whoever put it there.
 
 ## Issue Body Template
 
@@ -80,3 +82,4 @@ Intake applies `agent-task` and `ready` on its own, and the issue joins the queu
 - [ ] An issue that must stay out of the queue carries its own lifecycle label
 - [ ] Interaction-mode risk assessed → `full-ci` added when the change affects UI, rendering, or interaction
 - [ ] If the issue has `full-ci`, the PR gets `full-ci` when opened
+- [ ] Labels set on creation: `ready,agent-task` unless the human specified otherwise or the issue must stay out of the queue

--- a/README.md
+++ b/README.md
@@ -413,12 +413,12 @@ Required secrets: `PAT_TOKEN_COPILOT_AUTOMATION` (both agents — the loop dies 
 
 ### Trigger paths
 
-**Filing an issue is the whole handover.** Intake labels it `agent-task` + `ready` — whether it came from the issue form, the API, or a sentence typed on a phone — and it joins the queue in number order. The run that picks it up plans it, writes the tests, implements them, verifies the channels the change touches, and opens the pull request that closes it. Where the issue leaves a choice open, the run takes the default the specs imply and records it in the PR rather than waiting for an answer.
+**`ready` is the whole handover, and only a human or an authoring agent puts it there.** Intake no longer defaults an unlabelled issue into the queue — filing one is not by itself enough. The "Agent Task" issue form applies `agent-task` + `ready` itself; an agent creating an issue does the same per `agentic-issue-creation` unless told otherwise; a plain issue (the web form's blank option, the API, a sentence typed on a phone) stays out of the queue until `ready` is added by hand. However it arrives, the issue joins the queue in number order once `ready` is on it, and the run that picks it up plans it, writes the tests, implements them, verifies the channels the change touches, and opens the pull request that closes it. Where the issue leaves a choice open, the run takes the default the specs imply and records it in the PR rather than waiting for an answer.
 
 | Trigger | Result |
 |---------|--------|
-| **File an issue** | Labels it, then assigns the oldest unblocked `ready` issue |
-| Add `ready` to an issue | Same — this is also how you resume a `blocked` one, with nothing to dispatch by hand |
+| **File an issue via the "Agent Task" form** | Labels it `agent-task` + `ready`, then assigns the oldest unblocked `ready` issue |
+| Add `ready` to an issue | Same — this is also how you resume a `blocked` one, or opt in a plain/free-form issue, with nothing to dispatch by hand |
 | A merged PR whose body says `Closes #N` | Closes `#N`, then assigns the next `ready` issue the same way |
 | Hourly watchdog | Sweeps stalled runs, and restarts the queue when the pipeline sits idle with issues waiting |
 | Run the **"Pipeline: run the configured agent on the next ready issue"** workflow | Forces the queue forward by hand |


### PR DESCRIPTION
## Summary

`agentic-intake.yml` had two problems that together explain issue #474 (and any other unexpected Claude run):

- On `opened`/`reopened`, it defaulted **any** issue with no lifecycle label to `ready` + `agent-task` — so filing a plain issue, even a blank one with no intention of starting a run, immediately entered the autonomous queue.
- The `assign` job's trigger condition checked `github.event.action == 'labeled'` with no check on *which* label — so adding **any** label to **any** issue in the repo (not just `ready`) fired the "assign next ready issue" step, which could post the `@claude` mention on a completely unrelated issue at the head of the queue.

## Changes

- `agentic-intake.yml`: intake no longer applies `ready`/`agent-task` on its own. A run starts only when `ready` arrives with the issue (the "Agent Task" form's own `labels:` default, or an agent following `agentic-issue-creation`) or a human adds it by hand. The `assign` job's labelled-event trigger now checks `github.event.label.name == 'ready'` instead of matching any label.
- `agentic-issue-creation` skill (synced across `.claude/`, `.github/`, `.opencode/`): documents that an agent authoring an issue sets its own labels on `gh issue create` — `ready,agent-task` by default when the human gave no label instruction, otherwise following what was asked.
- Synced the documentation that described the old auto-label behavior as designed: `CLAUDE.md` / `AGENTS.md` / `copilot-instructions.md`, `agentic-autonomous-pipeline/references/github-loop.md` (all three runtimes), and `README.md`.

## Test plan

- [x] `npm run validate:context` — passes, including cross-runtime sync check for the three mirrored skill/doc sets
- [x] YAML syntax of `agentic-intake.yml` checked with `python3 -c "import yaml; yaml.safe_load(...)"`
- [ ] No TypeScript/runtime code changed — the Verification Gate (typecheck/test/scenarios/playtest) does not apply to this GitHub Actions + docs change

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_018qxCyCkySV9PqoetdvRCk8)_