### PR TITLE
fix: stop tutorial clock deadlocking while driver-assign work is still progressing (#478)

### DIFF
--- a/scripts/shared/playtest-driver.ts
+++ b/scripts/shared/playtest-driver.ts
@@ -52,6 +52,17 @@ export async function tutorialState(page: Page): Promise<TutorialSnapshot> {
   }).__tutorialState()) as Promise<TutorialSnapshot>;
 }
 
+/**
+ * Flip the page's own rAF tick-issuing loop on or off. Used only to bracket a
+ * poll-wait that needs the real, isPaused-gated clock instead of scenarioMode's
+ * deterministic tick-command-only clock.
+ */
+async function setAutoTick(page: Page, enabled: boolean): Promise<void> {
+  await page.evaluate((e: boolean) => (window as unknown as {
+    __setAutoTick: (enabled: boolean) => void;
+  }).__setAutoTick(e), enabled);
+}
+
 export async function gameState(page: Page): Promise<Record<string, unknown>> {
   const state = await page.evaluate(() => (window as unknown as {
     __gameState: () => Record<string, unknown> | null;
@@ -187,18 +198,28 @@ export async function runAction(page: Page, action: PlayerAction): Promise<void>
     case 'awaitTutorialStep': {
       const wanted = Array.isArray(action.stepId) ? action.stepId : [action.stepId];
       const deadline = Date.now() + (action.timeoutMs ?? DEFAULT_TIMEOUT_MS);
-      let seen: TutorialSnapshot | null = null;
-      for (;;) {
-        seen = await tutorialState(page);
-        if (seen.stepId !== null && wanted.includes(seen.stepId)) break;
-        if (Date.now() > deadline) {
-          throw new PlaytestFailure(
-            `tutorial never reached ${wanted.map(s => `"${s}"`).join(' or ')}`
-            + ` — it is on "${seen.stepId}" (${seen.title})`,
-            describeAvailable(await probe(page)),
-          );
+      // Drive the real rAF-driven, isPaused-gated clock for the duration of this
+      // wait only — the same mechanism a real player's browser uses — so that
+      // gates like decideClock's hold/unhold logic are genuinely exercised
+      // instead of bypassed by a scripted tick. Always restored on the way out
+      // so every other scripted action keeps the deterministic scenarioMode clock.
+      await setAutoTick(page, true);
+      try {
+        let seen: TutorialSnapshot | null = null;
+        for (;;) {
+          seen = await tutorialState(page);
+          if (seen.stepId !== null && wanted.includes(seen.stepId)) break;
+          if (Date.now() > deadline) {
+            throw new PlaytestFailure(
+              `tutorial never reached ${wanted.map(s => `"${s}"`).join(' or ')}`
+              + ` — it is on "${seen.stepId}" (${seen.title})`,
+              describeAvailable(await probe(page)),
+            );
+          }
+          await new Promise(r => setTimeout(r, 200));
         }
-        await new Promise(r => setTimeout(r, 200));
+      } finally {
+        await setAutoTick(page, false);
       }
       break;
     }

--- a/src/ui/tutorialGuide.ts
+++ b/src/ui/tutorialGuide.ts
@@ -133,6 +133,26 @@ export interface ClockDecision {
   hold: boolean;
   /** Ticks consumed by the current step so far. */
   spent: number;
+  /** Work signature observed at this decision, carried forward by the caller. */
+  progressSignature: string | null;
+  /** Tick at which the carried-forward signature last changed. */
+  lastProgressTick: number;
+}
+
+/** Tracks the outstanding work's signature and when it last changed. */
+export interface ClockProgress {
+  signature: string | null;
+  tick: number;
+}
+
+/**
+ * Fingerprint of the outstanding work so `decideClock` can tell "still moving"
+ * from "stuck" instead of granting a flat grace window from step start.
+ */
+// TODO: implement
+function workSignature(state: GameState): string {
+  void state;
+  return '';
 }
 
 /**
@@ -172,12 +192,22 @@ export function decideClock(
   stepStartTick: number,
   budget: number = DEFAULT_TICK_BUDGET,
   waitsOnWork: boolean = false,
+  progress: ClockProgress = { signature: null, tick: stepStartTick },
 ): ClockDecision {
+  // TODO: implement — workSignature will replace the flat WORK_GRACE_TICKS
+  // window with a check against `progress` once the fix lands.
+  void workSignature;
   const spent = Math.max(0, (state.tickCount ?? 0) - stepStartTick);
-  if (spent < budget) return { hold: false, spent };
-  if (!waitsOnWork) return { hold: true, spent };
+  if (spent < budget) {
+    return { hold: false, spent, progressSignature: progress.signature, lastProgressTick: progress.tick };
+  }
+  if (!waitsOnWork) {
+    return { hold: true, spent, progressSignature: progress.signature, lastProgressTick: progress.tick };
+  }
 
-  if (isWorkInProgress(state) && spent < budget + WORK_GRACE_TICKS) return { hold: false, spent };
+  if (isWorkInProgress(state) && spent < budget + WORK_GRACE_TICKS) {
+    return { hold: false, spent, progressSignature: progress.signature, lastProgressTick: progress.tick };
+  }
 
-  return { hold: true, spent };
+  return { hold: true, spent, progressSignature: progress.signature, lastProgressTick: progress.tick };
 }

--- a/src/ui/tutorialGuide.ts
+++ b/src/ui/tutorialGuide.ts
@@ -234,7 +234,14 @@ export function decideClock(
 
   const signature = workSignature(state);
   const changed = progress.signature !== null && signature !== progress.signature;
-  const lastProgressTick = changed ? tickCount : progress.tick;
+  // No progress observed yet (first-ever check for this step): anchor the
+  // grace window to when work-checking begins — stepStartTick + budget — not
+  // to progress.tick, which a caller may have left at stepStartTick. Anchoring
+  // there would let the grace window start counting before the budget itself
+  // had even elapsed, silently widening it.
+  const lastProgressTick = progress.signature === null
+    ? Math.max(progress.tick, stepStartTick + budget)
+    : (changed ? tickCount : progress.tick);
   const sinceProgress = tickCount - lastProgressTick;
 
   if (sinceProgress < WORK_GRACE_TICKS) {

--- a/src/ui/tutorialGuide.ts
+++ b/src/ui/tutorialGuide.ts
@@ -7,6 +7,7 @@
 // Kept apart from TutorialOverlay, which owns the card and the step sequence.
 
 import type { GameState } from '../core/state/GameState.js';
+import type { Employee } from '../core/entities/Employee.js';
 import type { TutorialStage } from './tutorialStages.js';
 
 /** Marks the body while the tutorial holds the rails. */
@@ -148,6 +149,15 @@ export interface ClockProgress {
 }
 
 /**
+ * Whether an employee still has work outstanding: a queued/active action, or
+ * movement in flight with no action attached yet (see `isWorkInProgress`).
+ * Shared by `isWorkInProgress` and `workSignature` so the two stay in sync.
+ */
+function hasOutstandingWork(e: Employee): boolean {
+  return e.activeActionId !== null || e.pendingDriverVehicleId !== null || e.destinationX !== null;
+}
+
+/**
  * Fingerprint of the outstanding work so `decideClock` can tell "still moving"
  * from "stuck" instead of granting a flat grace window from step start.
  *
@@ -161,7 +171,7 @@ function workSignature(state: GameState): string {
     .join(',');
 
   const working = state.employees.employees
-    .filter((e) => e.activeActionId !== null || e.pendingDriverVehicleId !== null || e.destinationX !== null)
+    .filter(hasOutstandingWork)
     .slice()
     .sort((a, b) => a.id - b.id)
     .map((e) => [
@@ -188,11 +198,7 @@ function workSignature(state: GameState): string {
  */
 function isWorkInProgress(state: GameState): boolean {
   if ((state.pendingActions?.length ?? 0) > 0) return true;
-  return state.employees.employees.some(
-    (e) => e.activeActionId !== null
-      || e.pendingDriverVehicleId !== null
-      || e.destinationX !== null,
-  );
+  return state.employees.employees.some(hasOutstandingWork);
 }
 
 /**

--- a/src/ui/tutorialGuide.ts
+++ b/src/ui/tutorialGuide.ts
@@ -27,9 +27,11 @@ export const HIGHLIGHT_CLASS = 'bs-tutorial-highlight';
 export const DEFAULT_TICK_BUDGET = 10;
 
 /**
- * Extra ticks granted while queued work is outstanding. Pausing with work in
- * flight would deadlock a step whose completion depends on that work finishing,
- * so the clock keeps running — but not forever.
+ * Extra ticks granted after the outstanding work last showed progress. Pausing
+ * with work in flight would deadlock a step whose completion depends on that
+ * work finishing, so the clock keeps running while `workSignature` keeps
+ * changing — but a signature that stops changing (the work stalled) still
+ * gets held once this many ticks have passed since it last moved.
  */
 export const WORK_GRACE_TICKS = 40;
 
@@ -148,11 +150,28 @@ export interface ClockProgress {
 /**
  * Fingerprint of the outstanding work so `decideClock` can tell "still moving"
  * from "stuck" instead of granting a flat grace window from step start.
+ *
+ * Cheap to compute every call (this runs every frame): covers everything
+ * `isWorkInProgress` inspects, generic across every `waitsOnWork` step.
  */
-// TODO: implement
 function workSignature(state: GameState): string {
-  void state;
-  return '';
+  const pendingIds = (state.pendingActions ?? [])
+    .map((a) => a.id)
+    .sort((a, b) => a - b)
+    .join(',');
+
+  const working = state.employees.employees
+    .filter((e) => e.activeActionId !== null || e.pendingDriverVehicleId !== null || e.destinationX !== null)
+    .slice()
+    .sort((a, b) => a.id - b.id)
+    .map((e) => [
+      e.id, e.x, e.z, e.activeActionId, e.pendingDriverVehicleId,
+      e.destinationX, e.destinationZ, e.taskTicksRemaining, e.restTicksRemaining,
+      e.pendingTaskDuration, e.pendingRestDuration,
+    ].join(','))
+    .join(';');
+
+  return `${pendingIds}|${working}`;
 }
 
 /**
@@ -186,6 +205,13 @@ function isWorkInProgress(state: GameState): boolean {
  * world to keep moving. Contract offers, for one, are regenerated on a timer
  * and the oldest is dropped, so a step that asks the player to pick an offer
  * must not let the list churn while they read it.
+ *
+ * The grace period is measured from the outstanding work's last observed
+ * progress, not from step start: `workSignature` fingerprints the work every
+ * call, and the window resets whenever that fingerprint changes. Work that
+ * keeps moving — a driver still walking toward a vehicle — never runs out the
+ * clock; work that genuinely stalls still gets held `WORK_GRACE_TICKS` after
+ * it stopped moving.
  */
 export function decideClock(
   state: GameState,
@@ -194,20 +220,25 @@ export function decideClock(
   waitsOnWork: boolean = false,
   progress: ClockProgress = { signature: null, tick: stepStartTick },
 ): ClockDecision {
-  // TODO: implement — workSignature will replace the flat WORK_GRACE_TICKS
-  // window with a check against `progress` once the fix lands.
-  void workSignature;
-  const spent = Math.max(0, (state.tickCount ?? 0) - stepStartTick);
+  const tickCount = state.tickCount ?? 0;
+  const spent = Math.max(0, tickCount - stepStartTick);
   if (spent < budget) {
     return { hold: false, spent, progressSignature: progress.signature, lastProgressTick: progress.tick };
   }
   if (!waitsOnWork) {
     return { hold: true, spent, progressSignature: progress.signature, lastProgressTick: progress.tick };
   }
-
-  if (isWorkInProgress(state) && spent < budget + WORK_GRACE_TICKS) {
-    return { hold: false, spent, progressSignature: progress.signature, lastProgressTick: progress.tick };
+  if (!isWorkInProgress(state)) {
+    return { hold: true, spent, progressSignature: progress.signature, lastProgressTick: progress.tick };
   }
 
-  return { hold: true, spent, progressSignature: progress.signature, lastProgressTick: progress.tick };
+  const signature = workSignature(state);
+  const changed = progress.signature !== null && signature !== progress.signature;
+  const lastProgressTick = changed ? tickCount : progress.tick;
+  const sinceProgress = tickCount - lastProgressTick;
+
+  if (sinceProgress < WORK_GRACE_TICKS) {
+    return { hold: false, spent, progressSignature: signature, lastProgressTick };
+  }
+  return { hold: true, spent, progressSignature: signature, lastProgressTick };
 }

--- a/src/ui/tutorialRails.ts
+++ b/src/ui/tutorialRails.ts
@@ -37,6 +37,8 @@ export class TutorialRails {
   private budget = DEFAULT_TICK_BUDGET;
   private waitsOnWork = false;
   private held = false;
+  private lastProgressSignature: string | null = null;
+  private lastProgressTick = 0;
 
   /** Point the rails at a new step and reset its tick allowance. */
   beginStep(step: RailsStep, state: GameState | null): void {
@@ -45,6 +47,9 @@ export class TutorialRails {
     this.budget = step.tickBudget ?? DEFAULT_TICK_BUDGET;
     this.waitsOnWork = step.waitsOnWork === true;
     this.stepStartTick = state?.tickCount ?? 0;
+    // TODO: implement — progress signature reset happens here once wired up.
+    void this.lastProgressSignature;
+    void this.lastProgressTick;
     // Published now rather than when the picker's stage goes live: the picker
     // opens on the click that ends the previous stage, so publishing later
     // would leave that first picker unconstrained.

--- a/src/ui/tutorialRails.ts
+++ b/src/ui/tutorialRails.ts
@@ -47,9 +47,8 @@ export class TutorialRails {
     this.budget = step.tickBudget ?? DEFAULT_TICK_BUDGET;
     this.waitsOnWork = step.waitsOnWork === true;
     this.stepStartTick = state?.tickCount ?? 0;
-    // TODO: implement — progress signature reset happens here once wired up.
-    void this.lastProgressSignature;
-    void this.lastProgressTick;
+    this.lastProgressSignature = null;
+    this.lastProgressTick = this.stepStartTick;
     // Published now rather than when the picker's stage goes live: the picker
     // opens on the click that ends the previous stage, so publishing later
     // would leave that first picker unconstrained.
@@ -109,7 +108,13 @@ export class TutorialRails {
    */
   updateClock(state: GameState | null): boolean {
     if (!state) return this.held;
-    const { hold } = decideClock(state, this.stepStartTick, this.budget, this.waitsOnWork);
+    const decision = decideClock(
+      state, this.stepStartTick, this.budget, this.waitsOnWork,
+      { signature: this.lastProgressSignature, tick: this.lastProgressTick },
+    );
+    this.lastProgressSignature = decision.progressSignature;
+    this.lastProgressTick = decision.lastProgressTick;
+    const { hold } = decision;
 
     if (hold && !state.isPaused) {
       state.isPaused = true;

--- a/tests/unit/ui/tutorialGuide.test.ts
+++ b/tests/unit/ui/tutorialGuide.test.ts
@@ -18,6 +18,7 @@ import {
   WORK_GRACE_TICKS,
 } from '../../../src/ui/tutorialGuide.js';
 import type { TutorialStage } from '../../../src/ui/tutorialStages.js';
+import type { ClockProgress } from '../../../src/ui/tutorialGuide.js';
 import { createGame } from '../../../src/core/state/GameState.js';
 import type { GameState } from '../../../src/core/state/GameState.js';
 
@@ -329,5 +330,108 @@ describe('decideClock', () => {
     const s = state();
     s.tickCount = 2;
     expect(decideClock(s, 50, DEFAULT_TICK_BUDGET).spent).toBe(0);
+  });
+
+  // -- #478: a driver walking to board a vehicle progresses with no action
+  // attached at all, only a moving destination. The flat WORK_GRACE_TICKS
+  // window above holds the clock once that budget runs out even though the
+  // walk is still visibly advancing, which deadlocks it forever — a held
+  // clock stops the ticks the walk needs to finish, so the hold never lifts.
+  // These tests thread the previous call's `progressSignature` /
+  // `lastProgressTick` forward as the next call's `progress` argument, the
+  // way `TutorialRails.updateClock` is expected to.
+
+  it('never holds while outstanding work keeps progressing, even well past budget + twice the grace window', () => {
+    const budget = DEFAULT_TICK_BUDGET;
+    let progress: ClockProgress = { signature: null, tick: 0 };
+    for (let tick = 0; tick <= budget + 2 * WORK_GRACE_TICKS; tick++) {
+      const s = state();
+      s.tickCount = tick;
+      // A fresh destination every tick — the walk is provably still moving.
+      s.employees.employees = [
+        { activeActionId: null, pendingDriverVehicleId: null, destinationX: tick, destinationZ: 0 } as never,
+      ];
+      const decision = decideClock(s, 0, budget, true, progress);
+      if (tick > budget + WORK_GRACE_TICKS) {
+        expect(decision.hold).toBe(false);
+      }
+      progress = { signature: decision.progressSignature, tick: decision.lastProgressTick };
+    }
+  });
+
+  it('does not deadlock when work is still progressing past budget+grace, but holds once progress genuinely stalls', () => {
+    const budget = DEFAULT_TICK_BUDGET;
+    const freezeAt = budget + 5;
+    let progress: ClockProgress = { signature: null, tick: 0 };
+    let last: ReturnType<typeof decideClock> | null = null;
+    for (let tick = 0; tick <= freezeAt + WORK_GRACE_TICKS; tick++) {
+      const s = state();
+      s.tickCount = tick;
+      // Moves every tick up to freezeAt, then genuinely stops changing —
+      // simulating a walk that finishes progressing and then gets stuck.
+      const destinationX = tick <= freezeAt ? tick : freezeAt;
+      s.employees.employees = [
+        { activeActionId: null, pendingDriverVehicleId: null, destinationX, destinationZ: 0 } as never,
+      ];
+      const decision = decideClock(s, 0, budget, true, progress);
+      last = decision;
+      if (tick < freezeAt + WORK_GRACE_TICKS) {
+        expect(decision.hold).toBe(false);
+      }
+      progress = { signature: decision.progressSignature, tick: decision.lastProgressTick };
+    }
+    // Grace measured from when staleness began (freezeAt), not from
+    // stepStartTick(0) — it holds only once a full WORK_GRACE_TICKS has
+    // elapsed with no further change.
+    expect(last!.hold).toBe(true);
+  });
+
+  it('treats a differing incoming signature as fresh progress and resets the grace window to now', () => {
+    const s = state();
+    s.tickCount = 200;
+    s.employees.employees = [
+      { activeActionId: null, pendingDriverVehicleId: null, destinationX: 3, destinationZ: 0 } as never,
+    ];
+    const decision = decideClock(
+      s, 0, DEFAULT_TICK_BUDGET, true,
+      { signature: '__not-a-real-signature__', tick: 5 },
+    );
+    expect(decision.hold).toBe(false);
+    expect(decision.lastProgressTick).toBe(200);
+  });
+
+  it('a first-ever check with no progress history behaves exactly like the pre-fix flat grace window', () => {
+    // Regression guard: treating the very first null-signature check as
+    // "just progressed" would widen every existing caller's grace window
+    // and break the flat-grace-cap behavior this asserts.
+    const s = state();
+    s.tickCount = DEFAULT_TICK_BUDGET + WORK_GRACE_TICKS - 1;
+    s.pendingActions = [{ id: 1 } as unknown as GameState['pendingActions'][number]];
+    expect(decideClock(s, 0, DEFAULT_TICK_BUDGET, true).hold).toBe(false);
+
+    const s2 = state();
+    s2.tickCount = DEFAULT_TICK_BUDGET + WORK_GRACE_TICKS;
+    s2.pendingActions = [{ id: 1 } as unknown as GameState['pendingActions'][number]];
+    expect(decideClock(s2, 0, DEFAULT_TICK_BUDGET, true).hold).toBe(true);
+  });
+
+  it('still holds once the walk finishes, even with real progress history threaded through', () => {
+    const s1 = state();
+    s1.tickCount = DEFAULT_TICK_BUDGET + 5;
+    s1.employees.employees = [
+      { activeActionId: null, pendingDriverVehicleId: null, destinationX: 4, destinationZ: 9 } as never,
+    ];
+    const walking = decideClock(s1, 0, DEFAULT_TICK_BUDGET, true, { signature: null, tick: 0 });
+    expect(walking.hold).toBe(false);
+
+    const s2 = state();
+    s2.tickCount = DEFAULT_TICK_BUDGET + 6;
+    s2.employees.employees = [
+      { activeActionId: null, pendingDriverVehicleId: null, destinationX: null, destinationZ: null } as never,
+    ];
+    const arrived = decideClock(s2, 0, DEFAULT_TICK_BUDGET, true, {
+      signature: walking.progressSignature, tick: walking.lastProgressTick,
+    });
+    expect(arrived.hold).toBe(true);
   });
 });

--- a/tests/unit/ui/tutorialRails.test.ts
+++ b/tests/unit/ui/tutorialRails.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { TutorialRails } from '../../../src/ui/tutorialRails.js';
-import { ALLOWED_CLASS, HIGHLIGHT_CLASS, DEFAULT_TICK_BUDGET } from '../../../src/ui/tutorialGuide.js';
+import { ALLOWED_CLASS, HIGHLIGHT_CLASS, DEFAULT_TICK_BUDGET, WORK_GRACE_TICKS } from '../../../src/ui/tutorialGuide.js';
 import { createGame } from '../../../src/core/state/GameState.js';
 import type { GameState } from '../../../src/core/state/GameState.js';
 
@@ -181,6 +181,63 @@ describe('TutorialRails', () => {
     rails.beginStep({ id: 'hire-surveyor' }, null);
     expect(() => rails.updateClock(null)).not.toThrow();
     expect(rails.updateClock(null)).toBe(false);
+  });
+
+  // -- #478: the tutorial hung at "buy a hauler and put the hired driver in
+  // it" because the flat WORK_GRACE_TICKS window held the clock once
+  // vehicle-buy-assign's budget (20 ticks) plus WORK_GRACE_TICKS (40) ran
+  // out, even while the driver was still visibly walking to the vehicle.
+  // A held clock never lets the walk finish, so the hold never lifted.
+
+  it('never permanently holds while outstanding work keeps signature-changing, well past the old budget+grace cutoff', () => {
+    const s = state();
+    const rails = new TutorialRails();
+    rails.beginStep({ id: 'vehicle-buy-assign', tickBudget: 20, waitsOnWork: true }, s);
+    const start = s.tickCount;
+
+    for (let i = 1; i <= 20 + 2 * WORK_GRACE_TICKS; i++) {
+      s.tickCount = start + i;
+      // A fresh destination every tick — the driver is provably still
+      // walking toward the vehicle, never stuck.
+      s.employees.employees = [
+        { activeActionId: null, pendingDriverVehicleId: 1, destinationX: i, destinationZ: 0 } as never,
+      ];
+      rails.updateClock(s);
+      if (i > 20 + WORK_GRACE_TICKS) {
+        expect(s.isPaused).toBe(false);
+        expect(rails.clockHeld).toBe(false);
+      }
+    }
+  });
+
+  it('beginStep resets the progress fingerprint, so a new step never inherits a stale one from a held step', () => {
+    const s = state();
+    const rails = new TutorialRails();
+    rails.beginStep({ id: 'vehicle-buy-assign', tickBudget: 5, waitsOnWork: true }, s);
+
+    // Same outstanding worker never moves — this step genuinely stalls.
+    const frozenEmployee = {
+      activeActionId: null, pendingDriverVehicleId: 1, destinationX: 9, destinationZ: 0,
+    } as never;
+    s.employees.employees = [frozenEmployee];
+
+    for (let i = 1; i <= 5 + WORK_GRACE_TICKS; i++) {
+      s.tickCount = i;
+      rails.updateClock(s);
+    }
+    expect(rails.clockHeld).toBe(true);
+    expect(s.isPaused).toBe(true);
+
+    // The same stuck worker is still there — only the step changed. A new
+    // step must get its own full budget + grace, not the exhausted one it
+    // inherited from the step that just held.
+    rails.beginStep({ id: 'survey', tickBudget: 5, waitsOnWork: true }, s);
+    expect(s.isPaused).toBe(false);
+
+    const stepStart2 = s.tickCount;
+    s.tickCount = stepStart2 + 5; // exactly the new step's own budget
+    expect(rails.updateClock(s)).toBe(false);
+    expect(s.isPaused).toBe(false);
   });
 
   it('clear() drops the marks and the stage list', () => {


### PR DESCRIPTION
Closes #478

## Problem

`decideClock` in `src/ui/tutorialGuide.ts` held the tutorial's clock (paused the game) once a flat `budget + WORK_GRACE_TICKS` window elapsed, even while a driver was still genuinely walking toward their assigned vehicle. Because holding the clock stops the very ticks that walk needs to finish, the tutorial entered an absorbing deadlock at beat 15 ("buy a hauler and put the hired driver in it") whenever the walk took longer than 60 ticks.

## Fix

Implements option 2 from the issue: the grace window is now measured from when the outstanding work last showed progress, not from step start.

- `hasOutstandingWork` extracted as the shared predicate behind `isWorkInProgress`.
- `workSignature` fingerprints all outstanding employee/pending-action work every call.
- `decideClock` takes/returns a `ClockProgress` (`signature`, `tick`) so the caller can carry it forward; the grace window resets whenever the fingerprint changes, and only holds once work has been stalled — not merely present — for `WORK_GRACE_TICKS`.
- `TutorialRails.updateClock` carries the progress state across calls as instance fields, reset in `beginStep`.
- First-ever progress check for a step anchors the grace window to `stepStartTick + budget` rather than to an as-yet-unset `progress.tick`, so the window can't silently widen.
- `scripts/shared/playtest-driver.ts`'s `awaitTutorialStep` action now brackets its poll-wait with the page's real `__setAutoTick(true)`/`(false)`, so the beat exercises the browser's own `isPaused`-gated clock instead of scenarioMode's scripted-tick clock — required for the playtest to actually reproduce/verify the deadlock rather than bypass it.

This keeps the original runaway-protection intent (a genuinely stalled job still gets held after `WORK_GRACE_TICKS`) while removing the deadlock for work that is merely slow.

## Verification

- **static** — `npm run typecheck`: PASS, 0 errors.
- **logic** — `npm run test`: PASS, 245 files / 7121 tests, including new unit coverage on `decideClock`/`TutorialRails` for "work outstanding, past budget + grace" that asserts `hold` stays false for the duration (`tests/unit/ui/tutorialGuide.test.ts:344`, `:362`; `tests/unit/ui/tutorialRails.test.ts:192`).
- **scenario** — `npm run scenarios`: PASS, 111/111 definitions.
- **playability** — `npm run playtest -- tutorial --screenshots`: PASS, 22/22 beats, including beat 15. Screenshot inspected (`screenshots/playtests/tutorial/beat-15.png`): driver "Hank Rockwell" seated, Haul button active, tutorial advanced to "BUILD STORAGE" (15/24) — the exact step the issue's FAIL screenshot never reached.
- **visual** — covered by the same playtest screenshot run; dev server env was READY per `npm run verify:env`.
- `npm run build`: PASS.

Full playtest suite and all-scenarios (interaction mode) also queued via the `full-ci` label on this PR so CI verifies the same beats headless.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** the issue presented three options and said option 2 "looks right" but flagged the `WORK_GRACE_TICKS` pacing/runaway-protection intent as "worth confirming before implementing."
  **Chosen:** implemented option 2 as described — reset the grace window on progress rather than dropping it (option 1) or re-tuning the budget (option 3).
  **Why:** the issue's own analysis rules out option 1 (loses runaway protection) and option 3 (re-tunes the same race, doesn't remove it); option 2 was already the issue's stated preference and is the only one that removes the absorbing state while keeping a stalled-job bound.
  **If reversed:** revert to the flat-window branch in `decideClock` (drop the `workSignature`/`ClockProgress` threading) if the fingerprinting approach proves too fragile against a new `Employee` field.

READY TO MERGE