### PR TITLE
feat: break oversized fragments with a Rock Fragmenter before hauling (#484)

### DIFF
--- a/scripts/scenario-defs/rock-fragmenter-breaking.json
+++ b/scripts/scenario-defs/rock-fragmenter-breaking.json
@@ -222,16 +222,16 @@
     },
     {
       "command": "vehicle break 2 fragment:1",
-      "description": "Sets break intent only — the fragmenter must still drive to the boulder before breaking it. In interaction mode, a reachable oversized fragment now makes .bs-vehicle-break-btn render for vehicle #2, so the same dispatch happens via a real click.",
+      "description": "Sets break intent only — the fragmenter must still drive to the boulder before breaking it. Command mode dispatches directly. In interaction mode, a reachable oversized fragment makes .bs-vehicle-break-btn render for vehicle #2, and the request is dispatched by a real click on that button — the button's own handler picks the fragment id (the eligibility cache's best reachable oversized fragment, which is fragment #1, the only oversized boulder on the ground) and calls the exact same console command the click handler in vehicleBreakButton.ts fires.",
       "interaction": [
-        {
-          "type": "command",
-          "command": "vehicle break 2 fragment:1"
-        },
         {
           "type": "waitForSelector",
           "selector": ".bs-vehicle-col[data-vehicle-id=\"2\"] .bs-vehicle-break-btn",
-          "timeout": 2000
+          "timeout": 5000
+        },
+        {
+          "type": "clickSelector",
+          "selector": ".bs-vehicle-col[data-vehicle-id=\"2\"] .bs-vehicle-break-btn"
         }
       ]
     },
@@ -266,16 +266,16 @@
     },
     {
       "command": "vehicle haul 1 fragment:64",
-      "description": "Hauls a resulting sub-fragment with the (still-idle) debris_hauler. In interaction mode, this fragment is on_ground and reachable, so .bs-vehicle-haul-btn renders for vehicle #1 and the same dispatch happens via a real click. Fragment id 64 is the first sub-fragment produced by the break at step 20/21 (seed 42, this exact command sequence) — not the stale fragment #2 left over from the original blast, which stays oversized and un-haulable. The scenario step vocabulary has no way to capture an id from a prior step's output, so this is hardcoded; re-derive it (via a 'fragments' step) if any upstream change to blast/break fragment-id assignment shifts it.",
+      "description": "Hauls a resulting sub-fragment with the (still-idle) debris_hauler. Command mode dispatches the hardcoded fragment:64 directly — the first sub-fragment produced by the break at step 20/21 (seed 42, this exact command sequence), not the stale fragment #2 left over from the original blast, which stays oversized and un-haulable; the scenario step vocabulary has no way to capture an id from a prior step's output, so this is hardcoded, and needs re-deriving (via a 'fragments' step) if any upstream change to blast/break fragment-id assignment shifts it. In interaction mode, this fragment is on_ground and reachable, so .bs-vehicle-haul-btn renders for vehicle #1, and the request is dispatched by a real click on that button — the button's own handler picks the fragment id (the eligibility cache's nearest reachable on-ground fragment) and calls the exact same console command the click handler in vehicleHaulButton.ts fires.",
       "interaction": [
-        {
-          "type": "command",
-          "command": "vehicle haul 1 fragment:64"
-        },
         {
           "type": "waitForSelector",
           "selector": ".bs-vehicle-col[data-vehicle-id=\"1\"] .bs-vehicle-haul-btn",
-          "timeout": 2000
+          "timeout": 5000
+        },
+        {
+          "type": "clickSelector",
+          "selector": ".bs-vehicle-col[data-vehicle-id=\"1\"] .bs-vehicle-haul-btn"
         }
       ]
     },

--- a/scripts/scenario-defs/rock-fragmenter-breaking.json
+++ b/scripts/scenario-defs/rock-fragmenter-breaking.json
@@ -265,12 +265,12 @@
       ]
     },
     {
-      "command": "vehicle haul 1 fragment:2",
-      "description": "Hauls a resulting sub-fragment with the (still-idle) debris_hauler. In interaction mode, this fragment is on_ground and reachable, so .bs-vehicle-haul-btn renders for vehicle #1 and the same dispatch happens via a real click.",
+      "command": "vehicle haul 1 fragment:64",
+      "description": "Hauls a resulting sub-fragment with the (still-idle) debris_hauler. In interaction mode, this fragment is on_ground and reachable, so .bs-vehicle-haul-btn renders for vehicle #1 and the same dispatch happens via a real click. Fragment id 64 is the first sub-fragment produced by the break at step 20/21 (seed 42, this exact command sequence) — not the stale fragment #2 left over from the original blast, which stays oversized and un-haulable. The scenario step vocabulary has no way to capture an id from a prior step's output, so this is hardcoded; re-derive it (via a 'fragments' step) if any upstream change to blast/break fragment-id assignment shifts it.",
       "interaction": [
         {
           "type": "command",
-          "command": "vehicle haul 1 fragment:2"
+          "command": "vehicle haul 1 fragment:64"
         },
         {
           "type": "waitForSelector",

--- a/scripts/scenario-defs/rock-fragmenter-breaking.json
+++ b/scripts/scenario-defs/rock-fragmenter-breaking.json
@@ -101,12 +101,8 @@
     },
     {
       "command": "vehicle buy debris_hauler",
-      "description": "Vehicle #1 — a real click on the tier-1 debris_hauler buy button.",
+      "description": "Vehicle #1 — a real click on the tier-1 debris_hauler buy button. Click is the sole purchase action in interaction mode (the top-level `command` covers command mode) — combining both double-buys (#484).",
       "interaction": [
-        {
-          "type": "command",
-          "command": "vehicle buy debris_hauler"
-        },
         {
           "type": "waitForSelector",
           "selector": "#bs-vehicle-panel [data-vtype=\"debris_hauler\"][data-tier=\"1\"]"
@@ -185,12 +181,8 @@
     },
     {
       "command": "vehicle buy rock_fragmenter",
-      "description": "Vehicle #2 — a real click on the tier-1 rock_fragmenter buy button.",
+      "description": "Vehicle #2 — a real click on the tier-1 rock_fragmenter buy button. Click is the sole purchase action in interaction mode (the top-level `command` covers command mode) — combining both double-buys (#484).",
       "interaction": [
-        {
-          "type": "command",
-          "command": "vehicle buy rock_fragmenter"
-        },
         {
           "type": "waitForSelector",
           "selector": "#bs-vehicle-panel [data-vtype=\"rock_fragmenter\"][data-tier=\"1\"]"

--- a/scripts/scenario-defs/rock-fragmenter-breaking.json
+++ b/scripts/scenario-defs/rock-fragmenter-breaking.json
@@ -1,0 +1,311 @@
+{
+  "name": "rock-fragmenter-breaking",
+  "description": "Chapter 5/2 (#484): an undercharged blast leaves an oversized boulder a debris_hauler must refuse; a crewed rock_fragmenter drives to it, breaks it via 'vehicle break', and a resulting sub-fragment is then hauled and stored — both through console commands and real Vehicles-panel clicks (buy, driver assign, .bs-vehicle-haul-btn, .bs-vehicle-break-btn).",
+  "steps": [
+    {
+      "command": "new_game seed:42 cash:100000",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "new_game seed:42 cash:100000"
+        }
+      ]
+    },
+    {
+      "command": "drill_plan grid rows:2 cols:2 spacing:5 depth:8 start:18,19",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "drill_plan grid rows:2 cols:2 spacing:5 depth:8 start:18,19"
+        }
+      ]
+    },
+    {
+      "command": "charge hole:* explosive:boomite amount:2 stemming:2",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "charge hole:* explosive:boomite amount:2 stemming:2"
+        }
+      ]
+    },
+    {
+      "command": "sequence auto delay_step:25",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "sequence auto delay_step:25"
+        }
+      ]
+    },
+    {
+      "command": "blast",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "blast"
+        }
+      ]
+    },
+    {
+      "command": "fragments",
+      "description": "Undercharged 2kg boomite at wide 5m spacing (mirrors blast-undercharge.json) reliably leaves a couple of oversized fragments (volume > OVERSIZED_FRAGMENT_THRESHOLD) among the ground fragments — this step's output exposes their ids.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "fragments"
+        }
+      ]
+    },
+    {
+      "command": "state full",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "state full"
+        }
+      ]
+    },
+    {
+      "command": "employee hire role:driver",
+      "description": "Employee #1 — will be crewed onto the debris_hauler.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "employee hire role:driver"
+        }
+      ]
+    },
+    {
+      "command": "employee assign_skill 1 skill:driving.truck level:5",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "employee assign_skill 1 skill:driving.truck level:5"
+        }
+      ]
+    },
+    {
+      "command": "vehicle list",
+      "description": "Opens the Vehicles panel via a real UI click so every later buy/driver/haul/break button click below targets a panel that is already on-screen (#411 pattern).",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle list"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-toolbar [data-panel=\"vehicles\"]"
+        }
+      ]
+    },
+    {
+      "command": "vehicle buy debris_hauler",
+      "description": "Vehicle #1 — a real click on the tier-1 debris_hauler buy button.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle buy debris_hauler"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": "#bs-vehicle-panel [data-vtype=\"debris_hauler\"][data-tier=\"1\"]"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-vehicle-panel [data-vtype=\"debris_hauler\"][data-tier=\"1\"]"
+        }
+      ]
+    },
+    {
+      "command": "vehicle driver 1 1",
+      "description": "Only one licensed (driving.truck) crew member is eligible, so the driver <select> already defaults to employee #1 — the assign button click alone boards them.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle driver 1 1"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": ".bs-vehicle-col[data-vehicle-id=\"1\"] .bs-vehicle-assign-btn"
+        },
+        {
+          "type": "clickSelector",
+          "selector": ".bs-vehicle-col[data-vehicle-id=\"1\"] .bs-vehicle-assign-btn"
+        }
+      ]
+    },
+    {
+      "command": "tick 10",
+      "description": "Lets the driver walk to and board the hauler.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 10"
+        }
+      ]
+    },
+    {
+      "command": "vehicle haul 1 fragment:1",
+      "description": "Must be refused: fragment #1 is oversized. No .bs-vehicle-haul-btn exists to click for it in interaction mode — the eligibility cache (findReachableGroundFragment) excludes oversized fragments outright, so the button never renders for this boulder; the command-mode attempt is what proves the rejection.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle haul 1 fragment:1"
+        }
+      ]
+    },
+    {
+      "command": "fragments",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "fragments"
+        }
+      ]
+    },
+    {
+      "command": "employee hire role:driver",
+      "description": "Employee #2 — will be crewed onto the rock_fragmenter.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "employee hire role:driver"
+        }
+      ]
+    },
+    {
+      "command": "employee assign_skill 2 skill:driving.excavator level:5",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "employee assign_skill 2 skill:driving.excavator level:5"
+        }
+      ]
+    },
+    {
+      "command": "vehicle buy rock_fragmenter",
+      "description": "Vehicle #2 — a real click on the tier-1 rock_fragmenter buy button.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle buy rock_fragmenter"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": "#bs-vehicle-panel [data-vtype=\"rock_fragmenter\"][data-tier=\"1\"]"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-vehicle-panel [data-vtype=\"rock_fragmenter\"][data-tier=\"1\"]"
+        }
+      ]
+    },
+    {
+      "command": "vehicle driver 2 2",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle driver 2 2"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": ".bs-vehicle-col[data-vehicle-id=\"2\"] .bs-vehicle-assign-btn"
+        },
+        {
+          "type": "clickSelector",
+          "selector": ".bs-vehicle-col[data-vehicle-id=\"2\"] .bs-vehicle-assign-btn"
+        }
+      ]
+    },
+    {
+      "command": "tick 10",
+      "description": "Lets the second driver walk to and board the rock_fragmenter.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 10"
+        }
+      ]
+    },
+    {
+      "command": "vehicle break 2 fragment:1",
+      "description": "Sets break intent only — the fragmenter must still drive to the boulder before breaking it. In interaction mode, a reachable oversized fragment now makes .bs-vehicle-break-btn render for vehicle #2, so the same dispatch happens via a real click.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle break 2 fragment:1"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": ".bs-vehicle-col[data-vehicle-id=\"2\"] .bs-vehicle-break-btn",
+          "timeout": 2000
+        }
+      ]
+    },
+    {
+      "command": "tick 30",
+      "description": "Padding: the fragmenter drives to the boulder's approach cell and breaks it on arrival.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 30"
+        }
+      ]
+    },
+    {
+      "command": "fragments",
+      "description": "Fragment #1 should now be gone from logistics, replaced by haulable sub-fragments (each under OVERSIZED_FRAGMENT_THRESHOLD) whose total volume matches the original boulder.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "fragments"
+        }
+      ]
+    },
+    {
+      "command": "build freight_warehouse at:13,13",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "build freight_warehouse at:13,13"
+        }
+      ]
+    },
+    {
+      "command": "vehicle haul 1 fragment:2",
+      "description": "Hauls a resulting sub-fragment with the (still-idle) debris_hauler. In interaction mode, this fragment is on_ground and reachable, so .bs-vehicle-haul-btn renders for vehicle #1 and the same dispatch happens via a real click.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "vehicle haul 1 fragment:2"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": ".bs-vehicle-col[data-vehicle-id=\"1\"] .bs-vehicle-haul-btn",
+          "timeout": 2000
+        }
+      ]
+    },
+    {
+      "command": "tick 30",
+      "description": "Padding: the hauler drives to the piece, loads it, drives to the warehouse, and delivers it.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 30"
+        }
+      ]
+    },
+    {
+      "command": "state full",
+      "description": "Final assertion point: logistics.storedMassKg must have grown by exactly the hauled piece's mass.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "state full"
+        }
+      ]
+    }
+  ]
+}

--- a/src/console/commands/vehicle.ts
+++ b/src/console/commands/vehicle.ts
@@ -13,6 +13,7 @@ import {
 } from '../../core/entities/Vehicle.js';
 import { requestBoardVehicle } from '../../core/entities/VehicleBoarding.js';
 import { requestHaulFragment } from '../../core/economy/HaulingTask.js';
+import { requestBreakBoulder } from '../../core/economy/BoulderBreaking.js';
 import { addExpense } from '../../core/economy/Finance.js';
 import { SPAWN_RING_SIZE, SPAWN_TILE_SPACING } from '../../core/config/balance.js';
 import { NavGrid } from '../../core/nav/NavGrid.js';
@@ -146,7 +147,22 @@ export function vehicleCommand(
       }
       return { success: true, output: `Vehicle #${vehicleId} hauling fragment #${fragmentId}.` };
     }
+    case 'break': {
+      const vehicleId = parseInt(args[1] ?? '', 10);
+      const fragmentId = parseInt(named['fragment'] ?? '', 10);
+      if (isNaN(vehicleId) || isNaN(fragmentId)) {
+        return { success: false, output: 'Usage: vehicle break <vehicleId> fragment:<fragmentId>' };
+      }
+      // Sets intent only — the vehicle must physically drive to the boulder
+      // before breaking it — resolved by ArrivalGate.tickArrivalGate/
+      // tickBreakProgress each tick (#484).
+      const result = requestBreakBoulder(state, vehicleId, fragmentId);
+      if (!result.success) {
+        return { success: false, output: result.error! };
+      }
+      return { success: true, output: `Vehicle #${vehicleId} breaking fragment #${fragmentId}.` };
+    }
     default:
-      return { success: false, output: 'Usage: vehicle (list|buy|assign|move|driver|haul)' };
+      return { success: false, output: 'Usage: vehicle (list|buy|assign|move|driver|haul|break)' };
   }
 }

--- a/src/core/economy/BoulderBreaking.ts
+++ b/src/core/economy/BoulderBreaking.ts
@@ -1,4 +1,4 @@
-// BlastSimulator2026 — Boulder breaking task (stub, issue #484)
+// BlastSimulator2026 — Boulder breaking task
 //
 // Position-gated in-place breaking of an oversized fragment: a
 // rock_fragmenter vehicle is dispatched to a boulder, breaks it only on
@@ -9,14 +9,21 @@
 
 import type { GameState } from '../state/GameState.js';
 import type { Vehicle } from '../entities/Vehicle.js';
+import type { FragmentData } from '../mining/BlastExecution.js';
+import { isOversized, fragmentBoulder, type Boulder } from '../mining/BlastCalc.js';
+import { fragmentApproachCell } from './FragmentApproach.js';
+import { tickVehicle, tickVehicleTaskState } from '../engine/EntityMovementTick.js';
+import { NavGrid } from '../nav/NavGrid.js';
+import { Random } from '../math/Random.js';
+import { scale, ZERO } from '../math/Vec3.js';
 
 /**
  * True when `vehicle` is a rock_fragmenter with a driver assigned and no
  * break task already in progress — the shared eligibility gate for
  * findReachableOversizedFragment and the UI's Break button.
  */
-export function isBreakEligibleVehicle(_vehicle: Vehicle | undefined): _vehicle is Vehicle {
-  throw new Error('not implemented');
+export function isBreakEligibleVehicle(vehicle: Vehicle | undefined): vehicle is Vehicle {
+  return !!vehicle && vehicle.type === 'rock_fragmenter' && vehicle.driverId !== null && vehicle.breakPhase === null;
 }
 
 /**
@@ -26,23 +33,163 @@ export function isBreakEligibleVehicle(_vehicle: Vehicle | undefined): _vehicle 
  * tickBreakProgress drive the phases.
  */
 export function requestBreakBoulder(
-  _state: GameState,
-  _vehicleId: number,
-  _fragmentId: number,
+  state: GameState,
+  vehicleId: number,
+  fragmentId: number,
 ): { success: boolean; error?: string } {
-  throw new Error('not implemented');
+  const vehicle = state.vehicles.vehicles.find(v => v.id === vehicleId);
+  if (!vehicle) return { success: false, error: 'Vehicle not found' };
+  if (vehicle.type !== 'rock_fragmenter') return { success: false, error: 'Vehicle is not a rock fragmenter' };
+  if (vehicle.driverId === null) return { success: false, error: 'Vehicle has no driver' };
+  if (vehicle.breakPhase !== null) return { success: false, error: 'Vehicle is already breaking a fragment' };
+
+  const tracked = state.logistics.fragments.find(
+    f => f.fragment.id === fragmentId && f.state === 'on_ground',
+  );
+  if (!tracked) return { success: false, error: 'Fragment not found or not on the ground' };
+  if (!isOversized(tracked.fragment.volume)) return { success: false, error: 'Fragment is not oversized' };
+
+  // Intent only — the vehicle does not split the boulder until
+  // tickBreakProgress (driven from ArrivalGate.tickArrivalGate) detects
+  // arrival. The movement target is set immediately so tickVehicle has
+  // somewhere to drive toward each tick.
+  const approach = fragmentApproachCell(tracked.fragment);
+  vehicle.breakFragmentId = fragmentId;
+  vehicle.breakPhase = 'to_boulder';
+  vehicle.task = 'moving';
+  vehicle.targetX = approach.x;
+  vehicle.targetZ = approach.z;
+
+  return { success: true };
 }
 
-/** Returns the id of the fragment split this tick, or null (still travelling / aborted / no-op). */
-export function tickBreakProgress(_state: GameState, _vehicle: Vehicle): number | null {
-  throw new Error('not implemented');
+/**
+ * Advance a single vehicle's in-progress break task by one tick: moves it
+ * toward the boulder, and on arrival splits it via fragmentBoulder, removing
+ * the original fragment from logistics and inserting each sub-fragment as a
+ * new on-ground fragment. Returns the original fragment's id on the tick it
+ * split, otherwise null (still travelling / aborted / no-op).
+ */
+export function tickBreakProgress(state: GameState, vehicle: Vehicle): number | null {
+  if (vehicle.breakPhase === null) return null;
+
+  const tracked = state.logistics.fragments.find(
+    f => f.fragment.id === vehicle.breakFragmentId && f.state === 'on_ground',
+  );
+  if (!tracked) {
+    // Fragment gone (broken/removed elsewhere) — abandon this break.
+    abortBreak(vehicle);
+    return null;
+  }
+
+  const approach = fragmentApproachCell(tracked.fragment);
+  vehicle.task = 'moving';
+  vehicle.targetX = approach.x;
+  vehicle.targetZ = approach.z;
+  tickVehicle(state, vehicle);
+
+  if (vehicle.x !== vehicle.targetX || vehicle.z !== vehicle.targetZ) {
+    tickVehicleTaskState(vehicle);
+    return null;
+  }
+
+  const boulder: Boulder = {
+    id: tracked.fragment.id,
+    volume: tracked.fragment.volume,
+    mass: tracked.fragment.mass,
+    rockId: tracked.fragment.rockId,
+    oreDensities: tracked.fragment.oreDensities,
+  };
+  const rng = new Random(breakSeed(tracked.fragment.id, state.tickCount));
+  const result = fragmentBoulder(boulder, rng);
+  if (!result.success) {
+    // Shouldn't happen (volume can't shrink between request and arrival),
+    // but never leave the vehicle stuck mid-break on an unexpected reject.
+    abortBreak(vehicle);
+    return null;
+  }
+
+  const originalId = tracked.fragment.id;
+  const idx = state.logistics.fragments.indexOf(tracked);
+  if (idx >= 0) state.logistics.fragments.splice(idx, 1);
+
+  let nextId = highestFragmentId(state) + 1;
+  for (const piece of result.fragments) {
+    const factor = Math.cbrt(piece.volume / boulder.volume);
+    const newFragment: FragmentData = {
+      id: nextId++,
+      position: tracked.fragment.position,
+      volume: piece.volume,
+      mass: piece.mass,
+      rockId: piece.rockId,
+      oreDensities: piece.oreDensities,
+      initialVelocity: ZERO,
+      isProjection: false,
+      halfExtents: scale(tracked.fragment.halfExtents, factor),
+      shapeSeed: rng.nextInt(0, 0x7fffffff),
+    };
+    state.logistics.fragments.push({ fragment: newFragment, state: 'on_ground', vehicleId: null });
+  }
+
+  abortBreak(vehicle);
+  return originalId;
 }
 
 /**
  * Find a reachability-aware oversized fragment for `vehicleId` to break: the
  * nearest 'on_ground' oversized fragment that is actually path-connected to
- * the vehicle's current position. Returns null when none qualify.
+ * the vehicle's current position. No storage-room check — breaking never
+ * touches the warehouse, unlike hauling. Returns null when none qualify.
  */
-export function findReachableOversizedFragment(_state: GameState, _vehicleId: number): number | null {
-  throw new Error('not implemented');
+export function findReachableOversizedFragment(state: GameState, vehicleId: number): number | null {
+  const vehicle = state.vehicles.vehicles.find(v => v.id === vehicleId);
+  if (!isBreakEligibleVehicle(vehicle)) return null;
+  if (!state.navGrid) return null;
+
+  const reachable = NavGrid.computeReachableSet(state.navGrid, vehicle.x, vehicle.z);
+  if (reachable.size === 0) return null;
+
+  let bestId: number | null = null;
+  let bestDistSq = Infinity;
+  for (const tracked of state.logistics.fragments) {
+    if (tracked.state !== 'on_ground') continue;
+    if (!isOversized(tracked.fragment.volume)) continue;
+    const { x: fx, z: fz } = fragmentApproachCell(tracked.fragment);
+    if (!reachable.has(fx, fz)) continue;
+    const distSq = (fx - vehicle.x) ** 2 + (fz - vehicle.z) ** 2;
+    if (distSq < bestDistSq) {
+      bestDistSq = distSq;
+      bestId = tracked.fragment.id;
+    }
+  }
+
+  return bestId;
+}
+
+/**
+ * Deterministic seed for one boulder's split — same fragment id at the same
+ * tick always breaks into the same shapeSeed sequence (FNV-1a-style mix,
+ * matching BlastExecution.ts's fragmentSeedFor pattern).
+ */
+function breakSeed(fragmentId: number, tickCount: number): number {
+  let seed = 2166136261;
+  seed = Math.imul(seed ^ fragmentId, 16777619);
+  seed = Math.imul(seed ^ tickCount, 16777619);
+  return Math.abs(seed) % 2147483647;
+}
+
+/** Highest fragment id currently tracked in logistics, or -1 if none. */
+function highestFragmentId(state: GameState): number {
+  let max = -1;
+  for (const f of state.logistics.fragments) {
+    if (f.fragment.id > max) max = f.fragment.id;
+  }
+  return max;
+}
+
+/** Cancel an in-progress break and return the vehicle to idle. */
+function abortBreak(vehicle: Vehicle): void {
+  vehicle.breakFragmentId = null;
+  vehicle.breakPhase = null;
+  vehicle.task = 'idle';
 }

--- a/src/core/economy/BoulderBreaking.ts
+++ b/src/core/economy/BoulderBreaking.ts
@@ -12,8 +12,8 @@ import type { Vehicle } from '../entities/Vehicle.js';
 import type { FragmentData } from '../mining/BlastExecution.js';
 import { isOversized, fragmentBoulder, type Boulder } from '../mining/BlastCalc.js';
 import { fragmentApproachCell } from './FragmentApproach.js';
-import { tickVehicle, tickVehicleTaskState } from '../engine/EntityMovementTick.js';
-import { NavGrid } from '../nav/NavGrid.js';
+import { findRequestVehicle, driveTowardFragment, findNearestReachableFragment } from './FragmentTaskLifecycle.js';
+import { tickVehicleTaskState } from '../engine/EntityMovementTick.js';
 import { Random } from '../math/Random.js';
 import { scale, vec3, ZERO } from '../math/Vec3.js';
 
@@ -37,8 +37,9 @@ export function requestBreakBoulder(
   vehicleId: number,
   fragmentId: number,
 ): { success: boolean; error?: string } {
-  const vehicle = state.vehicles.vehicles.find(v => v.id === vehicleId);
-  if (!vehicle) return { success: false, error: 'Vehicle not found' };
+  const found = findRequestVehicle(state, vehicleId);
+  if (!found.success) return found;
+  const vehicle = found.vehicle;
   if (vehicle.type !== 'rock_fragmenter') return { success: false, error: 'Vehicle is not a rock fragmenter' };
   if (vehicle.driverId === null) return { success: false, error: 'Vehicle has no driver' };
   if (vehicle.breakPhase !== null) return { success: false, error: 'Vehicle is already breaking a fragment' };
@@ -82,13 +83,8 @@ export function tickBreakProgress(state: GameState, vehicle: Vehicle): number | 
     return null;
   }
 
-  const approach = fragmentApproachCell(tracked.fragment, state, vehicle.id);
-  vehicle.task = 'moving';
-  vehicle.targetX = approach.x;
-  vehicle.targetZ = approach.z;
-  tickVehicle(state, vehicle);
-
-  if (vehicle.x !== vehicle.targetX || vehicle.z !== vehicle.targetZ) {
+  const arrived = driveTowardFragment(state, vehicle, tracked.fragment);
+  if (!arrived) {
     tickVehicleTaskState(vehicle);
     return null;
   }
@@ -155,26 +151,14 @@ export function tickBreakProgress(state: GameState, vehicle: Vehicle): number | 
 export function findReachableOversizedFragment(state: GameState, vehicleId: number): number | null {
   const vehicle = state.vehicles.vehicles.find(v => v.id === vehicleId);
   if (!isBreakEligibleVehicle(vehicle)) return null;
-  if (!state.navGrid) return null;
 
-  const reachable = NavGrid.computeReachableSet(state.navGrid, vehicle.x, vehicle.z);
-  if (reachable.size === 0) return null;
-
-  let bestId: number | null = null;
-  let bestDistSq = Infinity;
-  for (const tracked of state.logistics.fragments) {
-    if (tracked.state !== 'on_ground') continue;
-    if (!isOversized(tracked.fragment.volume)) continue;
-    const { x: fx, z: fz } = fragmentApproachCell(tracked.fragment, state, vehicleId);
-    if (!reachable.has(fx, fz)) continue;
-    const distSq = (fx - vehicle.x) ** 2 + (fz - vehicle.z) ** 2;
-    if (distSq < bestDistSq) {
-      bestDistSq = distSq;
-      bestId = tracked.fragment.id;
-    }
-  }
-
-  return bestId;
+  return findNearestReachableFragment(
+    state,
+    vehicleId,
+    vehicle.x,
+    vehicle.z,
+    tracked => isOversized(tracked.fragment.volume),
+  );
 }
 
 /**

--- a/src/core/economy/BoulderBreaking.ts
+++ b/src/core/economy/BoulderBreaking.ts
@@ -53,7 +53,7 @@ export function requestBreakBoulder(
   // tickBreakProgress (driven from ArrivalGate.tickArrivalGate) detects
   // arrival. The movement target is set immediately so tickVehicle has
   // somewhere to drive toward each tick.
-  const approach = fragmentApproachCell(tracked.fragment);
+  const approach = fragmentApproachCell(tracked.fragment, state, vehicle.id);
   vehicle.breakFragmentId = fragmentId;
   vehicle.breakPhase = 'to_boulder';
   vehicle.task = 'moving';
@@ -82,7 +82,7 @@ export function tickBreakProgress(state: GameState, vehicle: Vehicle): number | 
     return null;
   }
 
-  const approach = fragmentApproachCell(tracked.fragment);
+  const approach = fragmentApproachCell(tracked.fragment, state, vehicle.id);
   vehicle.task = 'moving';
   vehicle.targetX = approach.x;
   vehicle.targetZ = approach.z;
@@ -165,7 +165,7 @@ export function findReachableOversizedFragment(state: GameState, vehicleId: numb
   for (const tracked of state.logistics.fragments) {
     if (tracked.state !== 'on_ground') continue;
     if (!isOversized(tracked.fragment.volume)) continue;
-    const { x: fx, z: fz } = fragmentApproachCell(tracked.fragment);
+    const { x: fx, z: fz } = fragmentApproachCell(tracked.fragment, state, vehicleId);
     if (!reachable.has(fx, fz)) continue;
     const distSq = (fx - vehicle.x) ** 2 + (fz - vehicle.z) ** 2;
     if (distSq < bestDistSq) {

--- a/src/core/economy/BoulderBreaking.ts
+++ b/src/core/economy/BoulderBreaking.ts
@@ -1,0 +1,48 @@
+// BlastSimulator2026 — Boulder breaking task (stub, issue #484)
+//
+// Position-gated in-place breaking of an oversized fragment: a
+// rock_fragmenter vehicle is dispatched to a boulder, breaks it only on
+// arrival, replacing it in logistics with its sub-fragments. Mirrors
+// HaulingTask.ts's shape (eligibility gate, request, per-tick progress,
+// reachable-target lookup) for the break workflow instead of the haul one.
+// ArrivalGate.ts drives the phase transitions.
+
+import type { GameState } from '../state/GameState.js';
+import type { Vehicle } from '../entities/Vehicle.js';
+
+/**
+ * True when `vehicle` is a rock_fragmenter with a driver assigned and no
+ * break task already in progress — the shared eligibility gate for
+ * findReachableOversizedFragment and the UI's Break button.
+ */
+export function isBreakEligibleVehicle(_vehicle: Vehicle | undefined): _vehicle is Vehicle {
+  throw new Error('not implemented');
+}
+
+/**
+ * Request that a rock_fragmenter vehicle break an oversized fragment in
+ * place. Sets the vehicle's break intent (fragmentId, phase) without moving
+ * or breaking it immediately — ArrivalGate.tickArrivalGate and
+ * tickBreakProgress drive the phases.
+ */
+export function requestBreakBoulder(
+  _state: GameState,
+  _vehicleId: number,
+  _fragmentId: number,
+): { success: boolean; error?: string } {
+  throw new Error('not implemented');
+}
+
+/** Returns the id of the fragment split this tick, or null (still travelling / aborted / no-op). */
+export function tickBreakProgress(_state: GameState, _vehicle: Vehicle): number | null {
+  throw new Error('not implemented');
+}
+
+/**
+ * Find a reachability-aware oversized fragment for `vehicleId` to break: the
+ * nearest 'on_ground' oversized fragment that is actually path-connected to
+ * the vehicle's current position. Returns null when none qualify.
+ */
+export function findReachableOversizedFragment(_state: GameState, _vehicleId: number): number | null {
+  throw new Error('not implemented');
+}

--- a/src/core/economy/BoulderBreaking.ts
+++ b/src/core/economy/BoulderBreaking.ts
@@ -15,7 +15,7 @@ import { fragmentApproachCell } from './FragmentApproach.js';
 import { tickVehicle, tickVehicleTaskState } from '../engine/EntityMovementTick.js';
 import { NavGrid } from '../nav/NavGrid.js';
 import { Random } from '../math/Random.js';
-import { scale, ZERO } from '../math/Vec3.js';
+import { scale, vec3, ZERO } from '../math/Vec3.js';
 
 /**
  * True when `vehicle` is a rock_fragmenter with a driver assigned and no
@@ -110,10 +110,21 @@ export function tickBreakProgress(state: GameState, vehicle: Vehicle): number | 
   }
 
   const originalId = tracked.fragment.id;
+  // Computed before the splice below (and against the original fragment's own
+  // id) so a sub-fragment id can never collide with the boulder just removed
+  // or with any other fragment still tracked in logistics — computing this
+  // after the splice would let ids restart low and collide with unrelated
+  // on_ground fragments in a large field.
+  let nextId = Math.max(highestFragmentId(state), originalId) + 1;
   const idx = state.logistics.fragments.indexOf(tracked);
   if (idx >= 0) state.logistics.fragments.splice(idx, 1);
 
-  let nextId = highestFragmentId(state) + 1;
+  // Fixture/parent fragments built by hand (e.g. in tests) may omit
+  // halfExtents even though FragmentData declares it required — fall back to
+  // a cube approximation from the parent's own volume rather than crash.
+  const parentHalfExtents = tracked.fragment.halfExtents
+    ?? vec3(Math.cbrt(boulder.volume) / 2, Math.cbrt(boulder.volume) / 2, Math.cbrt(boulder.volume) / 2);
+
   for (const piece of result.fragments) {
     const factor = Math.cbrt(piece.volume / boulder.volume);
     const newFragment: FragmentData = {
@@ -125,7 +136,7 @@ export function tickBreakProgress(state: GameState, vehicle: Vehicle): number | 
       oreDensities: piece.oreDensities,
       initialVelocity: ZERO,
       isProjection: false,
-      halfExtents: scale(tracked.fragment.halfExtents, factor),
+      halfExtents: scale(parentHalfExtents, factor),
       shapeSeed: rng.nextInt(0, 0x7fffffff),
     };
     state.logistics.fragments.push({ fragment: newFragment, state: 'on_ground', vehicleId: null });

--- a/src/core/economy/FragmentApproach.ts
+++ b/src/core/economy/FragmentApproach.ts
@@ -1,12 +1,20 @@
 // BlastSimulator2026 — Walkable approach cell for a boulder fragment
 //
-// Stub (issue #484): the NavGrid cell a vehicle must reach to load or break
-// a fragment. Mirrors BuildingApproach.ts's findBuildingApproachCell pattern
-// for fragments instead of buildings.
+// The NavGrid cell a vehicle must reach to load or break a fragment. Both
+// HaulingTask.ts (loading) and BoulderBreaking.ts (breaking) call this one
+// function so the two workflows can never drift onto different rules —
+// unlike a building (see BuildingApproach.ts's findBuildingApproachCell,
+// which targets a walkable ring cell adjacent to the building since the
+// building's own tile is NavGrid-blocked), a fragment sits directly on a
+// walkable tile, so the target is simply that tile: the fragment's own
+// position, rounded to grid coordinates.
 
 import type { FragmentData } from '../mining/BlastExecution.js';
 
 /** The NavGrid cell a vehicle must reach to load or break `fragment`. */
-export function fragmentApproachCell(_fragment: FragmentData): { x: number; z: number } {
-  throw new Error('not implemented');
+export function fragmentApproachCell(fragment: FragmentData): { x: number; z: number } {
+  return {
+    x: Math.round(fragment.position.x),
+    z: Math.round(fragment.position.z),
+  };
 }

--- a/src/core/economy/FragmentApproach.ts
+++ b/src/core/economy/FragmentApproach.ts
@@ -8,13 +8,76 @@
 // building's own tile is NavGrid-blocked), a fragment sits directly on a
 // walkable tile, so the target is simply that tile: the fragment's own
 // position, rounded to grid coordinates.
-
+//
+// The primary cell can itself be occupied by another vehicle — most notably
+// a rock_fragmenter that just finished a BoulderBreaking task, which parks
+// (idle, but still occupying per EntityMovementTick.ts's
+// isCellOccupiedByOtherVehicle) on exactly the cell its sub-fragments spawn
+// on. A second vehicle later dispatched to one of those sub-fragments would
+// target that same occupied cell and — since an idle vehicle never leaves it
+// on its own and TRAFFIC_JAM detection needs multiple queued vehicles —
+// wait there forever (#484). When the primary cell is occupied, fall back to
+// the nearest free walkable neighbour instead, mirroring how
+// findBuildingApproachCell already resolves a blocked primary target to a
+// walkable cell nearby.
 import type { FragmentData } from '../mining/BlastExecution.js';
+import type { GameState } from '../state/GameState.js';
 
-/** The NavGrid cell a vehicle must reach to load or break `fragment`. */
-export function fragmentApproachCell(fragment: FragmentData): { x: number; z: number } {
-  return {
+/**
+ * The NavGrid cell a vehicle must reach to load or break `fragment`.
+ *
+ * When `state` (and thus the live vehicle roster) is supplied and the
+ * fragment's own cell is occupied by a vehicle other than `excludeVehicleId`,
+ * returns the nearest free, walkable neighbouring cell instead — recomputed
+ * every call, so it tracks the occupant moving away on a later tick. Falls
+ * back to the primary cell when no free neighbour exists (caller's own
+ * stuck-detection handles a genuinely unreachable target) or when `state` is
+ * omitted (callers that only need the nominal cell, e.g. reachability probes
+ * that don't care about a transient occupant).
+ */
+export function fragmentApproachCell(
+  fragment: FragmentData,
+  state?: GameState,
+  excludeVehicleId?: number,
+): { x: number; z: number } {
+  const primary = {
     x: Math.round(fragment.position.x),
     z: Math.round(fragment.position.z),
   };
+
+  if (!state) return primary;
+  if (!isCellOccupiedByOtherVehicle(state, primary.x, primary.z, excludeVehicleId)) return primary;
+
+  let best: { x: number; z: number } | null = null;
+  let bestDistSq = Infinity;
+  for (let dx = -1; dx <= 1; dx++) {
+    for (let dz = -1; dz <= 1; dz++) {
+      if (dx === 0 && dz === 0) continue;
+      const x = primary.x + dx;
+      const z = primary.z + dz;
+
+      if (state.navGrid) {
+        const cell = state.navGrid.cellAt(x, z);
+        if (!cell || cell.type === 'blocked' || cell.type === 'void') continue;
+      }
+      if (isCellOccupiedByOtherVehicle(state, x, z, excludeVehicleId)) continue;
+
+      const distSq = dx * dx + dz * dz;
+      if (distSq < bestDistSq) {
+        bestDistSq = distSq;
+        best = { x, z };
+      }
+    }
+  }
+
+  return best ?? primary;
+}
+
+function isCellOccupiedByOtherVehicle(
+  state: GameState,
+  x: number,
+  z: number,
+  excludeVehicleId?: number,
+): boolean {
+  return state.vehicles.vehicles.some(v => v.id !== excludeVehicleId && v.x === x && v.z === z);
 }

--- a/src/core/economy/FragmentApproach.ts
+++ b/src/core/economy/FragmentApproach.ts
@@ -1,0 +1,12 @@
+// BlastSimulator2026 — Walkable approach cell for a boulder fragment
+//
+// Stub (issue #484): the NavGrid cell a vehicle must reach to load or break
+// a fragment. Mirrors BuildingApproach.ts's findBuildingApproachCell pattern
+// for fragments instead of buildings.
+
+import type { FragmentData } from '../mining/BlastExecution.js';
+
+/** The NavGrid cell a vehicle must reach to load or break `fragment`. */
+export function fragmentApproachCell(_fragment: FragmentData): { x: number; z: number } {
+  throw new Error('not implemented');
+}

--- a/src/core/economy/FragmentTaskLifecycle.ts
+++ b/src/core/economy/FragmentTaskLifecycle.ts
@@ -1,0 +1,84 @@
+// BlastSimulator2026 — Shared task-lifecycle helpers for fragment-targeting vehicle tasks
+//
+// BoulderBreaking.ts (breaking) and HaulingTask.ts (hauling) are both
+// position-gated vehicle tasks that target a fragment: request looks up and
+// validates the vehicle, tick drives it toward the fragment's approach cell
+// one movement tick at a time, and search picks the nearest reachable
+// candidate fragment. This file holds the three steps that are identical
+// between the two workflows so BoulderBreaking.ts and HaulingTask.ts only
+// carry what differs: eligibility rules, phase names, and what happens on
+// arrival.
+
+import type { GameState } from '../state/GameState.js';
+import type { Vehicle } from '../entities/Vehicle.js';
+import type { FragmentData } from '../mining/BlastExecution.js';
+import type { TrackedFragment } from './Logistics.js';
+import { fragmentApproachCell } from './FragmentApproach.js';
+import { tickVehicle } from '../engine/EntityMovementTick.js';
+import { NavGrid } from '../nav/NavGrid.js';
+
+/**
+ * Look up `vehicleId` for a request-phase task entry point (requestBreakBoulder,
+ * requestHaulFragment). Both callers keep their own further checks (vehicle
+ * type, driver assigned, not already busy) — this only covers the one check
+ * that's identical between them: does the vehicle exist at all.
+ */
+export function findRequestVehicle(
+  state: GameState,
+  vehicleId: number,
+): { success: true; vehicle: Vehicle } | { success: false; error: string } {
+  const vehicle = state.vehicles.vehicles.find(v => v.id === vehicleId);
+  if (!vehicle) return { success: false, error: 'Vehicle not found' };
+  return { success: true, vehicle };
+}
+
+/**
+ * Point `vehicle` at `fragment`'s approach cell and advance its movement by
+ * one tick. Returns true once the vehicle has arrived (x/z match target) —
+ * the caller then performs its own arrival effect (load onto vehicle vs.
+ * split it in place) instead of this helper knowing which.
+ */
+export function driveTowardFragment(state: GameState, vehicle: Vehicle, fragment: FragmentData): boolean {
+  const approach = fragmentApproachCell(fragment, state, vehicle.id);
+  vehicle.task = 'moving';
+  vehicle.targetX = approach.x;
+  vehicle.targetZ = approach.z;
+  tickVehicle(state, vehicle);
+  return vehicle.x === vehicle.targetX && vehicle.z === vehicle.targetZ;
+}
+
+/**
+ * Nearest 'on_ground' fragment reachable from (originX, originZ) via NavGrid,
+ * among those `extraEligible` accepts — the search and reachability check
+ * are identical between findReachableOversizedFragment (breaking) and
+ * findReachableGroundFragment (hauling); only the per-fragment eligibility
+ * predicate differs (oversized-only vs. non-oversized-and-fits-in-storage).
+ */
+export function findNearestReachableFragment(
+  state: GameState,
+  vehicleId: number,
+  originX: number,
+  originZ: number,
+  extraEligible: (tracked: TrackedFragment) => boolean,
+): number | null {
+  if (!state.navGrid) return null;
+
+  const reachable = NavGrid.computeReachableSet(state.navGrid, originX, originZ);
+  if (reachable.size === 0) return null;
+
+  let bestId: number | null = null;
+  let bestDistSq = Infinity;
+  for (const tracked of state.logistics.fragments) {
+    if (tracked.state !== 'on_ground') continue;
+    if (!extraEligible(tracked)) continue;
+    const { x: fx, z: fz } = fragmentApproachCell(tracked.fragment, state, vehicleId);
+    if (!reachable.has(fx, fz)) continue;
+    const distSq = (fx - originX) ** 2 + (fz - originZ) ** 2;
+    if (distSq < bestDistSq) {
+      bestDistSq = distSq;
+      bestId = tracked.fragment.id;
+    }
+  }
+
+  return bestId;
+}

--- a/src/core/economy/HaulingTask.ts
+++ b/src/core/economy/HaulingTask.ts
@@ -59,7 +59,7 @@ export function requestHaulFragment(
   // Intent only — the vehicle does not load until tickHaulingProgress (driven
   // from ArrivalGate.tickArrivalGate) detects arrival. The movement target is
   // set immediately so tickVehicle has somewhere to drive toward each tick.
-  const approach = fragmentApproachCell(tracked.fragment);
+  const approach = fragmentApproachCell(tracked.fragment, state, vehicle.id);
   vehicle.haulingFragmentId = fragmentId;
   vehicle.haulingPhase = 'to_fragment';
   vehicle.haulingDepotBuildingId = depot.id;
@@ -87,7 +87,7 @@ export function tickHaulingProgress(state: GameState, vehicle: Vehicle): void {
       return;
     }
 
-    const approach = fragmentApproachCell(tracked.fragment);
+    const approach = fragmentApproachCell(tracked.fragment, state, vehicle.id);
     vehicle.task = 'moving';
     vehicle.targetX = approach.x;
     vehicle.targetZ = approach.z;
@@ -175,7 +175,7 @@ export function findReachableGroundFragment(state: GameState, vehicleId: number)
     // an early warehouse holds, so skipping them here is what keeps the fleet
     // working instead of silently deadlocked on the nearest rock.
     if (tracked.fragment.mass > roomKg) continue;
-    const { x: fx, z: fz } = fragmentApproachCell(tracked.fragment);
+    const { x: fx, z: fz } = fragmentApproachCell(tracked.fragment, state, vehicleId);
     if (!reachable.has(fx, fz)) continue;
     const distSq = (fx - vehicle.x) ** 2 + (fz - vehicle.z) ** 2;
     if (distSq < bestDistSq) {

--- a/src/core/economy/HaulingTask.ts
+++ b/src/core/economy/HaulingTask.ts
@@ -10,9 +10,9 @@ import { findNearestActiveBuildingOfType, getBuildingDef, type Building } from '
 import { findBuildingApproachCell } from '../nav/BuildingApproach.js';
 import { tickVehicle, tickVehicleTaskState } from '../engine/EntityMovementTick.js';
 import { pickupFragment, deliverToDepot } from './Logistics.js';
-import { NavGrid } from '../nav/NavGrid.js';
 import { isOversized } from '../mining/BlastCalc.js';
 import { fragmentApproachCell } from './FragmentApproach.js';
+import { findRequestVehicle, driveTowardFragment, findNearestReachableFragment } from './FragmentTaskLifecycle.js';
 
 /**
  * True when `vehicle` is a debris_hauler with a driver assigned and no
@@ -39,8 +39,9 @@ export function requestHaulFragment(
   vehicleId: number,
   fragmentId: number,
 ): { success: boolean; error?: string } {
-  const vehicle = state.vehicles.vehicles.find(v => v.id === vehicleId);
-  if (!vehicle) return { success: false, error: 'Vehicle not found' };
+  const found = findRequestVehicle(state, vehicleId);
+  if (!found.success) return found;
+  const vehicle = found.vehicle;
   if (vehicle.type !== 'debris_hauler') return { success: false, error: 'Vehicle is not a debris hauler' };
   if (vehicle.driverId === null) return { success: false, error: 'Vehicle has no driver' };
   if (vehicle.haulingPhase !== null) return { success: false, error: 'Vehicle is already hauling' };
@@ -87,13 +88,9 @@ export function tickHaulingProgress(state: GameState, vehicle: Vehicle): void {
       return;
     }
 
-    const approach = fragmentApproachCell(tracked.fragment, state, vehicle.id);
-    vehicle.task = 'moving';
-    vehicle.targetX = approach.x;
-    vehicle.targetZ = approach.z;
-    tickVehicle(state, vehicle);
+    const arrived = driveTowardFragment(state, vehicle, tracked.fragment);
 
-    if (vehicle.x === vehicle.targetX && vehicle.z === vehicle.targetZ) {
+    if (arrived) {
       const loaded = pickupFragment(state.logistics, vehicle.haulingFragmentId!, String(vehicle.id));
       if (loaded) {
         vehicle.payloadKg = tracked.fragment.mass;
@@ -154,37 +151,22 @@ export function tickHaulingProgress(state: GameState, vehicle: Vehicle): void {
 export function findReachableGroundFragment(state: GameState, vehicleId: number): number | null {
   const vehicle = state.vehicles.vehicles.find(v => v.id === vehicleId);
   if (!isHaulEligibleVehicle(vehicle)) return null;
-  if (!state.navGrid) return null;
-
-  const reachable = NavGrid.computeReachableSet(state.navGrid, vehicle.x, vehicle.z);
-  if (reachable.size === 0) return null;
 
   const roomKg = state.logistics.storageCapacityKg - state.logistics.storedMassKg;
 
-  let bestId: number | null = null;
-  let bestDistSq = Infinity;
-  for (const tracked of state.logistics.fragments) {
-    if (tracked.state !== 'on_ground') continue;
+  return findNearestReachableFragment(state, vehicleId, vehicle.x, vehicle.z, tracked => {
     // An oversized fragment can never be hauled until a Rock Fragmenter
     // breaks it into sub-fragments first (#484) — offering it here would
     // dispatch a hauler that requestHaulFragment immediately rejects.
-    if (isOversized(tracked.fragment.volume)) continue;
+    if (isOversized(tracked.fragment.volume)) return false;
     // A fragment heavier than the room left in storage can never be delivered:
     // the hauler would drive to it, load it, drive to the depot and be turned
     // away every tick from then on. Blasts throw off boulders far heavier than
     // an early warehouse holds, so skipping them here is what keeps the fleet
     // working instead of silently deadlocked on the nearest rock.
-    if (tracked.fragment.mass > roomKg) continue;
-    const { x: fx, z: fz } = fragmentApproachCell(tracked.fragment, state, vehicleId);
-    if (!reachable.has(fx, fz)) continue;
-    const distSq = (fx - vehicle.x) ** 2 + (fz - vehicle.z) ** 2;
-    if (distSq < bestDistSq) {
-      bestDistSq = distSq;
-      bestId = tracked.fragment.id;
-    }
-  }
-
-  return bestId;
+    if (tracked.fragment.mass > roomKg) return false;
+    return true;
+  });
 }
 
 /**

--- a/src/core/economy/HaulingTask.ts
+++ b/src/core/economy/HaulingTask.ts
@@ -11,6 +11,12 @@ import { findBuildingApproachCell } from '../nav/BuildingApproach.js';
 import { tickVehicle, tickVehicleTaskState } from '../engine/EntityMovementTick.js';
 import { pickupFragment, deliverToDepot } from './Logistics.js';
 import { NavGrid } from '../nav/NavGrid.js';
+import { isOversized } from '../mining/BlastCalc.js';
+
+// TODO(#484): isOversized will gate requestHaulFragment/findReachableGroundFragment
+// against oversized fragments — referenced here only to keep the import live
+// until that logic lands (noUnusedLocals).
+void isOversized;
 
 /**
  * True when `vehicle` is a debris_hauler with a driver assigned and no
@@ -47,6 +53,7 @@ export function requestHaulFragment(
     f => f.fragment.id === fragmentId && f.state === 'on_ground',
   );
   if (!tracked) return { success: false, error: 'Fragment not found or not on the ground' };
+  // TODO(#484): reject oversized fragments here
 
   const depot = findNearestActiveBuildingOfType(state.buildings, 'freight_warehouse', vehicle.x, vehicle.z);
   if (!depot) return { success: false, error: 'No active freight warehouse available' };
@@ -156,6 +163,7 @@ export function findReachableGroundFragment(state: GameState, vehicleId: number)
 
   let bestId: number | null = null;
   let bestDistSq = Infinity;
+  // TODO(#484): reject oversized fragments here
   for (const tracked of state.logistics.fragments) {
     if (tracked.state !== 'on_ground') continue;
     // A fragment heavier than the room left in storage can never be delivered:

--- a/src/core/economy/HaulingTask.ts
+++ b/src/core/economy/HaulingTask.ts
@@ -12,11 +12,7 @@ import { tickVehicle, tickVehicleTaskState } from '../engine/EntityMovementTick.
 import { pickupFragment, deliverToDepot } from './Logistics.js';
 import { NavGrid } from '../nav/NavGrid.js';
 import { isOversized } from '../mining/BlastCalc.js';
-
-// TODO(#484): isOversized will gate requestHaulFragment/findReachableGroundFragment
-// against oversized fragments — referenced here only to keep the import live
-// until that logic lands (noUnusedLocals).
-void isOversized;
+import { fragmentApproachCell } from './FragmentApproach.js';
 
 /**
  * True when `vehicle` is a debris_hauler with a driver assigned and no
@@ -53,7 +49,9 @@ export function requestHaulFragment(
     f => f.fragment.id === fragmentId && f.state === 'on_ground',
   );
   if (!tracked) return { success: false, error: 'Fragment not found or not on the ground' };
-  // TODO(#484): reject oversized fragments here
+  if (isOversized(tracked.fragment.volume)) {
+    return { success: false, error: 'Fragment is oversized and needs a Rock Fragmenter first' };
+  }
 
   const depot = findNearestActiveBuildingOfType(state.buildings, 'freight_warehouse', vehicle.x, vehicle.z);
   if (!depot) return { success: false, error: 'No active freight warehouse available' };
@@ -61,11 +59,12 @@ export function requestHaulFragment(
   // Intent only — the vehicle does not load until tickHaulingProgress (driven
   // from ArrivalGate.tickArrivalGate) detects arrival. The movement target is
   // set immediately so tickVehicle has somewhere to drive toward each tick.
+  const approach = fragmentApproachCell(tracked.fragment);
   vehicle.haulingFragmentId = fragmentId;
   vehicle.haulingPhase = 'to_fragment';
   vehicle.haulingDepotBuildingId = depot.id;
-  vehicle.targetX = Math.round(tracked.fragment.position.x);
-  vehicle.targetZ = Math.round(tracked.fragment.position.z);
+  vehicle.targetX = approach.x;
+  vehicle.targetZ = approach.z;
 
   return { success: true };
 }
@@ -88,9 +87,10 @@ export function tickHaulingProgress(state: GameState, vehicle: Vehicle): void {
       return;
     }
 
+    const approach = fragmentApproachCell(tracked.fragment);
     vehicle.task = 'moving';
-    vehicle.targetX = Math.round(tracked.fragment.position.x);
-    vehicle.targetZ = Math.round(tracked.fragment.position.z);
+    vehicle.targetX = approach.x;
+    vehicle.targetZ = approach.z;
     tickVehicle(state, vehicle);
 
     if (vehicle.x === vehicle.targetX && vehicle.z === vehicle.targetZ) {
@@ -163,17 +163,19 @@ export function findReachableGroundFragment(state: GameState, vehicleId: number)
 
   let bestId: number | null = null;
   let bestDistSq = Infinity;
-  // TODO(#484): reject oversized fragments here
   for (const tracked of state.logistics.fragments) {
     if (tracked.state !== 'on_ground') continue;
+    // An oversized fragment can never be hauled until a Rock Fragmenter
+    // breaks it into sub-fragments first (#484) — offering it here would
+    // dispatch a hauler that requestHaulFragment immediately rejects.
+    if (isOversized(tracked.fragment.volume)) continue;
     // A fragment heavier than the room left in storage can never be delivered:
     // the hauler would drive to it, load it, drive to the depot and be turned
     // away every tick from then on. Blasts throw off boulders far heavier than
     // an early warehouse holds, so skipping them here is what keeps the fleet
     // working instead of silently deadlocked on the nearest rock.
     if (tracked.fragment.mass > roomKg) continue;
-    const fx = Math.round(tracked.fragment.position.x);
-    const fz = Math.round(tracked.fragment.position.z);
+    const { x: fx, z: fz } = fragmentApproachCell(tracked.fragment);
     if (!reachable.has(fx, fz)) continue;
     const distSq = (fx - vehicle.x) ** 2 + (fz - vehicle.z) ** 2;
     if (distSq < bestDistSq) {

--- a/src/core/engine/ArrivalGate.ts
+++ b/src/core/engine/ArrivalGate.ts
@@ -98,9 +98,20 @@ export function tickArrivalGate(state: GameState, emitter?: EventEmitter): Arriv
   for (const vehicle of state.vehicles.vehicles) {
     if (vehicle.breakPhase === null) continue;
 
-    // TODO(#484): tickBreakProgress currently throws 'not implemented' — this
-    // wiring mirrors the hauling tick call above, ready for the implementer.
-    tickBreakProgress(state, vehicle);
+    // tickBreakProgress only returns the original fragment's id on the tick
+    // it actually splits the boulder — mirror the haul loop above by
+    // detecting that (rather than threading an emitter into the tick
+    // function itself) and deriving the produced piece ids from what
+    // appeared in logistics.fragments during this call.
+    const beforeIds = new Set(state.logistics.fragments.map(f => f.fragment.id));
+    const vehicleId = vehicle.id;
+    const splitFragmentId = tickBreakProgress(state, vehicle);
+    if (splitFragmentId !== null) {
+      const pieceIds = state.logistics.fragments
+        .filter(f => !beforeIds.has(f.fragment.id))
+        .map(f => f.fragment.id);
+      emitter?.emit('vehicle:boulder_broken', { vehicleId, fragmentId: splitFragmentId, pieceIds });
+    }
   }
 
   return result;

--- a/src/core/engine/ArrivalGate.ts
+++ b/src/core/engine/ArrivalGate.ts
@@ -10,6 +10,7 @@ import type { Employee } from '../entities/Employee.js';
 import type { EventEmitter } from '../state/EventEmitter.js';
 import { assignDriver } from '../entities/Vehicle.js';
 import { tickHaulingProgress } from '../economy/HaulingTask.js';
+import { tickBreakProgress } from '../economy/BoulderBreaking.js';
 
 /** Summary of what the arrival gate started/cancelled on this tick. */
 export interface ArrivalGateResult {
@@ -92,6 +93,14 @@ export function tickArrivalGate(state: GameState, emitter?: EventEmitter): Arriv
         emitter?.emit('vehicle:haul_delivered', { vehicleId: vehicle.id, fragmentId: prevFragmentId });
       }
     }
+  }
+
+  for (const vehicle of state.vehicles.vehicles) {
+    if (vehicle.breakPhase === null) continue;
+
+    // TODO(#484): tickBreakProgress currently throws 'not implemented' — this
+    // wiring mirrors the hauling tick call above, ready for the implementer.
+    tickBreakProgress(state, vehicle);
   }
 
   return result;

--- a/src/core/entities/Vehicle.ts
+++ b/src/core/entities/Vehicle.ts
@@ -3,7 +3,8 @@
 // Base stats and tier multipliers live in src/core/config/balance.ts.
 
 import { VEHICLE_BASE_STATS, VEHICLE_TIER_MULTIPLIERS } from '../config/balance.js';
-import type { EmployeeState, SkillCategory } from '../entities/Employee.js';
+
+export { ROLE_LICENCE_REQUIRED, canAssignDriver, assignDriver, getExcavatorLoadingRate } from './VehicleDriverAssignment.js';
 
 // ── Vehicle roles ──
 
@@ -145,6 +146,10 @@ export interface Vehicle {
   haulingPhase: 'to_fragment' | 'to_depot' | null;
   /** Depot/warehouse building ID the current haul is delivering to, or null. */
   haulingDepotBuildingId: number | null;
+  /** Fragment ID this rock_fragmenter is currently breaking, or null. */
+  breakFragmentId: number | null;
+  /** Single-leg break phase — travelling to the boulder. Null when idle. */
+  breakPhase: 'to_boulder' | null;
 }
 
 // ── Fleet state ──
@@ -187,6 +192,8 @@ export function purchaseVehicle(
     haulingFragmentId: null,
     haulingPhase: null,
     haulingDepotBuildingId: null,
+    breakFragmentId: null,
+    breakPhase: null,
   };
   state.vehicles.push(vehicle);
   return { vehicle, cost: def.purchaseCost };
@@ -248,71 +255,5 @@ export function getVehicleCostsPerTick(state: VehicleState): number {
   return total;
 }
 
-// ── Licence mapping ──
-
-/** Qualification category a driver needs for each vehicle role. */
-export const ROLE_LICENCE_REQUIRED: Record<VehicleRole, SkillCategory> = {
-  debris_hauler: 'driving.truck',
-  building_destroyer: 'driving.truck',
-  rock_digger: 'driving.excavator',
-  rock_fragmenter: 'driving.excavator',
-  drill_rig: 'driving.drill_rig',
-};
-
-/**
- * Validate that an employee may become a vehicle's driver: vehicle exists,
- * employee exists and is alive, holds the role's required licence, isn't
- * already driving another vehicle, and the vehicle has no driver yet.
- * Shared by `assignDriver` (immediate assignment) and
- * `VehicleBoarding.requestBoardVehicle` (deferred, arrival-gated assignment,
- * #437) so the two stay in lockstep — same checks, same order, same error
- * strings — without duplicating the logic itself.
- */
-export function canAssignDriver(
-  vehicleState: VehicleState,
-  employeeState: EmployeeState,
-  vehicleId: number,
-  employeeId: number,
-): { success: true; vehicle: Vehicle; employee: EmployeeState['employees'][number] } | { success: false; error: string } {
-  const vehicle = vehicleState.vehicles.find(v => v.id === vehicleId);
-  if (!vehicle) return { success: false, error: 'Vehicle not found' };
-
-  const employee = employeeState.employees.find(e => e.id === employeeId);
-  if (!employee || !employee.alive) return { success: false, error: 'Employee not found' };
-
-  const requiredLicence = ROLE_LICENCE_REQUIRED[vehicle.type];
-  const hasLicence = employee.qualifications.some(q => q.category === requiredLicence);
-  if (!hasLicence) return { success: false, error: 'Employee lacks licence for this role' };
-
-  const alreadyDriving = vehicleState.vehicles.some(v => v.driverId === employeeId);
-  if (alreadyDriving) return { success: false, error: 'Employee already driving another vehicle' };
-
-  if (vehicle.driverId !== null) return { success: false, error: 'Vehicle already has a driver' };
-
-  return { success: true, vehicle, employee };
-}
-
-/** Assign a driver (employee) to a vehicle, enforcing licence and availability checks. */
-export function assignDriver(
-  vehicleState: VehicleState,
-  employeeState: EmployeeState,
-  vehicleId: number,
-  employeeId: number,
-): { success: boolean; error?: string } {
-  const check = canAssignDriver(vehicleState, employeeState, vehicleId, employeeId);
-  if (!check.success) return check;
-
-  check.vehicle.driverId = employeeId;
-  return { success: true };
-}
-
-/**
- * Returns the loading rate (kg/tick) for a rock_digger, or 0 for any other role.
- *
- * @note Function name intentionally kept as `getExcavatorLoadingRate` for
- *       public-API backward compatibility — do not rename without updating all callers.
- */
-export function getExcavatorLoadingRate(vehicle: Vehicle): number {
-  if (vehicle.type !== 'rock_digger') return 0;
-  return getVehicleDef('rock_digger').capacity;
-}
+// ── Licence mapping / driver assignment / loading rate ──
+// Moved to VehicleDriverAssignment.ts (#484), re-exported above.

--- a/src/core/entities/VehicleDriverAssignment.ts
+++ b/src/core/entities/VehicleDriverAssignment.ts
@@ -1,0 +1,78 @@
+// BlastSimulator2026 — Vehicle driver assignment
+// Split out of Vehicle.ts to keep it under the 300-line file-size convention
+// (dev-coding-conventions). Pure code-move (#484) — licence mapping, driver
+// assignment checks, and the excavator loading-rate helper, verbatim from
+// Vehicle.ts.
+
+import type { EmployeeState, SkillCategory } from '../entities/Employee.js';
+import type { Vehicle, VehicleRole, VehicleState } from './Vehicle.js';
+import { getVehicleDef } from './Vehicle.js';
+
+// ── Licence mapping ──
+
+/** Qualification category a driver needs for each vehicle role. */
+export const ROLE_LICENCE_REQUIRED: Record<VehicleRole, SkillCategory> = {
+  debris_hauler: 'driving.truck',
+  building_destroyer: 'driving.truck',
+  rock_digger: 'driving.excavator',
+  rock_fragmenter: 'driving.excavator',
+  drill_rig: 'driving.drill_rig',
+};
+
+/**
+ * Validate that an employee may become a vehicle's driver: vehicle exists,
+ * employee exists and is alive, holds the role's required licence, isn't
+ * already driving another vehicle, and the vehicle has no driver yet.
+ * Shared by `assignDriver` (immediate assignment) and
+ * `VehicleBoarding.requestBoardVehicle` (deferred, arrival-gated assignment,
+ * #437) so the two stay in lockstep — same checks, same order, same error
+ * strings — without duplicating the logic itself.
+ */
+export function canAssignDriver(
+  vehicleState: VehicleState,
+  employeeState: EmployeeState,
+  vehicleId: number,
+  employeeId: number,
+): { success: true; vehicle: Vehicle; employee: EmployeeState['employees'][number] } | { success: false; error: string } {
+  const vehicle = vehicleState.vehicles.find(v => v.id === vehicleId);
+  if (!vehicle) return { success: false, error: 'Vehicle not found' };
+
+  const employee = employeeState.employees.find(e => e.id === employeeId);
+  if (!employee || !employee.alive) return { success: false, error: 'Employee not found' };
+
+  const requiredLicence = ROLE_LICENCE_REQUIRED[vehicle.type];
+  const hasLicence = employee.qualifications.some(q => q.category === requiredLicence);
+  if (!hasLicence) return { success: false, error: 'Employee lacks licence for this role' };
+
+  const alreadyDriving = vehicleState.vehicles.some(v => v.driverId === employeeId);
+  if (alreadyDriving) return { success: false, error: 'Employee already driving another vehicle' };
+
+  if (vehicle.driverId !== null) return { success: false, error: 'Vehicle already has a driver' };
+
+  return { success: true, vehicle, employee };
+}
+
+/** Assign a driver (employee) to a vehicle, enforcing licence and availability checks. */
+export function assignDriver(
+  vehicleState: VehicleState,
+  employeeState: EmployeeState,
+  vehicleId: number,
+  employeeId: number,
+): { success: boolean; error?: string } {
+  const check = canAssignDriver(vehicleState, employeeState, vehicleId, employeeId);
+  if (!check.success) return check;
+
+  check.vehicle.driverId = employeeId;
+  return { success: true };
+}
+
+/**
+ * Returns the loading rate (kg/tick) for a rock_digger, or 0 for any other role.
+ *
+ * @note Function name intentionally kept as `getExcavatorLoadingRate` for
+ *       public-API backward compatibility — do not rename without updating all callers.
+ */
+export function getExcavatorLoadingRate(vehicle: Vehicle): number {
+  if (vehicle.type !== 'rock_digger') return 0;
+  return getVehicleDef('rock_digger').capacity;
+}

--- a/src/core/i18n/locales/en.json
+++ b/src/core/i18n/locales/en.json
@@ -2448,6 +2448,7 @@
   "ui.vehicles.driver": "Driver",
   "ui.vehicles.no_qualified": "No crew licensed for {licence}",
   "ui.vehicles.haul": "Haul",
+  "ui.vehicles.break": "Break",
   "ui.contracts.deliver": "Deliver",
   "ui.contracts.deliver_amount": "Kilograms to deliver",
   "ui.build.ramp_section": "Terrain",

--- a/src/core/i18n/locales/fr.json
+++ b/src/core/i18n/locales/fr.json
@@ -2448,6 +2448,7 @@
   "ui.vehicles.driver": "Conducteur",
   "ui.vehicles.no_qualified": "Aucun employé habilité pour {licence}",
   "ui.vehicles.haul": "Transporter",
+  "ui.vehicles.break": "Casser",
   "ui.contracts.deliver": "Livrer",
   "ui.contracts.deliver_amount": "Kilogrammes à livrer",
   "ui.build.ramp_section": "Terrain",

--- a/src/core/state/EventEmitter.ts
+++ b/src/core/state/EventEmitter.ts
@@ -37,6 +37,7 @@ export interface GameEventMap {
   'vehicle:driver_boarded': { employeeId: number; vehicleId: number };
   'vehicle:haul_loaded': { vehicleId: number; fragmentId: number };
   'vehicle:haul_delivered': { vehicleId: number; fragmentId: number };
+  'vehicle:boulder_broken': { vehicleId: number; fragmentId: number; pieceIds: number[] };
 }
 
 type EventHandler<T> = (data: T) => void;

--- a/src/ui/VehiclePanel.ts
+++ b/src/ui/VehiclePanel.ts
@@ -7,6 +7,7 @@ import type { GameState } from '../core/state/GameState.js';
 import type { Vehicle, VehicleRole, VehicleTier } from '../core/entities/Vehicle.js';
 import { getAllVehicleRoles, getVehicleDefByTier, ROLE_LICENCE_REQUIRED } from '../core/entities/Vehicle.js';
 import { HaulEligibilityCache, makeHaulButton, refreshHaulButtons } from './vehicleHaulButton.js';
+import { BreakEligibilityCache, makeBreakButton, refreshBreakButtons } from './vehicleBreakButton.js';
 
 const VEHICLE_TIERS: VehicleTier[] = [1, 2, 3];
 
@@ -26,6 +27,8 @@ export class VehiclePanel {
   private readonly locale = new LocaleTextRegistry();
   /** Per-tick cache of each vehicle's best reachable haul fragment — see vehicleHaulButton.ts. */
   private readonly haulCache = new HaulEligibilityCache();
+  /** Per-tick cache of each vehicle's best reachable oversized fragment — see vehicleBreakButton.ts. */
+  private readonly breakCache = new BreakEligibilityCache();
 
   constructor(container: HTMLElement) {
     this.el = document.createElement('div');
@@ -93,6 +96,7 @@ export class VehiclePanel {
     // once per rendered frame — refresh() below is a no-op except on the
     // first update() call for a given state.tickCount.
     this.haulCache.refresh(state);
+    this.breakCache.refresh(state);
 
     // Rebuilt only when the fleet changes: this list holds a driver <select>,
     // and a per-frame rebuild would discard the player's choice mid-interaction.
@@ -103,6 +107,7 @@ export class VehiclePanel {
     if (signature === this.lastSignature) {
       this.refreshTierButtons(state.cash);
       refreshHaulButtons(this.listEl, state, this.haulCache, this.dispatch);
+      refreshBreakButtons(this.listEl, state, this.breakCache, this.dispatch);
       return;
     }
     this.lastSignature = signature;
@@ -122,6 +127,7 @@ export class VehiclePanel {
 
     this.refreshTierButtons(state.cash);
     refreshHaulButtons(this.listEl, state, this.haulCache, this.dispatch);
+    refreshBreakButtons(this.listEl, state, this.breakCache, this.dispatch);
   }
 
   dispose(): void { this.el.remove(); }
@@ -152,6 +158,8 @@ export class VehiclePanel {
     col.append(info, status, this.makeDriverRow(v, state));
     const haulBtn = makeHaulButton(v, this.haulCache, this.dispatch);
     if (haulBtn) col.appendChild(haulBtn);
+    const breakBtn = makeBreakButton(v, this.breakCache, this.dispatch);
+    if (breakBtn) col.appendChild(breakBtn);
     row.append(col, scrapBtn);
     return row;
   }

--- a/src/ui/vehicleBreakButton.ts
+++ b/src/ui/vehicleBreakButton.ts
@@ -1,24 +1,36 @@
 // BlastSimulator2026 — Vehicle panel "Break" button and its per-tick eligibility cache.
 //
-// Stub (issue #484), mirrors vehicleHaulButton.ts's shape for the boulder-
-// breaking workflow instead of hauling. Split out of VehiclePanel.ts to keep
-// it under the 300-line file-size convention (dev-coding-conventions).
+// Mirrors vehicleHaulButton.ts's shape for the boulder-breaking workflow
+// instead of hauling. Split out of VehiclePanel.ts to keep it under the
+// 300-line file-size convention (dev-coding-conventions).
 
+import { t } from '../core/i18n/I18n.js';
 import type { GameState } from '../core/state/GameState.js';
 import type { Vehicle } from '../core/entities/Vehicle.js';
+import { findReachableOversizedFragment, isBreakEligibleVehicle } from '../core/economy/BoulderBreaking.js';
 
 /**
  * Caches each eligible vehicle's best reachable oversized fragment for one
  * game tick — mirrors HaulEligibilityCache.
  */
 export class BreakEligibilityCache {
-  refresh(_state: GameState): void {
-    throw new Error('not implemented');
+  private tick = -1;
+  private readonly fragmentIdByVehicle = new Map<number, number | null>();
+
+  /** Recompute every eligible vehicle's best oversized fragment; no-op if already done this tick. */
+  refresh(state: GameState): void {
+    if (state.tickCount === this.tick) return;
+    this.tick = state.tickCount;
+    this.fragmentIdByVehicle.clear();
+    for (const v of state.vehicles.vehicles) {
+      if (!isBreakEligibleVehicle(v)) continue;
+      this.fragmentIdByVehicle.set(v.id, findReachableOversizedFragment(state, v.id));
+    }
   }
 
   /** Cached best oversized fragment for `vehicleId` — null if ineligible or no reachable fragment. */
-  fragmentIdFor(_vehicleId: number): number | null {
-    throw new Error('not implemented');
+  fragmentIdFor(vehicleId: number): number | null {
+    return this.fragmentIdByVehicle.get(vehicleId) ?? null;
   }
 }
 
@@ -28,18 +40,54 @@ export class BreakEligibilityCache {
  * nothing) for any other vehicle.
  */
 export function makeBreakButton(
-  _v: Vehicle, _cache: BreakEligibilityCache, _gameConsole: ((cmd: string) => unknown) | undefined,
+  v: Vehicle,
+  cache: BreakEligibilityCache,
+  gameConsole: ((cmd: string) => unknown) | undefined,
 ): HTMLElement | null {
-  throw new Error('not implemented');
+  if (cache.fragmentIdFor(v.id) === null) return null;
+
+  const wrap = document.createElement('div');
+  wrap.className = 'bs-vehicle-break-wrap';
+  wrap.dataset['vehicleId'] = String(v.id);
+  wrap.style.cssText = 'display:flex;align-items:center;gap:4px;margin-top:3px';
+
+  const breakBtn = document.createElement('button');
+  breakBtn.className = 'bs-btn bs-btn-primary bs-vehicle-break-btn';
+  breakBtn.style.cssText = 'padding:1px 6px;font-size:10px';
+  breakBtn.textContent = t('ui.vehicles.break');
+  breakBtn.addEventListener('click', () => {
+    const fragmentId = cache.fragmentIdFor(v.id);
+    if (fragmentId === null) return;
+    gameConsole?.(`vehicle break ${v.id} fragment:${fragmentId}`);
+  });
+
+  wrap.appendChild(breakBtn);
+  return wrap;
 }
 
 /**
  * Adds/removes each vehicle's Break button wrapper in place as reachable-
  * fragment eligibility changes tick to tick — mirrors refreshHaulButtons.
+ * `col` elements are tagged with data-vehicle-id by makeVehicleRow.
  */
 export function refreshBreakButtons(
-  _listEl: HTMLElement, _state: GameState, _cache: BreakEligibilityCache,
-  _gameConsole: ((cmd: string) => unknown) | undefined,
+  listEl: HTMLElement,
+  state: GameState,
+  cache: BreakEligibilityCache,
+  gameConsole: ((cmd: string) => unknown) | undefined,
 ): void {
-  throw new Error('not implemented');
+  const cols = listEl.querySelectorAll<HTMLElement>('.bs-vehicle-col');
+  cols.forEach(col => {
+    const vehicleId = Number(col.dataset['vehicleId']);
+    const existing = col.querySelector<HTMLElement>('.bs-vehicle-break-wrap');
+    const eligible = cache.fragmentIdFor(vehicleId) !== null;
+
+    if (eligible && !existing) {
+      const vehicle = state.vehicles.vehicles.find(v => v.id === vehicleId);
+      const btn = vehicle ? makeBreakButton(vehicle, cache, gameConsole) : null;
+      if (btn) col.appendChild(btn);
+    } else if (!eligible && existing) {
+      existing.remove();
+    }
+  });
 }

--- a/src/ui/vehicleBreakButton.ts
+++ b/src/ui/vehicleBreakButton.ts
@@ -1,0 +1,45 @@
+// BlastSimulator2026 — Vehicle panel "Break" button and its per-tick eligibility cache.
+//
+// Stub (issue #484), mirrors vehicleHaulButton.ts's shape for the boulder-
+// breaking workflow instead of hauling. Split out of VehiclePanel.ts to keep
+// it under the 300-line file-size convention (dev-coding-conventions).
+
+import type { GameState } from '../core/state/GameState.js';
+import type { Vehicle } from '../core/entities/Vehicle.js';
+
+/**
+ * Caches each eligible vehicle's best reachable oversized fragment for one
+ * game tick — mirrors HaulEligibilityCache.
+ */
+export class BreakEligibilityCache {
+  refresh(_state: GameState): void {
+    throw new Error('not implemented');
+  }
+
+  /** Cached best oversized fragment for `vehicleId` — null if ineligible or no reachable fragment. */
+  fragmentIdFor(_vehicleId: number): number | null {
+    throw new Error('not implemented');
+  }
+}
+
+/**
+ * "Break" button for a rock_fragmenter with a driver, no in-progress break,
+ * and a reachable oversized fragment right now. Returns null (renders
+ * nothing) for any other vehicle.
+ */
+export function makeBreakButton(
+  _v: Vehicle, _cache: BreakEligibilityCache, _gameConsole: ((cmd: string) => unknown) | undefined,
+): HTMLElement | null {
+  throw new Error('not implemented');
+}
+
+/**
+ * Adds/removes each vehicle's Break button wrapper in place as reachable-
+ * fragment eligibility changes tick to tick — mirrors refreshHaulButtons.
+ */
+export function refreshBreakButtons(
+  _listEl: HTMLElement, _state: GameState, _cache: BreakEligibilityCache,
+  _gameConsole: ((cmd: string) => unknown) | undefined,
+): void {
+  throw new Error('not implemented');
+}

--- a/tests/integration/blast-oversized-boulders.integration.test.ts
+++ b/tests/integration/blast-oversized-boulders.integration.test.ts
@@ -1,0 +1,162 @@
+// BlastSimulator2026 — Integration test: oversized boulder breaking (#484)
+//
+// A debris_hauler must refuse an oversized fragment; a crewed
+// rock_fragmenter must be able to drive to it and break it in place via the
+// real "vehicle break" console command, replacing it in logistics with
+// haulable sub-fragments that preserve total volume. Mirrors
+// economy.integration.test.ts's "completes the full economy loop" case and
+// blast-undercharge.json's charge parameters (small charge = oversized
+// fragments, zero projections).
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { type GameContext, newGameCommand } from '../../src/console/commands/world.js';
+import { buildCommand } from '../../src/console/commands/entities.js';
+import { employeeCommand } from '../../src/console/commands/employees.js';
+import { vehicleCommand } from '../../src/console/commands/vehicle.js';
+import { tickCommand } from '../../src/console/commands/events.js';
+import {
+  drillPlanCommand,
+  chargeCommand,
+  sequenceCommand,
+  blastCommand,
+} from '../../src/console/commands/mining.js';
+import { EventEmitter } from '../../src/core/state/EventEmitter.js';
+import { isOversized } from '../../src/core/mining/BlastCalc.js';
+
+function makeCtx(): GameContext {
+  const ctx: GameContext = { state: null, grid: null, emitter: new EventEmitter() };
+  newGameCommand(ctx, [], { mine_type: 'desert', seed: '42', size: '32' });
+  return ctx;
+}
+
+/**
+ * Drill+charge+sequence+blast an undercharged, wide-spacing pattern at
+ * (18,19) — same origin as economy.integration.test.ts's full-loop case: it
+ * sits on the same flat NavGrid bench as the vehicle spawn and warehouse, so
+ * fragments land somewhere a vehicle can actually reach. Mirrors
+ * blast-undercharge.json's charge parameters (2kg, wide 5m spacing), which
+ * reliably leaves a couple of oversized fragments with zero projections.
+ */
+function blastUndercharged(ctx: GameContext): void {
+  const drillResult = drillPlanCommand(ctx as any, ['grid'], {
+    origin: '18,19',
+    rows: '2',
+    cols: '2',
+    spacing: '5',
+    depth: '8',
+  });
+  expect(drillResult.success).toBe(true);
+
+  const chargeResult = chargeCommand(ctx as any, [], {
+    hole: '*',
+    explosive: 'boomite',
+    amount: '2kg',
+    stemming: '2m',
+  });
+  expect(chargeResult.success).toBe(true);
+
+  const seqResult = sequenceCommand(ctx as any, ['auto'], {});
+  expect(seqResult.success).toBe(true);
+
+  const blastResult = blastCommand(ctx as any, [], {});
+  expect(blastResult.success).toBe(true);
+}
+
+describe('Blast → oversized boulder → break in place (#484)', () => {
+  let ctx: GameContext;
+
+  beforeEach(() => {
+    ctx = makeCtx();
+  });
+
+  it('an undercharged, wide-spacing blast produces at least one oversized fragment', () => {
+    blastUndercharged(ctx);
+
+    const oversized = ctx.state!.logistics.fragments.filter(f => isOversized(f.fragment.volume));
+    expect(oversized.length).toBeGreaterThan(0);
+  });
+
+  it('a crewed debris_hauler refuses an oversized fragment; a crewed rock_fragmenter breaks it in place; a resulting piece can then be hauled and stored', () => {
+    // 1. Blast to produce an oversized fragment.
+    blastUndercharged(ctx);
+
+    const oversizedTracked = ctx.state!.logistics.fragments.find(f => isOversized(f.fragment.volume));
+    expect(oversizedTracked).toBeDefined();
+    const oversizedId = oversizedTracked!.fragment.id;
+    const oversizedVolume = oversizedTracked!.fragment.volume;
+
+    // 2. Crew a debris_hauler and attempt to haul the oversized fragment — must be refused.
+    const hireHaulerDriver = employeeCommand(ctx, ['hire'], { role: 'driver' });
+    expect(hireHaulerDriver.success).toBe(true);
+    const haulerDriverId = ctx.state!.employees.employees.find(e => e.role === 'driver')!.id;
+    employeeCommand(ctx, ['assign_skill', String(haulerDriverId)], { skill: 'driving.truck', level: '5' });
+
+    const buyHauler = vehicleCommand(ctx, ['buy', 'debris_hauler'], {});
+    expect(buyHauler.success).toBe(true);
+    const haulerId = ctx.state!.vehicles.vehicles.find(v => v.type === 'debris_hauler')!.id;
+
+    const assignHauler = vehicleCommand(ctx, ['driver', String(haulerId), String(haulerDriverId)], {});
+    expect(assignHauler.success).toBe(true);
+    for (let i = 0; i < 10; i++) tickCommand(ctx, ['1'], {});
+
+    const haulAttempt = vehicleCommand(ctx, ['haul', String(haulerId)], { fragment: String(oversizedId) });
+    expect(haulAttempt.success).toBe(false);
+    expect(haulAttempt.output.length).toBeGreaterThan(0);
+    expect(ctx.state!.logistics.fragments.find(f => f.fragment.id === oversizedId)!.state).toBe('on_ground');
+
+    // 3. Crew a rock_fragmenter and break the oversized fragment in place.
+    const hireFragmenterDriver = employeeCommand(ctx, ['hire'], { role: 'driver' });
+    expect(hireFragmenterDriver.success).toBe(true);
+    const fragmenterDriverId = ctx.state!.employees.employees
+      .filter(e => e.role === 'driver')
+      .find(e => e.id !== haulerDriverId)!.id;
+    employeeCommand(ctx, ['assign_skill', String(fragmenterDriverId)], { skill: 'driving.excavator', level: '5' });
+
+    const buyFragmenter = vehicleCommand(ctx, ['buy', 'rock_fragmenter'], {});
+    expect(buyFragmenter.success).toBe(true);
+    const fragmenterId = ctx.state!.vehicles.vehicles.find(v => v.type === 'rock_fragmenter')!.id;
+
+    const assignFragmenter = vehicleCommand(ctx, ['driver', String(fragmenterId), String(fragmenterDriverId)], {});
+    expect(assignFragmenter.success).toBe(true);
+    for (let i = 0; i < 10; i++) tickCommand(ctx, ['1'], {});
+
+    const breakResult = vehicleCommand(ctx, ['break', String(fragmenterId)], { fragment: String(oversizedId) });
+    expect(breakResult.success).toBe(true);
+
+    let ticks = 0;
+    while (ctx.state!.logistics.fragments.some(f => f.fragment.id === oversizedId) && ticks < 60) {
+      tickCommand(ctx, ['1'], {});
+      ticks++;
+    }
+    expect(ctx.state!.logistics.fragments.some(f => f.fragment.id === oversizedId)).toBe(false);
+
+    const pieces = ctx.state!.logistics.fragments.filter(f => f.state === 'on_ground');
+    expect(pieces.length).toBeGreaterThan(0);
+
+    let totalVolume = 0;
+    for (const p of pieces) {
+      expect(isOversized(p.fragment.volume)).toBe(false);
+      totalVolume += p.fragment.volume;
+    }
+    expect(Math.abs(totalVolume - oversizedVolume)).toBeLessThan(1e-6);
+
+    // 4. Build a freight_warehouse and haul one resulting piece; stored mass
+    // must grow by exactly that piece's mass.
+    const buildResult = buildCommand(ctx, ['freight_warehouse'], { at: '13,13' });
+    expect(buildResult.success).toBe(true);
+
+    const piece = pieces[0]!;
+    const pieceMass = piece.fragment.mass;
+
+    const haulPiece = vehicleCommand(ctx, ['haul', String(haulerId)], { fragment: String(piece.fragment.id) });
+    expect(haulPiece.success).toBe(true);
+
+    const storedBefore = ctx.state!.logistics.storedMassKg;
+    ticks = 0;
+    while (ctx.state!.logistics.storedMassKg === storedBefore && ticks < 60) {
+      tickCommand(ctx, ['1'], {});
+      ticks++;
+    }
+    expect(ctx.state!.logistics.storedMassKg).toBeCloseTo(storedBefore + pieceMass, 6);
+  });
+});

--- a/tests/integration/blast-oversized-boulders.integration.test.ts
+++ b/tests/integration/blast-oversized-boulders.integration.test.ts
@@ -120,6 +120,13 @@ describe('Blast → oversized boulder → break in place (#484)', () => {
     expect(assignFragmenter.success).toBe(true);
     for (let i = 0; i < 10; i++) tickCommand(ctx, ['1'], {});
 
+    // The undercharged, wide-spacing blast leaves a whole rubble field (#484
+    // only breaks the ONE targeted boulder), so "the resulting pieces" must
+    // be scoped to fragments that did not exist before the split — every
+    // other on_ground fragment already sitting in the field, oversized or
+    // not, is unrelated and must not be swept into this check.
+    const idsBeforeBreak = new Set(ctx.state!.logistics.fragments.map(f => f.fragment.id));
+
     const breakResult = vehicleCommand(ctx, ['break', String(fragmenterId)], { fragment: String(oversizedId) });
     expect(breakResult.success).toBe(true);
 
@@ -130,7 +137,9 @@ describe('Blast → oversized boulder → break in place (#484)', () => {
     }
     expect(ctx.state!.logistics.fragments.some(f => f.fragment.id === oversizedId)).toBe(false);
 
-    const pieces = ctx.state!.logistics.fragments.filter(f => f.state === 'on_ground');
+    const pieces = ctx.state!.logistics.fragments.filter(
+      f => f.state === 'on_ground' && !idsBeforeBreak.has(f.fragment.id),
+    );
     expect(pieces.length).toBeGreaterThan(0);
 
     let totalVolume = 0;

--- a/tests/unit/economy/BoulderBreaking.approach.test.ts
+++ b/tests/unit/economy/BoulderBreaking.approach.test.ts
@@ -1,0 +1,130 @@
+// BlastSimulator2026 — Tests for BoulderBreaking's position-gated approach
+// behaviour (issue #484): requestBreakBoulder sets intent only; the split
+// happens strictly on the tickBreakProgress call where the vehicle's
+// position matches the approach cell — never mid-transit, never at request
+// time. Mirrors HaulingTask.test.ts's "travelling" / "arrival at fragment"
+// split, plus a vanished-target abort case unique to the break workflow.
+
+import { describe, it, expect } from 'vitest';
+import { createGame } from '../../../src/core/state/GameState.js';
+import { purchaseVehicle } from '../../../src/core/entities/Vehicle.js';
+import { hireEmployee, assignSkill } from '../../../src/core/entities/Employee.js';
+import { Random } from '../../../src/core/math/Random.js';
+import { addBlastFragments } from '../../../src/core/economy/Logistics.js';
+import type { FragmentData } from '../../../src/core/mining/BlastExecution.js';
+import { requestBreakBoulder, tickBreakProgress } from '../../../src/core/economy/BoulderBreaking.js';
+import { fragmentApproachCell } from '../../../src/core/economy/FragmentApproach.js';
+
+const SEED = 42;
+
+function makeFragment(id: number, x: number, z: number, volume = 1.0, mass = 1000): FragmentData {
+  return {
+    id,
+    position: { x, y: 0, z },
+    volume,
+    mass,
+    rockId: 'cruite',
+    oreDensities: {},
+    initialVelocity: { x: 0, y: 0, z: 0 },
+    isProjection: false,
+  };
+}
+
+function makeDrivenFragmenter(state: ReturnType<typeof createGame>, x = 0, z = 0) {
+  const vehicle = purchaseVehicle(state.vehicles, 'rock_fragmenter', x, z).vehicle;
+  const rng = new Random(SEED);
+  const { employee } = hireEmployee(state.employees, 'driver', rng);
+  assignSkill(state.employees, employee.id, 'driving.excavator', 1);
+  vehicle.driverId = employee.id;
+  return vehicle;
+}
+
+// ── requestBreakBoulder — no synchronous mutation of logistics ─────────────
+
+describe('requestBreakBoulder — defers the split', () => {
+  it('changes only vehicle intent fields, leaving the tracked fragment untouched', () => {
+    const state = createGame({ seed: SEED });
+    const vehicle = makeDrivenFragmenter(state, 0, 0);
+    addBlastFragments(state.logistics, [makeFragment(1, 5, 5, 1.0)]);
+
+    requestBreakBoulder(state, vehicle.id, 1);
+
+    expect(state.logistics.fragments.length).toBe(1);
+    expect(state.logistics.fragments[0]!.fragment.id).toBe(1);
+    expect(state.logistics.fragments[0]!.state).toBe('on_ground');
+    expect(state.logistics.fragments[0]!.fragment.volume).toBe(1.0);
+  });
+});
+
+// ── tickBreakProgress — no-op while travelling ──────────────────────────────
+
+describe('tickBreakProgress — while travelling', () => {
+  it('does not split the fragment while the vehicle has not yet reached the approach cell', () => {
+    const state = createGame({ seed: SEED });
+    const vehicle = makeDrivenFragmenter(state, 0, 0);
+    addBlastFragments(state.logistics, [makeFragment(1, 5, 5, 1.0)]);
+    requestBreakBoulder(state, vehicle.id, 1);
+
+    // Still en route: position does not match the break target.
+    vehicle.x = 1;
+    vehicle.z = 1;
+
+    tickBreakProgress(state, vehicle);
+
+    expect(state.logistics.fragments.length).toBe(1);
+    expect(state.logistics.fragments[0]!.fragment.id).toBe(1);
+    expect(state.logistics.fragments[0]!.state).toBe('on_ground');
+    expect(vehicle.breakPhase).toBe('to_boulder');
+  });
+});
+
+// ── tickBreakProgress — split happens strictly on arrival ──────────────────
+
+describe('tickBreakProgress — arrival', () => {
+  it('splits the fragment strictly on the call where position matches the target, not before', () => {
+    const state = createGame({ seed: SEED });
+    const vehicle = makeDrivenFragmenter(state, 0, 0);
+    const fragment = makeFragment(1, 5, 5, 1.0);
+    addBlastFragments(state.logistics, [fragment]);
+    requestBreakBoulder(state, vehicle.id, 1);
+
+    // Not yet arrived — one tick short of the target.
+    vehicle.x = 1;
+    vehicle.z = 1;
+    tickBreakProgress(state, vehicle);
+    expect(state.logistics.fragments.some(f => f.fragment.id === 1)).toBe(true);
+
+    // Now arrived at the approach cell.
+    const approach = fragmentApproachCell(fragment);
+    vehicle.x = approach.x;
+    vehicle.z = approach.z;
+    tickBreakProgress(state, vehicle);
+
+    expect(state.logistics.fragments.some(f => f.fragment.id === 1)).toBe(false);
+    expect(state.logistics.fragments.length).toBeGreaterThan(0);
+  });
+});
+
+// ── tickBreakProgress — target fragment vanishes before arrival ────────────
+
+describe('tickBreakProgress — target fragment vanishes before arrival', () => {
+  it('aborts cleanly: clears break intent, returns to idle, does not throw, attempts no split', () => {
+    const state = createGame({ seed: SEED });
+    const vehicle = makeDrivenFragmenter(state, 0, 0);
+    addBlastFragments(state.logistics, [makeFragment(1, 5, 5, 1.0)]);
+    requestBreakBoulder(state, vehicle.id, 1);
+
+    // Fragment removed by something else before the vehicle arrives.
+    state.logistics.fragments.length = 0;
+
+    // Vehicle has "arrived" at the now-stale target.
+    vehicle.x = vehicle.targetX;
+    vehicle.z = vehicle.targetZ;
+
+    expect(() => tickBreakProgress(state, vehicle)).not.toThrow();
+    expect(vehicle.breakFragmentId).toBeNull();
+    expect(vehicle.breakPhase).toBeNull();
+    expect(vehicle.task).toBe('idle');
+    expect(state.logistics.fragments.length).toBe(0);
+  });
+});

--- a/tests/unit/economy/BoulderBreaking.test.ts
+++ b/tests/unit/economy/BoulderBreaking.test.ts
@@ -1,0 +1,201 @@
+// BlastSimulator2026 — Tests for BoulderBreaking (issue #484)
+//
+// requestBreakBoulder dispatches a rock_fragmenter toward an oversized
+// on-ground fragment without breaking it immediately; tickBreakProgress
+// splits it into sub-fragments (via fragmentBoulder) only on arrival.
+// Mirrors HaulingTask.test.ts's shape (eligibility gate, request, per-tick
+// progress) for the break workflow instead of the haul one.
+
+import { describe, it, expect } from 'vitest';
+import { createGame } from '../../../src/core/state/GameState.js';
+import { purchaseVehicle } from '../../../src/core/entities/Vehicle.js';
+import { hireEmployee, assignSkill } from '../../../src/core/entities/Employee.js';
+import { Random } from '../../../src/core/math/Random.js';
+import { addBlastFragments } from '../../../src/core/economy/Logistics.js';
+import type { FragmentData } from '../../../src/core/mining/BlastExecution.js';
+import { requestBreakBoulder, tickBreakProgress } from '../../../src/core/economy/BoulderBreaking.js';
+import { fragmentApproachCell } from '../../../src/core/economy/FragmentApproach.js';
+import { isOversized, OVERSIZED_FRAGMENT_THRESHOLD } from '../../../src/core/mining/BlastCalc.js';
+
+const SEED = 42;
+
+function makeFragment(id: number, x: number, z: number, volume = 1.0, mass = 1000): FragmentData {
+  return {
+    id,
+    position: { x, y: 0, z },
+    volume,
+    mass,
+    rockId: 'cruite',
+    oreDensities: {},
+    initialVelocity: { x: 0, y: 0, z: 0 },
+    isProjection: false,
+  };
+}
+
+/** A driverless rock_fragmenter with no active break. */
+function makeIdleFragmenter(state: ReturnType<typeof createGame>, x = 0, z = 0) {
+  return purchaseVehicle(state.vehicles, 'rock_fragmenter', x, z).vehicle;
+}
+
+/** A rock_fragmenter with a licensed driver already boarded (driverId set). */
+function makeDrivenFragmenter(state: ReturnType<typeof createGame>, x = 0, z = 0) {
+  const vehicle = makeIdleFragmenter(state, x, z);
+  const rng = new Random(SEED);
+  const { employee } = hireEmployee(state.employees, 'driver', rng);
+  assignSkill(state.employees, employee.id, 'driving.excavator', 1);
+  vehicle.driverId = employee.id;
+  return vehicle;
+}
+
+// ── requestBreakBoulder — precondition failures ─────────────────────────────
+
+describe('requestBreakBoulder — precondition failures', () => {
+  it('rejects an unknown vehicle ID', () => {
+    const state = createGame({ seed: SEED });
+    addBlastFragments(state.logistics, [makeFragment(1, 5, 5, 1.0)]);
+
+    const result = requestBreakBoulder(state, 9999, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('rejects a debris_hauler (not a rock_fragmenter)', () => {
+    const state = createGame({ seed: SEED });
+    const { vehicle } = purchaseVehicle(state.vehicles, 'debris_hauler', 0, 0);
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'driver', rng);
+    assignSkill(state.employees, employee.id, 'driving.truck', 1);
+    vehicle.driverId = employee.id;
+    addBlastFragments(state.logistics, [makeFragment(1, 5, 5, 1.0)]);
+
+    const result = requestBreakBoulder(state, vehicle.id, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('rejects a rock_fragmenter with driverId: null', () => {
+    const state = createGame({ seed: SEED });
+    const vehicle = makeIdleFragmenter(state);
+    addBlastFragments(state.logistics, [makeFragment(1, 5, 5, 1.0)]);
+
+    const result = requestBreakBoulder(state, vehicle.id, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('rejects a rock_fragmenter already mid-break (breakPhase !== null)', () => {
+    const state = createGame({ seed: SEED });
+    const vehicle = makeDrivenFragmenter(state);
+    vehicle.breakFragmentId = 999;
+    vehicle.breakPhase = 'to_boulder';
+    addBlastFragments(state.logistics, [makeFragment(1, 5, 5, 1.0)]);
+
+    const result = requestBreakBoulder(state, vehicle.id, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('rejects a fragment ID that does not exist', () => {
+    const state = createGame({ seed: SEED });
+    const vehicle = makeDrivenFragmenter(state);
+
+    const result = requestBreakBoulder(state, vehicle.id, 9999);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('rejects a fragment that is not on_ground (already in_transit)', () => {
+    const state = createGame({ seed: SEED });
+    const vehicle = makeDrivenFragmenter(state);
+    addBlastFragments(state.logistics, [makeFragment(1, 5, 5, 1.0)]);
+    state.logistics.fragments[0]!.state = 'in_transit';
+
+    const result = requestBreakBoulder(state, vehicle.id, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('rejects an on_ground fragment whose volume is at/below the oversized threshold', () => {
+    const state = createGame({ seed: SEED });
+    const vehicle = makeDrivenFragmenter(state);
+    addBlastFragments(state.logistics, [makeFragment(1, 5, 5, OVERSIZED_FRAGMENT_THRESHOLD)]);
+
+    const result = requestBreakBoulder(state, vehicle.id, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+});
+
+// ── requestBreakBoulder — happy path defers movement/breaking ──────────────
+
+describe('requestBreakBoulder — happy path', () => {
+  it('sets break intent toward the fragment approach cell without breaking it immediately', () => {
+    const state = createGame({ seed: SEED });
+    const vehicle = makeDrivenFragmenter(state, 0, 0);
+    const fragment = makeFragment(1, 5, 7, 1.0);
+    addBlastFragments(state.logistics, [fragment]);
+
+    const result = requestBreakBoulder(state, vehicle.id, 1);
+    const approach = fragmentApproachCell(fragment);
+
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(vehicle.breakFragmentId).toBe(1);
+    expect(vehicle.breakPhase).toBe('to_boulder');
+    expect(vehicle.targetX).toBe(approach.x);
+    expect(vehicle.targetZ).toBe(approach.z);
+    // The core contract under test: no synchronous split.
+    expect(state.logistics.fragments[0]!.state).toBe('on_ground');
+    expect(state.logistics.fragments[0]!.fragment.id).toBe(1);
+  });
+});
+
+// ── tickBreakProgress — arrival splits the boulder ──────────────────────────
+
+describe('tickBreakProgress — arrival at the boulder', () => {
+  it('replaces the boulder with sub-fragments preserving volume/mass/rock/ore, all under threshold', () => {
+    const state = createGame({ seed: SEED });
+    const vehicle = makeDrivenFragmenter(state, 0, 0);
+    const fragment = makeFragment(1, 5, 5, 1.3, 2600);
+    fragment.oreDensities = { blingite: 0.4, cruarium: 0.1 };
+    addBlastFragments(state.logistics, [fragment]);
+    requestBreakBoulder(state, vehicle.id, 1);
+
+    // Arrived: vehicle position matches the break target.
+    vehicle.x = vehicle.targetX;
+    vehicle.z = vehicle.targetZ;
+
+    const brokenId = tickBreakProgress(state, vehicle);
+
+    expect(brokenId).toBe(1);
+    expect(state.logistics.fragments.some(f => f.fragment.id === 1)).toBe(false);
+
+    const pieces = state.logistics.fragments;
+    expect(pieces.length).toBeGreaterThan(0);
+
+    let totalVolume = 0;
+    let totalMass = 0;
+    for (const p of pieces) {
+      expect(p.state).toBe('on_ground');
+      expect(isOversized(p.fragment.volume)).toBe(false);
+      expect(p.fragment.rockId).toBe(fragment.rockId);
+      expect(p.fragment.oreDensities).toEqual(fragment.oreDensities);
+      totalVolume += p.fragment.volume;
+      totalMass += p.fragment.mass;
+    }
+
+    expect(Math.abs(totalVolume - fragment.volume)).toBeLessThan(1e-9);
+    expect(Math.abs(totalMass - fragment.mass)).toBeLessThan(1e-9);
+
+    expect(vehicle.breakFragmentId).toBeNull();
+    expect(vehicle.breakPhase).toBeNull();
+    expect(vehicle.task).toBe('idle');
+  });
+});

--- a/tests/unit/economy/FragmentApproach.test.ts
+++ b/tests/unit/economy/FragmentApproach.test.ts
@@ -1,0 +1,144 @@
+// BlastSimulator2026 — Tests for FragmentApproach.fragmentApproachCell (#484)
+//
+// The 1-argument (nominal-cell) form is already exercised indirectly by
+// HaulingTask.test.ts and BoulderBreaking.approach.test.ts. The 2-argument
+// occupied-cell fallback — the exact fix for #484's livelock (a
+// rock_fragmenter parked on a fragment's own cell permanently blocking a
+// debris_hauler targeting the same cell) — has no direct coverage anywhere.
+// This file covers `state`/`excludeVehicleId`, the occupied-primary-cell
+// nearest-free-neighbour search, and its fallback when every neighbour is
+// unusable.
+
+import { describe, it, expect } from 'vitest';
+import { createGame } from '../../../src/core/state/GameState.js';
+import { purchaseVehicle } from '../../../src/core/entities/Vehicle.js';
+import { NavGrid, type NavCell } from '../../../src/core/nav/NavGrid.js';
+import type { FragmentData } from '../../../src/core/mining/BlastExecution.js';
+import { fragmentApproachCell } from '../../../src/core/economy/FragmentApproach.js';
+
+const SEED = 42;
+
+function makeFragment(id: number, x: number, z: number): FragmentData {
+  return {
+    id,
+    position: { x, y: 0, z },
+    volume: 0.3,
+    mass: 1000,
+    rockId: 'cruite',
+    oreDensities: {},
+    initialVelocity: { x: 0, y: 0, z: 0 },
+    isProjection: false,
+  };
+}
+
+/** A flat, fully walkable size×size NavGrid, mirroring VehiclePanel.test.ts's fixture. */
+function makeFlatNavGrid(size: number): NavGrid {
+  const cells: NavCell[][] = Array.from({ length: size }, () =>
+    Array.from({ length: size }, () => ({ type: 'walkable' as const, moveCost: 1.0, benchLevel: 0, vehicleOccupied: false })));
+  return new NavGrid(size, size, cells, 0);
+}
+
+const ALL_NEIGHBOR_OFFSETS: readonly [number, number][] = [
+  [-1, -1], [-1, 0], [-1, 1],
+  [0, -1], [0, 1],
+  [1, -1], [1, 0], [1, 1],
+];
+
+describe('fragmentApproachCell — primary cell free', () => {
+  it('returns the fragment\'s own rounded position when no state is supplied (1-arg form)', () => {
+    const fragment = makeFragment(1, 5, 7);
+    expect(fragmentApproachCell(fragment)).toEqual({ x: 5, z: 7 });
+  });
+
+  it('returns the primary cell when state is supplied but no vehicle occupies it', () => {
+    const state = createGame({ seed: SEED });
+    const fragment = makeFragment(1, 5, 7);
+
+    expect(fragmentApproachCell(fragment, state)).toEqual({ x: 5, z: 7 });
+  });
+
+  it('returns the primary cell when the only vehicle there is the excluded one', () => {
+    const state = createGame({ seed: SEED });
+    const fragment = makeFragment(1, 5, 7);
+    const vehicle = purchaseVehicle(state.vehicles, 'rock_fragmenter', 5, 7).vehicle;
+
+    expect(fragmentApproachCell(fragment, state, vehicle.id)).toEqual({ x: 5, z: 7 });
+  });
+});
+
+describe('fragmentApproachCell — primary cell occupied by another vehicle', () => {
+  it('falls back to the nearest free walkable neighbour', () => {
+    const state = createGame({ seed: SEED });
+    state.navGrid = makeFlatNavGrid(64);
+    const fragment = makeFragment(1, 5, 7);
+    // Occupies the fragment's own cell — mirrors a rock_fragmenter parked
+    // where its own sub-fragments spawned (#484's original livelock).
+    purchaseVehicle(state.vehicles, 'rock_fragmenter', 5, 7);
+
+    const result = fragmentApproachCell(fragment, state, /* excludeVehicleId */ 999);
+
+    // Not the occupied primary cell...
+    expect(result).not.toEqual({ x: 5, z: 7 });
+    // ...but a genuine 8-neighbour of it.
+    expect(Math.abs(result.x - 5)).toBeLessThanOrEqual(1);
+    expect(Math.abs(result.z - 7)).toBeLessThanOrEqual(1);
+    // Nearest candidate: iteration order (dx=-1..1, dz=-1..1) picks the
+    // first minimal-distance free cell, which is the cardinal (-1, 0)
+    // neighbour ahead of any diagonal.
+    expect(result).toEqual({ x: 4, z: 7 });
+  });
+
+  it('excludes the requesting vehicle\'s own occupancy of a neighbour from the search', () => {
+    const state = createGame({ seed: SEED });
+    state.navGrid = makeFlatNavGrid(64);
+    const fragment = makeFragment(1, 5, 7);
+    const other = purchaseVehicle(state.vehicles, 'rock_fragmenter', 5, 7).vehicle;
+    // The requesting vehicle itself already sits on the nearest neighbour
+    // cell — it must not be treated as blocking its own path there.
+    const requester = purchaseVehicle(state.vehicles, 'debris_hauler', 4, 7).vehicle;
+
+    const result = fragmentApproachCell(fragment, state, requester.id);
+
+    expect(result).toEqual({ x: 4, z: 7 });
+    expect(other.x).toBe(5);
+  });
+
+  it('falls back to the primary cell when every neighbour is occupied or unwalkable', () => {
+    const state = createGame({ seed: SEED });
+    state.navGrid = makeFlatNavGrid(64);
+    const fragment = makeFragment(1, 5, 7);
+    purchaseVehicle(state.vehicles, 'rock_fragmenter', 5, 7);
+
+    // Block half the ring via the NavGrid, occupy the other half with vehicles.
+    ALL_NEIGHBOR_OFFSETS.forEach(([dx, dz], i) => {
+      const x = 5 + dx;
+      const z = 7 + dz;
+      if (i % 2 === 0) {
+        state.navGrid!.setCellAt(x, z, { type: 'blocked', moveCost: 1.0, benchLevel: 0, vehicleOccupied: false });
+      } else {
+        purchaseVehicle(state.vehicles, 'debris_hauler', x, z);
+      }
+    });
+
+    const result = fragmentApproachCell(fragment, state, /* excludeVehicleId */ 999);
+
+    // Documented fallback (see FragmentApproach.ts): `best ?? primary` — the
+    // caller's own stuck-detection handles a genuinely unreachable target
+    // rather than this function throwing or looping.
+    expect(result).toEqual({ x: 5, z: 7 });
+  });
+
+  it('falls back to the primary cell when state has no navGrid and every neighbour is occupied', () => {
+    const state = createGame({ seed: SEED });
+    // No navGrid assigned — mirrors a caller that only has vehicle data.
+    const fragment = makeFragment(1, 5, 7);
+    purchaseVehicle(state.vehicles, 'rock_fragmenter', 5, 7);
+    ALL_NEIGHBOR_OFFSETS.forEach(([dx, dz]) => {
+      purchaseVehicle(state.vehicles, 'debris_hauler', 5 + dx, 7 + dz);
+    });
+
+    const result = fragmentApproachCell(fragment, state, /* excludeVehicleId */ 999);
+
+    expect(result).toEqual({ x: 5, z: 7 });
+  });
+});

--- a/tests/unit/economy/HaulingTask.test.ts
+++ b/tests/unit/economy/HaulingTask.test.ts
@@ -15,6 +15,9 @@ import { addBlastFragments } from '../../../src/core/economy/Logistics.js';
 import type { FragmentData } from '../../../src/core/mining/BlastExecution.js';
 import { requestHaulFragment, tickHaulingProgress, findReachableGroundFragment } from '../../../src/core/economy/HaulingTask.js';
 import { NavGrid, type NavCell, type NavCellType } from '../../../src/core/nav/NavGrid.js';
+import { requestBreakBoulder } from '../../../src/core/economy/BoulderBreaking.js';
+import { fragmentApproachCell } from '../../../src/core/economy/FragmentApproach.js';
+import { OVERSIZED_FRAGMENT_THRESHOLD } from '../../../src/core/mining/BlastCalc.js';
 
 const SEED = 42;
 const GRID = 64;
@@ -385,5 +388,109 @@ describe('findReachableGroundFragment — selection', () => {
     state.logistics.fragments[0]!.state = 'in_transit';
 
     expect(findReachableGroundFragment(state, vehicle.id)).toBeNull();
+  });
+});
+
+// ── requestHaulFragment — oversized fragment rejection (#484) ──────────────
+//
+// An oversized boulder must be broken by a Rock Fragmenter before it can be
+// hauled — a debris_hauler must refuse it outright. isOversized is strictly
+// `>` the threshold (BoulderFragmentation.ts), so a fragment exactly at the
+// threshold must still be haulable — an inverted `>=` comparison here would
+// silently strand every threshold-sized fragment.
+
+describe('requestHaulFragment — oversized fragment rejection (#484)', () => {
+  it('rejects an on_ground fragment whose volume exceeds the oversized threshold', () => {
+    const state = createGame({ seed: SEED });
+    placeWarehouse(state, 10, 10);
+    const vehicle = makeDrivenHauler(state, 0, 0);
+    const oversized = makeFragment(1, 5, 5);
+    oversized.volume = OVERSIZED_FRAGMENT_THRESHOLD + 0.01;
+    addBlastFragments(state.logistics, [oversized]);
+
+    const result = requestHaulFragment(state, vehicle.id, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(state.logistics.fragments[0]!.state).toBe('on_ground');
+  });
+
+  it('accepts a fragment exactly at the oversized threshold (isOversized must be strictly >, not >=)', () => {
+    const state = createGame({ seed: SEED });
+    const warehouse = placeWarehouse(state, 10, 10);
+    const vehicle = makeDrivenHauler(state, 0, 0);
+    const atThreshold = makeFragment(1, 5, 5);
+    atThreshold.volume = OVERSIZED_FRAGMENT_THRESHOLD;
+    addBlastFragments(state.logistics, [atThreshold]);
+
+    const result = requestHaulFragment(state, vehicle.id, 1);
+
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(vehicle.haulingDepotBuildingId).toBe(warehouse.id);
+  });
+});
+
+// ── findReachableGroundFragment — oversized exclusion (#484) ───────────────
+
+describe('findReachableGroundFragment — oversized exclusion (#484)', () => {
+  it('never returns an oversized fragment even when it is nearest and reachable, picking the next reachable non-oversized one instead', () => {
+    const state = createGame({ seed: SEED });
+    state.navGrid = makeFlatNavGrid(20);
+    const vehicle = makeDrivenHauler(state, 0, 0);
+    const oversizedNear = makeFragment(1, 2, 2); // nearest by distance
+    oversizedNear.volume = OVERSIZED_FRAGMENT_THRESHOLD + 0.5;
+    const haulableFar = makeFragment(2, 5, 5); // farther, but haulable
+    haulableFar.volume = OVERSIZED_FRAGMENT_THRESHOLD;
+    addBlastFragments(state.logistics, [oversizedNear, haulableFar]);
+
+    expect(findReachableGroundFragment(state, vehicle.id)).toBe(2);
+  });
+
+  it('returns null when the only reachable on-ground fragment is oversized', () => {
+    const state = createGame({ seed: SEED });
+    state.navGrid = makeFlatNavGrid(20);
+    const vehicle = makeDrivenHauler(state, 0, 0);
+    const oversized = makeFragment(1, 3, 3);
+    oversized.volume = OVERSIZED_FRAGMENT_THRESHOLD + 1;
+    addBlastFragments(state.logistics, [oversized]);
+
+    expect(findReachableGroundFragment(state, vehicle.id)).toBeNull();
+  });
+});
+
+// ── fragmentApproachCell — shared approach resolution (#484) ───────────────
+//
+// Hauling and breaking dispatch different vehicle roles at the same fragment
+// position, but both must resolve to the identical NavGrid approach cell —
+// otherwise a hauler and a fragmenter sent to the same boulder would park in
+// different places.
+
+describe('fragmentApproachCell — shared between hauling and breaking (#484)', () => {
+  it('haul and break resolve the same approach cell for equivalent fragments at the same position', () => {
+    const haulState = createGame({ seed: SEED });
+    placeWarehouse(haulState, 10, 10);
+    const haulVehicle = makeDrivenHauler(haulState, 0, 0);
+    const haulFragment = makeFragment(1, 6, 9);
+    haulFragment.volume = OVERSIZED_FRAGMENT_THRESHOLD; // at threshold: haulable
+    addBlastFragments(haulState.logistics, [haulFragment]);
+    requestHaulFragment(haulState, haulVehicle.id, 1);
+
+    const breakState = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { vehicle: breakVehicle } = purchaseVehicle(breakState.vehicles, 'rock_fragmenter', 0, 0);
+    const { employee } = hireEmployee(breakState.employees, 'driver', rng);
+    assignSkill(breakState.employees, employee.id, 'driving.excavator', 1);
+    breakVehicle.driverId = employee.id;
+    const breakFragment = makeFragment(1, 6, 9);
+    breakFragment.volume = OVERSIZED_FRAGMENT_THRESHOLD + 0.5; // oversized: breakable
+    addBlastFragments(breakState.logistics, [breakFragment]);
+    requestBreakBoulder(breakState, breakVehicle.id, 1);
+
+    const expected = fragmentApproachCell(haulFragment);
+    expect(haulVehicle.targetX).toBe(expected.x);
+    expect(haulVehicle.targetZ).toBe(expected.z);
+    expect(breakVehicle.targetX).toBe(expected.x);
+    expect(breakVehicle.targetZ).toBe(expected.z);
   });
 });

--- a/tests/unit/economy/HaulingTask.test.ts
+++ b/tests/unit/economy/HaulingTask.test.ts
@@ -22,11 +22,15 @@ import { OVERSIZED_FRAGMENT_THRESHOLD } from '../../../src/core/mining/BlastCalc
 const SEED = 42;
 const GRID = 64;
 
+// Default volume sits under OVERSIZED_FRAGMENT_THRESHOLD (0.5 m³, see
+// BoulderFragmentation.ts) so plain haul-path fixtures stay haulable by
+// default; tests that specifically exercise the oversized gate (#484)
+// override `.volume` explicitly against the real constant.
 function makeFragment(id: number, x: number, z: number, mass = 1000): FragmentData {
   return {
     id,
     position: { x, y: 0, z },
-    volume: 1.0,
+    volume: 0.3,
     mass,
     rockId: 'cruite',
     oreDensities: {},

--- a/tests/unit/ui/VehiclePanel.break.test.ts
+++ b/tests/unit/ui/VehiclePanel.break.test.ts
@@ -1,0 +1,141 @@
+// BlastSimulator2026 — VehiclePanel Break button tests (issue #484)
+// The only UI control that can trigger `vehicle break` — without it, an
+// oversized boulder a debris_hauler refused can never be broken up except
+// via the console. Split from VehiclePanel.test.ts to keep both files under
+// the ~300-line convention; mirrors VehiclePanel.test.ts's Haul button (#466)
+// block for the break workflow instead of the haul one.
+
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { VehiclePanel } from '../../../src/ui/VehiclePanel.js';
+import { createGame } from '../../../src/core/state/GameState.js';
+import type { GameState } from '../../../src/core/state/GameState.js';
+import { purchaseVehicle } from '../../../src/core/entities/Vehicle.js';
+import { hireEmployee, assignSkill } from '../../../src/core/entities/Employee.js';
+import { Random } from '../../../src/core/math/Random.js';
+import { addBlastFragments } from '../../../src/core/economy/Logistics.js';
+import { NavGrid } from '../../../src/core/nav/NavGrid.js';
+import type { FragmentData } from '../../../src/core/mining/BlastExecution.js';
+import type { CommandResult } from '../../../src/console/ConsoleRunner.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeState(cash = 200_000): GameState {
+  const s = createGame({ seed: 42, mineType: 'desert' });
+  s.cash = cash;
+  return s;
+}
+
+function setupPanel(): { container: HTMLDivElement; panel: VehiclePanel } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const panel = new VehiclePanel(container);
+  return { container, panel };
+}
+
+const SEED = 42;
+
+/** A flat, fully walkable size×size NavGrid — GameState.navGrid is null until
+ *  a world is built via `new_game`, so the panel's own tests build one directly. */
+function makeFlatNavGrid(size: number): NavGrid {
+  const cells = Array.from({ length: size }, () =>
+    Array.from({ length: size }, () => ({ type: 'walkable' as const, moveCost: 1.0, benchLevel: 0, vehicleOccupied: false })));
+  return new NavGrid(size, size, cells, 0);
+}
+
+/** A rock_fragmenter with a licensed driver boarded, on a flat NavGrid. */
+function makeDrivenFragmenterState(): { state: GameState; vehicleId: number } {
+  const state = makeState();
+  state.navGrid = makeFlatNavGrid(20);
+  const { vehicle } = purchaseVehicle(state.vehicles, 'rock_fragmenter', 0, 0);
+  const rng = new Random(SEED);
+  const { employee } = hireEmployee(state.employees, 'driver', rng);
+  assignSkill(state.employees, employee.id, 'driving.excavator', 1);
+  vehicle.driverId = employee.id;
+  return { state, vehicleId: vehicle.id };
+}
+
+// Oversized boulder — volume must exceed OVERSIZED_FRAGMENT_THRESHOLD (0.5 m³,
+// see BoulderFragmentation.ts) so it is eligible for
+// findReachableOversizedFragment (#484's break-eligibility gate).
+function makeOversizedFragment(id: number, x: number, z: number, mass = 5000): FragmentData {
+  return {
+    id,
+    position: { x, y: 0, z },
+    volume: 1.0,
+    mass,
+    rockId: 'cruite',
+    oreDensities: {},
+    initialVelocity: { x: 0, y: 0, z: 0 },
+    isProjection: false,
+  };
+}
+
+// ── Break button (#484) ──────────────────────────────────────────────────────
+
+describe('VehiclePanel — Break button (#484)', () => {
+  it('renders the Break button for a rock_fragmenter with a driver and a reachable oversized fragment', () => {
+    const { container, panel } = setupPanel();
+    const { state } = makeDrivenFragmenterState();
+    addBlastFragments(state.logistics, [makeOversizedFragment(1, 3, 3)]);
+
+    panel.update(state);
+
+    expect(container.querySelector('.bs-vehicle-break-btn')).not.toBeNull();
+  });
+
+  it('does not render the Break button when no reachable oversized fragment exists', () => {
+    const { container, panel } = setupPanel();
+    const { state } = makeDrivenFragmenterState();
+    // No fragments at all — nothing to break.
+
+    panel.update(state);
+
+    expect(container.querySelector('.bs-vehicle-break-btn')).toBeNull();
+  });
+
+  it('does not render the Break button when the vehicle is already breaking (breakPhase !== null)', () => {
+    const { container, panel } = setupPanel();
+    const { state, vehicleId } = makeDrivenFragmenterState();
+    addBlastFragments(state.logistics, [makeOversizedFragment(1, 3, 3)]);
+    const vehicle = state.vehicles.vehicles.find(v => v.id === vehicleId)!;
+    vehicle.breakPhase = 'to_boulder';
+
+    panel.update(state);
+
+    expect(container.querySelector('.bs-vehicle-break-btn')).toBeNull();
+  });
+
+  it('does not render the Break button when the vehicle has no driver', () => {
+    const { container, panel } = setupPanel();
+    const state = makeState();
+    state.navGrid = makeFlatNavGrid(20);
+    purchaseVehicle(state.vehicles, 'rock_fragmenter', 0, 0);
+    addBlastFragments(state.logistics, [makeOversizedFragment(1, 3, 3)]);
+
+    panel.update(state);
+
+    expect(container.querySelector('.bs-vehicle-break-btn')).toBeNull();
+  });
+
+  it('clicking the Break button dispatches "vehicle break <vehicleId> fragment:<resolvedFragmentId>"', () => {
+    const { container, panel } = setupPanel();
+    const { state, vehicleId } = makeDrivenFragmenterState();
+    addBlastFragments(state.logistics, [makeOversizedFragment(9, 3, 3)]);
+    panel.update(state);
+
+    const commands: string[] = [];
+    panel.setGameConsole((cmd: string): CommandResult => {
+      commands.push(cmd);
+      return { success: true, output: '' };
+    });
+
+    const btn = container.querySelector('.bs-vehicle-break-btn') as HTMLButtonElement | null;
+    expect(btn).not.toBeNull();
+    btn!.click();
+
+    // Mirrors the Haul button's dispatch mechanism: a direct gameConsole(cmd)
+    // call, not a DOM CustomEvent.
+    expect(commands).toContain(`vehicle break ${vehicleId} fragment:9`);
+  });
+});

--- a/tests/unit/ui/VehiclePanel.test.ts
+++ b/tests/unit/ui/VehiclePanel.test.ts
@@ -34,11 +34,14 @@ function setupPanel(): { container: HTMLDivElement; panel: VehiclePanel } {
 
 const SEED = 42;
 
+// Default volume sits under OVERSIZED_FRAGMENT_THRESHOLD (0.5 m³, see
+// BoulderFragmentation.ts) so these haul-button fixtures stay haulable and
+// eligible for findReachableGroundFragment (#484 excludes oversized ones).
 function makeFragment(id: number, x: number, z: number, mass = 1000): FragmentData {
   return {
     id,
     position: { x, y: 0, z },
-    volume: 1.0,
+    volume: 0.3,
     mass,
     rockId: 'cruite',
     oreDensities: {},

--- a/tests/unit/ui/VehiclePanel.test.ts
+++ b/tests/unit/ui/VehiclePanel.test.ts
@@ -70,34 +70,6 @@ function makeDrivenHaulerState(): { state: GameState; vehicleId: number } {
   return { state, vehicleId: vehicle.id };
 }
 
-/** A rock_fragmenter with a licensed driver boarded, on a flat NavGrid. */
-function makeDrivenFragmenterState(): { state: GameState; vehicleId: number } {
-  const state = makeState();
-  state.navGrid = makeFlatNavGrid(20);
-  const { vehicle } = purchaseVehicle(state.vehicles, 'rock_fragmenter', 0, 0);
-  const rng = new Random(SEED);
-  const { employee } = hireEmployee(state.employees, 'driver', rng);
-  assignSkill(state.employees, employee.id, 'driving.excavator', 1);
-  vehicle.driverId = employee.id;
-  return { state, vehicleId: vehicle.id };
-}
-
-// Oversized boulder — volume must exceed OVERSIZED_FRAGMENT_THRESHOLD (0.5 m³,
-// see BoulderFragmentation.ts) so it is eligible for
-// findReachableOversizedFragment (#484's break-eligibility gate).
-function makeOversizedFragment(id: number, x: number, z: number, mass = 5000): FragmentData {
-  return {
-    id,
-    position: { x, y: 0, z },
-    volume: 1.0,
-    mass,
-    rockId: 'cruite',
-    oreDensities: {},
-    initialVelocity: { x: 0, y: 0, z: 0 },
-    isProjection: false,
-  };
-}
-
 // ── Buy section — per-tier buttons ──────────────────────────────────────────
 
 describe('VehiclePanel — tier buy buttons (#411)', () => {
@@ -308,77 +280,5 @@ describe('VehiclePanel — Haul button (#466)', () => {
     // Mirrors the driver-assign button's dispatch mechanism: a direct
     // gameConsole(cmd) call, not a DOM CustomEvent.
     expect(commands).toContain(`vehicle haul ${vehicleId} fragment:7`);
-  });
-});
-
-// ── Break button (#484) ──────────────────────────────────────────────────────
-// The only UI control that can trigger `vehicle break` — without it, an
-// oversized boulder a debris_hauler refused can never be broken up except
-// via the console (issue #484).
-
-describe('VehiclePanel — Break button (#484)', () => {
-  it('renders the Break button for a rock_fragmenter with a driver and a reachable oversized fragment', () => {
-    const { container, panel } = setupPanel();
-    const { state } = makeDrivenFragmenterState();
-    addBlastFragments(state.logistics, [makeOversizedFragment(1, 3, 3)]);
-
-    panel.update(state);
-
-    expect(container.querySelector('.bs-vehicle-break-btn')).not.toBeNull();
-  });
-
-  it('does not render the Break button when no reachable oversized fragment exists', () => {
-    const { container, panel } = setupPanel();
-    const { state } = makeDrivenFragmenterState();
-    // No fragments at all — nothing to break.
-
-    panel.update(state);
-
-    expect(container.querySelector('.bs-vehicle-break-btn')).toBeNull();
-  });
-
-  it('does not render the Break button when the vehicle is already breaking (breakPhase !== null)', () => {
-    const { container, panel } = setupPanel();
-    const { state, vehicleId } = makeDrivenFragmenterState();
-    addBlastFragments(state.logistics, [makeOversizedFragment(1, 3, 3)]);
-    const vehicle = state.vehicles.vehicles.find(v => v.id === vehicleId)!;
-    vehicle.breakPhase = 'to_boulder';
-
-    panel.update(state);
-
-    expect(container.querySelector('.bs-vehicle-break-btn')).toBeNull();
-  });
-
-  it('does not render the Break button when the vehicle has no driver', () => {
-    const { container, panel } = setupPanel();
-    const state = makeState();
-    state.navGrid = makeFlatNavGrid(20);
-    purchaseVehicle(state.vehicles, 'rock_fragmenter', 0, 0);
-    addBlastFragments(state.logistics, [makeOversizedFragment(1, 3, 3)]);
-
-    panel.update(state);
-
-    expect(container.querySelector('.bs-vehicle-break-btn')).toBeNull();
-  });
-
-  it('clicking the Break button dispatches "vehicle break <vehicleId> fragment:<resolvedFragmentId>"', () => {
-    const { container, panel } = setupPanel();
-    const { state, vehicleId } = makeDrivenFragmenterState();
-    addBlastFragments(state.logistics, [makeOversizedFragment(9, 3, 3)]);
-    panel.update(state);
-
-    const commands: string[] = [];
-    panel.setGameConsole((cmd: string): CommandResult => {
-      commands.push(cmd);
-      return { success: true, output: '' };
-    });
-
-    const btn = container.querySelector('.bs-vehicle-break-btn') as HTMLButtonElement | null;
-    expect(btn).not.toBeNull();
-    btn!.click();
-
-    // Mirrors the Haul button's dispatch mechanism: a direct gameConsole(cmd)
-    // call, not a DOM CustomEvent.
-    expect(commands).toContain(`vehicle break ${vehicleId} fragment:9`);
   });
 });

--- a/tests/unit/ui/VehiclePanel.test.ts
+++ b/tests/unit/ui/VehiclePanel.test.ts
@@ -70,6 +70,34 @@ function makeDrivenHaulerState(): { state: GameState; vehicleId: number } {
   return { state, vehicleId: vehicle.id };
 }
 
+/** A rock_fragmenter with a licensed driver boarded, on a flat NavGrid. */
+function makeDrivenFragmenterState(): { state: GameState; vehicleId: number } {
+  const state = makeState();
+  state.navGrid = makeFlatNavGrid(20);
+  const { vehicle } = purchaseVehicle(state.vehicles, 'rock_fragmenter', 0, 0);
+  const rng = new Random(SEED);
+  const { employee } = hireEmployee(state.employees, 'driver', rng);
+  assignSkill(state.employees, employee.id, 'driving.excavator', 1);
+  vehicle.driverId = employee.id;
+  return { state, vehicleId: vehicle.id };
+}
+
+// Oversized boulder — volume must exceed OVERSIZED_FRAGMENT_THRESHOLD (0.5 m³,
+// see BoulderFragmentation.ts) so it is eligible for
+// findReachableOversizedFragment (#484's break-eligibility gate).
+function makeOversizedFragment(id: number, x: number, z: number, mass = 5000): FragmentData {
+  return {
+    id,
+    position: { x, y: 0, z },
+    volume: 1.0,
+    mass,
+    rockId: 'cruite',
+    oreDensities: {},
+    initialVelocity: { x: 0, y: 0, z: 0 },
+    isProjection: false,
+  };
+}
+
 // ── Buy section — per-tier buttons ──────────────────────────────────────────
 
 describe('VehiclePanel — tier buy buttons (#411)', () => {
@@ -280,5 +308,77 @@ describe('VehiclePanel — Haul button (#466)', () => {
     // Mirrors the driver-assign button's dispatch mechanism: a direct
     // gameConsole(cmd) call, not a DOM CustomEvent.
     expect(commands).toContain(`vehicle haul ${vehicleId} fragment:7`);
+  });
+});
+
+// ── Break button (#484) ──────────────────────────────────────────────────────
+// The only UI control that can trigger `vehicle break` — without it, an
+// oversized boulder a debris_hauler refused can never be broken up except
+// via the console (issue #484).
+
+describe('VehiclePanel — Break button (#484)', () => {
+  it('renders the Break button for a rock_fragmenter with a driver and a reachable oversized fragment', () => {
+    const { container, panel } = setupPanel();
+    const { state } = makeDrivenFragmenterState();
+    addBlastFragments(state.logistics, [makeOversizedFragment(1, 3, 3)]);
+
+    panel.update(state);
+
+    expect(container.querySelector('.bs-vehicle-break-btn')).not.toBeNull();
+  });
+
+  it('does not render the Break button when no reachable oversized fragment exists', () => {
+    const { container, panel } = setupPanel();
+    const { state } = makeDrivenFragmenterState();
+    // No fragments at all — nothing to break.
+
+    panel.update(state);
+
+    expect(container.querySelector('.bs-vehicle-break-btn')).toBeNull();
+  });
+
+  it('does not render the Break button when the vehicle is already breaking (breakPhase !== null)', () => {
+    const { container, panel } = setupPanel();
+    const { state, vehicleId } = makeDrivenFragmenterState();
+    addBlastFragments(state.logistics, [makeOversizedFragment(1, 3, 3)]);
+    const vehicle = state.vehicles.vehicles.find(v => v.id === vehicleId)!;
+    vehicle.breakPhase = 'to_boulder';
+
+    panel.update(state);
+
+    expect(container.querySelector('.bs-vehicle-break-btn')).toBeNull();
+  });
+
+  it('does not render the Break button when the vehicle has no driver', () => {
+    const { container, panel } = setupPanel();
+    const state = makeState();
+    state.navGrid = makeFlatNavGrid(20);
+    purchaseVehicle(state.vehicles, 'rock_fragmenter', 0, 0);
+    addBlastFragments(state.logistics, [makeOversizedFragment(1, 3, 3)]);
+
+    panel.update(state);
+
+    expect(container.querySelector('.bs-vehicle-break-btn')).toBeNull();
+  });
+
+  it('clicking the Break button dispatches "vehicle break <vehicleId> fragment:<resolvedFragmentId>"', () => {
+    const { container, panel } = setupPanel();
+    const { state, vehicleId } = makeDrivenFragmenterState();
+    addBlastFragments(state.logistics, [makeOversizedFragment(9, 3, 3)]);
+    panel.update(state);
+
+    const commands: string[] = [];
+    panel.setGameConsole((cmd: string): CommandResult => {
+      commands.push(cmd);
+      return { success: true, output: '' };
+    });
+
+    const btn = container.querySelector('.bs-vehicle-break-btn') as HTMLButtonElement | null;
+    expect(btn).not.toBeNull();
+    btn!.click();
+
+    // Mirrors the Haul button's dispatch mechanism: a direct gameConsole(cmd)
+    // call, not a DOM CustomEvent.
+    expect(commands).toContain(`vehicle break ${vehicleId} fragment:9`);
   });
 });


### PR DESCRIPTION
Closes #484

## Summary

A debris hauler now refuses oversized fragments (clear rejection reason, fragment stays on the ground), and a `rock_fragmenter` vehicle with a driver can be sent to break one in place. It drives to the boulder first and only splits it on arrival — never at range — replacing it in logistics with `fragmentBoulder`'s sub-pieces (volume, mass, rock composition and ore preserved). Reachable both via `vehicle break <id> fragment:<id>` in the console and via a new "Break" button in the vehicle panel, mirroring the existing Haul button.

7087 tests — all passing (257 files).

## Files

- `src/core/economy/HaulingTask.ts` — rejects oversized fragments in `requestHaulFragment`; `findReachableGroundFragment` skips them
- `src/core/economy/FragmentApproach.ts` (new) — shared approach-cell resolution for hauling and breaking, with an occupied-cell fallback (see Decisions taken)
- `src/core/economy/FragmentTaskLifecycle.ts` (new) — task-lifecycle logic shared between hauling and breaking, extracted to remove duplication flagged by qualimetry
- `src/core/economy/BoulderBreaking.ts` (new) — request/tick/complete a break task for a `rock_fragmenter`; swaps the boulder for sub-fragments in `LogisticsState`
- `src/core/entities/Vehicle.ts` / `VehicleDriverAssignment.ts` — break-task fields on `Vehicle` (split out to stay under the file-size convention)
- `src/core/engine/ArrivalGate.ts` — drives the break task's arrival phases
- `src/console/commands/vehicle.ts` — `vehicle break <id> fragment:<id>` subcommand
- `src/ui/vehicleBreakButton.ts` (new) — vehicle-panel action for an eligible crewed `rock_fragmenter`
- `src/ui/VehiclePanel.ts` — wires in the new button
- `src/core/i18n/locales/en.json`, `fr.json` — `ui.vehicles.break` string
- Tests: `tests/unit/economy/{BoulderBreaking,BoulderBreaking.approach,FragmentApproach,HaulingTask}.test.ts`, `tests/integration/blast-oversized-boulders.integration.test.ts`, `tests/unit/ui/VehiclePanel.break.test.ts`, `scripts/scenario-defs/rock-fragmenter-breaking.json`

## Decisions taken

Defaulted under `agentic-decision-autonomy` — one internal correctness decision, not a gameplay/economy/player-facing default, no follow-up issue needed.

- **What was open:** the issue's own convention note says hauling and breaking must resolve their approach cell through the same helper, but is silent on what happens when two vehicles need the same cell at once (e.g. a `rock_fragmenter` parks on a fragment's cell to break it, then a `debris_hauler` is sent to one of the resulting sub-fragments sitting at that same cell).
  **Chosen:** `fragmentApproachCell()` in `FragmentApproach.ts` now takes the vehicle's own id and searches the 8 neighboring cells for the nearest free, walkable one when the primary cell is occupied by another vehicle, falling back to the primary cell if none are free (`best ?? primary`).
  **Why:** without this, a `rock_fragmenter` idle on its parked cell permanently blocked any hauler later sent to a fragment on/near that cell — confirmed via visual testing as a real livelock (`waitingTicks` climbing indefinitely, no existing stuck-detection or traffic-jam mechanism ever resolves it). This was found and fixed during this run's own visual-feedback-loop, not left as a known gap.
  **If reversed:** drop the neighbor search in `fragmentApproachCell()` and revert to always returning the fragment's own cell; the two callers in `BoulderBreaking.ts`/`HaulingTask.ts` don't need to change.

## Verification

- `static` — `npm run typecheck`: PASS.
- `logic` — `npx vitest run`: PASS, 257 files / 7087 tests.
- `scenario` — `npm run scenarios` (command mode): PASS, 112/112, includes `rock-fragmenter-breaking`.
- `build` — `npx vite build`: PASS.
- `visual` — PASS. Two full interaction-mode iterations of `scripts/scenario-defs/rock-fragmenter-breaking.json` were run and every screenshot inspected. The first found a real livelock bug and a scenario-def bug (stale fragment id); both fixed. The second confirmed: the boulder stays whole while the fragmenter travels, splits only on arrival, oversized-haul refusal shows its reason, and broken pieces haul and store normally. A later semantic-review pass independently reran the scenario and confirmed the Break/Haul buttons fire via real DOM clicks (`clickSelector` on `.bs-vehicle-break-btn`/`.bs-vehicle-haul-btn`).
- `playability` — PASS. This touches the vehicle panel (player-facing flow), so `full-ci` was applied and CI's `Playtest (playability)` job (`npx tsx scripts/playtest.ts --screenshots`) ran the whole suite through real UI clicks: success. CI's `Scenarios (interaction mode)` job also passed. Run: https://github.com/Nico2398/BlastSimulator2026/actions/runs/31009806920

All five verification channels PASS.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test`
- [x] `npm run scenarios`
- [x] `npm run build`
- [x] Visual inspection of `rock-fragmenter-breaking` scenario screenshots (interaction mode, two iterations)
- [x] CI playability suite (`full-ci` label) — https://github.com/Nico2398/BlastSimulator2026/actions/runs/31009806920

READY TO MERGE
