### PR TITLE
fix: skip full recipe evaluation for runner-up cover material at low blend weight (#475)

### DIFF
--- a/src/renderer/terrain/TerrainMaterial.ts
+++ b/src/renderer/terrain/TerrainMaterial.ts
@@ -59,10 +59,12 @@ const DETAIL_FULL_DISTANCE = 40;   // metres — everything on
 // actually looks from.
 const DETAIL_FADE_DISTANCE = 320;
 
-// A runner-up cover contributing less than this share of the blend is not
-// worth a full material evaluation — see materialFlatColor / the cover-blend
-// skip below (#475). Exported so test-writer can reference it by name;
-// wired into the GLSL by @implementer.
+// Minimum blend `share` (see the `share` computation further down — a
+// pow(ratio, 3.0) * 0.5 term, range 0..0.5) a runner-up cover material must
+// reach before its cheap flat-colour contribution (materialFlatColor) is
+// even computed. Below it, the pixel shows the winning material's colour
+// with no blend at all: the difference would be at most
+// share * |c_flat - c1|, imperceptible at that low a weight (#475).
 export const COVER_BLEND_SKIP_SHARE = 0.02;
 
 
@@ -142,9 +144,11 @@ vec3 materialAlbedo(int i, vec3 wp, float lod, out float bumpAmt, out float roug
 }
 
 /**
- * Cheap stand-in for materialAlbedo, used for a runner-up cover whose blend
- * share is too small to be worth a full recipe/noise evaluation — plain
- * uniform reads and a mix, no evalRecipe.
+ * Cheap stand-in for materialAlbedo, used for a runner-up cover once its
+ * blend share clears COVER_BLEND_SKIP_SHARE — large enough a weight that a
+ * cheap approximation is worth computing, in place of the full, expensive
+ * recipe/noise evaluation materialAlbedo would otherwise run. Plain uniform
+ * reads and a mix, no evalRecipe.
  */
 vec3 materialFlatColor(int i, out float bumpAmt, out float roughAdj){
   vec4 look = uMatLook[i];
@@ -309,9 +313,13 @@ if (bestI >= 0 && bestW > 0.0) {
   float b1, b2, r1, r2;
   vec3 c1 = materialAlbedo(bestI, vWorldPos, lod, b1, r1);
   vec3 c2 = c1; b2 = b1; r2 = r1;
-  // A runner-up contributing less than COVER_BLEND_SKIP_SHARE of the blend is
-  // shaded with the cheap materialFlatColor stand-in instead of a full
-  // recipe/noise evaluation — its result is barely visible at that weight.
+  // A runner-up contributing MORE than COVER_BLEND_SKIP_SHARE gets the cheap
+  // materialFlatColor stand-in instead of the full recipe/noise evaluation —
+  // materialAlbedo is now never called for the runner-up at all, which is
+  // the performance win. At or below the threshold the blend is dropped
+  // entirely and c2 stays at its c1 default, so the winner's colour stands
+  // alone; this further "skip" costs nothing extra since the difference at
+  // that low a weight would be sub-perceptual.
   if (secondI >= 0 && share > ${COVER_BLEND_SKIP_SHARE}) c2 = materialFlatColor(secondI, b2, r2);
   // Ratio blend, so the crossover between two covers is a gradient whose
   // width follows how close their scores are — never a step.

--- a/src/renderer/terrain/TerrainMaterial.ts
+++ b/src/renderer/terrain/TerrainMaterial.ts
@@ -59,6 +59,12 @@ const DETAIL_FULL_DISTANCE = 40;   // metres — everything on
 // actually looks from.
 const DETAIL_FADE_DISTANCE = 320;
 
+// A runner-up cover contributing less than this share of the blend is not
+// worth a full material evaluation — see materialFlatColor / the cover-blend
+// skip below (#475). Exported so test-writer can reference it by name;
+// wired into the GLSL by @implementer.
+export const COVER_BLEND_SKIP_SHARE = 0.02;
+
 
 // ---------- A19.2 — uniforms, attributes, varyings ----------
 const SUPPORT_GLSL = /* glsl */`
@@ -134,6 +140,9 @@ vec3 materialAlbedo(int i, vec3 wp, float lod, out float bumpAmt, out float roug
   roughAdj = look.z;
   return mix(uMatColor[i], uMatColorAlt[i], t);
 }
+
+// TODO(#475): materialFlatColor(int i, out float bumpAmt, out float roughAdj)
+// goes here — cheap runner-up stand-in (uniform reads + mix, no evalRecipe).
 `;
 
 const FRAGMENT_COMMON_EXTRA = `
@@ -291,6 +300,8 @@ if (bestI >= 0 && bestW > 0.0) {
   float b1, b2, r1, r2;
   vec3 c1 = materialAlbedo(bestI, vWorldPos, lod, b1, r1);
   vec3 c2 = c1; b2 = b1; r2 = r1;
+  // TODO(#475): skip full materialAlbedo for the runner-up when its share is
+  // below COVER_BLEND_SKIP_SHARE — use materialFlatColor instead.
   if (secondI >= 0) c2 = materialAlbedo(secondI, vWorldPos, lod, b2, r2);
   // Ratio blend, so the crossover between two covers is a gradient whose
   // width follows how close their scores are — never a step.

--- a/src/renderer/terrain/TerrainMaterial.ts
+++ b/src/renderer/terrain/TerrainMaterial.ts
@@ -141,8 +141,17 @@ vec3 materialAlbedo(int i, vec3 wp, float lod, out float bumpAmt, out float roug
   return mix(uMatColor[i], uMatColorAlt[i], t);
 }
 
-// TODO(#475): materialFlatColor(int i, out float bumpAmt, out float roughAdj)
-// goes here — cheap runner-up stand-in (uniform reads + mix, no evalRecipe).
+/**
+ * Cheap stand-in for materialAlbedo, used for a runner-up cover whose blend
+ * share is too small to be worth a full recipe/noise evaluation — plain
+ * uniform reads and a mix, no evalRecipe.
+ */
+vec3 materialFlatColor(int i, out float bumpAmt, out float roughAdj){
+  vec4 look = uMatLook[i];
+  bumpAmt = look.y * 0.5;
+  roughAdj = look.z;
+  return mix(uMatColor[i], uMatColorAlt[i], 0.5);
+}
 `;
 
 const FRAGMENT_COMMON_EXTRA = `
@@ -300,9 +309,10 @@ if (bestI >= 0 && bestW > 0.0) {
   float b1, b2, r1, r2;
   vec3 c1 = materialAlbedo(bestI, vWorldPos, lod, b1, r1);
   vec3 c2 = c1; b2 = b1; r2 = r1;
-  // TODO(#475): skip full materialAlbedo for the runner-up when its share is
-  // below COVER_BLEND_SKIP_SHARE — use materialFlatColor instead.
-  if (secondI >= 0) c2 = materialAlbedo(secondI, vWorldPos, lod, b2, r2);
+  // A runner-up contributing less than COVER_BLEND_SKIP_SHARE of the blend is
+  // shaded with the cheap materialFlatColor stand-in instead of a full
+  // recipe/noise evaluation — its result is barely visible at that weight.
+  if (secondI >= 0 && share > ${COVER_BLEND_SKIP_SHARE}) c2 = materialFlatColor(secondI, b2, r2);
   // Ratio blend, so the crossover between two covers is a gradient whose
   // width follows how close their scores are — never a step.
   coverCol = mix(c1, c2, share);

--- a/tests/unit/renderer/TerrainMaterial.test.ts
+++ b/tests/unit/renderer/TerrainMaterial.test.ts
@@ -201,7 +201,9 @@ describe('TerrainMaterial', () => {
     describe('cover-blend flat-colour skip for runner-up material (#475)', () => {
       // The runner-up cover used to always pay a full materialAlbedo() eval
       // (recipe + noise), even when its blend share was negligible. These pin
-      // the cheap materialFlatColor() stand-in that replaces it below share.
+      // the cheap materialFlatColor() stand-in that replaces it once share
+      // exceeds COVER_BLEND_SKIP_SHARE; below the threshold the blend is
+      // skipped entirely and only the winner's colour shows.
       it('declares materialFlatColor(int i, ...) alongside materialAlbedo', () => {
         const mat = makeMaterial();
         const shader = makeFakeShader();

--- a/tests/unit/renderer/TerrainMaterial.test.ts
+++ b/tests/unit/renderer/TerrainMaterial.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect } from 'vitest';
 import * as THREE from 'three';
-import { TerrainMaterial } from '../../../src/renderer/terrain/TerrainMaterial.js';
+import { TerrainMaterial, COVER_BLEND_SKIP_SHARE } from '../../../src/renderer/terrain/TerrainMaterial.js';
 import { getAllRocks } from '../../../src/core/world/RockCatalog.js';
 import { getAllOres } from '../../../src/core/world/OreCatalog.js';
 
@@ -195,6 +195,51 @@ describe('TerrainMaterial', () => {
       it('bumps the program cache key so the old compiled shader is not reused', () => {
         const mat = makeMaterial();
         expect(mat.customProgramCacheKey()).toBe('terrain-material-v5');
+      });
+    });
+
+    describe('cover-blend flat-colour skip for runner-up material (#475)', () => {
+      // The runner-up cover used to always pay a full materialAlbedo() eval
+      // (recipe + noise), even when its blend share was negligible. These pin
+      // the cheap materialFlatColor() stand-in that replaces it below share.
+      it('declares materialFlatColor(int i, ...) alongside materialAlbedo', () => {
+        const mat = makeMaterial();
+        const shader = makeFakeShader();
+        mat.onBeforeCompile(shader, undefined as unknown as THREE.WebGLRenderer);
+
+        expect(shader.fragmentShader).toContain('vec3 materialFlatColor(int i');
+      });
+
+      it('the winner material still gets a full materialAlbedo(bestI, ...) evaluation', () => {
+        const mat = makeMaterial();
+        const shader = makeFakeShader();
+        mat.onBeforeCompile(shader, undefined as unknown as THREE.WebGLRenderer);
+
+        expect(shader.fragmentShader).toContain('materialAlbedo(bestI');
+      });
+
+      it('the runner-up cover is shaded via materialFlatColor(secondI, ...), not materialAlbedo', () => {
+        const mat = makeMaterial();
+        const shader = makeFakeShader();
+        mat.onBeforeCompile(shader, undefined as unknown as THREE.WebGLRenderer);
+
+        expect(shader.fragmentShader).toContain('materialFlatColor(secondI');
+      });
+
+      it('no longer unconditionally calls materialAlbedo(secondI, ...) for the runner-up (regression pin)', () => {
+        const mat = makeMaterial();
+        const shader = makeFakeShader();
+        mat.onBeforeCompile(shader, undefined as unknown as THREE.WebGLRenderer);
+
+        expect(shader.fragmentShader).not.toContain('materialAlbedo(secondI');
+      });
+
+      it('gates the runner-up eval on share exceeding the exported COVER_BLEND_SKIP_SHARE constant', () => {
+        const mat = makeMaterial();
+        const shader = makeFakeShader();
+        mat.onBeforeCompile(shader, undefined as unknown as THREE.WebGLRenderer);
+
+        expect(shader.fragmentShader).toContain(`share > ${COVER_BLEND_SKIP_SHARE}`);
       });
     });
   });


### PR DESCRIPTION
Closes #475

## Summary

Continues the terrain-material shader performance work from #475. Prior optimisations landed in earlier PRs got frame time from ~11600 ms down to ~6400 ms/frame under software rasterization; the material system still roughly doubles frame time vs. the pre-material-system baseline (~3400 ms).

This PR implements option 3 from the issue's remaining-work list: **reduce to one full recipe evaluation per pixel**, blending colours rather than patterns at cover boundaries.

### Change

`src/renderer/terrain/TerrainMaterial.ts`:
- Added `materialFlatColor(int i, out float bumpAmt, out float roughAdj)` — a cheap GLSL stand-in for the runner-up ("second") cover material at a blend boundary: plain uniform reads (`uMatColor`, `uMatColorAlt`, `uMatLook`) and a `mix`, no noise/recipe evaluation.
- Added `COVER_BLEND_SKIP_SHARE = 0.02` constant (same convention as the file's existing `DETAIL_FULL_DISTANCE`/`DETAIL_FADE_DISTANCE` tunables).
- The cover-blend line changed from unconditionally calling the full, expensive `materialAlbedo(secondI, ...)` for the runner-up material, to:
  ```glsl
  if (secondI >= 0 && share > COVER_BLEND_SKIP_SHARE) c2 = materialFlatColor(secondI, b2, r2);
  ```
  `materialAlbedo` is now never called for the runner-up material at all — that's the performance win. Above the skip threshold, the runner-up gets the cheap flat-colour approximation (visible enough to be worth it); at or below it, the blend is dropped entirely and the winning material's colour stands alone (imperceptible difference at that low a weight).
- The winner material (`bestI`) is untouched — still gets a full `materialAlbedo` evaluation. Rock recipe path, `NoiseGLSL.ts`, `MaterialRecipesGLSL.ts` untouched — this scope is cover-blend runner-up shading only.

### Verification

- **static**: `npm run typecheck` — clean.
- **logic**: `npm run test` — 245 files, 7114 tests, all passing.
- **build**: `npm run build` — clean.
- **visual**: screenshots captured and inspected (dev server, `dusty_hollow` campaign level, pre- and post-blast). Terrain shows continuous per-material colour variation (tan/sandy slopes, shadowed ridgelines, ore-tinted streaks, pale cover patches) with smooth blending at material boundaries and at the freshly exposed post-blast crater rock — no seams, no flat/uniform fallback wash (the GLSL-compile-error trap the issue specifically warns about was checked for and not observed). `npm run a11y` and state validation also passed as supporting checks.
- **scenario/playability**: not owed — this change touches only shader-internal rendering cost, no gameplay, UI, or player-facing flow.

7114 tests — all passing.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** the issue lists four remaining options (bake a 3D material texture at load time, cheaper base noise in recipes, one recipe eval per pixel with colour blending, or reduce scenario-harness render resolution) without picking one for this run.
  **Chosen:** option 3 — one full recipe evaluation per pixel (winner only), flat-colour blend for the runner-up.
  **Why:** option 1 (baked 3D texture) is structurally large — load-time generation, memory budget, and the "correct on any cut face" property would need real-GPU verification this pipeline can't do blind in one automated pass. Option 2 (swap gradient noise for value noise per recipe) is a per-material artistic judgment call best validated by eye against CI screenshots iteratively, not in a single blind pass. Option 4 is the issue's own explicitly lowest-preference workaround and doesn't reduce player-facing cost. Option 3 is a single mechanical, easily-verified change with the best payoff-to-risk ratio for one automated TDD cycle.
  **If reversed:** in `src/renderer/terrain/TerrainMaterial.ts`, delete `materialFlatColor` and restore `if (secondI >= 0) c2 = materialAlbedo(secondI, vWorldPos, lod, b2, r2);`.

- **What was open:** the exact skip-threshold value below which the runner-up's blend contribution is dropped entirely.
  **Chosen:** `COVER_BLEND_SKIP_SHARE = 0.02`.
  **Why:** the issue's own "already done" list claims a runner-up-skip-below-a-twentieth-of-blend already existed on `main`; it did not (verified against current `main` — the call was unconditional). Since `share`'s ceiling is 0.5 (`pow(ratio, 3.0) * 0.5`), 0.02 is the closest round constant to "a twentieth of the blend" once that ceiling is accounted for, and matches the file's existing convention of named, commented, tunable render constants.
  **If reversed:** change or remove `COVER_BLEND_SKIP_SHARE` in the same file; removing it collapses the guard to always computing the flat colour.

- **What was open:** per-recipe base-noise substitution (option 2) was not attempted in this run.
  **Chosen:** out of scope; left for a future run.
  **Why:** requires visual iteration against real screenshots per material to avoid changing a material's visual identity (e.g. marble's banding), which this single blind pass can't safely validate.
  **If reversed:** n/a — nothing was implemented to reverse; a follow-up issue can pick this up standalone.

None of these decisions are material to gameplay, economy, or a player-facing default (this is a rendering-performance-only change), so no `decision-review` follow-up issue was filed.

READY TO MERGE
