### PR TITLE
Pipeline: only a manual dispatch or a merged PR may start a run

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -45,7 +45,7 @@ Prefix categories:
 
 ## ▶ Autonomous pipeline sessions
 
-The project takes one human input: a GitHub issue. Filing one does not by itself start a run — label assignment stays with the filer. A run starts once `ready` is on the issue (the issue form's own default, an agent authoring the issue per `agentic-issue-creation`, or a human adding it by hand); the queue then assigns it and carries it to a merged pull request or to a stated blocker. A run always leaves its issue in a terminal state; an issue left holding `in-progress` stalls every assignment behind it.
+The project takes one human input: a GitHub issue. Filing one starts nothing, and neither does labelling it. `ready` means the issue is **eligible** — it joins the queue and waits there. A run starts in exactly two ways, and no others: a human dispatching `agentic-trigger.yml`, or a merged pipeline pull request chaining to the next `ready` issue. Nothing on a schedule and no issue event ever starts a session. Once started, a run carries its issue to a merged pull request or to a stated blocker, and always leaves it in a terminal state; an issue left holding `in-progress` stalls every assignment behind it.
 
 A session started by the autonomous pipeline — a GitHub Actions run woken by the `@claude` mention in a pipeline assignment comment — is not an ordinary session. Its first action is to hand the task to the `orchestrator` agent, which classifies it and delegates every step to specialists. Never implement a pipeline-assigned task in the main session, and never explore the codebase before the orchestrator has classified it. The `/agentic-run` command carries that mandate; the system around it is described in `agentic-autonomous-pipeline`.
 

--- a/.claude/skills/agentic-autonomous-pipeline/references/github-loop.md
+++ b/.claude/skills/agentic-autonomous-pipeline/references/github-loop.md
@@ -3,12 +3,12 @@
 How a filed issue becomes a merged pull request with nobody watching, and every mechanism that keeps the chain from going quiet.
 
 ```
-issue filed / reopened / labelled `ready`        merged PR        hourly sweep        manual dispatch
-      │                                               │                 │                    │
-      ▼                                               ▼                 ▼                    ▼
-agentic-intake.yml                          auto-assign-next.yml  agentic-watchdog.yml  agentic-trigger.yml
-      └──────────────────────────────┬────────────────┴─────────────────┴────────────────────┘
-                                     ▼
+       merged PR                 manual dispatch
+            │                           │
+            ▼                           ▼
+   auto-assign-next.yml         agentic-trigger.yml
+            └─────────────┬─────────────┘
+                          ▼
                         [agentic-assign] oldest unblocked `ready` issue
                                      │  ready → in-progress, then post the assignment comment
                                      ▼
@@ -27,16 +27,16 @@ agentic-intake.yml                          auto-assign-next.yml  agentic-watchd
                                      └─ [agentic-assign] next `ready` issue → back to the top
 ```
 
-## Four ways in, and why each exists
+## Two ways in, and nothing else
 
 | Entry | Fires on | Covers |
 |-------|----------|--------|
-| `agentic-intake.yml` | `issues: opened, reopened, labeled` | The only human input, but filing alone does not start a run — `ready` does, whether it arrives with the issue (the form's own `labels:` default, or an agent authoring the issue per `agentic-issue-creation`) or a human adds it later. A `ready` label on a previously `blocked` issue is the whole resume procedure |
-| `auto-assign-next.yml` | `pull_request: opened, synchronize, closed` | Auto-merge on `READY TO MERGE`, then chain from the merge to the next issue |
-| `agentic-watchdog.yml` | hourly schedule | Sweeps stalled runs, then restarts the queue if the pipeline is idle |
-| `agentic-trigger.yml` | manual dispatch | A human forcing the queue forward |
+| `agentic-trigger.yml` | manual dispatch | A human starting the pipeline on the oldest unblocked `ready` issue. This is how a run begins from a standing start |
+| `auto-assign-next.yml` | `pull_request: opened, synchronize, closed` | Auto-merge on `READY TO MERGE`, then chain from the merge to the next issue. This is how a run begins from the previous one finishing |
 
-Events get lost — GitHub keeps one pending run per concurrency group and drops the next, a webhook can be missed, a run can end without chaining. Every entry above except the watchdog is event-driven, which is why the watchdog also assigns: it is the only mechanism on a clock, so it is the floor under the queue. At worst an idle pipeline with ready issues restarts itself within the hour.
+**Nothing else may start a session.** Filing an issue, labelling one `ready`, reopening one, and the passage of time all leave the queue exactly where it was. `agentic-intake.yml` still reacts to `issues: opened, reopened`, but only to keep the label definitions present and to drop a stale `done` from a reopened issue — it assigns nothing. `agentic-watchdog.yml` still sweeps hourly, but only to release issues whose runs died; it does not restart the queue.
+
+The consequence is deliberate and worth stating plainly: **a `ready` issue can sit in the queue indefinitely.** Nothing is scheduled to notice it. Events genuinely do get lost — GitHub keeps one pending run per concurrency group and drops the next, a webhook can be missed, a run can end its turn without chaining — and when that happens the chain stops until a human dispatches `agentic-trigger.yml`. That is the intended trade: an idle pipeline is preferable to sessions nobody asked for.
 
 ## Issue labels are the loop's state machine
 
@@ -49,7 +49,9 @@ Events get lost — GitHub keeps one pending run per concurrency group and drops
 | `done` | Finished | The merged-PR chain, or a run releasing a non-PR deliverable | — |
 | `decision-review` | A default the run chose, revisit at leisure. Carries no `ready`, so it never enters the queue | The run — see `agentic-decision-autonomy` | A human, by adding `ready` |
 
-Intake never applies `agent-task` or `ready` itself — that would take label assignment out of the hands of whoever files the issue. `agentic-assign` selects on `ready` alone, so an issue only enters the queue once something puts `ready` on it: the "Agent Task" form's own `labels:` default, an agent following `agentic-issue-creation`, or a human adding it by hand — including to resume a `blocked` issue, or to opt a free-form/API-filed issue in. A human filing without the form and without `ready` gets an issue that sits unlabelled and out of the queue until they choose to add it; that is deliberate, not an oversight.
+Intake never applies `agent-task` or `ready` itself — that would take label assignment out of the hands of whoever files the issue. `agentic-assign` selects on `ready` alone, so an issue only becomes *selectable* once something puts `ready` on it: the "Agent Task" form's own `labels:` default, an agent following `agentic-issue-creation`, or a human adding it by hand — including to resume a `blocked` issue, or to opt a free-form/API-filed issue in.
+
+`ready` marks an issue as **eligible**, never as **started**. The label puts it in the queue; only a manual dispatch or a merged pipeline PR takes it out again. This is the distinction to hold on to when reading anything below that talks about an issue "entering the queue": entering the queue is not being picked up.
 
 **An issue is released by whoever finishes it.** A run whose deliverable is a pull request is released by the merge. A run whose deliverable is an answer or an executed command releases its own issue — closes it, labels it `done`, drops `in-progress`. Skipping that leaves single flight deferring behind a run that already succeeded, until the watchdog ages it out and reports it as lost.
 
@@ -62,19 +64,19 @@ Intake never applies `agent-task` or `ready` itself — that would take label as
    **A consequence to respect:** under the PAT, everything the session posts is authored by a real user rather than a bot, and the runners' trigger guard filters on `comment.user.type != 'Bot'`. An agent-authored comment containing the agent's own mention would therefore wake a new run. No pipeline comment may contain `@claude` or `@opencode` — the assignment comment is the only comment allowed to carry a mention.
 2. **The assignment comment carries the whole assignment.** It names the issue, mandates orchestrator-first delegation, states the branch names, the verification expectation, and the PR conventions. Its text is identical for every agent apart from the mention on the first line — the runtimes read the same instructions.
 
-An issue the agent closes without opening a PR raises no `pull_request` event either, so each runner ends with its own chaining step for exactly that case.
+An issue the agent closes without opening a PR raises no `pull_request` event either, so nothing chains from it. The runners used to carry their own step for that case; it was removed, because a run starting the next run is the pipeline deciding to run again on its own. Such a run still *releases* its issue — closes it, labels it `done`, drops `in-progress` — so the queue is free the moment somebody asks for the next one.
 
 ## Single flight
 
 Two agent sessions must never run at once — they would compete over the same `pipeline/*` branch names and the same working tree. Two independent mechanisms enforce it:
 
 - **`agentic-assign` defers.** An issue keeps `in-progress` until its run is finished, so any *other* issue still carrying that label means a run is live. The action logs why and assigns nothing; finishing the outstanding run re-enters the step. It defers whether or not that issue has a linked PR, and **it never diagnoses**: a run 40 seconds old and a run that died hours ago look identical from the labels alone, so declaring one lost belongs to the watchdog, which is the only mechanism that ages it. `agentic-assign` used to comment "Pipeline halted — no linked PR was created" on sight, which it posted on #404 while that run was one minute into a two-hour session.
-- **Intake serialises its assignments** through a job-level `agentic-assignment` concurrency group. The single-flight check reads the `in-progress` label, so parallel intakes — one per issue when a human files a batch in one sitting — would each read the list before any of them writes to it, and every one would assign. Labelling stays outside the group: a dropped run there would cost an issue its `ready` label and make it invisible, while a dropped assignment costs nothing the hourly sweep does not pick back up.
-- **The runners share a `concurrency` group** named `agentic-runner`, declared identically in `claude-runner.yml` and `opencode-runner.yml`. Concurrency groups are repo-wide, so the two runners serialise against each other as well as themselves. `cancel-in-progress: false` — a queued run waits rather than killing the live one. GitHub keeps only one run pending per group; a third is dropped, which the watchdog's idle restart then recovers.
+- **The two entries cannot race by construction.** A manual dispatch is one act by one human, and the merged-PR chain fires once per merge — there is no longer an events-per-issue path that could assign a batch in parallel. (Intake used to need an `agentic-assignment` concurrency group for exactly that reason: one intake per issue when a human filed several in a sitting, each reading the `in-progress` label before any of them wrote it. Removing intake's assignment removed the race with it.)
+- **The runners share a `concurrency` group** named `agentic-runner`, declared identically in `claude-runner.yml` and `opencode-runner.yml`. Concurrency groups are repo-wide, so the two runners serialise against each other as well as themselves. `cancel-in-progress: false` — a queued run waits rather than killing the live one. GitHub keeps only one run pending per group; a third is dropped, and nothing recovers it automatically — dispatch `agentic-trigger.yml` to pick the queue back up.
 
 ## Halt conditions
 
-The loop stops deliberately when an issue is labelled `blocked`, while an issue is still `in-progress` (single flight), or when no unblocked `ready` issue remains. `handle-failure.yml` comments on `blocked` issues with the resume procedure — add `ready`, and intake takes it from there.
+The loop stops deliberately when an issue is labelled `blocked`, while an issue is still `in-progress` (single flight), or when no unblocked `ready` issue remains. `handle-failure.yml` comments on `blocked` issues with the resume procedure: add `ready` to put the issue back in the queue, then dispatch `agentic-trigger.yml` to start it — the label alone resumes nothing.
 
 A run that dies without labelling anything — OOM, a hung tool call, the job timeout, a revoked token, a turn ended on outstanding work — would otherwise leave its issue `in-progress` forever and halt the chain silently. `agentic-watchdog.yml` sweeps hourly: an issue `in-progress` past `AGENTIC_STALL_MINUTES` with no linked PR is commented on, labelled `blocked`, and stripped of `in-progress`. That labelling is what surfaces the failure, so the watchdog must use the PAT — a label applied with `GITHUB_TOKEN` raises no `issues: labeled` event and `handle-failure.yml` would never fire.
 
@@ -96,7 +98,7 @@ Intent is not a mechanism, so `agentic-rescue` runs last in both runners, with `
 
 The rescue PR is a diagnosis, not a deliverable: unreviewed and unvalidated by definition. Finishing it or dropping it is a human decision, and adding `ready` back to the issue is the whole resume procedure.
 
-**An escalation does not chain to the next issue, and that is deliberate.** The runner's own chaining step covers a run whose deliverable was not a diff — an issue closed and labelled `done`. A run that failed is different: chaining from it means the queue restarts as fast as runs fail, and a systemic failure (an expired token, a broken `main`) would march through the whole backlog labelling every issue `blocked` in minutes. The hourly sweep restarts the queue instead, which rate-limits the damage to one issue an hour and gives a human time to see the first notification.
+**An escalation does not chain to the next issue**, and neither does anything else a runner does. Chaining from a failure would restart the queue as fast as runs fail, and a systemic failure (an expired token, a broken `main`) would march through the whole backlog labelling every issue `blocked` in minutes. A failure therefore stops the pipeline outright: `handle-failure.yml` notifies, and the queue moves again when a human dispatches the trigger, having seen what went wrong.
 
 ## Dependencies between issues
 
@@ -107,7 +109,7 @@ The rescue PR is a diagnosis, not a deliverable: unreviewed and unvalidated by d
 | Variable | Values | Effect |
 |----------|--------|--------|
 | `AGENTIC_AGENT` | `@claude` / `@opencode` (leading `@` and case optional; unset means `@opencode`) | The agent that assignment comments address, and therefore the runner workflow that starts |
-| `AGENTIC_AUTO_ASSIGN_ENABLED` | `true` / anything else | Whether a finished issue chains to the next ready one, and whether the watchdog restarts an idle queue |
+| `AGENTIC_AUTO_ASSIGN_ENABLED` | `true` / anything else | Whether a merged pipeline PR chains to the next ready issue. Set to anything else, the manual trigger is the only way a run ever starts |
 | `AGENTIC_AUTO_MERGE_ENABLED` | `true` / anything else | Whether a `READY TO MERGE` PR gets GitHub native auto-merge |
 | `AGENTIC_STALL_MINUTES` | minutes, default `420`; a value below the runners' 360-minute job timeout is clamped up to it | How long an issue may stay `in-progress` without a linked PR before the watchdog marks it `blocked`. Below the job timeout it would sweep live runs |
 

--- a/.claude/skills/agentic-decision-autonomy/SKILL.md
+++ b/.claude/skills/agentic-decision-autonomy/SKILL.md
@@ -40,7 +40,7 @@ gh issue create --label decision-review \
   --body "<the Decisions taken block>, linking the PR"
 ```
 
-The `decision-review` label carries no `ready`, so the issue stays out of the assignment queue and halts nothing: `agentic-assign` selects on `ready` alone, and intake leaves the labels of an issue that already carries a lifecycle label untouched. It is where a human goes to revisit a default at leisure; adding `ready` later is how they send it back through the pipeline. Creating the issue **with** the `decision-review` label is what keeps it out — an issue filed carrying no lifecycle label at all is labelled `ready` on arrival and joins the queue.
+The `decision-review` label carries no `ready`, so the issue stays out of the assignment queue and halts nothing: `agentic-assign` selects on `ready` alone, and nothing in the pipeline ever applies `ready` to an issue a human filed. It is where a human goes to revisit a default at leisure; adding `ready` later is how they put it back in the queue, and a manual dispatch or the next merged pipeline PR is what starts it.
 
 `--force` updates the label when it already exists, so the step is safe to run on every issue rather than only the first. Both runners give the agent's shell a `GH_TOKEN` that already opens PRs and edits labels, and both workflows declare `issues: write`, so no extra permission is needed.
 

--- a/.claude/skills/agentic-issue-creation/SKILL.md
+++ b/.claude/skills/agentic-issue-creation/SKILL.md
@@ -16,7 +16,7 @@ Two shapes are valid, and they differ in how much of the answer is already known
 | **Intent** | A human filing from the issue form or free-form | Context, Task, Verification, and any Blocked by. The planner derives the files and the tests. |
 | **Complete** | An agent decomposing a feature into atomic tasks | Every section below. The decomposition already knows the file layout, so it states it. |
 
-Both enter the same queue once `ready` lands on the issue — a two-line issue typed from a phone is still a valid input, and where it leaves a choice open, the run defaults it under `agentic-decision-autonomy` rather than bouncing it back.
+Both enter the same queue once `ready` lands on the issue — a two-line issue typed from a phone is still a valid input, and where it leaves a choice open, the run defaults it under `agentic-decision-autonomy` rather than bouncing it back. Entering the queue is not being picked up: runs start only on a manual dispatch of `agentic-trigger.yml` or from a merged pipeline pull request.
 
 ## ▶ PROCEDURE — EXECUTE IN ORDER
 
@@ -25,7 +25,7 @@ Both enter the same queue once `ready` lands on the issue — a two-line issue t
 3. Verify the Rules are satisfied
 4. Run through the Checklist
 5. Create the issue with `gh issue create`, setting labels yourself:
-   - Human gave no instruction about labels → `--label ready,agent-task`. That is the default, not intake's — a **Complete**-shape issue you authored is ready to run the moment it exists, and intake no longer assigns `ready` on its own.
+   - Human gave no instruction about labels → `--label ready,agent-task`. `ready` means eligible, not started: it places the issue in the queue, where it waits until a human dispatches `agentic-trigger.yml` or a merged pipeline PR chains to it. Creating an issue never starts a run.
    - Human specified labels, or said the issue should wait — `decision-review` for a default to revisit later, or an explicit hold — → follow that instruction instead, and leave `ready` off.
 
 An issue that must **stay out** of the queue is created carrying a lifecycle label of its own instead of `ready` — `decision-review` for a default to revisit later. The issue joins the queue in number order once `ready` is on it, whoever put it there.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,6 @@
-# A free-form issue is a valid pipeline input. `agentic-intake.yml` labels
-# whatever arrives — form, API, or a sentence typed from a phone — so an issue
-# never has to be well-formed to be picked up, and underspecification is
-# resolved by the run rather than bounced back to the filer.
+# A free-form issue is a valid pipeline input — form, API, or a sentence typed
+# from a phone — and underspecification is resolved by the run rather than
+# bounced back to the filer. Nothing labels an issue on arrival, and no issue
+# event starts a run: add `ready` to put it in the queue, then dispatch
+# "Pipeline: run the configured agent on the next ready issue" to start it.
 blank_issues_enabled: true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,7 +71,7 @@ Five independent channels prove a change works. Each catches what the others mis
 
 ## ▶ Autonomous pipeline sessions
 
-The project takes one human input: a GitHub issue. Filing one does not by itself start a run — label assignment stays with the filer. A run starts once `ready` is on the issue (the issue form's own default, an agent authoring the issue per `agentic-issue-creation`, or a human adding it by hand); the queue then assigns it and carries it to a merged pull request or to a stated blocker. A run always leaves its issue in a terminal state; an issue left holding `in-progress` stalls every assignment behind it.
+The project takes one human input: a GitHub issue. Filing one starts nothing, and neither does labelling it. `ready` means the issue is **eligible** — it joins the queue and waits there. A run starts in exactly two ways, and no others: a human dispatching `agentic-trigger.yml`, or a merged pipeline pull request chaining to the next `ready` issue. Nothing on a schedule and no issue event ever starts a session. Once started, a run carries its issue to a merged pull request or to a stated blocker, and always leaves it in a terminal state; an issue left holding `in-progress` stalls every assignment behind it.
 
 A session started by the autonomous pipeline — a GitHub Actions run woken by the configured agent mention in a pipeline assignment comment — is not an ordinary session. Its first action is to run as the orchestrator: classify the task, then delegate every step to specialists. Never implement a pipeline-assigned task directly, and never explore the codebase before the task has been classified. The `/agentic-run` command carries that mandate; the system around it is described in `agentic-autonomous-pipeline`.
 

--- a/.github/skills/agentic-autonomous-pipeline/references/github-loop.md
+++ b/.github/skills/agentic-autonomous-pipeline/references/github-loop.md
@@ -3,12 +3,12 @@
 How a filed issue becomes a merged pull request with nobody watching, and every mechanism that keeps the chain from going quiet.
 
 ```
-issue filed / reopened / labelled `ready`        merged PR        hourly sweep        manual dispatch
-      │                                               │                 │                    │
-      ▼                                               ▼                 ▼                    ▼
-agentic-intake.yml                          auto-assign-next.yml  agentic-watchdog.yml  agentic-trigger.yml
-      └──────────────────────────────┬────────────────┴─────────────────┴────────────────────┘
-                                     ▼
+       merged PR                 manual dispatch
+            │                           │
+            ▼                           ▼
+   auto-assign-next.yml         agentic-trigger.yml
+            └─────────────┬─────────────┘
+                          ▼
                         [agentic-assign] oldest unblocked `ready` issue
                                      │  ready → in-progress, then post the assignment comment
                                      ▼
@@ -27,16 +27,16 @@ agentic-intake.yml                          auto-assign-next.yml  agentic-watchd
                                      └─ [agentic-assign] next `ready` issue → back to the top
 ```
 
-## Four ways in, and why each exists
+## Two ways in, and nothing else
 
 | Entry | Fires on | Covers |
 |-------|----------|--------|
-| `agentic-intake.yml` | `issues: opened, reopened, labeled` | The only human input, but filing alone does not start a run — `ready` does, whether it arrives with the issue (the form's own `labels:` default, or an agent authoring the issue per `agentic-issue-creation`) or a human adds it later. A `ready` label on a previously `blocked` issue is the whole resume procedure |
-| `auto-assign-next.yml` | `pull_request: opened, synchronize, closed` | Auto-merge on `READY TO MERGE`, then chain from the merge to the next issue |
-| `agentic-watchdog.yml` | hourly schedule | Sweeps stalled runs, then restarts the queue if the pipeline is idle |
-| `agentic-trigger.yml` | manual dispatch | A human forcing the queue forward |
+| `agentic-trigger.yml` | manual dispatch | A human starting the pipeline on the oldest unblocked `ready` issue. This is how a run begins from a standing start |
+| `auto-assign-next.yml` | `pull_request: opened, synchronize, closed` | Auto-merge on `READY TO MERGE`, then chain from the merge to the next issue. This is how a run begins from the previous one finishing |
 
-Events get lost — GitHub keeps one pending run per concurrency group and drops the next, a webhook can be missed, a run can end without chaining. Every entry above except the watchdog is event-driven, which is why the watchdog also assigns: it is the only mechanism on a clock, so it is the floor under the queue. At worst an idle pipeline with ready issues restarts itself within the hour.
+**Nothing else may start a session.** Filing an issue, labelling one `ready`, reopening one, and the passage of time all leave the queue exactly where it was. `agentic-intake.yml` still reacts to `issues: opened, reopened`, but only to keep the label definitions present and to drop a stale `done` from a reopened issue — it assigns nothing. `agentic-watchdog.yml` still sweeps hourly, but only to release issues whose runs died; it does not restart the queue.
+
+The consequence is deliberate and worth stating plainly: **a `ready` issue can sit in the queue indefinitely.** Nothing is scheduled to notice it. Events genuinely do get lost — GitHub keeps one pending run per concurrency group and drops the next, a webhook can be missed, a run can end its turn without chaining — and when that happens the chain stops until a human dispatches `agentic-trigger.yml`. That is the intended trade: an idle pipeline is preferable to sessions nobody asked for.
 
 ## Issue labels are the loop's state machine
 
@@ -49,7 +49,9 @@ Events get lost — GitHub keeps one pending run per concurrency group and drops
 | `done` | Finished | The merged-PR chain, or a run releasing a non-PR deliverable | — |
 | `decision-review` | A default the run chose, revisit at leisure. Carries no `ready`, so it never enters the queue | The run — see `agentic-decision-autonomy` | A human, by adding `ready` |
 
-Intake never applies `agent-task` or `ready` itself — that would take label assignment out of the hands of whoever files the issue. `agentic-assign` selects on `ready` alone, so an issue only enters the queue once something puts `ready` on it: the "Agent Task" form's own `labels:` default, an agent following `agentic-issue-creation`, or a human adding it by hand — including to resume a `blocked` issue, or to opt a free-form/API-filed issue in. A human filing without the form and without `ready` gets an issue that sits unlabelled and out of the queue until they choose to add it; that is deliberate, not an oversight.
+Intake never applies `agent-task` or `ready` itself — that would take label assignment out of the hands of whoever files the issue. `agentic-assign` selects on `ready` alone, so an issue only becomes *selectable* once something puts `ready` on it: the "Agent Task" form's own `labels:` default, an agent following `agentic-issue-creation`, or a human adding it by hand — including to resume a `blocked` issue, or to opt a free-form/API-filed issue in.
+
+`ready` marks an issue as **eligible**, never as **started**. The label puts it in the queue; only a manual dispatch or a merged pipeline PR takes it out again. This is the distinction to hold on to when reading anything below that talks about an issue "entering the queue": entering the queue is not being picked up.
 
 **An issue is released by whoever finishes it.** A run whose deliverable is a pull request is released by the merge. A run whose deliverable is an answer or an executed command releases its own issue — closes it, labels it `done`, drops `in-progress`. Skipping that leaves single flight deferring behind a run that already succeeded, until the watchdog ages it out and reports it as lost.
 
@@ -62,19 +64,19 @@ Intake never applies `agent-task` or `ready` itself — that would take label as
    **A consequence to respect:** under the PAT, everything the session posts is authored by a real user rather than a bot, and the runners' trigger guard filters on `comment.user.type != 'Bot'`. An agent-authored comment containing the agent's own mention would therefore wake a new run. No pipeline comment may contain `@claude` or `@opencode` — the assignment comment is the only comment allowed to carry a mention.
 2. **The assignment comment carries the whole assignment.** It names the issue, mandates orchestrator-first delegation, states the branch names, the verification expectation, and the PR conventions. Its text is identical for every agent apart from the mention on the first line — the runtimes read the same instructions.
 
-An issue the agent closes without opening a PR raises no `pull_request` event either, so each runner ends with its own chaining step for exactly that case.
+An issue the agent closes without opening a PR raises no `pull_request` event either, so nothing chains from it. The runners used to carry their own step for that case; it was removed, because a run starting the next run is the pipeline deciding to run again on its own. Such a run still *releases* its issue — closes it, labels it `done`, drops `in-progress` — so the queue is free the moment somebody asks for the next one.
 
 ## Single flight
 
 Two agent sessions must never run at once — they would compete over the same `pipeline/*` branch names and the same working tree. Two independent mechanisms enforce it:
 
 - **`agentic-assign` defers.** An issue keeps `in-progress` until its run is finished, so any *other* issue still carrying that label means a run is live. The action logs why and assigns nothing; finishing the outstanding run re-enters the step. It defers whether or not that issue has a linked PR, and **it never diagnoses**: a run 40 seconds old and a run that died hours ago look identical from the labels alone, so declaring one lost belongs to the watchdog, which is the only mechanism that ages it. `agentic-assign` used to comment "Pipeline halted — no linked PR was created" on sight, which it posted on #404 while that run was one minute into a two-hour session.
-- **Intake serialises its assignments** through a job-level `agentic-assignment` concurrency group. The single-flight check reads the `in-progress` label, so parallel intakes — one per issue when a human files a batch in one sitting — would each read the list before any of them writes to it, and every one would assign. Labelling stays outside the group: a dropped run there would cost an issue its `ready` label and make it invisible, while a dropped assignment costs nothing the hourly sweep does not pick back up.
-- **The runners share a `concurrency` group** named `agentic-runner`, declared identically in `claude-runner.yml` and `opencode-runner.yml`. Concurrency groups are repo-wide, so the two runners serialise against each other as well as themselves. `cancel-in-progress: false` — a queued run waits rather than killing the live one. GitHub keeps only one run pending per group; a third is dropped, which the watchdog's idle restart then recovers.
+- **The two entries cannot race by construction.** A manual dispatch is one act by one human, and the merged-PR chain fires once per merge — there is no longer an events-per-issue path that could assign a batch in parallel. (Intake used to need an `agentic-assignment` concurrency group for exactly that reason: one intake per issue when a human filed several in a sitting, each reading the `in-progress` label before any of them wrote it. Removing intake's assignment removed the race with it.)
+- **The runners share a `concurrency` group** named `agentic-runner`, declared identically in `claude-runner.yml` and `opencode-runner.yml`. Concurrency groups are repo-wide, so the two runners serialise against each other as well as themselves. `cancel-in-progress: false` — a queued run waits rather than killing the live one. GitHub keeps only one run pending per group; a third is dropped, and nothing recovers it automatically — dispatch `agentic-trigger.yml` to pick the queue back up.
 
 ## Halt conditions
 
-The loop stops deliberately when an issue is labelled `blocked`, while an issue is still `in-progress` (single flight), or when no unblocked `ready` issue remains. `handle-failure.yml` comments on `blocked` issues with the resume procedure — add `ready`, and intake takes it from there.
+The loop stops deliberately when an issue is labelled `blocked`, while an issue is still `in-progress` (single flight), or when no unblocked `ready` issue remains. `handle-failure.yml` comments on `blocked` issues with the resume procedure: add `ready` to put the issue back in the queue, then dispatch `agentic-trigger.yml` to start it — the label alone resumes nothing.
 
 A run that dies without labelling anything — OOM, a hung tool call, the job timeout, a revoked token, a turn ended on outstanding work — would otherwise leave its issue `in-progress` forever and halt the chain silently. `agentic-watchdog.yml` sweeps hourly: an issue `in-progress` past `AGENTIC_STALL_MINUTES` with no linked PR is commented on, labelled `blocked`, and stripped of `in-progress`. That labelling is what surfaces the failure, so the watchdog must use the PAT — a label applied with `GITHUB_TOKEN` raises no `issues: labeled` event and `handle-failure.yml` would never fire.
 
@@ -96,7 +98,7 @@ Intent is not a mechanism, so `agentic-rescue` runs last in both runners, with `
 
 The rescue PR is a diagnosis, not a deliverable: unreviewed and unvalidated by definition. Finishing it or dropping it is a human decision, and adding `ready` back to the issue is the whole resume procedure.
 
-**An escalation does not chain to the next issue, and that is deliberate.** The runner's own chaining step covers a run whose deliverable was not a diff — an issue closed and labelled `done`. A run that failed is different: chaining from it means the queue restarts as fast as runs fail, and a systemic failure (an expired token, a broken `main`) would march through the whole backlog labelling every issue `blocked` in minutes. The hourly sweep restarts the queue instead, which rate-limits the damage to one issue an hour and gives a human time to see the first notification.
+**An escalation does not chain to the next issue**, and neither does anything else a runner does. Chaining from a failure would restart the queue as fast as runs fail, and a systemic failure (an expired token, a broken `main`) would march through the whole backlog labelling every issue `blocked` in minutes. A failure therefore stops the pipeline outright: `handle-failure.yml` notifies, and the queue moves again when a human dispatches the trigger, having seen what went wrong.
 
 ## Dependencies between issues
 
@@ -107,7 +109,7 @@ The rescue PR is a diagnosis, not a deliverable: unreviewed and unvalidated by d
 | Variable | Values | Effect |
 |----------|--------|--------|
 | `AGENTIC_AGENT` | `@claude` / `@opencode` (leading `@` and case optional; unset means `@opencode`) | The agent that assignment comments address, and therefore the runner workflow that starts |
-| `AGENTIC_AUTO_ASSIGN_ENABLED` | `true` / anything else | Whether a finished issue chains to the next ready one, and whether the watchdog restarts an idle queue |
+| `AGENTIC_AUTO_ASSIGN_ENABLED` | `true` / anything else | Whether a merged pipeline PR chains to the next ready issue. Set to anything else, the manual trigger is the only way a run ever starts |
 | `AGENTIC_AUTO_MERGE_ENABLED` | `true` / anything else | Whether a `READY TO MERGE` PR gets GitHub native auto-merge |
 | `AGENTIC_STALL_MINUTES` | minutes, default `420`; a value below the runners' 360-minute job timeout is clamped up to it | How long an issue may stay `in-progress` without a linked PR before the watchdog marks it `blocked`. Below the job timeout it would sweep live runs |
 

--- a/.github/skills/agentic-decision-autonomy/SKILL.md
+++ b/.github/skills/agentic-decision-autonomy/SKILL.md
@@ -40,7 +40,7 @@ gh issue create --label decision-review \
   --body "<the Decisions taken block>, linking the PR"
 ```
 
-The `decision-review` label carries no `ready`, so the issue stays out of the assignment queue and halts nothing: `agentic-assign` selects on `ready` alone, and intake leaves the labels of an issue that already carries a lifecycle label untouched. It is where a human goes to revisit a default at leisure; adding `ready` later is how they send it back through the pipeline. Creating the issue **with** the `decision-review` label is what keeps it out — an issue filed carrying no lifecycle label at all is labelled `ready` on arrival and joins the queue.
+The `decision-review` label carries no `ready`, so the issue stays out of the assignment queue and halts nothing: `agentic-assign` selects on `ready` alone, and nothing in the pipeline ever applies `ready` to an issue a human filed. It is where a human goes to revisit a default at leisure; adding `ready` later is how they put it back in the queue, and a manual dispatch or the next merged pipeline PR is what starts it.
 
 `--force` updates the label when it already exists, so the step is safe to run on every issue rather than only the first. Both runners give the agent's shell a `GH_TOKEN` that already opens PRs and edits labels, and both workflows declare `issues: write`, so no extra permission is needed.
 

--- a/.github/skills/agentic-issue-creation/SKILL.md
+++ b/.github/skills/agentic-issue-creation/SKILL.md
@@ -16,7 +16,7 @@ Two shapes are valid, and they differ in how much of the answer is already known
 | **Intent** | A human filing from the issue form or free-form | Context, Task, Verification, and any Blocked by. The planner derives the files and the tests. |
 | **Complete** | An agent decomposing a feature into atomic tasks | Every section below. The decomposition already knows the file layout, so it states it. |
 
-Both enter the same queue once `ready` lands on the issue — a two-line issue typed from a phone is still a valid input, and where it leaves a choice open, the run defaults it under `agentic-decision-autonomy` rather than bouncing it back.
+Both enter the same queue once `ready` lands on the issue — a two-line issue typed from a phone is still a valid input, and where it leaves a choice open, the run defaults it under `agentic-decision-autonomy` rather than bouncing it back. Entering the queue is not being picked up: runs start only on a manual dispatch of `agentic-trigger.yml` or from a merged pipeline pull request.
 
 ## ▶ PROCEDURE — EXECUTE IN ORDER
 
@@ -25,7 +25,7 @@ Both enter the same queue once `ready` lands on the issue — a two-line issue t
 3. Verify the Rules are satisfied
 4. Run through the Checklist
 5. Create the issue with `gh issue create`, setting labels yourself:
-   - Human gave no instruction about labels → `--label ready,agent-task`. That is the default, not intake's — a **Complete**-shape issue you authored is ready to run the moment it exists, and intake no longer assigns `ready` on its own.
+   - Human gave no instruction about labels → `--label ready,agent-task`. `ready` means eligible, not started: it places the issue in the queue, where it waits until a human dispatches `agentic-trigger.yml` or a merged pipeline PR chains to it. Creating an issue never starts a run.
    - Human specified labels, or said the issue should wait — `decision-review` for a default to revisit later, or an explicit hold — → follow that instruction instead, and leave `ready` off.
 
 An issue that must **stay out** of the queue is created carrying a lifecycle label of its own instead of `ready` — `decision-review` for a default to revisit later. The issue joins the queue in number order once `ready` is on it, whoever put it there.

--- a/.github/workflows/agentic-intake.yml
+++ b/.github/workflows/agentic-intake.yml
@@ -1,34 +1,29 @@
 name: "Pipeline: intake a filed issue"
 
-# The one human input the pipeline takes is a GitHub issue, but filing one is
-# not by itself enough to start a run — that would take label assignment out
-# of human hands. A run starts only once `ready` is on the issue: set by a
-# human (by hand, or through the issue form's own `labels:` default) or by an
-# agent authoring the issue per `agentic-issue-creation`. This workflow reacts
-# to that label arriving; `auto-assign-next.yml` only fires on a merged pull
-# request and `agentic-trigger.yml` is manual dispatch, so without this one an
-# issue that already carries `ready` would wait for a human to press a button.
+# Filing an issue records work; it never starts a run. Exactly two mechanisms
+# start an autonomous session, and both are deliberate acts:
+#
+#   - `agentic-trigger.yml` — a human dispatching the workflow by hand.
+#   - `auto-assign-next.yml` — a merged pipeline pull request chaining to the
+#     next `ready` issue.
+#
+# This workflow assigns nothing. It exists only to keep the lifecycle labels
+# usable by hand: it makes sure the label definitions exist so a human can pick
+# them from the GitHub UI, and it drops a stale `done` from a reopened issue.
+# An issue carrying `ready` waits in the queue until one of the two mechanisms
+# above reaches it — filing it, labelling it, or reopening it does not.
 on:
   issues:
-    types: [opened, reopened, labeled]
+    types: [opened, reopened]
 
 permissions:
   issues: write
 
 jobs:
-  # Filing an issue no longer opts it into the queue by itself — that decision
-  # stays with whoever set `ready`: a human, by hand or through the issue
-  # form's own `labels:` default, or an agent authoring the issue per
-  # `agentic-issue-creation`. This job only tidies stale state and reports
-  # whether `ready` already arrived on the payload; it never applies `ready`.
   label:
-    if: github.event.action == 'opened' || github.event.action == 'reopened'
     runs-on: ubuntu-latest
-    outputs:
-      assignable: ${{ steps.labels.outputs.assignable || 'false' }}
     steps:
       - name: Normalise lifecycle labels
-        id: labels
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -57,55 +52,11 @@ jobs:
               await github.rest.issues.removeLabel({ owner, repo, issue_number: n, name: 'done' })
                 .catch(() => {});
               on.delete('done');
-              core.info(`#${n}: reopened, dropped stale done. Add ready to re-enter the queue.`);
+              core.info(`#${n}: reopened, dropped stale done.`);
             }
 
-            // `ready` here means it arrived with the issue itself — the "Agent
-            // Task" form's `labels:` default, or an agent that set it at
-            // creation. Nothing in this step ever adds it.
-            core.setOutput('assignable', on.has('ready') ? 'true' : 'false');
-
-  assign:
-    needs: label
-    # The `labeled` branch is deliberately narrow: only the `ready` label
-    # itself may start a run. Matching on `action == 'labeled'` alone used to
-    # fire this job for *any* label added to *any* issue in the repo.
-    if: (github.event.action == 'labeled' && github.event.label.name == 'ready') || needs.label.outputs.assignable == 'true'
-    runs-on: ubuntu-latest
-    # Filing a batch of issues in one sitting fires one intake per issue, and
-    # single flight lives in the assign action rather than in GitHub: parallel
-    # intakes each read the `in-progress` list before any of them writes to it,
-    # and every one of them assigns. The runners then serialise, GitHub keeps
-    # one pending run per concurrency group and drops the rest, and the extra
-    # issues sit `in-progress` with no session behind them until the watchdog
-    # calls them stalled. Serialising the assignment itself is what makes the
-    # single-flight check mean anything. Labelling stays outside this group, so
-    # a dropped run here costs an assignment, never an issue's `ready` label —
-    # and the hourly sweep picks the queue back up regardless.
-    concurrency:
-      group: agentic-assignment
-      cancel-in-progress: false
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      # Single flight lives in the action: when a run is already live this defers
-      # and assigns nothing. It also picks the oldest `ready` issue rather than
-      # this one, so filing an issue joins the queue instead of jumping it.
-      - name: Assign the next ready issue
-        id: assign
-        uses: ./.github/actions/agentic-assign
-        with:
-          token: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
-          agent: ${{ vars.AGENTIC_AGENT }}
-          reason: issue #${{ github.event.issue.number }} entered the queue
-
-      - name: Report
-        run: |
-          if [ -n "${{ steps.assign.outputs.issue }}" ]; then
-            echo "Assigned issue #${{ steps.assign.outputs.issue }} to ${{ steps.assign.outputs.mention }}."
-          else
-            echo "Nothing assigned — see the assign step for the reason."
-          fi
+            core.info(
+              on.has('ready')
+                ? `#${n}: carries ready and waits in the queue. Dispatch "Pipeline: run the configured agent on the next ready issue" to start it, or let a merged pipeline PR chain to it.`
+                : `#${n}: no ready label, so it is not in the queue.`
+            );

--- a/.github/workflows/agentic-watchdog.yml
+++ b/.github/workflows/agentic-watchdog.yml
@@ -13,10 +13,9 @@ jobs:
   sweep:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
+      # No checkout: the sweep is `actions/github-script` and reads nothing from
+      # the workspace. The composite action that needed one was the idle-queue
+      # restart, which this workflow no longer performs.
 
       # A run that dies without labelling the issue `blocked` — OOM, a hung
       # tool call, the job timeout, a revoked token — leaves the issue
@@ -118,31 +117,15 @@ jobs:
 
             core.info(`Swept ${swept} stalled issue(s).`);
 
-      # Every other entry into the queue is an event: a merged PR, a filed issue,
-      # a `ready` label. Events get lost — GitHub keeps one pending run per
-      # concurrency group and drops the next, a webhook can be missed, a run can
-      # end its turn without chaining. Each of those leaves ready issues waiting
-      # on an idle pipeline with nothing scheduled to notice.
+      # The sweep above is the whole of this workflow: it reports lost runs and
+      # releases the issues they were holding. It deliberately does NOT restart
+      # the queue.
       #
-      # This is the one mechanism that runs on a clock rather than an event, so
-      # it is where the queue gets its floor: at worst the pipeline restarts
-      # itself within the hour. `agentic-assign` defers on its own when a run is
-      # live, so a healthy pipeline sees a no-op here.
-      - name: Restart an idle queue
-        id: assign
-        if: vars.AGENTIC_AUTO_ASSIGN_ENABLED == 'true'
-        uses: ./.github/actions/agentic-assign
-        with:
-          token: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
-          agent: ${{ vars.AGENTIC_AGENT }}
-          reason: hourly watchdog sweep found the pipeline idle
-
+      # A clock-driven restart would start agent sessions nobody asked for —
+      # every hour, for as long as any `ready` issue exists. Starting a run is a
+      # deliberate act, and there are exactly two: a human dispatching
+      # `agentic-trigger.yml`, or a merged pipeline pull request chaining
+      # through `auto-assign-next.yml`. An idle queue is therefore an idle
+      # queue, and stays one until somebody asks for the next run.
       - name: Report
-        run: |
-          if [ "${{ vars.AGENTIC_AUTO_ASSIGN_ENABLED }}" != "true" ]; then
-            echo 'Auto-assign is disabled (AGENTIC_AUTO_ASSIGN_ENABLED is not "true").'
-          elif [ -n "${{ steps.assign.outputs.issue }}" ]; then
-            echo "Restarted the queue on issue #${{ steps.assign.outputs.issue }}."
-          else
-            echo "Queue not restarted — see the assign step for the reason."
-          fi
+        run: echo 'Sweep complete. This workflow never assigns — start a run with the manual trigger, or let a merged pipeline PR chain to the next issue.'

--- a/.github/workflows/claude-runner.yml
+++ b/.github/workflows/claude-runner.yml
@@ -270,14 +270,12 @@ jobs:
           token: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
           head: pipeline/feature-${{ steps.context.outputs.issue }}
 
-      # When the run closed the issue without opening a PR, no pull_request event
-      # will ever fire, so auto-assign-next.yml cannot carry the chain. Do it here.
-      - name: Chain to next issue if resolved without PR
-        if: steps.context.outputs.issue != '' && vars.AGENTIC_AUTO_ASSIGN_ENABLED == 'true'
-        uses: ./.github/actions/agentic-assign
-        with:
-          token: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
-          agent: ${{ vars.AGENTIC_AGENT }}
-          guard: closed_without_pr
-          completed_issue: ${{ steps.context.outputs.issue }}
-          reason: auto-assigned after issue #${{ steps.context.outputs.issue }} was resolved without a PR
+      # No chaining step here, deliberately. A run whose deliverable was an
+      # answer or an executed command closes its own issue and stops there: it
+      # opened no PR, so there is no merge to chain from, and starting the next
+      # session without one would be the pipeline deciding to run again on its
+      # own. Only two things start a session — a human dispatching
+      # `agentic-trigger.yml`, or a merged pipeline PR via
+      # `auto-assign-next.yml`. The issue is still released (closed, `done`,
+      # `in-progress` dropped), so the queue is free the moment somebody asks
+      # for the next run.

--- a/.github/workflows/opencode-runner.yml
+++ b/.github/workflows/opencode-runner.yml
@@ -223,14 +223,12 @@ jobs:
           token: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
           head: pipeline/feature-${{ steps.context.outputs.issue }}
 
-      # When the run closed the issue without opening a PR, no pull_request event
-      # will ever fire, so auto-assign-next.yml cannot carry the chain. Do it here.
-      - name: Chain to next issue if resolved without PR
-        if: steps.context.outputs.issue != '' && vars.AGENTIC_AUTO_ASSIGN_ENABLED == 'true'
-        uses: ./.github/actions/agentic-assign
-        with:
-          token: ${{ secrets.PAT_TOKEN_COPILOT_AUTOMATION }}
-          agent: ${{ vars.AGENTIC_AGENT }}
-          guard: closed_without_pr
-          completed_issue: ${{ steps.context.outputs.issue }}
-          reason: auto-assigned after issue #${{ steps.context.outputs.issue }} was resolved without a PR
+      # No chaining step here, deliberately. A run whose deliverable was an
+      # answer or an executed command closes its own issue and stops there: it
+      # opened no PR, so there is no merge to chain from, and starting the next
+      # session without one would be the pipeline deciding to run again on its
+      # own. Only two things start a session — a human dispatching
+      # `agentic-trigger.yml`, or a merged pipeline PR via
+      # `auto-assign-next.yml`. The issue is still released (closed, `done`,
+      # `in-progress` dropped), so the queue is free the moment somebody asks
+      # for the next run.

--- a/.opencode/AGENTS.md
+++ b/.opencode/AGENTS.md
@@ -71,7 +71,7 @@ Five independent channels prove a change works. Each catches what the others mis
 
 ## ▶ Autonomous pipeline sessions
 
-The project takes one human input: a GitHub issue. Filing one does not by itself start a run — label assignment stays with the filer. A run starts once `ready` is on the issue (the issue form's own default, an agent authoring the issue per `agentic-issue-creation`, or a human adding it by hand); the queue then assigns it and carries it to a merged pull request or to a stated blocker. A run always leaves its issue in a terminal state; an issue left holding `in-progress` stalls every assignment behind it.
+The project takes one human input: a GitHub issue. Filing one starts nothing, and neither does labelling it. `ready` means the issue is **eligible** — it joins the queue and waits there. A run starts in exactly two ways, and no others: a human dispatching `agentic-trigger.yml`, or a merged pipeline pull request chaining to the next `ready` issue. Nothing on a schedule and no issue event ever starts a session. Once started, a run carries its issue to a merged pull request or to a stated blocker, and always leaves it in a terminal state; an issue left holding `in-progress` stalls every assignment behind it.
 
 A session started by the autonomous pipeline — a GitHub Actions run woken by the configured agent mention in a pipeline assignment comment — is not an ordinary session. Its first action is to run as the orchestrator: classify the task, then delegate every step to specialists. Never implement a pipeline-assigned task directly, and never explore the codebase before the task has been classified. The `/agentic-run` command carries that mandate; the system around it is described in `agentic-autonomous-pipeline`.
 

--- a/.opencode/skills/agentic-autonomous-pipeline/references/github-loop.md
+++ b/.opencode/skills/agentic-autonomous-pipeline/references/github-loop.md
@@ -3,12 +3,12 @@
 How a filed issue becomes a merged pull request with nobody watching, and every mechanism that keeps the chain from going quiet.
 
 ```
-issue filed / reopened / labelled `ready`        merged PR        hourly sweep        manual dispatch
-      │                                               │                 │                    │
-      ▼                                               ▼                 ▼                    ▼
-agentic-intake.yml                          auto-assign-next.yml  agentic-watchdog.yml  agentic-trigger.yml
-      └──────────────────────────────┬────────────────┴─────────────────┴────────────────────┘
-                                     ▼
+       merged PR                 manual dispatch
+            │                           │
+            ▼                           ▼
+   auto-assign-next.yml         agentic-trigger.yml
+            └─────────────┬─────────────┘
+                          ▼
                         [agentic-assign] oldest unblocked `ready` issue
                                      │  ready → in-progress, then post the assignment comment
                                      ▼
@@ -27,16 +27,16 @@ agentic-intake.yml                          auto-assign-next.yml  agentic-watchd
                                      └─ [agentic-assign] next `ready` issue → back to the top
 ```
 
-## Four ways in, and why each exists
+## Two ways in, and nothing else
 
 | Entry | Fires on | Covers |
 |-------|----------|--------|
-| `agentic-intake.yml` | `issues: opened, reopened, labeled` | The only human input, but filing alone does not start a run — `ready` does, whether it arrives with the issue (the form's own `labels:` default, or an agent authoring the issue per `agentic-issue-creation`) or a human adds it later. A `ready` label on a previously `blocked` issue is the whole resume procedure |
-| `auto-assign-next.yml` | `pull_request: opened, synchronize, closed` | Auto-merge on `READY TO MERGE`, then chain from the merge to the next issue |
-| `agentic-watchdog.yml` | hourly schedule | Sweeps stalled runs, then restarts the queue if the pipeline is idle |
-| `agentic-trigger.yml` | manual dispatch | A human forcing the queue forward |
+| `agentic-trigger.yml` | manual dispatch | A human starting the pipeline on the oldest unblocked `ready` issue. This is how a run begins from a standing start |
+| `auto-assign-next.yml` | `pull_request: opened, synchronize, closed` | Auto-merge on `READY TO MERGE`, then chain from the merge to the next issue. This is how a run begins from the previous one finishing |
 
-Events get lost — GitHub keeps one pending run per concurrency group and drops the next, a webhook can be missed, a run can end without chaining. Every entry above except the watchdog is event-driven, which is why the watchdog also assigns: it is the only mechanism on a clock, so it is the floor under the queue. At worst an idle pipeline with ready issues restarts itself within the hour.
+**Nothing else may start a session.** Filing an issue, labelling one `ready`, reopening one, and the passage of time all leave the queue exactly where it was. `agentic-intake.yml` still reacts to `issues: opened, reopened`, but only to keep the label definitions present and to drop a stale `done` from a reopened issue — it assigns nothing. `agentic-watchdog.yml` still sweeps hourly, but only to release issues whose runs died; it does not restart the queue.
+
+The consequence is deliberate and worth stating plainly: **a `ready` issue can sit in the queue indefinitely.** Nothing is scheduled to notice it. Events genuinely do get lost — GitHub keeps one pending run per concurrency group and drops the next, a webhook can be missed, a run can end its turn without chaining — and when that happens the chain stops until a human dispatches `agentic-trigger.yml`. That is the intended trade: an idle pipeline is preferable to sessions nobody asked for.
 
 ## Issue labels are the loop's state machine
 
@@ -49,7 +49,9 @@ Events get lost — GitHub keeps one pending run per concurrency group and drops
 | `done` | Finished | The merged-PR chain, or a run releasing a non-PR deliverable | — |
 | `decision-review` | A default the run chose, revisit at leisure. Carries no `ready`, so it never enters the queue | The run — see `agentic-decision-autonomy` | A human, by adding `ready` |
 
-Intake never applies `agent-task` or `ready` itself — that would take label assignment out of the hands of whoever files the issue. `agentic-assign` selects on `ready` alone, so an issue only enters the queue once something puts `ready` on it: the "Agent Task" form's own `labels:` default, an agent following `agentic-issue-creation`, or a human adding it by hand — including to resume a `blocked` issue, or to opt a free-form/API-filed issue in. A human filing without the form and without `ready` gets an issue that sits unlabelled and out of the queue until they choose to add it; that is deliberate, not an oversight.
+Intake never applies `agent-task` or `ready` itself — that would take label assignment out of the hands of whoever files the issue. `agentic-assign` selects on `ready` alone, so an issue only becomes *selectable* once something puts `ready` on it: the "Agent Task" form's own `labels:` default, an agent following `agentic-issue-creation`, or a human adding it by hand — including to resume a `blocked` issue, or to opt a free-form/API-filed issue in.
+
+`ready` marks an issue as **eligible**, never as **started**. The label puts it in the queue; only a manual dispatch or a merged pipeline PR takes it out again. This is the distinction to hold on to when reading anything below that talks about an issue "entering the queue": entering the queue is not being picked up.
 
 **An issue is released by whoever finishes it.** A run whose deliverable is a pull request is released by the merge. A run whose deliverable is an answer or an executed command releases its own issue — closes it, labels it `done`, drops `in-progress`. Skipping that leaves single flight deferring behind a run that already succeeded, until the watchdog ages it out and reports it as lost.
 
@@ -62,19 +64,19 @@ Intake never applies `agent-task` or `ready` itself — that would take label as
    **A consequence to respect:** under the PAT, everything the session posts is authored by a real user rather than a bot, and the runners' trigger guard filters on `comment.user.type != 'Bot'`. An agent-authored comment containing the agent's own mention would therefore wake a new run. No pipeline comment may contain `@claude` or `@opencode` — the assignment comment is the only comment allowed to carry a mention.
 2. **The assignment comment carries the whole assignment.** It names the issue, mandates orchestrator-first delegation, states the branch names, the verification expectation, and the PR conventions. Its text is identical for every agent apart from the mention on the first line — the runtimes read the same instructions.
 
-An issue the agent closes without opening a PR raises no `pull_request` event either, so each runner ends with its own chaining step for exactly that case.
+An issue the agent closes without opening a PR raises no `pull_request` event either, so nothing chains from it. The runners used to carry their own step for that case; it was removed, because a run starting the next run is the pipeline deciding to run again on its own. Such a run still *releases* its issue — closes it, labels it `done`, drops `in-progress` — so the queue is free the moment somebody asks for the next one.
 
 ## Single flight
 
 Two agent sessions must never run at once — they would compete over the same `pipeline/*` branch names and the same working tree. Two independent mechanisms enforce it:
 
 - **`agentic-assign` defers.** An issue keeps `in-progress` until its run is finished, so any *other* issue still carrying that label means a run is live. The action logs why and assigns nothing; finishing the outstanding run re-enters the step. It defers whether or not that issue has a linked PR, and **it never diagnoses**: a run 40 seconds old and a run that died hours ago look identical from the labels alone, so declaring one lost belongs to the watchdog, which is the only mechanism that ages it. `agentic-assign` used to comment "Pipeline halted — no linked PR was created" on sight, which it posted on #404 while that run was one minute into a two-hour session.
-- **Intake serialises its assignments** through a job-level `agentic-assignment` concurrency group. The single-flight check reads the `in-progress` label, so parallel intakes — one per issue when a human files a batch in one sitting — would each read the list before any of them writes to it, and every one would assign. Labelling stays outside the group: a dropped run there would cost an issue its `ready` label and make it invisible, while a dropped assignment costs nothing the hourly sweep does not pick back up.
-- **The runners share a `concurrency` group** named `agentic-runner`, declared identically in `claude-runner.yml` and `opencode-runner.yml`. Concurrency groups are repo-wide, so the two runners serialise against each other as well as themselves. `cancel-in-progress: false` — a queued run waits rather than killing the live one. GitHub keeps only one run pending per group; a third is dropped, which the watchdog's idle restart then recovers.
+- **The two entries cannot race by construction.** A manual dispatch is one act by one human, and the merged-PR chain fires once per merge — there is no longer an events-per-issue path that could assign a batch in parallel. (Intake used to need an `agentic-assignment` concurrency group for exactly that reason: one intake per issue when a human filed several in a sitting, each reading the `in-progress` label before any of them wrote it. Removing intake's assignment removed the race with it.)
+- **The runners share a `concurrency` group** named `agentic-runner`, declared identically in `claude-runner.yml` and `opencode-runner.yml`. Concurrency groups are repo-wide, so the two runners serialise against each other as well as themselves. `cancel-in-progress: false` — a queued run waits rather than killing the live one. GitHub keeps only one run pending per group; a third is dropped, and nothing recovers it automatically — dispatch `agentic-trigger.yml` to pick the queue back up.
 
 ## Halt conditions
 
-The loop stops deliberately when an issue is labelled `blocked`, while an issue is still `in-progress` (single flight), or when no unblocked `ready` issue remains. `handle-failure.yml` comments on `blocked` issues with the resume procedure — add `ready`, and intake takes it from there.
+The loop stops deliberately when an issue is labelled `blocked`, while an issue is still `in-progress` (single flight), or when no unblocked `ready` issue remains. `handle-failure.yml` comments on `blocked` issues with the resume procedure: add `ready` to put the issue back in the queue, then dispatch `agentic-trigger.yml` to start it — the label alone resumes nothing.
 
 A run that dies without labelling anything — OOM, a hung tool call, the job timeout, a revoked token, a turn ended on outstanding work — would otherwise leave its issue `in-progress` forever and halt the chain silently. `agentic-watchdog.yml` sweeps hourly: an issue `in-progress` past `AGENTIC_STALL_MINUTES` with no linked PR is commented on, labelled `blocked`, and stripped of `in-progress`. That labelling is what surfaces the failure, so the watchdog must use the PAT — a label applied with `GITHUB_TOKEN` raises no `issues: labeled` event and `handle-failure.yml` would never fire.
 
@@ -96,7 +98,7 @@ Intent is not a mechanism, so `agentic-rescue` runs last in both runners, with `
 
 The rescue PR is a diagnosis, not a deliverable: unreviewed and unvalidated by definition. Finishing it or dropping it is a human decision, and adding `ready` back to the issue is the whole resume procedure.
 
-**An escalation does not chain to the next issue, and that is deliberate.** The runner's own chaining step covers a run whose deliverable was not a diff — an issue closed and labelled `done`. A run that failed is different: chaining from it means the queue restarts as fast as runs fail, and a systemic failure (an expired token, a broken `main`) would march through the whole backlog labelling every issue `blocked` in minutes. The hourly sweep restarts the queue instead, which rate-limits the damage to one issue an hour and gives a human time to see the first notification.
+**An escalation does not chain to the next issue**, and neither does anything else a runner does. Chaining from a failure would restart the queue as fast as runs fail, and a systemic failure (an expired token, a broken `main`) would march through the whole backlog labelling every issue `blocked` in minutes. A failure therefore stops the pipeline outright: `handle-failure.yml` notifies, and the queue moves again when a human dispatches the trigger, having seen what went wrong.
 
 ## Dependencies between issues
 
@@ -107,7 +109,7 @@ The rescue PR is a diagnosis, not a deliverable: unreviewed and unvalidated by d
 | Variable | Values | Effect |
 |----------|--------|--------|
 | `AGENTIC_AGENT` | `@claude` / `@opencode` (leading `@` and case optional; unset means `@opencode`) | The agent that assignment comments address, and therefore the runner workflow that starts |
-| `AGENTIC_AUTO_ASSIGN_ENABLED` | `true` / anything else | Whether a finished issue chains to the next ready one, and whether the watchdog restarts an idle queue |
+| `AGENTIC_AUTO_ASSIGN_ENABLED` | `true` / anything else | Whether a merged pipeline PR chains to the next ready issue. Set to anything else, the manual trigger is the only way a run ever starts |
 | `AGENTIC_AUTO_MERGE_ENABLED` | `true` / anything else | Whether a `READY TO MERGE` PR gets GitHub native auto-merge |
 | `AGENTIC_STALL_MINUTES` | minutes, default `420`; a value below the runners' 360-minute job timeout is clamped up to it | How long an issue may stay `in-progress` without a linked PR before the watchdog marks it `blocked`. Below the job timeout it would sweep live runs |
 

--- a/.opencode/skills/agentic-decision-autonomy/SKILL.md
+++ b/.opencode/skills/agentic-decision-autonomy/SKILL.md
@@ -40,7 +40,7 @@ gh issue create --label decision-review \
   --body "<the Decisions taken block>, linking the PR"
 ```
 
-The `decision-review` label carries no `ready`, so the issue stays out of the assignment queue and halts nothing: `agentic-assign` selects on `ready` alone, and intake leaves the labels of an issue that already carries a lifecycle label untouched. It is where a human goes to revisit a default at leisure; adding `ready` later is how they send it back through the pipeline. Creating the issue **with** the `decision-review` label is what keeps it out — an issue filed carrying no lifecycle label at all is labelled `ready` on arrival and joins the queue.
+The `decision-review` label carries no `ready`, so the issue stays out of the assignment queue and halts nothing: `agentic-assign` selects on `ready` alone, and nothing in the pipeline ever applies `ready` to an issue a human filed. It is where a human goes to revisit a default at leisure; adding `ready` later is how they put it back in the queue, and a manual dispatch or the next merged pipeline PR is what starts it.
 
 `--force` updates the label when it already exists, so the step is safe to run on every issue rather than only the first. Both runners give the agent's shell a `GH_TOKEN` that already opens PRs and edits labels, and both workflows declare `issues: write`, so no extra permission is needed.
 

--- a/.opencode/skills/agentic-issue-creation/SKILL.md
+++ b/.opencode/skills/agentic-issue-creation/SKILL.md
@@ -16,7 +16,7 @@ Two shapes are valid, and they differ in how much of the answer is already known
 | **Intent** | A human filing from the issue form or free-form | Context, Task, Verification, and any Blocked by. The planner derives the files and the tests. |
 | **Complete** | An agent decomposing a feature into atomic tasks | Every section below. The decomposition already knows the file layout, so it states it. |
 
-Both enter the same queue once `ready` lands on the issue — a two-line issue typed from a phone is still a valid input, and where it leaves a choice open, the run defaults it under `agentic-decision-autonomy` rather than bouncing it back.
+Both enter the same queue once `ready` lands on the issue — a two-line issue typed from a phone is still a valid input, and where it leaves a choice open, the run defaults it under `agentic-decision-autonomy` rather than bouncing it back. Entering the queue is not being picked up: runs start only on a manual dispatch of `agentic-trigger.yml` or from a merged pipeline pull request.
 
 ## ▶ PROCEDURE — EXECUTE IN ORDER
 
@@ -25,7 +25,7 @@ Both enter the same queue once `ready` lands on the issue — a two-line issue t
 3. Verify the Rules are satisfied
 4. Run through the Checklist
 5. Create the issue with `gh issue create`, setting labels yourself:
-   - Human gave no instruction about labels → `--label ready,agent-task`. That is the default, not intake's — a **Complete**-shape issue you authored is ready to run the moment it exists, and intake no longer assigns `ready` on its own.
+   - Human gave no instruction about labels → `--label ready,agent-task`. `ready` means eligible, not started: it places the issue in the queue, where it waits until a human dispatches `agentic-trigger.yml` or a merged pipeline PR chains to it. Creating an issue never starts a run.
    - Human specified labels, or said the issue should wait — `decision-review` for a default to revisit later, or an explicit hold — → follow that instruction instead, and leave `ready` off.
 
 An issue that must **stay out** of the queue is created carrying a lifecycle label of its own instead of `ready` — `decision-review` for a default to revisit later. The issue joins the queue in number order once `ready` is on it, whoever put it there.

--- a/tests/unit/config/autonomy-loop.test.ts
+++ b/tests/unit/config/autonomy-loop.test.ts
@@ -1,9 +1,12 @@
 // BlastSimulator2026 — Autonomy loop wiring
-// The pipeline takes one human input, a filed issue, and every step from there
-// to a merged pull request is a workflow reacting to an event. A removed
-// trigger or a swapped token breaks the chain in silence: nothing errors, the
-// queue simply stops moving and no run is there to notice. These tests pin the
-// wiring that keeps it moving.
+// A filed issue is eligible for the pipeline, never a start signal for it. A
+// run begins in exactly two ways — a human dispatching `agentic-trigger.yml`,
+// or a merged pipeline pull request chaining to the next `ready` issue — and
+// from there every step to the merge is a workflow reacting to an event.
+// Both halves fail in silence. A removed trigger or a swapped token stops the
+// queue with nothing raised, and a new assignment path starts sessions nobody
+// asked for, which is how filing issue #489 woke a runner. These tests pin the
+// entry points shut and pin the chain between them open.
 
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
@@ -14,36 +17,49 @@ const workflow = (name: string): string =>
   readFileSync(join(ROOT, '.github/workflows', name), 'utf8');
 
 const ASSIGN_ACTION = 'uses: ./.github/actions/agentic-assign';
+const AUTO_MERGE_ACTION = 'uses: ./.github/actions/agentic-auto-merge';
 
-/** Every workflow that can put an issue in front of an agent. */
-const ASSIGNING_WORKFLOWS = [
+/** The only two workflows allowed to put an issue in front of an agent. */
+const ASSIGNING_WORKFLOWS = ['auto-assign-next.yml', 'agentic-trigger.yml'];
+
+// Each of these once assigned, and each removal was deliberate. Named
+// individually rather than swept up by a glob, so restoring assignment to one
+// of them fails here instead of quietly widening the entry points again.
+const NON_ASSIGNING_WORKFLOWS = [
   'agentic-intake.yml',
-  'auto-assign-next.yml',
   'agentic-watchdog.yml',
-  'agentic-trigger.yml',
   'claude-runner.yml',
   'opencode-runner.yml',
 ];
 
 describe('entry points into the assignment queue', () => {
-  it('starts a run from a filed issue', () => {
-    const intake = workflow('agentic-intake.yml');
-    expect(intake).toMatch(/issues:\s*\n\s*types:\s*\[opened, reopened, labeled\]/);
-    expect(intake).toContain(ASSIGN_ACTION);
+  it('opens exactly two ways in', () => {
+    for (const name of ASSIGNING_WORKFLOWS) {
+      expect(workflow(name), `${name} no longer assigns`).toContain(ASSIGN_ACTION);
+    }
+    for (const name of NON_ASSIGNING_WORKFLOWS) {
+      expect(workflow(name), `${name} assigns again`).not.toContain(ASSIGN_ACTION);
+    }
   });
 
-  it('re-enters intake on `ready` alone, so pipeline labels cannot retrigger it', () => {
+  // `ready` marks an issue eligible and nothing more: it joins the queue and
+  // waits there. Filing one used to reach `agentic-assign` through intake,
+  // which is how an issue created with the documented default labels started a
+  // session the moment it existed.
+  it('starts nothing when an issue is filed or labelled', () => {
     const intake = workflow('agentic-intake.yml');
-    expect(intake).toContain("github.event.label.name == 'ready'");
+    expect(intake).not.toContain(ASSIGN_ACTION);
+    expect(intake).not.toContain('labeled');
+    expect(intake).not.toMatch(/\n {2}assign:/);
   });
 
-  // Parallel intakes each read the `in-progress` label before any of them
-  // writes it, so without this every issue of a filed batch gets assigned.
-  it('serialises assignment while leaving labelling unserialised', () => {
-    const intake = workflow('agentic-intake.yml');
-    const assignJob = intake.slice(intake.indexOf('\n  assign:'));
-    expect(assignJob).toMatch(/concurrency:\s*\n\s*group: agentic-assignment/);
-    expect(intake.slice(0, intake.indexOf('\n  assign:'))).not.toContain('concurrency:');
+  it('starts a run from a human dispatching the trigger', () => {
+    const trigger = workflow('agentic-trigger.yml');
+    const triggers = trigger.slice(trigger.indexOf('\non:'), trigger.indexOf('\npermissions:'));
+    expect(triggers).toContain('workflow_dispatch:');
+    expect(triggers).not.toContain('schedule:');
+    expect(triggers).not.toContain('issues:');
+    expect(trigger).toContain(ASSIGN_ACTION);
   });
 
   it('chains from a merged pull request to the next issue', () => {
@@ -64,11 +80,27 @@ describe('entry points into the assignment queue', () => {
     }
   });
 
-  it('restarts an idle queue from the hourly sweep', () => {
+  // The sweep is the one clock left in the pipeline, and it exists to release
+  // issues, never to claim them. It used to restart an idle queue as well,
+  // which meant any `ready` issue eventually started a run on a timer.
+  it('sweeps stalled runs on a schedule without assigning anything', () => {
     const watchdog = workflow('agentic-watchdog.yml');
     expect(watchdog).toContain('schedule:');
-    expect(watchdog).toContain(ASSIGN_ACTION);
+    expect(watchdog).not.toContain(ASSIGN_ACTION);
+    expect(watchdog).toContain('in-progress');
   });
+
+  // A run that answers a question or executes a command closes its own issue
+  // and opens no PR, so there is no merge to chain from. Starting the next
+  // session there would be the pipeline deciding to run again on its own.
+  it.each(['claude-runner.yml', 'opencode-runner.yml'])(
+    '%s releases its issue without starting the next run',
+    (name) => {
+      const text = workflow(name);
+      expect(text).not.toContain(ASSIGN_ACTION);
+      expect(text).toContain(AUTO_MERGE_ACTION);
+    }
+  );
 });
 
 describe('assignment tokens', () => {
@@ -130,8 +162,6 @@ describe('dependency gating', () => {
 // same job, on the branch it was told to build — the one moment that exists
 // whoever the PR ends up attributed to.
 describe('auto-merge does not depend on the PR author', () => {
-  const AUTO_MERGE_ACTION = 'uses: ./.github/actions/agentic-auto-merge';
-
   /** Every workflow that can put a PR into auto-merge. */
   const MERGING_WORKFLOWS = [
     'claude-runner.yml',
@@ -161,7 +191,9 @@ describe('auto-merge does not depend on the PR author', () => {
     '%s arms the branch it was told to build, even when the agent step failed',
     (name) => {
       const text = workflow(name);
-      const step = text.slice(text.indexOf('- name: Arm auto-merge'), text.indexOf(ASSIGN_ACTION, text.indexOf('- name: Arm auto-merge')));
+      const start = text.indexOf('- name: Arm auto-merge');
+      const next = text.indexOf('\n      - name:', start);
+      const step = text.slice(start, next > -1 ? next : undefined);
       expect(step).toContain(AUTO_MERGE_ACTION);
       expect(step).toContain('head: pipeline/feature-${{ steps.context.outputs.issue }}');
       expect(step).toMatch(/if:\s*always\(\)/);


### PR DESCRIPTION
## Why

Filing issue #489 started an autonomous session nobody asked for. `agentic-intake.yml` assigned the queue on `issues: opened` and on the `ready` label, so an issue created with the documented default labels (`ready,agent-task`) woke a runner the moment it existed.

Two further paths could start a session with no human involved:

- `agentic-watchdog.yml` restarted an idle queue on its hourly cron — any `ready` issue eventually started a run on a clock.
- Both runners chained to the next issue when a run's deliverable was an answer or an executed command rather than a PR. No merge is involved in that path.

## What changed

Exactly two mechanisms now call `agentic-assign`:

| Entry | Fires on |
|---|---|
| `agentic-trigger.yml` | manual `workflow_dispatch` |
| `auto-assign-next.yml` | a merged pipeline pull request |

`ready` now means **eligible**, never **started**: it places an issue in the queue, where it waits until one of the two above reaches it.

**Workflows**
- `agentic-intake.yml` — `assign` job removed; `labeled` dropped from the trigger. It keeps the lifecycle label definitions present and drops a stale `done` from a reopened issue, and assigns nothing.
- `agentic-watchdog.yml` — `Restart an idle queue` removed (and with it the now-unused checkout). The stalled-run sweep is untouched, so a lost run is still reported, labelled `blocked`, and its issue released.
- `claude-runner.yml`, `opencode-runner.yml` — `Chain to next issue if resolved without PR` removed. A run whose deliverable is not a diff still releases its own issue (closes it, `done`, drops `in-progress`), so the queue is free for the next deliberate start.

**Context, across all three runtimes**
- `agentic-autonomous-pipeline/references/github-loop.md` — diagram and the entry table rewritten from "four ways in" to two, plus the single-flight, halt-condition, escalation and repo-variable passages that described the removed paths.
- `agentic-issue-creation` — creating an issue never starts a run.
- `agentic-decision-autonomy` — dropped the stale claim that an unlabelled issue is labelled `ready` on arrival.
- `.claude/CLAUDE.md`, `.github/copilot-instructions.md`, `.opencode/AGENTS.md` — pipeline section restated.
- `.github/ISSUE_TEMPLATE/config.yml` — comment no longer claims intake labels what arrives.

## The trade, stated deliberately

A `ready` issue can now sit in the queue indefinitely — nothing is scheduled to notice it. When an event is lost (GitHub drops the third run in a concurrency group, a webhook goes missing), the chain stops until the trigger is dispatched. That is the intended cost of never starting a session nobody asked for.

## Judgement call to review

The runners' no-PR chaining step is the one removal your rule did not literally name — it chained from finished pipeline work, but without a merge. I removed it on the strict reading. If you want it back, it is one step restored in each of the two runner workflows.

## Verification

- `npm run validate:context` — **pass** (frontmatter schemas, bundled files, runtime entry points, cross-runtime sync).
- All four edited workflows parse as YAML; jobs and steps enumerated after the edit.
- `agentic-assign` call sites audited across `.github/workflows/`: only `agentic-trigger.yml` and `auto-assign-next.yml` remain.

No application code was touched, so the game's five verification channels do not apply to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017raovarBXTwRbEr2EWJraH


---
_Generated by [Claude Code](https://claude.ai/code/session_017raovarBXTwRbEr2EWJraH)_