### PR TITLE
feat: fragment tumble and settle animation during blast collapse (#485)

### DIFF
--- a/.claude/skills/gameplay-blast-system/SKILL.md
+++ b/.claude/skills/gameplay-blast-system/SKILL.md
@@ -162,6 +162,15 @@ straight; the vertical is the parabola joining those points in the flight's own 
 gravity, so **the animation cannot end anywhere but the fragment's authoritative position**. For a
 straight drop it reduces to free fall from rest. Skipping playback entirely is always safe.
 
+While airborne a fragment also tumbles about its own seeded axis, at a rate scaled by how hard it
+was thrown (`impactSpeed` against `MAX_PROJECTION_VELOCITY`; a mere drop barely rotates —
+`TUMBLE_DROP_FACTOR`, `TUMBLE_MAX_RATE_RAD_S`). On landing it eases the tumble back to exactly its
+untumbled spawn orientation while its scale does a damped squash-and-stretch bounce
+(`SETTLE_DURATION_S`, `SETTLE_SQUASH_MAGNITUDE`, `SETTLE_BOUNCE_OSCILLATIONS`), then snaps to the
+identity transform rather than approaching it asymptotically. This math (`FragmentTransformMath.ts`)
+is a pure function of `(flight, t)`, so a seek and a run of per-frame updates landing on the same `t`
+agree, and `finish()` puts every fragment at exactly the untumbled, unsettled rest transform.
+
 **A screenshot taken right after a blast is a screenshot of an animation, not of a muck pile.**
 `SceneManager` caps a frame at 0.1 s of animation time, and a frame costs seconds without a GPU, so
 a collapse takes many minutes of wall clock to finish on screen and rock photographs as if it were
@@ -174,9 +183,12 @@ than the times the frame rate allowed.
 by seeded planes into a closed convex "cut stone" (`FragmentGeometry.ts`), scaled per instance to the
 fragment's half-extents, with a seeded orientation and slight shear so instances of one variant read
 as different rocks. The stones are watertight by construction and by test — never go back to
-jittering a box's vertices, whose per-face duplicates tear apart into floating planes. The shear
-lives inside the instance matrix, so position updates must write the translation column only; a
-TRS decompose/recompose silently strips it.
+jittering a box's vertices, whose per-face duplicates tear apart into floating planes. The
+rotation/shear/scale part of a fragment's spawn transform never changes over its life and is built
+once (`buildBaseTransform`); each frame's `updateTransforms` recomposes only the cheap part —
+position, tumble rotation, settle scale — on top of it (`composeInstanceMatrix`), so a settled
+fragment's matrix is bit-identical to its spawn one. Never decompose/recompose the instance matrix
+as TRS — the shear does not survive that round trip.
 
 **The whole blast resolves synchronously inside the click**, so the pipeline's cost is a frame the
 player feels. Its hot paths are engineered accordingly — typed-array frontier in propagation, per-

--- a/.github/skills/gameplay-blast-system/SKILL.md
+++ b/.github/skills/gameplay-blast-system/SKILL.md
@@ -162,6 +162,15 @@ straight; the vertical is the parabola joining those points in the flight's own 
 gravity, so **the animation cannot end anywhere but the fragment's authoritative position**. For a
 straight drop it reduces to free fall from rest. Skipping playback entirely is always safe.
 
+While airborne a fragment also tumbles about its own seeded axis, at a rate scaled by how hard it
+was thrown (`impactSpeed` against `MAX_PROJECTION_VELOCITY`; a mere drop barely rotates —
+`TUMBLE_DROP_FACTOR`, `TUMBLE_MAX_RATE_RAD_S`). On landing it eases the tumble back to exactly its
+untumbled spawn orientation while its scale does a damped squash-and-stretch bounce
+(`SETTLE_DURATION_S`, `SETTLE_SQUASH_MAGNITUDE`, `SETTLE_BOUNCE_OSCILLATIONS`), then snaps to the
+identity transform rather than approaching it asymptotically. This math (`FragmentTransformMath.ts`)
+is a pure function of `(flight, t)`, so a seek and a run of per-frame updates landing on the same `t`
+agree, and `finish()` puts every fragment at exactly the untumbled, unsettled rest transform.
+
 **A screenshot taken right after a blast is a screenshot of an animation, not of a muck pile.**
 `SceneManager` caps a frame at 0.1 s of animation time, and a frame costs seconds without a GPU, so
 a collapse takes many minutes of wall clock to finish on screen and rock photographs as if it were
@@ -174,9 +183,12 @@ than the times the frame rate allowed.
 by seeded planes into a closed convex "cut stone" (`FragmentGeometry.ts`), scaled per instance to the
 fragment's half-extents, with a seeded orientation and slight shear so instances of one variant read
 as different rocks. The stones are watertight by construction and by test — never go back to
-jittering a box's vertices, whose per-face duplicates tear apart into floating planes. The shear
-lives inside the instance matrix, so position updates must write the translation column only; a
-TRS decompose/recompose silently strips it.
+jittering a box's vertices, whose per-face duplicates tear apart into floating planes. The
+rotation/shear/scale part of a fragment's spawn transform never changes over its life and is built
+once (`buildBaseTransform`); each frame's `updateTransforms` recomposes only the cheap part —
+position, tumble rotation, settle scale — on top of it (`composeInstanceMatrix`), so a settled
+fragment's matrix is bit-identical to its spawn one. Never decompose/recompose the instance matrix
+as TRS — the shear does not survive that round trip.
 
 **The whole blast resolves synchronously inside the click**, so the pipeline's cost is a frame the
 player feels. Its hot paths are engineered accordingly — typed-array frontier in propagation, per-

--- a/.opencode/skills/gameplay-blast-system/SKILL.md
+++ b/.opencode/skills/gameplay-blast-system/SKILL.md
@@ -162,6 +162,15 @@ straight; the vertical is the parabola joining those points in the flight's own 
 gravity, so **the animation cannot end anywhere but the fragment's authoritative position**. For a
 straight drop it reduces to free fall from rest. Skipping playback entirely is always safe.
 
+While airborne a fragment also tumbles about its own seeded axis, at a rate scaled by how hard it
+was thrown (`impactSpeed` against `MAX_PROJECTION_VELOCITY`; a mere drop barely rotates —
+`TUMBLE_DROP_FACTOR`, `TUMBLE_MAX_RATE_RAD_S`). On landing it eases the tumble back to exactly its
+untumbled spawn orientation while its scale does a damped squash-and-stretch bounce
+(`SETTLE_DURATION_S`, `SETTLE_SQUASH_MAGNITUDE`, `SETTLE_BOUNCE_OSCILLATIONS`), then snaps to the
+identity transform rather than approaching it asymptotically. This math (`FragmentTransformMath.ts`)
+is a pure function of `(flight, t)`, so a seek and a run of per-frame updates landing on the same `t`
+agree, and `finish()` puts every fragment at exactly the untumbled, unsettled rest transform.
+
 **A screenshot taken right after a blast is a screenshot of an animation, not of a muck pile.**
 `SceneManager` caps a frame at 0.1 s of animation time, and a frame costs seconds without a GPU, so
 a collapse takes many minutes of wall clock to finish on screen and rock photographs as if it were
@@ -174,9 +183,12 @@ than the times the frame rate allowed.
 by seeded planes into a closed convex "cut stone" (`FragmentGeometry.ts`), scaled per instance to the
 fragment's half-extents, with a seeded orientation and slight shear so instances of one variant read
 as different rocks. The stones are watertight by construction and by test — never go back to
-jittering a box's vertices, whose per-face duplicates tear apart into floating planes. The shear
-lives inside the instance matrix, so position updates must write the translation column only; a
-TRS decompose/recompose silently strips it.
+jittering a box's vertices, whose per-face duplicates tear apart into floating planes. The
+rotation/shear/scale part of a fragment's spawn transform never changes over its life and is built
+once (`buildBaseTransform`); each frame's `updateTransforms` recomposes only the cheap part —
+position, tumble rotation, settle scale — on top of it (`composeInstanceMatrix`), so a settled
+fragment's matrix is bit-identical to its spawn one. Never decompose/recompose the instance matrix
+as TRS — the shear does not survive that round trip.
 
 **The whole blast resolves synchronously inside the click**, so the pipeline's cost is a frame the
 player feels. Its hot paths are engineered accordingly — typed-array frontier in propagation, per-

--- a/src/core/config/balance.ts
+++ b/src/core/config/balance.ts
@@ -367,6 +367,23 @@ export const THROW_DISTANCE_CATASTROPHIC = 25;
 /** Minimum fragment render height (voxels) above the grid floor. */
 export const FRAGMENT_MIN_RENDER_Y = 0.05;
 
+// ─── Fragment Tumble and Settle (renderer playback, #485) ───────────────────
+
+/** Fastest a fragment tumbles about its seeded axis while airborne (rad/s). */
+export const TUMBLE_MAX_RATE_RAD_S = Math.PI * 2;
+
+/** How much a fragment's fall speed scales into its tumble rate (0–1). */
+export const TUMBLE_DROP_FACTOR = 0.12;
+
+/** How long the squash-and-bounce settle plays after a fragment lands (s). */
+export const SETTLE_DURATION_S = 0.35;
+
+/** Peak scale deviation from 1.0 during the landing squash. */
+export const SETTLE_SQUASH_MAGNITUDE = 0.15;
+
+/** Number of decaying bounce oscillations in the settle animation. */
+export const SETTLE_BOUNCE_OSCILLATIONS = 2;
+
 /** Default minimum search radius (metres) for the expanding-ring terrain-surface
  *  search in getBlastOriginSurfaceY (BlastOriginSampling.ts). A fixed 3m ring only
  *  clears a small blast's own crater; the search widens by this step until it

--- a/src/core/config/balance.ts
+++ b/src/core/config/balance.ts
@@ -372,7 +372,10 @@ export const FRAGMENT_MIN_RENDER_Y = 0.05;
 /** Fastest a fragment tumbles about its seeded axis while airborne (rad/s). */
 export const TUMBLE_MAX_RATE_RAD_S = Math.PI * 2;
 
-/** How much a fragment's fall speed scales into its tumble rate (0–1). */
+/** Flat multiplier on the (already impact-speed-scaled) tumble rate for a
+ *  fragment that merely dropped rather than was thrown (0–1) — not itself a
+ *  fall-speed term, since impact speed already drives the base rate for both
+ *  thrown and dropped fragments. */
 export const TUMBLE_DROP_FACTOR = 0.12;
 
 /** How long the squash-and-bounce settle plays after a fragment lands (s). */

--- a/src/renderer/FragmentAnimator.ts
+++ b/src/renderer/FragmentAnimator.ts
@@ -12,18 +12,66 @@
 import type { FragmentFlight } from '../core/mining/BlastResolve.js';
 import { flightPositionAt, totalFlightDuration } from '../core/mining/BlastResolve.js';
 import type { FragmentMesh, FragmentInstanceTransform } from './FragmentMesh.js';
+import {
+  MAX_PROJECTION_VELOCITY,
+  TUMBLE_MAX_RATE_RAD_S,
+  TUMBLE_DROP_FACTOR,
+  SETTLE_DURATION_S,
+  SETTLE_SQUASH_MAGNITUDE,
+  SETTLE_BOUNCE_OSCILLATIONS,
+} from '../core/config/balance.js';
 
-/** How fast a fragment tumbles while it falls, in rad/s (#485). */
-function tumbleRate(_flight: FragmentFlight): number {
-  return undefined as unknown as number;
+/**
+ * How fast a fragment tumbles while it falls, in rad/s (#485). Scales with
+ * how hard it was thrown — a fragment that merely dropped barely rotates.
+ */
+function tumbleRate(flight: FragmentFlight): number {
+  const speedFrac = Math.max(0, Math.min(1, flight.impactSpeed / MAX_PROJECTION_VELOCITY));
+  const rate = TUMBLE_MAX_RATE_RAD_S * speedFrac;
+  return flight.thrown ? rate : rate * TUMBLE_DROP_FACTOR;
 }
 
-/** Tumble angle and settle-squash scale for a flight at time `t` (#485). */
-function tumbleAndSettle(_flight: FragmentFlight, _t: number): { tumbleAngle: number; settleScale: { x: number; y: number; z: number } } {
-  // TODO(impl): derive tumbleAngle from tumbleRate(_flight) integrated over
-  // airborne time, and settleScale from the post-landing squash-and-bounce.
-  tumbleRate(_flight);
-  return undefined as unknown as { tumbleAngle: number; settleScale: { x: number; y: number; z: number } };
+/**
+ * Tumble angle and settle-squash scale for a flight at time `t` (#485).
+ *
+ * Pure function of (flight, t) — a seek and a run of per-frame updates that
+ * land on the same `t` must produce the same result, and fragments landing
+ * at the same instant must not interfere with each other.
+ *
+ * Three phases:
+ *  - airborne: tumbleAngle accumulates at tumbleRate() from the moment the
+ *    fragment actually starts moving (after its delay); settleScale is rest.
+ *  - settling: a short window after landing where tumbleAngle eases back down
+ *    to exactly 0 (resting orientation is the untumbled spawn orientation)
+ *    and settleScale does a damped squash-and-stretch bounce that starts and
+ *    ends at (1,1,1).
+ *  - settled: exactly the identity transform, snapped rather than asymptotic.
+ */
+function tumbleAndSettle(flight: FragmentFlight, t: number): { tumbleAngle: number; settleScale: { x: number; y: number; z: number } } {
+  const landingT = flight.delayS + flight.durationS;
+  const settleEndT = landingT + SETTLE_DURATION_S;
+  const REST_SCALE = { x: 1, y: 1, z: 1 };
+
+  if (t < landingT) {
+    const airborneS = Math.max(0, t - flight.delayS);
+    return { tumbleAngle: tumbleRate(flight) * airborneS, settleScale: REST_SCALE };
+  }
+
+  if (t < settleEndT) {
+    const settleT = t - landingT;
+    const envelope = 1 - settleT / SETTLE_DURATION_S;
+    const landingAngle = tumbleRate(flight) * flight.durationS;
+    const squash = SETTLE_SQUASH_MAGNITUDE * envelope
+      * Math.sin((settleT / SETTLE_DURATION_S) * SETTLE_BOUNCE_OSCILLATIONS * Math.PI);
+    return {
+      tumbleAngle: landingAngle * envelope,
+      // Squash on y, a matching stretch on x/z, so it reads as compressing
+      // into the landing rather than just shrinking.
+      settleScale: { x: 1 + squash * 0.5, y: 1 - squash, z: 1 + squash * 0.5 },
+    };
+  }
+
+  return { tumbleAngle: 0, settleScale: REST_SCALE };
 }
 
 export class FragmentAnimator {
@@ -56,9 +104,10 @@ export class FragmentAnimator {
     this.source = flights.filter(f => f.durationS > 0 && !samePlace(f));
     this.flights = this.source.slice();
     this.elapsedS = 0;
-    // TODO(impl): endsAtS must include SETTLE_DURATION_S so playback holds
-    // through the landing squash-and-bounce instead of ending on impact.
-    this.endsAtS = totalFlightDuration(this.flights);
+    // Playback holds through the landing squash-and-bounce, not just to
+    // impact, so idle-detection (isPlaying / update()'s final write) waits
+    // for every fragment to have fully settled.
+    this.endsAtS = this.flights.length > 0 ? totalFlightDuration(this.flights) + SETTLE_DURATION_S : 0;
     // Put everything at its starting point immediately, or the first frame
     // would show the finished pile before the collapse begins.
     if (this.flights.length > 0) this.apply();

--- a/src/renderer/FragmentAnimator.ts
+++ b/src/renderer/FragmentAnimator.ts
@@ -12,6 +12,7 @@
 import type { FragmentFlight } from '../core/mining/BlastResolve.js';
 import { flightPositionAt, totalFlightDuration } from '../core/mining/BlastResolve.js';
 import type { FragmentMesh, FragmentInstanceTransform } from './FragmentMesh.js';
+import type { PlainVec3 } from './FragmentTransformMath.js';
 import {
   MAX_PROJECTION_VELOCITY,
   TUMBLE_MAX_RATE_RAD_S,
@@ -27,7 +28,7 @@ import {
  * path (applyTo(), up to ~2000 fragments/frame during a big collapse), and
  * this is what most calls return (#485 review).
  */
-const REST_SCALE: Readonly<{ x: number; y: number; z: number }> = Object.freeze({ x: 1, y: 1, z: 1 });
+const REST_SCALE: Readonly<PlainVec3> = Object.freeze({ x: 1, y: 1, z: 1 });
 
 /**
  * How fast a fragment tumbles while it falls, in rad/s (#485). Scales with
@@ -55,7 +56,7 @@ function tumbleRate(flight: FragmentFlight): number {
  *    ends at (1,1,1).
  *  - settled: exactly the identity transform, snapped rather than asymptotic.
  */
-function tumbleAndSettle(flight: FragmentFlight, t: number): { tumbleAngle: number; settleScale: { x: number; y: number; z: number } } {
+function tumbleAndSettle(flight: FragmentFlight, t: number): { tumbleAngle: number; settleScale: PlainVec3 } {
   const landingT = flight.delayS + flight.durationS;
   const settleEndT = landingT + SETTLE_DURATION_S;
 

--- a/src/renderer/FragmentAnimator.ts
+++ b/src/renderer/FragmentAnimator.ts
@@ -22,6 +22,14 @@ import {
 } from '../core/config/balance.js';
 
 /**
+ * Rest transform — untumbled, unsettled. Frozen and shared rather than
+ * allocated per call: tumbleAndSettle() is on the per-frame, per-fragment hot
+ * path (applyTo(), up to ~2000 fragments/frame during a big collapse), and
+ * this is what most calls return (#485 review).
+ */
+const REST_SCALE: Readonly<{ x: number; y: number; z: number }> = Object.freeze({ x: 1, y: 1, z: 1 });
+
+/**
  * How fast a fragment tumbles while it falls, in rad/s (#485). Scales with
  * how hard it was thrown — a fragment that merely dropped barely rotates.
  */
@@ -50,7 +58,6 @@ function tumbleRate(flight: FragmentFlight): number {
 function tumbleAndSettle(flight: FragmentFlight, t: number): { tumbleAngle: number; settleScale: { x: number; y: number; z: number } } {
   const landingT = flight.delayS + flight.durationS;
   const settleEndT = landingT + SETTLE_DURATION_S;
-  const REST_SCALE = { x: 1, y: 1, z: 1 };
 
   if (t < landingT) {
     const airborneS = Math.max(0, t - flight.delayS);

--- a/src/renderer/FragmentAnimator.ts
+++ b/src/renderer/FragmentAnimator.ts
@@ -11,7 +11,20 @@
 
 import type { FragmentFlight } from '../core/mining/BlastResolve.js';
 import { flightPositionAt, totalFlightDuration } from '../core/mining/BlastResolve.js';
-import type { FragmentMesh } from './FragmentMesh.js';
+import type { FragmentMesh, FragmentInstanceTransform } from './FragmentMesh.js';
+
+/** How fast a fragment tumbles while it falls, in rad/s (#485). */
+function tumbleRate(_flight: FragmentFlight): number {
+  return undefined as unknown as number;
+}
+
+/** Tumble angle and settle-squash scale for a flight at time `t` (#485). */
+function tumbleAndSettle(_flight: FragmentFlight, _t: number): { tumbleAngle: number; settleScale: { x: number; y: number; z: number } } {
+  // TODO(impl): derive tumbleAngle from tumbleRate(_flight) integrated over
+  // airborne time, and settleScale from the post-landing squash-and-bounce.
+  tumbleRate(_flight);
+  return undefined as unknown as { tumbleAngle: number; settleScale: { x: number; y: number; z: number } };
+}
 
 export class FragmentAnimator {
   /** The collapse still being advanced by the render loop; emptied when it ends. */
@@ -21,7 +34,7 @@ export class FragmentAnimator {
   private elapsedS = 0;
   private endsAtS = 0;
   /** Reused across frames so a large blast does not allocate a map per frame. */
-  private readonly positions = new Map<number, { x: number; y: number; z: number }>();
+  private readonly transforms = new Map<number, FragmentInstanceTransform>();
 
   constructor(private readonly fragments: FragmentMesh) {}
 
@@ -43,6 +56,8 @@ export class FragmentAnimator {
     this.source = flights.filter(f => f.durationS > 0 && !samePlace(f));
     this.flights = this.source.slice();
     this.elapsedS = 0;
+    // TODO(impl): endsAtS must include SETTLE_DURATION_S so playback holds
+    // through the landing squash-and-bounce instead of ending on impact.
     this.endsAtS = totalFlightDuration(this.flights);
     // Put everything at its starting point immediately, or the first frame
     // would show the finished pile before the collapse begins.
@@ -110,11 +125,13 @@ export class FragmentAnimator {
   }
 
   private applyTo(flights: readonly FragmentFlight[]): void {
-    this.positions.clear();
+    this.transforms.clear();
     for (const flight of flights) {
-      this.positions.set(flight.fragmentId, flightPositionAt(flight, this.elapsedS));
+      const pos = flightPositionAt(flight, this.elapsedS);
+      const { tumbleAngle, settleScale } = tumbleAndSettle(flight, this.elapsedS);
+      this.transforms.set(flight.fragmentId, { x: pos.x, y: pos.y, z: pos.z, tumbleAngle, settleScale });
     }
-    this.fragments.updatePositions(this.positions);
+    this.fragments.updateTransforms(this.transforms);
   }
 }
 

--- a/src/renderer/FragmentMesh.ts
+++ b/src/renderer/FragmentMesh.ts
@@ -16,7 +16,7 @@ import { oreIndexOf } from '../core/world/OreCatalog.js';
 import { FRAGMENT_MIN_RENDER_Y } from '../core/config/balance.js';
 import { sampleEvenly } from './FragmentRenderSampling.js';
 import { buildFragmentGeometries } from './FragmentGeometry.js';
-import { buildBaseTransform, composeInstanceMatrix, type FragmentBaseTransform } from './FragmentTransformMath.js';
+import { buildBaseTransform, composeInstanceMatrix, type FragmentBaseTransform, type PlainVec3 } from './FragmentTransformMath.js';
 
 // ---------- Config ----------
 
@@ -61,7 +61,7 @@ export interface FragmentInstanceTransform {
   /** Extra rotation (radians) about the fragment's own seeded tumble axis, on top of its spawn orientation. 0 = untouched. */
   tumbleAngle: number;
   /** Multiplier on the fragment's spawn scale. (1,1,1) = untouched. */
-  settleScale: { x: number; y: number; z: number };
+  settleScale: PlainVec3;
 }
 
 /** The highest-density ore in a fragment's ore record, or '' if none (#458 T4.1/A18). */

--- a/src/renderer/FragmentMesh.ts
+++ b/src/renderer/FragmentMesh.ts
@@ -23,6 +23,7 @@ import { oreIndexOf } from '../core/world/OreCatalog.js';
 import { FRAGMENT_MIN_RENDER_Y } from '../core/config/balance.js';
 import { sampleEvenly } from './FragmentRenderSampling.js';
 import { buildFragmentGeometries } from './FragmentGeometry.js';
+import type { FragmentBaseTransform } from './FragmentTransformMath.js';
 
 // ---------- Config ----------
 
@@ -66,6 +67,20 @@ interface SlotInfo {
   slotIdx: number;
 }
 
+/**
+ * Per-instance transform data written by the animator each frame: current
+ * position plus how far it has tumbled and settled since spawn (#485).
+ */
+export interface FragmentInstanceTransform {
+  x: number;
+  y: number;
+  z: number;
+  /** Extra rotation (radians) about the fragment's own seeded tumble axis, on top of its spawn orientation. 0 = untouched. */
+  tumbleAngle: number;
+  /** Multiplier on the fragment's spawn scale. (1,1,1) = untouched. */
+  settleScale: { x: number; y: number; z: number };
+}
+
 /** The highest-density ore in a fragment's ore record, or '' if none (#458 T4.1/A18). */
 function dominantOre(oreDensities: Record<string, number>): { id: string; amt: number } {
   let id = '';
@@ -88,6 +103,8 @@ export class FragmentMesh {
   private readonly fragIdToSlot = new Map<number, SlotInfo>();
   /** slotIdx → fragId for each bucket (to support swap-on-delete) */
   private readonly bucketSlotToFrag: number[][] = [];
+  /** fragId → the fixed rotation/shear/tumble-axis part of its spawn transform (#485). */
+  private readonly fragBaseTransform = new Map<number, FragmentBaseTransform>();
 
   /** Per-shape-variant per-instance rock/ore attributes, shading the shared TerrainMaterial (#458 T4.1/A18). */
   private readonly instanceRockA: THREE.InstancedBufferAttribute[] = [];
@@ -226,26 +243,15 @@ export class FragmentMesh {
   }
 
   /**
-   * Update fragment positions during physics simulation.
-   * Call on each physics step with the current body positions.
+   * Update fragment position, tumble, and settle-scale during collapse
+   * playback. Call each frame with the animator's current transforms.
    */
-  updatePositions(positions: Map<number, { x: number; y: number; z: number }>): void {
-    const dirtyBuckets = new Set<number>();
-    for (const [id, pos] of positions) {
-      const slot = this.fragIdToSlot.get(id);
-      if (!slot) continue;
-      const im = this.instancedMeshes[slot.meshIdx]!;
-      im.getMatrixAt(slot.slotIdx, FragmentMesh._mtx);
-      // Only the translation column changes. Decomposing to TRS and
-      // recomposing — the old way — silently destroyed the per-instance shear
-      // (TRS cannot represent it), and cost a decompose per fragment per frame.
-      FragmentMesh._mtx.setPosition(pos.x, pos.y, pos.z);
-      im.setMatrixAt(slot.slotIdx, FragmentMesh._mtx);
-      dirtyBuckets.add(slot.meshIdx);
-    }
-    for (const idx of dirtyBuckets) {
-      this.instancedMeshes[idx]!.instanceMatrix.needsUpdate = true;
-    }
+  updateTransforms(_updates: Map<number, FragmentInstanceTransform>): void {
+    // TODO: implement — replaces updatePositions; look up each fragment's
+    // fragBaseTransform (rotation/shear/tumble axis) and recompose via
+    // FragmentTransformMath.composeInstanceMatrix.
+    void this.fragBaseTransform;
+    throw new Error('not implemented');
   }
 
   /**

--- a/src/renderer/FragmentMesh.ts
+++ b/src/renderer/FragmentMesh.ts
@@ -1,20 +1,13 @@
 // BlastSimulator2026 — Fragment Meshes (Performance-optimised)
 // Renders blast fragments using InstancedMesh for batched GPU rendering.
-// 24 shape variants × 1 InstancedMesh each = 24 draw calls regardless of count.
-// Each instance is scaled to the fragment's own bounding box, so the size and
-// proportions the blast carved are what the player sees.
-// Rock/ore identity is carried per-instance (aRockA/aRockB/aRockWeight/aOre)
-// and shaded by the shared TerrainMaterial, so a fragment's cut face matches
-// the rock it broke off from (#458 T4.1/D9/A18).
-//
-// The variant geometries are closed cut-stone polyhedra (FragmentGeometry.ts).
-// Each instance also gets a seeded orientation and a slight shear, so two
-// instances of one variant never read as the same rock. The shear lives inside
-// the instance matrix — position updates must preserve it (see updatePositions).
-//
-// Performance target: 2000 fragments at 60fps
-// Previous: 2000 individual meshes × material clones → thousands of draw calls
-// Now:      24 InstancedMesh objects → 24 draw calls for any fragment count
+// 24 shape variants × 1 InstancedMesh each = 24 draw calls regardless of count
+// (was 2000 individual meshes × material clones). Each instance is scaled to
+// the fragment's own bounding box, carries a seeded orientation and slight
+// shear so two instances of one variant never read as the same rock, and
+// shades rock/ore identity (aRockA/aRockB/aRockWeight/aOre) through the
+// shared TerrainMaterial (#458 T4.1/D9/A18). The rotation/shear/tumble-axis
+// math lives in FragmentTransformMath.ts, shared with FragmentAnimator so a
+// settled fragment's transform is bit-identical to its spawn one (#485).
 
 import * as THREE from 'three';
 import type { FragmentData } from '../core/mining/BlastExecution.js';
@@ -23,7 +16,7 @@ import { oreIndexOf } from '../core/world/OreCatalog.js';
 import { FRAGMENT_MIN_RENDER_Y } from '../core/config/balance.js';
 import { sampleEvenly } from './FragmentRenderSampling.js';
 import { buildFragmentGeometries } from './FragmentGeometry.js';
-import type { FragmentBaseTransform } from './FragmentTransformMath.js';
+import { buildBaseTransform, composeInstanceMatrix, type FragmentBaseTransform } from './FragmentTransformMath.js';
 
 // ---------- Config ----------
 
@@ -38,10 +31,6 @@ const MAX_RENDERED_FRAGMENTS = 2000;
 // Number of irregular shape variants
 const SHAPE_VARIANTS = 24;
 
-// How far a fragment's unit shape is skewed by its per-instance shear. Small on
-// purpose: at 0.18 the silhouette changes, the volume barely does.
-const SHEAR_MAX = 0.18;
-
 // Capacity per variant bucket — evenly split; some buckets may have slightly more
 const BUCKET_CAPACITY = Math.ceil(MAX_RENDERED_FRAGMENTS / SHAPE_VARIANTS);
 
@@ -52,12 +41,6 @@ let sharedGeometries: THREE.BufferGeometry[] | null = null;
 function getSharedGeometries(): THREE.BufferGeometry[] {
   if (!sharedGeometries) sharedGeometries = buildFragmentGeometries(SHAPE_VARIANTS);
   return sharedGeometries;
-}
-
-/** Deterministic pseudo-random in [0, 1) from a fragment's shape seed. */
-function seedUnit(seed: number, salt: number): number {
-  const x = Math.sin(seed * 127.1 + salt * 311.7) * 43758.5453;
-  return x - Math.floor(x);
 }
 
 // ---------- Per-instance slot tracking ----------
@@ -113,12 +96,12 @@ export class FragmentMesh {
   private readonly instanceOre: THREE.InstancedBufferAttribute[] = [];
 
   private static readonly _mtx = new THREE.Matrix4();
-  private static readonly _shear = new THREE.Matrix4();
   private static readonly _scale = new THREE.Vector3();
-  private static readonly _quat = new THREE.Quaternion();
   private static readonly _pos = new THREE.Vector3();
-  private static readonly _euler = new THREE.Euler();
-  private static readonly _unit = new THREE.Vector3(1, 1, 1);
+  /** Identity settle-scale, reused for the spawn matrix (fragment is at rest, untumbled, unsettled). */
+  private static readonly _unitScale = { x: 1, y: 1, z: 1 };
+  /** Which buckets `updateTransforms` touched this call — reused so a frame with many fragments allocates nothing. */
+  private readonly dirtyBuckets = new Array<boolean>(SHAPE_VARIANTS).fill(false);
 
   /** `material` is the shared TerrainMaterial (borrowed from TerrainMesh, which owns and disposes it — #458 T4.1/D9). */
   constructor(scene: THREE.Scene, material: THREE.Material) {
@@ -149,10 +132,7 @@ export class FragmentMesh {
     }
   }
 
-  /**
-   * The preferred bucket if it has room, otherwise the next one that does.
-   * Returns -1 when every bucket is full.
-   */
+  /** The preferred bucket if it has room, otherwise the next that does; -1 if all full. */
   private pickBucket(preferred: number): number {
     for (let i = 0; i < SHAPE_VARIANTS; i++) {
       const idx = (preferred + i) % SHAPE_VARIANTS;
@@ -172,45 +152,30 @@ export class FragmentMesh {
     const toRender = sampleEvenly(fragments, MAX_RENDERED_FRAGMENTS);
 
     for (const frag of toRender) {
-      // Keyed on the fragment's own shape seed rather than its id: ids run
-      // consecutively, so `id % SHAPE_VARIANTS` marched through the variants in
-      // lockstep and produced a visible repeating pattern across the muck pile.
-      // Shape seeds are random, so buckets do not fill evenly. Falling through
-      // to any bucket with room keeps the full render budget usable instead of
-      // dropping fragments once one variant happens to fill up.
+      // Keyed on the shape seed, not the id — ids run consecutively so
+      // `id % SHAPE_VARIANTS` marched through variants in lockstep, giving a
+      // visible repeating pattern. Falling through to any bucket with room
+      // keeps the full render budget usable once a variant fills up.
       const meshIdx = this.pickBucket(frag.shapeSeed % SHAPE_VARIANTS);
       if (meshIdx < 0) continue; // every bucket full
       const count = this.bucketCount[meshIdx]!;
 
       const im = this.instancedMeshes[meshIdx]!;
 
-      // Each fragment is drawn at the size and proportions it was carved with,
-      // so a slab reads as a slab and a boulder as a boulder. Positions are the
-      // real centroids of the rock that broke, inside the volume the blast just
-      // removed — no crater offset or scatter is needed to fake that any more.
+      // Fragment is drawn at the size/proportions it was carved with, at its
+      // real centroid inside the volume the blast removed.
       FragmentMesh._pos.set(frag.position.x, Math.max(FRAGMENT_MIN_RENDER_Y, frag.position.y), frag.position.z);
       FragmentMesh._scale.set(
         Math.max(MIN_RENDER_EXTENT, frag.halfExtents.x * 2),
         Math.max(MIN_RENDER_EXTENT, frag.halfExtents.y * 2),
         Math.max(MIN_RENDER_EXTENT, frag.halfExtents.z * 2),
       );
-      FragmentMesh._quat.setFromEuler(FragmentMesh._euler.set(
-        seedUnit(frag.shapeSeed, 1) * Math.PI * 2,
-        seedUnit(frag.shapeSeed, 2) * Math.PI * 2,
-        seedUnit(frag.shapeSeed, 3) * Math.PI * 2,
-      ));
-      // A slight seeded shear, so two instances of the same variant stone never
-      // read as identical. It sits *between* rotation and scale (T·R·Shear·S):
-      // applied outside the scale, a slab's long axis would bleed into its thin
-      // one and a flat fragment stopped rendering flat.
-      const shear = FragmentMesh._shear.identity();
-      const e = shear.elements;
-      e[4] = (seedUnit(frag.shapeSeed, 4) * 2 - 1) * SHEAR_MAX;  // x from y
-      e[8] = (seedUnit(frag.shapeSeed, 5) * 2 - 1) * SHEAR_MAX;  // x from z
-      e[9] = (seedUnit(frag.shapeSeed, 6) * 2 - 1) * SHEAR_MAX;  // y from z
-      FragmentMesh._mtx.compose(FragmentMesh._pos, FragmentMesh._quat, FragmentMesh._unit);
-      FragmentMesh._mtx.multiply(shear);
-      FragmentMesh._mtx.scale(FragmentMesh._scale);
+      // Rotation, shear, and size are fixed for the fragment's whole life —
+      // build that part once and keep it, so each frame's update only has to
+      // recompose the cheap tumble/settle part on top (#485).
+      const base = buildBaseTransform(frag.shapeSeed, FragmentMesh._scale);
+      this.fragBaseTransform.set(frag.id, base);
+      composeInstanceMatrix(base, FragmentMesh._pos, 0, FragmentMesh._unitScale, FragmentMesh._mtx);
       im.setMatrixAt(count, FragmentMesh._mtx);
 
       // Rock/ore identity for the shared TerrainMaterial shader — a fragment
@@ -242,16 +207,23 @@ export class FragmentMesh {
     }
   }
 
-  /**
-   * Update fragment position, tumble, and settle-scale during collapse
-   * playback. Call each frame with the animator's current transforms.
-   */
-  updateTransforms(_updates: Map<number, FragmentInstanceTransform>): void {
-    // TODO: implement — replaces updatePositions; look up each fragment's
-    // fragBaseTransform (rotation/shear/tumble axis) and recompose via
-    // FragmentTransformMath.composeInstanceMatrix.
-    void this.fragBaseTransform;
-    throw new Error('not implemented');
+  /** Update fragment position/tumble/settle-scale during collapse playback. */
+  updateTransforms(updates: Map<number, FragmentInstanceTransform>): void {
+    this.dirtyBuckets.fill(false);
+
+    for (const [fragId, transform] of updates) {
+      const slot = this.fragIdToSlot.get(fragId);
+      const base = this.fragBaseTransform.get(fragId);
+      if (!slot || !base) continue;
+
+      composeInstanceMatrix(base, transform, transform.tumbleAngle, transform.settleScale, FragmentMesh._mtx);
+      this.instancedMeshes[slot.meshIdx]!.setMatrixAt(slot.slotIdx, FragmentMesh._mtx);
+      this.dirtyBuckets[slot.meshIdx] = true;
+    }
+
+    for (let i = 0; i < SHAPE_VARIANTS; i++) {
+      if (this.dirtyBuckets[i]) this.instancedMeshes[i]!.instanceMatrix.needsUpdate = true;
+    }
   }
 
   /**
@@ -294,6 +266,7 @@ export class FragmentMesh {
     this.instanceOre[meshIdx]!.needsUpdate = true;
 
     this.fragIdToSlot.delete(fragmentId);
+    this.fragBaseTransform.delete(fragmentId);
     this.bucketSlotToFrag[meshIdx]![lastIdx] = -1;
   }
 
@@ -304,6 +277,7 @@ export class FragmentMesh {
       this.instancedMeshes[i]!.count = 0;
     }
     this.fragIdToSlot.clear();
+    this.fragBaseTransform.clear();
     for (const bucket of this.bucketSlotToFrag) bucket.fill(-1);
   }
 

--- a/src/renderer/FragmentTransformMath.ts
+++ b/src/renderer/FragmentTransformMath.ts
@@ -20,6 +20,13 @@ import * as THREE from 'three';
 // purpose: at 0.18 the silhouette changes, the volume barely does.
 const SHEAR_MAX = 0.18;
 
+/**
+ * A plain {x,y,z} — not a THREE.Vector3 — for a position or scale crossing
+ * the per-frame animation hot path, where callers pass data straight out of
+ * a FragmentFlight/transform record without constructing a Three.js object.
+ */
+export type PlainVec3 = { x: number; y: number; z: number };
+
 // Matrix4.scale() takes a real THREE.Vector3, not the {x,y,z}-shaped
 // settleScale callers pass in — reused across calls (composeInstanceMatrix is
 // on the per-frame hot path) instead of allocating or `as`-casting the plain
@@ -112,9 +119,9 @@ export function buildBaseTransform(shapeSeed: number, scale: THREE.Vector3): Fra
  */
 export function composeInstanceMatrix(
   base: FragmentBaseTransform,
-  position: { x: number; y: number; z: number },
+  position: PlainVec3,
   tumbleAngle: number,
-  settleScale: { x: number; y: number; z: number },
+  settleScale: PlainVec3,
   out: THREE.Matrix4,
 ): void {
   out.makeRotationAxis(base.axis, tumbleAngle);

--- a/src/renderer/FragmentTransformMath.ts
+++ b/src/renderer/FragmentTransformMath.ts
@@ -5,40 +5,80 @@
 // InstancedMesh state lives here — everything is a function of a fragment's
 // own seeded shape and the transform the caller supplies for this frame.
 //
-// TODO: implement — extraction of existing spawnFragments math
-// (src/renderer/FragmentMesh.ts) plus new tumble/compose pieces (#485).
+// A fragment's spawn transform is T(position) · R(shapeSeed) · Shear(shapeSeed)
+// · Scale(size). The rotation/shear/size part never changes over a fragment's
+// life, so it is built once (buildBaseTransform) and folded into `rs`; each
+// frame only recomposes the cheap part — an extra tumble rotation and a
+// settle-scale multiplier on top of `rs` (composeInstanceMatrix). With
+// tumbleAngle 0 and settleScale (1,1,1) this reduces to exactly the spawn
+// matrix, which is what keeps a settled fragment bit-identical to where the
+// blast put it (#485).
 
 import * as THREE from 'three';
 
+// How far a fragment's unit shape is skewed by its per-instance shear. Small on
+// purpose: at 0.18 the silhouette changes, the volume barely does.
+const SHEAR_MAX = 0.18;
+
 /** Deterministic pseudo-random in [0, 1) from a fragment's shape seed. */
-export function seedUnit(_seed: number, _salt: number): number {
-  return undefined as unknown as number;
+export function seedUnit(seed: number, salt: number): number {
+  const x = Math.sin(seed * 127.1 + salt * 311.7) * 43758.5453;
+  return x - Math.floor(x);
 }
 
 /** Seeded spawn-orientation quaternion for a fragment's shape seed. */
-export function spawnOrientation(_shapeSeed: number): THREE.Quaternion {
-  return undefined as unknown as THREE.Quaternion;
+export function spawnOrientation(shapeSeed: number): THREE.Quaternion {
+  const euler = new THREE.Euler(
+    seedUnit(shapeSeed, 1) * Math.PI * 2,
+    seedUnit(shapeSeed, 2) * Math.PI * 2,
+    seedUnit(shapeSeed, 3) * Math.PI * 2,
+  );
+  return new THREE.Quaternion().setFromEuler(euler);
 }
 
-/** Seeded slight shear matrix, so two instances of one shape variant never read as identical. */
-export function spawnShear(_shapeSeed: number): THREE.Matrix4 {
-  return undefined as unknown as THREE.Matrix4;
+/**
+ * Seeded slight shear matrix, so two instances of one shape variant never
+ * read as identical. Sits *between* rotation and scale (R·Shear·S): applied
+ * outside the scale, a slab's long axis would bleed into its thin one and a
+ * flat fragment stopped rendering flat.
+ */
+export function spawnShear(shapeSeed: number): THREE.Matrix4 {
+  const shear = new THREE.Matrix4();
+  const e = shear.elements;
+  e[4] = (seedUnit(shapeSeed, 4) * 2 - 1) * SHEAR_MAX;  // x from y
+  e[8] = (seedUnit(shapeSeed, 5) * 2 - 1) * SHEAR_MAX;  // x from z
+  e[9] = (seedUnit(shapeSeed, 6) * 2 - 1) * SHEAR_MAX;  // y from z
+  return shear;
 }
 
-/** Seeded axis a fragment tumbles about while it falls. */
-export function tumbleAxis(_shapeSeed: number): THREE.Vector3 {
-  return undefined as unknown as THREE.Vector3;
+/**
+ * Seeded axis a fragment tumbles about while it falls. Distinct salts from
+ * orientation (1-3) and shear (4-6) so the tumble axis is independent of the
+ * fragment's spawn look.
+ */
+export function tumbleAxis(shapeSeed: number): THREE.Vector3 {
+  const v = new THREE.Vector3(
+    seedUnit(shapeSeed, 7) * 2 - 1,
+    seedUnit(shapeSeed, 8) * 2 - 1,
+    seedUnit(shapeSeed, 9) * 2 - 1,
+  );
+  if (v.lengthSq() < 1e-8) return new THREE.Vector3(0, 1, 0);
+  return v.normalize();
 }
 
 /** The rotation+shear part of a fragment's spawn transform, and the axis it tumbles about, fixed for the fragment's lifetime. */
 export interface FragmentBaseTransform {
+  /** R(shapeSeed) · Shear(shapeSeed) · Scale(size) — everything about a fragment's look that never changes after spawn. */
   rs: THREE.Matrix4;
   axis: THREE.Vector3;
 }
 
 /** Build a fragment's base (rotation, shear, tumble axis) transform from its shape seed and spawn scale. */
-export function buildBaseTransform(_shapeSeed: number, _scale: THREE.Vector3): FragmentBaseTransform {
-  return undefined as unknown as FragmentBaseTransform;
+export function buildBaseTransform(shapeSeed: number, scale: THREE.Vector3): FragmentBaseTransform {
+  const rs = new THREE.Matrix4().makeRotationFromQuaternion(spawnOrientation(shapeSeed));
+  rs.multiply(spawnShear(shapeSeed));
+  rs.scale(scale);
+  return { rs, axis: tumbleAxis(shapeSeed) };
 }
 
 /**
@@ -46,13 +86,22 @@ export function buildBaseTransform(_shapeSeed: number, _scale: THREE.Vector3): F
  * transform, current position, extra tumble rotation, and settle scale.
  * Writes into `out` rather than allocating, so a per-frame update over many
  * fragments costs no garbage.
+ *
+ * out = T(position) · Rotation(base.axis, tumbleAngle) · base.rs · Scale(settleScale)
+ *
+ * With tumbleAngle 0 (Rotation = identity) and settleScale (1,1,1) (Scale =
+ * identity) this is exactly T(position) · base.rs — the same matrix
+ * `spawnFragments` composes at spawn time, bit-for-bit.
  */
 export function composeInstanceMatrix(
-  _base: FragmentBaseTransform,
-  _position: { x: number; y: number; z: number },
-  _tumbleAngle: number,
-  _settleScale: { x: number; y: number; z: number },
-  _out: THREE.Matrix4,
+  base: FragmentBaseTransform,
+  position: { x: number; y: number; z: number },
+  tumbleAngle: number,
+  settleScale: { x: number; y: number; z: number },
+  out: THREE.Matrix4,
 ): void {
-  // TODO: implement
+  out.makeRotationAxis(base.axis, tumbleAngle);
+  out.multiply(base.rs);
+  out.scale(settleScale as THREE.Vector3);
+  out.setPosition(position.x, position.y, position.z);
 }

--- a/src/renderer/FragmentTransformMath.ts
+++ b/src/renderer/FragmentTransformMath.ts
@@ -20,6 +20,12 @@ import * as THREE from 'three';
 // purpose: at 0.18 the silhouette changes, the volume barely does.
 const SHEAR_MAX = 0.18;
 
+// Matrix4.scale() takes a real THREE.Vector3, not the {x,y,z}-shaped
+// settleScale callers pass in — reused across calls (composeInstanceMatrix is
+// on the per-frame hot path) instead of allocating or `as`-casting the plain
+// object into a class it doesn't structurally satisfy (#485 review).
+const _scaleScratch = new THREE.Vector3();
+
 /** Deterministic pseudo-random in [0, 1) from a fragment's shape seed. */
 export function seedUnit(seed: number, salt: number): number {
   const x = Math.sin(seed * 127.1 + salt * 311.7) * 43758.5453;
@@ -52,6 +58,18 @@ export function spawnShear(shapeSeed: number): THREE.Matrix4 {
 }
 
 /**
+ * Normalizes `v` in place, falling back to `fallback` rather than producing
+ * NaN when `v` is degenerate (near-zero length). Split out from tumbleAxis so
+ * the fallback branch is directly testable without needing to find a shape
+ * seed whose hash coincidentally lands within 1e-8 of the zero vector (#485
+ * review).
+ */
+export function normalizeOrFallback(v: THREE.Vector3, fallback: THREE.Vector3): THREE.Vector3 {
+  if (v.lengthSq() < 1e-8) return fallback;
+  return v.normalize();
+}
+
+/**
  * Seeded axis a fragment tumbles about while it falls. Distinct salts from
  * orientation (1-3) and shear (4-6) so the tumble axis is independent of the
  * fragment's spawn look.
@@ -62,8 +80,7 @@ export function tumbleAxis(shapeSeed: number): THREE.Vector3 {
     seedUnit(shapeSeed, 8) * 2 - 1,
     seedUnit(shapeSeed, 9) * 2 - 1,
   );
-  if (v.lengthSq() < 1e-8) return new THREE.Vector3(0, 1, 0);
-  return v.normalize();
+  return normalizeOrFallback(v, new THREE.Vector3(0, 1, 0));
 }
 
 /** The rotation+shear part of a fragment's spawn transform, and the axis it tumbles about, fixed for the fragment's lifetime. */
@@ -102,6 +119,7 @@ export function composeInstanceMatrix(
 ): void {
   out.makeRotationAxis(base.axis, tumbleAngle);
   out.multiply(base.rs);
-  out.scale(settleScale as THREE.Vector3);
+  _scaleScratch.set(settleScale.x, settleScale.y, settleScale.z);
+  out.scale(_scaleScratch);
   out.setPosition(position.x, position.y, position.z);
 }

--- a/src/renderer/FragmentTransformMath.ts
+++ b/src/renderer/FragmentTransformMath.ts
@@ -1,0 +1,58 @@
+// BlastSimulator2026 — Fragment instance-transform math
+//
+// Pure Three.js matrix/quaternion helpers shared by FragmentMesh's spawn path
+// and FragmentAnimator's per-frame update path. No THREE.Scene or
+// InstancedMesh state lives here — everything is a function of a fragment's
+// own seeded shape and the transform the caller supplies for this frame.
+//
+// TODO: implement — extraction of existing spawnFragments math
+// (src/renderer/FragmentMesh.ts) plus new tumble/compose pieces (#485).
+
+import * as THREE from 'three';
+
+/** Deterministic pseudo-random in [0, 1) from a fragment's shape seed. */
+export function seedUnit(_seed: number, _salt: number): number {
+  return undefined as unknown as number;
+}
+
+/** Seeded spawn-orientation quaternion for a fragment's shape seed. */
+export function spawnOrientation(_shapeSeed: number): THREE.Quaternion {
+  return undefined as unknown as THREE.Quaternion;
+}
+
+/** Seeded slight shear matrix, so two instances of one shape variant never read as identical. */
+export function spawnShear(_shapeSeed: number): THREE.Matrix4 {
+  return undefined as unknown as THREE.Matrix4;
+}
+
+/** Seeded axis a fragment tumbles about while it falls. */
+export function tumbleAxis(_shapeSeed: number): THREE.Vector3 {
+  return undefined as unknown as THREE.Vector3;
+}
+
+/** The rotation+shear part of a fragment's spawn transform, and the axis it tumbles about, fixed for the fragment's lifetime. */
+export interface FragmentBaseTransform {
+  rs: THREE.Matrix4;
+  axis: THREE.Vector3;
+}
+
+/** Build a fragment's base (rotation, shear, tumble axis) transform from its shape seed and spawn scale. */
+export function buildBaseTransform(_shapeSeed: number, _scale: THREE.Vector3): FragmentBaseTransform {
+  return undefined as unknown as FragmentBaseTransform;
+}
+
+/**
+ * Compose a fragment's full per-frame instance matrix from its fixed base
+ * transform, current position, extra tumble rotation, and settle scale.
+ * Writes into `out` rather than allocating, so a per-frame update over many
+ * fragments costs no garbage.
+ */
+export function composeInstanceMatrix(
+  _base: FragmentBaseTransform,
+  _position: { x: number; y: number; z: number },
+  _tumbleAngle: number,
+  _settleScale: { x: number; y: number; z: number },
+  _out: THREE.Matrix4,
+): void {
+  // TODO: implement
+}

--- a/tests/unit/renderer/FragmentAnimator.test.ts
+++ b/tests/unit/renderer/FragmentAnimator.test.ts
@@ -201,7 +201,8 @@ describe('FragmentAnimator', () => {
     expect(animator.durationS).toBe(0);
     animator.begin([flight({ durationS: 2, delayS: 1.5 })]);
 
-    expect(animator.durationS).toBeCloseTo(3.5, 6);
+    // Idle is measured against settle completion, not landing (#485).
+    expect(animator.durationS).toBeCloseTo(1.5 + 2 + SETTLE_DURATION_S, 6);
   });
 
   it('lands everything at once when told to finish', () => {

--- a/tests/unit/renderer/FragmentAnimator.test.ts
+++ b/tests/unit/renderer/FragmentAnimator.test.ts
@@ -1,17 +1,18 @@
 import { describe, it, expect, vi } from 'vitest';
 import { FragmentAnimator } from '../../../src/renderer/FragmentAnimator.js';
 import type { FragmentFlight } from '../../../src/core/mining/BlastResolve.js';
-import type { FragmentMesh } from '../../../src/renderer/FragmentMesh.js';
+import type { FragmentMesh, FragmentInstanceTransform } from '../../../src/renderer/FragmentMesh.js';
+import { TUMBLE_DROP_FACTOR, SETTLE_DURATION_S } from '../../../src/core/config/balance.js';
 
 /** A stand-in for FragmentMesh that just records what it was told to draw. */
 function recorder() {
-  const frames: Array<Map<number, { x: number; y: number; z: number }>> = [];
+  const frames: Array<Map<number, FragmentInstanceTransform>> = [];
   const mesh = {
-    updatePositions: vi.fn((positions: Map<number, { x: number; y: number; z: number }>) => {
-      frames.push(new Map(positions));
+    updateTransforms: vi.fn((transforms: Map<number, FragmentInstanceTransform>) => {
+      frames.push(new Map(transforms));
     }),
   };
-  return { mesh: mesh as unknown as FragmentMesh, frames, spy: mesh.updatePositions };
+  return { mesh: mesh as unknown as FragmentMesh, frames, spy: mesh.updateTransforms };
 }
 
 function flight(overrides: Partial<FragmentFlight> = {}): FragmentFlight {
@@ -27,6 +28,11 @@ function flight(overrides: Partial<FragmentFlight> = {}): FragmentFlight {
   };
 }
 
+/** Reads just x/y/z off a transform, ignoring tumble/settle fields (#485). */
+function pos(t: FragmentInstanceTransform | undefined): { x: number; y: number; z: number } {
+  return { x: t!.x, y: t!.y, z: t!.z };
+}
+
 describe('FragmentAnimator', () => {
   it('puts rock at its starting point the moment the blast fires', () => {
     const { mesh, frames } = recorder();
@@ -36,7 +42,7 @@ describe('FragmentAnimator', () => {
 
     // Without this first write the player would see the finished pile for one
     // frame before the collapse started.
-    expect(frames[0]!.get(0)).toEqual({ x: 0, y: 20, z: 0 });
+    expect(pos(frames[0]!.get(0))).toEqual({ x: 0, y: 20, z: 0 });
   });
 
   it('moves rock downward as time passes', () => {
@@ -60,7 +66,7 @@ describe('FragmentAnimator', () => {
 
     animator.update(5);
 
-    expect(frames[frames.length - 1]!.get(0)).toEqual(f.to);
+    expect(pos(frames[frames.length - 1]!.get(0))).toEqual(f.to);
   });
 
   it('stops costing anything once the rock has landed', () => {
@@ -170,7 +176,7 @@ describe('FragmentAnimator', () => {
 
     animator.seek(99);
 
-    expect(frames[frames.length - 1]!.get(0)).toEqual(f.to);
+    expect(pos(frames[frames.length - 1]!.get(0))).toEqual(f.to);
     expect(animator.isPlaying).toBe(false);
   });
 
@@ -208,8 +214,8 @@ describe('FragmentAnimator', () => {
     animator.finish();
 
     const last = frames[frames.length - 1]!;
-    expect(last.get(0)).toEqual(near.to);
-    expect(last.get(1)).toEqual(far.to);
+    expect(pos(last.get(0))).toEqual(near.to);
+    expect(pos(last.get(1))).toEqual(far.to);
     expect(animator.isPlaying).toBe(false);
   });
 
@@ -245,5 +251,204 @@ describe('FragmentAnimator', () => {
 
     expect(animator.isPlaying).toBe(false);
     expect(spy.mock.calls.length).toBe(calls);
+  });
+
+  // ─── Tumble and settle (#485) ────────────────────────────────────────────
+
+  it('tumbles more as a thrown fragment falls, not just a fixed pose', () => {
+    const { mesh, frames } = recorder();
+    const animator = new FragmentAnimator(mesh);
+    const f = flight({ thrown: true, impactSpeed: 20, durationS: 2 });
+    animator.begin([f]);
+
+    animator.seek(0.5);
+    const early = frames[frames.length - 1]!.get(0)!.tumbleAngle;
+    animator.seek(1.0);
+    const mid = frames[frames.length - 1]!.get(0)!.tumbleAngle;
+    animator.seek(1.5);
+    const late = frames[frames.length - 1]!.get(0)!.tumbleAngle;
+
+    expect(Math.abs(mid)).toBeGreaterThan(Math.abs(early));
+    expect(Math.abs(late)).toBeGreaterThan(Math.abs(mid));
+  });
+
+  it('tumbles far less when dropped than when thrown, at the same impact speed', () => {
+    const { mesh: thrownMesh, frames: thrownFrames } = recorder();
+    const thrownAnimator = new FragmentAnimator(thrownMesh);
+    thrownAnimator.begin([flight({ thrown: true, impactSpeed: 15, durationS: 2 })]);
+    thrownAnimator.seek(1.0);
+    const thrownAngle = thrownFrames[thrownFrames.length - 1]!.get(0)!.tumbleAngle;
+
+    const { mesh: droppedMesh, frames: droppedFrames } = recorder();
+    const droppedAnimator = new FragmentAnimator(droppedMesh);
+    droppedAnimator.begin([flight({ thrown: false, impactSpeed: 15, durationS: 2 })]);
+    droppedAnimator.seek(1.0);
+    const droppedAngle = droppedFrames[droppedFrames.length - 1]!.get(0)!.tumbleAngle;
+
+    expect(Math.abs(droppedAngle)).toBeLessThan(Math.abs(thrownAngle));
+    // "Bounded by the drop factor ratio" — a small margin covers rounding, not a
+    // different formula entirely.
+    expect(Math.abs(droppedAngle)).toBeLessThanOrEqual(Math.abs(thrownAngle) * TUMBLE_DROP_FACTOR + 1e-6);
+  });
+
+  it('barely tumbles at all when the impact speed is near zero, thrown or dropped', () => {
+    for (const thrown of [true, false]) {
+      const { mesh, frames } = recorder();
+      const animator = new FragmentAnimator(mesh);
+      animator.begin([flight({ thrown, impactSpeed: 0.0001, durationS: 2 })]);
+
+      for (const t of [0.25, 0.5, 1, 1.5]) {
+        animator.seek(t);
+        const angle = frames[frames.length - 1]!.get(0)!.tumbleAngle;
+        expect(Math.abs(angle)).toBeLessThan(0.01);
+      }
+    }
+  });
+
+  it('holds a fully settled fragment at exactly no tumble and no squash', () => {
+    const { mesh, frames } = recorder();
+    const animator = new FragmentAnimator(mesh);
+    const f = flight({ thrown: true, impactSpeed: 15, durationS: 2, delayS: 0.5 });
+    animator.begin([f]);
+
+    animator.seek(f.delayS + f.durationS + SETTLE_DURATION_S);
+    const settled = frames[frames.length - 1]!.get(0)!;
+
+    expect(settled.tumbleAngle).toBe(0);
+    expect(settled.settleScale).toEqual({ x: 1, y: 1, z: 1 });
+
+    // Stays settled well past the settle window too.
+    animator.seek(f.delayS + f.durationS + SETTLE_DURATION_S + 10);
+    const later = frames[frames.length - 1]!.get(0)!;
+    expect(later.tumbleAngle).toBe(0);
+    expect(later.settleScale).toEqual({ x: 1, y: 1, z: 1 });
+  });
+
+  it('squashes away from identity mid-settle and returns to identity by window end, with no jump at landing', () => {
+    const { mesh, frames } = recorder();
+    const animator = new FragmentAnimator(mesh);
+    const f = flight({ thrown: true, impactSpeed: 12, durationS: 2, delayS: 0 });
+    animator.begin([f]);
+    const landingT = f.delayS + f.durationS;
+
+    animator.seek(landingT - 0.001);
+    const justBeforeLanding = frames[frames.length - 1]!.get(0)!;
+
+    animator.seek(landingT);
+    const atLanding = frames[frames.length - 1]!.get(0)!;
+
+    animator.seek(landingT + SETTLE_DURATION_S * 0.5);
+    const midSettle = frames[frames.length - 1]!.get(0)!;
+
+    animator.seek(landingT + SETTLE_DURATION_S);
+    const endSettle = frames[frames.length - 1]!.get(0)!;
+
+    // Settle starts exactly where flight left off — no discontinuous pop.
+    expect(atLanding.settleScale).toEqual({ x: 1, y: 1, z: 1 });
+    expect(Math.abs(atLanding.tumbleAngle - justBeforeLanding.tumbleAngle)).toBeLessThan(0.05);
+
+    // Somewhere in the settle window the scale visibly deviates from identity —
+    // that's the bounce/squash the issue asks for.
+    const deviatesFromIdentity =
+      midSettle.settleScale.x !== 1 || midSettle.settleScale.y !== 1 || midSettle.settleScale.z !== 1;
+    expect(deviatesFromIdentity).toBe(true);
+
+    // And it's back to exact identity by the end of the settle window.
+    expect(endSettle.settleScale).toEqual({ x: 1, y: 1, z: 1 });
+  });
+
+  it('keeps resting position exact regardless of tumble/settle', () => {
+    const { mesh, frames } = recorder();
+    const animator = new FragmentAnimator(mesh);
+    const f = flight({ to: { x: 4, y: 3, z: -2 }, thrown: true, impactSpeed: 30, durationS: 2 });
+    animator.begin([f]);
+
+    animator.seek(f.durationS + SETTLE_DURATION_S);
+    const settled = frames[frames.length - 1]!.get(0)!;
+
+    expect(pos(settled)).toEqual(f.to);
+  });
+
+  it('reaches identical tumble/settle values by seeking directly or by accumulating update() calls', () => {
+    const { mesh: seekMesh, frames: seekFrames } = recorder();
+    const seekAnimator = new FragmentAnimator(seekMesh);
+    seekAnimator.begin([flight({ thrown: true, impactSpeed: 18, durationS: 2 })]);
+    seekAnimator.seek(1.3);
+    const seeked = seekFrames[seekFrames.length - 1]!.get(0)!;
+
+    const { mesh: stepMesh, frames: stepFrames } = recorder();
+    const stepAnimator = new FragmentAnimator(stepMesh);
+    stepAnimator.begin([flight({ thrown: true, impactSpeed: 18, durationS: 2 })]);
+    stepAnimator.update(0.3);
+    stepAnimator.update(0.4);
+    stepAnimator.update(0.6);
+    const stepped = stepFrames[stepFrames.length - 1]!.get(0)!;
+
+    expect(stepped.tumbleAngle).toBeCloseTo(seeked.tumbleAngle, 9);
+    expect(stepped.settleScale.x).toBeCloseTo(seeked.settleScale.x, 9);
+    expect(stepped.settleScale.y).toBeCloseTo(seeked.settleScale.y, 9);
+    expect(stepped.settleScale.z).toBeCloseTo(seeked.settleScale.z, 9);
+  });
+
+  it('produces identical tumble/settle sequences for identical flight input across separate animators', () => {
+    const makeRun = () => {
+      const { mesh, frames } = recorder();
+      const animator = new FragmentAnimator(mesh);
+      animator.begin([flight({ thrown: true, impactSpeed: 22, durationS: 2, delayS: 0.3 })]);
+      const samples: FragmentInstanceTransform[] = [];
+      for (const t of [0, 0.5, 1, 1.5, 2, 2.2, 2.5]) {
+        animator.seek(t);
+        samples.push(frames[frames.length - 1]!.get(0)!);
+      }
+      return samples;
+    };
+
+    expect(makeRun()).toEqual(makeRun());
+  });
+
+  it('stops costing anything only once settle has finished, not merely on landing', () => {
+    const { mesh, spy } = recorder();
+    const animator = new FragmentAnimator(mesh);
+    animator.begin([flight({ durationS: 2 })]);
+
+    animator.update(2); // exactly at the landing instant
+    expect(animator.isPlaying).toBe(true);
+
+    animator.update(SETTLE_DURATION_S);
+    expect(animator.isPlaying).toBe(false);
+
+    const callsAfterSettle = spy.mock.calls.length;
+    animator.update(1);
+    animator.update(1);
+    expect(spy.mock.calls.length).toBe(callsAfterSettle);
+  });
+
+  it('settles each fragment independently even when several land in the same frame', () => {
+    const a = flight({ fragmentId: 0, thrown: true, impactSpeed: 5, durationS: 2, delayS: 0 });
+    const b = flight({ fragmentId: 1, thrown: true, impactSpeed: 40, durationS: 1, delayS: 1 });
+    const sampleT = 2 + SETTLE_DURATION_S * 0.5; // both land at t=2
+
+    const { mesh, frames } = recorder();
+    const animator = new FragmentAnimator(mesh);
+    animator.begin([a, b]);
+    animator.seek(sampleT);
+    const combined = frames[frames.length - 1]!;
+
+    const { mesh: meshA, frames: framesA } = recorder();
+    const animatorA = new FragmentAnimator(meshA);
+    animatorA.begin([a]);
+    animatorA.seek(sampleT);
+    const soloA = framesA[framesA.length - 1]!.get(0)!;
+
+    const { mesh: meshB, frames: framesB } = recorder();
+    const animatorB = new FragmentAnimator(meshB);
+    animatorB.begin([b]);
+    animatorB.seek(sampleT);
+    const soloB = framesB[framesB.length - 1]!.get(1)!;
+
+    expect(combined.get(0)!.tumbleAngle).toBeCloseTo(soloA.tumbleAngle, 9);
+    expect(combined.get(0)!.settleScale).toEqual(soloA.settleScale);
+    expect(combined.get(1)!.tumbleAngle).toBeCloseTo(soloB.tumbleAngle, 9);
+    expect(combined.get(1)!.settleScale).toEqual(soloB.settleScale);
   });
 });

--- a/tests/unit/renderer/FragmentMesh.test.ts
+++ b/tests/unit/renderer/FragmentMesh.test.ts
@@ -153,9 +153,9 @@ describe('FragmentMesh (InstancedMesh)', () => {
     expect(im.count).toBe(1);
   });
 
-  it('updatePositions changes instance matrix position', () => {
+  it('updateTransforms changes instance matrix position', () => {
     fm.spawnFragments([makeFragment(0)]);
-    fm.updatePositions(new Map([[0, { x: 10, y: 20, z: 30 }]]));
+    fm.updateTransforms(new Map([[0, { x: 10, y: 20, z: 30, tumbleAngle: 0, settleScale: { x: 1, y: 1, z: 1 } }]]));
 
     // Extract position from the instanced matrix
     const im = scene.children[0] as THREE.InstancedMesh;

--- a/tests/unit/renderer/FragmentTransformMath.test.ts
+++ b/tests/unit/renderer/FragmentTransformMath.test.ts
@@ -1,0 +1,208 @@
+// FragmentTransformMath — unit tests (#485 code review: previously zero direct
+// coverage of the module that owns the "settled fragment is bit-identical to
+// its spawn transform" invariant).
+
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import {
+  seedUnit,
+  spawnOrientation,
+  spawnShear,
+  normalizeOrFallback,
+  tumbleAxis,
+  buildBaseTransform,
+  composeInstanceMatrix,
+} from '../../../src/renderer/FragmentTransformMath.js';
+
+describe('seedUnit', () => {
+  it('is deterministic for the same seed and salt', () => {
+    expect(seedUnit(7, 2)).toBe(seedUnit(7, 2));
+  });
+
+  it('varies with the seed', () => {
+    expect(seedUnit(1, 2)).not.toBe(seedUnit(2, 2));
+  });
+
+  it('varies with the salt', () => {
+    expect(seedUnit(7, 1)).not.toBe(seedUnit(7, 2));
+  });
+
+  it('stays in [0, 1) — it is `x - Math.floor(x)`, a fractional part', () => {
+    for (let seed = 0; seed < 200; seed++) {
+      const v = seedUnit(seed, 3);
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+});
+
+describe('spawnOrientation', () => {
+  it('is deterministic per shapeSeed', () => {
+    const a = spawnOrientation(5);
+    const b = spawnOrientation(5);
+    expect(a.x).toBeCloseTo(b.x, 10);
+    expect(a.y).toBeCloseTo(b.y, 10);
+    expect(a.z).toBeCloseTo(b.z, 10);
+    expect(a.w).toBeCloseTo(b.w, 10);
+  });
+
+  it('differs between shape seeds (spot check)', () => {
+    const a = spawnOrientation(1);
+    const b = spawnOrientation(2);
+    const same = Math.abs(a.x - b.x) < 1e-9 && Math.abs(a.y - b.y) < 1e-9
+      && Math.abs(a.z - b.z) < 1e-9 && Math.abs(a.w - b.w) < 1e-9;
+    expect(same).toBe(false);
+  });
+});
+
+describe('spawnShear', () => {
+  it('is deterministic per shapeSeed', () => {
+    const a = spawnShear(9).elements;
+    const b = spawnShear(9).elements;
+    expect(a).toEqual(b);
+  });
+
+  it('differs between shape seeds (spot check)', () => {
+    const a = spawnShear(1).elements;
+    const b = spawnShear(2).elements;
+    expect(a).not.toEqual(b);
+  });
+
+  it('only sets the three documented off-diagonal shear entries', () => {
+    const e = spawnShear(3).elements;
+    for (let i = 0; i < 16; i++) {
+      if (i === 4 || i === 8 || i === 9) continue;
+      // Matrix4 starts as identity; untouched entries keep the identity value.
+      const identity = i === 0 || i === 5 || i === 10 || i === 15 ? 1 : 0;
+      expect(e[i]).toBe(identity);
+    }
+  });
+});
+
+describe('normalizeOrFallback', () => {
+  it('normalizes a well-defined vector to unit length', () => {
+    const v = new THREE.Vector3(3, 0, 4);
+    const out = normalizeOrFallback(v, new THREE.Vector3(0, 1, 0));
+    expect(out.length()).toBeCloseTo(1, 10);
+    expect(out.x).toBeCloseTo(0.6, 10);
+    expect(out.y).toBeCloseTo(0, 10);
+    expect(out.z).toBeCloseTo(0.8, 10);
+  });
+
+  it('falls back rather than normalizing a near-zero vector', () => {
+    const fallback = new THREE.Vector3(0, 1, 0);
+    const out = normalizeOrFallback(new THREE.Vector3(1e-6, 1e-6, 1e-6), fallback);
+    expect(out).toBe(fallback);
+    expect(out.x).toBe(0);
+    expect(out.y).toBe(1);
+    expect(out.z).toBe(0);
+  });
+
+  it('falls back on the exact zero vector rather than producing NaN', () => {
+    const fallback = new THREE.Vector3(0, 1, 0);
+    const out = normalizeOrFallback(new THREE.Vector3(0, 0, 0), fallback);
+    expect(out).toBe(fallback);
+    expect(Number.isNaN(out.x)).toBe(false);
+  });
+});
+
+describe('tumbleAxis', () => {
+  it('returns a unit-length vector for a typical seed', () => {
+    const axis = tumbleAxis(42);
+    expect(axis.length()).toBeCloseTo(1, 10);
+  });
+
+  it('is deterministic per shapeSeed', () => {
+    expect(tumbleAxis(11).toArray()).toEqual(tumbleAxis(11).toArray());
+  });
+
+  it('varies between shape seeds (spot check)', () => {
+    expect(tumbleAxis(1).toArray()).not.toEqual(tumbleAxis(2).toArray());
+  });
+});
+
+describe('buildBaseTransform', () => {
+  it('returns a consistent {rs, axis} for the same shapeSeed', () => {
+    const scale = new THREE.Vector3(2, 3, 4);
+    const a = buildBaseTransform(6, scale);
+    const b = buildBaseTransform(6, scale);
+    expect(a.rs.elements).toEqual(b.rs.elements);
+    expect(a.axis.toArray()).toEqual(b.axis.toArray());
+  });
+
+  it('rs folds in the supplied scale — a bigger scale means bigger basis columns', () => {
+    const small = buildBaseTransform(6, new THREE.Vector3(1, 1, 1));
+    const big = buildBaseTransform(6, new THREE.Vector3(2, 2, 2));
+    const colLen = (m: THREE.Matrix4) => Math.hypot(m.elements[0]!, m.elements[1]!, m.elements[2]!);
+    expect(colLen(big.rs)).toBeCloseTo(colLen(small.rs) * 2, 6);
+  });
+});
+
+describe('composeInstanceMatrix', () => {
+  it('identity tumble/settle reproduces the same matrix as a fresh call with the same inputs (settled === spawn, #485 invariant)', () => {
+    // FragmentMesh.spawnFragments composes the spawn matrix as
+    // composeInstanceMatrix(base, position, 0, {1,1,1}, out) — a "settled"
+    // fragment (tumbleAngle 0, settleScale identity) at the same position
+    // must be bit-identical to that spawn call.
+    const base = buildBaseTransform(17, new THREE.Vector3(1.5, 0.4, 0.9));
+    const position = { x: 5, y: 2, z: -3 };
+    const identityScale = { x: 1, y: 1, z: 1 };
+
+    const spawnMtx = new THREE.Matrix4();
+    composeInstanceMatrix(base, position, 0, identityScale, spawnMtx);
+
+    const settledMtx = new THREE.Matrix4();
+    composeInstanceMatrix(base, position, 0, identityScale, settledMtx);
+
+    expect(settledMtx.elements).toEqual(spawnMtx.elements);
+  });
+
+  it('reduces to T(position) · base.rs when tumbleAngle is 0 and settleScale is identity', () => {
+    const base = buildBaseTransform(23, new THREE.Vector3(1, 1, 1));
+    const position = { x: 1, y: 2, z: 3 };
+
+    const out = new THREE.Matrix4();
+    composeInstanceMatrix(base, position, 0, { x: 1, y: 1, z: 1 }, out);
+
+    const expected = base.rs.clone();
+    expected.setPosition(position.x, position.y, position.z);
+
+    expect(out.elements).toEqual(expected.elements);
+  });
+
+  it('a non-zero tumbleAngle produces a different matrix than the settled case', () => {
+    const base = buildBaseTransform(23, new THREE.Vector3(1, 1, 1));
+    const position = { x: 1, y: 2, z: 3 };
+    const identityScale = { x: 1, y: 1, z: 1 };
+
+    const settled = new THREE.Matrix4();
+    composeInstanceMatrix(base, position, 0, identityScale, settled);
+
+    const tumbled = new THREE.Matrix4();
+    composeInstanceMatrix(base, position, Math.PI / 3, identityScale, tumbled);
+
+    expect(tumbled.elements).not.toEqual(settled.elements);
+  });
+
+  it('a non-identity settleScale produces a different matrix than the settled case', () => {
+    const base = buildBaseTransform(23, new THREE.Vector3(1, 1, 1));
+    const position = { x: 1, y: 2, z: 3 };
+
+    const settled = new THREE.Matrix4();
+    composeInstanceMatrix(base, position, 0, { x: 1, y: 1, z: 1 }, settled);
+
+    const squashed = new THREE.Matrix4();
+    composeInstanceMatrix(base, position, 0, { x: 1.1, y: 0.8, z: 1.1 }, squashed);
+
+    expect(squashed.elements).not.toEqual(settled.elements);
+  });
+
+  it('writes into the supplied out matrix rather than allocating a new one', () => {
+    const base = buildBaseTransform(23, new THREE.Vector3(1, 1, 1));
+    const out = new THREE.Matrix4();
+    const result = composeInstanceMatrix(base, { x: 0, y: 0, z: 0 }, 0, { x: 1, y: 1, z: 1 }, out);
+    expect(result).toBeUndefined();
+    // out itself was mutated — its position column now reflects the call.
+    expect(out.elements[12]).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #485

7119 tests — all passing (258 test files)

## Summary

Fragments now tumble in the air and settle on landing instead of sliding rigidly on rails and freezing on impact:

- **Tumble**: rotation axis derived deterministically from the fragment's own `shapeSeed` (cached at spawn time in `FragmentMesh`, salts 7/8/9, distinct from the existing orientation/shear salts); rotation magnitude/timing derived purely from flight kinematics (`impactSpeed`, `thrown`) in `FragmentAnimator`, which stays Three.js-free. Thrown fragments spin at up to `TUMBLE_MAX_RATE_RAD_S` (~1 rev/s at `MAX_PROJECTION_VELOCITY`); dropped fragments spin at `TUMBLE_DROP_FACTOR` (0.12×) of that. No `Math.random()` anywhere — same blast always looks the same.
- **Settle**: a `SETTLE_DURATION_S` (0.35s) damped-sine squash/stretch bounce eases every fragment into its final resting transform after landing, instead of freezing instantly.
- **Invariant preserved**: a fully-settled fragment's transform is bit-identical to what `spawnFragments` would write for it — both paths route through one shared `composeInstanceMatrix` in the new `src/renderer/FragmentTransformMath.ts`, so there is no second place that could compute a slightly different rest matrix. Verified by direct matrix-element tests, not just output-DTO checks.
- **Idle cost stays zero**: `FragmentAnimator.begin()`'s `endsAtS` now includes `SETTLE_DURATION_S`, so the animator keeps writing instances until the last fragment has actually settled, then stops — matching the issue's explicit requirement.
- `src/core/mining/BlastResolve.ts` and `tests/unit/mining/flightPlayback.test.ts` are unchanged — no core data model changes were needed (see Decisions taken).

### Files changed
- `src/renderer/FragmentTransformMath.ts` (new) — pure Three.js matrix/quaternion math, shared by spawn and per-frame update paths
- `src/renderer/FragmentMesh.ts` — `updatePositions` → `updateTransforms`, spawn math extracted into `FragmentTransformMath.ts`
- `src/renderer/FragmentAnimator.ts` — tumble/settle derivation, `endsAtS` extended
- `src/core/config/balance.ts` — `TUMBLE_MAX_RATE_RAD_S`, `TUMBLE_DROP_FACTOR`, `SETTLE_DURATION_S`, `SETTLE_SQUASH_MAGNITUDE`, `SETTLE_BOUNCE_OSCILLATIONS`
- `tests/unit/renderer/FragmentAnimator.test.ts`, `tests/unit/renderer/FragmentMesh.test.ts` — extended/updated
- `tests/unit/renderer/FragmentTransformMath.test.ts` (new) — 22 tests, added during code review to close a gap on the settled-vs-spawn matrix-identity invariant

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** whether `FragmentFlight`/`LandableFragment` need a new field to carry `shapeSeed` or a spin/settle hint into the renderer.
  **Chosen:** no — `FragmentMesh.spawnFragments` already receives `shapeSeed` before any flight exists, caching the tumble axis itself at spawn time; `FragmentAnimator` derives tumble magnitude/timing purely from existing `FragmentFlight` fields.
  **Why:** keeps rotation/settle a renderer-only concern, exactly as the issue frames it ("cosmetic... must not feed back into game state"); `BlastResolve.ts` and `flightPlayback.test.ts` stay untouched, keeping the core/renderer boundary as strict as before this issue.
  **If reversed:** add `shapeSeed: number` to `LandableFragment`/`FragmentFlight` in `BlastResolve.ts`, move axis derivation into `FragmentAnimator`.

- **What was open:** tumble rate, drop-vs-thrown ratio, settle duration, and settle magnitude have no numeric spec in the issue.
  **Chosen:** `TUMBLE_MAX_RATE_RAD_S = 2π`, `TUMBLE_DROP_FACTOR = 0.12`, `SETTLE_DURATION_S = 0.35`, `SETTLE_SQUASH_MAGNITUDE = 0.15`, `SETTLE_BOUNCE_OSCILLATIONS = 2`.
  **Why:** reuses the already-established `MAX_PROJECTION_VELOCITY` scale; values read clearly at the game's cartoon scale without stalling a multi-fragment collapse's pacing.
  **If reversed:** change the five named constants in `balance.ts`; no call site moves.

- **What was open:** how to split rotation derivation between `shapeSeed` (axis) and flight (magnitude/timing) across renderer files without either reaching into the other's Three.js internals.
  **Chosen:** `FragmentMesh`/`FragmentTransformMath` own axis derivation and matrix composition; `FragmentAnimator` stays framework-free, passing only plain numbers.
  **Why:** matches the codebase's existing division — `FragmentAnimator.test.ts` mocks `FragmentMesh` as a plain object with no Three.js dependency; this preserves that testability.
  **If reversed:** move axis/compose calls into `FragmentAnimator`, pass a full `Quaternion`/`Matrix4` instead of a scalar (requires the first decision's reversal too).

- **What was open:** `FragmentMesh.ts` was already over the 300-line convention before this issue.
  **Chosen:** extracted `FragmentTransformMath.ts` — pure matrix/quaternion helpers shared by spawn and per-frame update.
  **Why:** keeps the file near budget and removes the risk of the two paths silently diverging, which would break the settled-equals-spawned invariant.
  **If reversed:** inline `FragmentTransformMath.ts`'s contents back into `FragmentMesh.ts`.

- **What was open:** `durationS`/`isPlaying`'s contract implicitly changes meaning (now spans settle, not just flight).
  **Chosen:** `endsAtS` includes `SETTLE_DURATION_S`, so idle-detection waits for settle completion.
  **Why:** the issue's idle-cost requirement is stated in terms of settling, not landing.
  **If reversed:** track a separate pre-settle "landing" instant alongside `endsAtS` if a future caller needs it.

None of these change gameplay, economy, or a player-facing default beyond animation feel — no follow-up `decision-review` issue filed.

## Verification

- **static**: `npm run typecheck` — clean.
- **logic**: `npm run test` — 7119/7119 passing (258 files).
- **scenario**: `npm run scenarios` — 112/112 passing (command mode).
- **build**: `npm run build` — succeeds.
- **visual**: dev server + harness confirmed working; post-load and post-blast settled-state screenshots inspected directly (vision) — fragments render with valid, non-degenerate transforms, no NaN/corruption, no console errors, a11y and state-schema checks pass. Mid-collapse tumble itself could not be captured locally — headless Chrome has no GPU (~6s/frame per #475), exactly as the issue's own verification section anticipates ("the browser CI jobs behind full-ci are where this is judged"). Labelling this PR `full-ci` so the `Scenarios (interaction mode)` CI job renders and judges the mid-collapse frames before merge.
- **playability**: not applicable — no player-facing interactive flow (tutorial/panels/hiring/skills/contracts/building/vehicles) is altered; this is cosmetic blast-collapse rendering only.
- **qualimetry**: `npx jscpd` on changed files — 0 clones.
- **code review**: security, quality, i18n, duplication, semantic reviewers all PASS clean (one round of fixes for a per-frame allocation regression and a test-coverage gap on the core matrix-identity invariant, both closed and re-verified).

READY TO MERGE
