### PR TITLE
feat: sync decorative ambient motion to game time (#490)

### DIFF
--- a/.claude/rules/rendering.md
+++ b/.claude/rules/rendering.md
@@ -24,3 +24,4 @@ Headless Chrome has no GPU — jagged edges and slightly dark shadows are artifa
 
 - Renderer and UI read `GameState` and subscribe to core events. They never mutate core state directly.
 - Player-visible text goes through `t('key')` with matching `en.json` and `fr.json` entries — including fictional rock, ore, and explosive names.
+- In `GameRenderer.update(dt)`, ambient/decorative modules (wind, clouds, birds, chimney smoke, water surface, dust devils, fireflies, vegetation sway) run on game time: feed them `gameDt` (`dt * state.timeScale`, `0` while `state.isPaused`), never raw `dt`, so they scale and pause with the sim. Playback/UI/camera modules (fragment collapse, skybox, blast effects, characters, ghosts, border wall, vehicles) stay on raw `dt`. New ambient modules follow the `gameDt` convention.

--- a/scripts/scenario-defs/ambient-timescale-sync.json
+++ b/scripts/scenario-defs/ambient-timescale-sync.json
@@ -1,0 +1,72 @@
+{
+  "name": "ambient-timescale-sync",
+  "description": "Ambient decoration (birds, vegetation sway, chimney smoke, water, clouds, dust devils, fireflies, wind) must advance on state.timeScale/isPaused, not raw wall-clock frame delta (#490). Dumps window.__gameState().ambientClockSeconds around speed changes and a pause/resume cycle. Command mode has no renderer, so ambientClockSeconds is null/absent in those step dumps by design — this scenario is meaningful only in interaction mode (`--mode interaction`), where the render loop's own rAF actually drives GameRenderer.update().",
+  "steps": [
+    {
+      "command": "new_game seed:42",
+      "interaction": [
+        { "type": "command", "command": "new_game seed:42" }
+      ]
+    },
+    {
+      "command": "time speed 1",
+      "description": "1x speed baseline.",
+      "interaction": [
+        { "type": "command", "command": "time speed 1" }
+      ]
+    },
+    {
+      "command": "state full",
+      "description": "Let some wall-clock time pass at 1x before capturing ambientClockSeconds.",
+      "interaction": [
+        { "type": "wait", "durationMs": 1000 },
+        { "type": "command", "command": "state full" }
+      ]
+    },
+    {
+      "command": "time speed 4",
+      "description": "Switch to 4x — same wall-clock wait below should now advance the ambient clock roughly 4x as far per second.",
+      "interaction": [
+        { "type": "command", "command": "time speed 4" }
+      ]
+    },
+    {
+      "command": "state full",
+      "interaction": [
+        { "type": "wait", "durationMs": 1000 },
+        { "type": "command", "command": "state full" }
+      ]
+    },
+    {
+      "command": "time pause",
+      "description": "Pausing must freeze ambientClockSeconds even though wall-clock time keeps passing.",
+      "interaction": [
+        { "type": "command", "command": "time pause" }
+      ]
+    },
+    {
+      "command": "state full",
+      "interaction": [
+        { "type": "wait", "durationMs": 1000 },
+        { "type": "command", "command": "state full" }
+      ]
+    },
+    {
+      "command": "time resume",
+      "description": "Resuming continues the ambient clock from where it froze — no catch-up jump for the time spent paused.",
+      "interaction": [
+        { "type": "command", "command": "time resume" }
+      ]
+    },
+    {
+      "command": "state full",
+      "interaction": [
+        { "type": "wait", "durationMs": 1000 },
+        { "type": "command", "command": "state full" }
+      ]
+    }
+  ],
+  "shots": [
+    { "name": "overview", "yaw": 20, "pitch": 60 }
+  ]
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -474,6 +474,7 @@ window.__gameState = () => {
     })() : null,
     // Terrain mesh bounding box from Three.js geometry
     meshBounds: gameRenderer.terrain?.getBounds() ?? null,
+    ambientClockSeconds: gameRenderer.ambientClockSeconds,
   };
 };
 

--- a/src/renderer/GameRenderer.ts
+++ b/src/renderer/GameRenderer.ts
@@ -241,8 +241,14 @@ export class GameRenderer {
     return this.fragmentAnimator?.durationS ?? 0;
   }
 
+  /** Ambient shader clock, in game-time seconds — advances at state.timeScale, frozen while paused (#490). */
+  get ambientClockSeconds(): number {
+    throw new Error('not implemented');
+  }
+
   /** Per-frame update — call from the render loop. */
   update(dt: number): void {
+    // TODO(#490): derive gameDt from state.timeScale/isPaused and feed ambient modules — see issue #490
     const cam = this.sm.camera;
 
     // Rock still falling from the last blast.

--- a/src/renderer/GameRenderer.ts
+++ b/src/renderer/GameRenderer.ts
@@ -243,12 +243,20 @@ export class GameRenderer {
 
   /** Ambient shader clock, in game-time seconds — advances at state.timeScale, frozen while paused (#490). */
   get ambientClockSeconds(): number {
-    throw new Error('not implemented');
+    return this.ambientUniforms.uTime.value;
   }
 
   /** Per-frame update — call from the render loop. */
   update(dt: number): void {
-    // TODO(#490): derive gameDt from state.timeScale/isPaused and feed ambient modules — see issue #490
+    // Ambient decoration (wind, clouds, birds, smoke, water, dust devils, fireflies,
+    // vegetation sway via ambientUniforms.uTime) runs on game time: it scales with
+    // state.timeScale and freezes with state.isPaused, so speeding up or pausing the
+    // sim speeds up or freezes the decoration by the same factor. Everything else in
+    // this method (fragment collapse playback, skybox, blast effects, characters,
+    // ghosts, border wall, vehicles) is deliberately real-time and stays on raw dt.
+    const gameDt = this.lastState && !this.lastState.isPaused
+      ? dt * this.lastState.timeScale
+      : 0;
     const cam = this.sm.camera;
 
     // Rock still falling from the last blast.
@@ -264,8 +272,8 @@ export class GameRenderer {
     // terrain material's cloud-shadow term directly, so visible clouds and
     // their ground shadows share the exact same scroll — never desynced.
     if (this.windState && this.clouds) {
-      this.windState.update(dt, this.lastWeather);
-      this.clouds.update(dt, this.windState.vector);
+      this.windState.update(gameDt, this.lastWeather);
+      this.clouds.update(gameDt, this.windState.vector);
       const uniforms = this.terrain?.sharedMaterial.customUniforms;
       if (uniforms) {
         (uniforms['uCloudOffset']!.value as THREE.Vector2).copy(this.clouds.cloudOffset);
@@ -279,14 +287,14 @@ export class GameRenderer {
     // values here is the whole update.
     if (this.windState) {
       const wind = this.windState.vector;
-      this.ambientUniforms.uTime.value += dt;
+      this.ambientUniforms.uTime.value += gameDt;
       this.borderWall?.update(dt, this.sm.cameraController.viewTarget);
       this.ambientUniforms.uWind.value.set(wind.x, wind.z);
-      this.birds?.update(dt);
-      this.smoke?.update(dt, wind, cam.position);
-      this.water?.update(dt, wind);
-      this.dustDevils?.update(dt);
-      this.fireflies?.update(dt);
+      this.birds?.update(gameDt);
+      this.smoke?.update(gameDt, wind, cam.position);
+      this.water?.update(gameDt, wind);
+      this.dustDevils?.update(gameDt);
+      this.fireflies?.update(gameDt);
     }
 
     if (this.blastEffects) {

--- a/tests/unit/renderer/GameRenderer.test.ts
+++ b/tests/unit/renderer/GameRenderer.test.ts
@@ -537,3 +537,104 @@ describe('GameRenderer — scene picking (P2)', () => {
     expect(renderer.resolveFragmentId(0, 0)).toBeNull();
   });
 });
+
+describe('GameRenderer — ambient decoration follows game clock, not wall clock (#490)', () => {
+  it('ambient clock stays at zero while the game starts paused', () => {
+    const renderer = new GameRenderer(makeMockSceneManager() as any);
+    const ctx = makeCtx();
+    ctx.state!.isPaused = true;
+    renderer.syncFromContext(ctx);
+
+    for (let i = 0; i < 5; i++) renderer.update(0.5);
+
+    expect(renderer.ambientClockSeconds).toBe(0);
+  });
+
+  it('ambient clock advances 4x as far at 4x timeScale as at 1x, for the same wall-clock delta', () => {
+    const renderer1 = new GameRenderer(makeMockSceneManager() as any);
+    const ctx1 = makeCtx();
+    ctx1.state!.timeScale = 1;
+    ctx1.state!.isPaused = false;
+    renderer1.syncFromContext(ctx1);
+
+    const renderer4 = new GameRenderer(makeMockSceneManager() as any);
+    const ctx4 = makeCtx();
+    ctx4.state!.timeScale = 4;
+    ctx4.state!.isPaused = false;
+    renderer4.syncFromContext(ctx4);
+
+    for (let i = 0; i < 10; i++) {
+      renderer1.update(0.1);
+      renderer4.update(0.1);
+    }
+
+    expect(renderer4.ambientClockSeconds).toBeCloseTo(renderer1.ambientClockSeconds * 4, 5);
+  });
+
+  it('two half-steps advance the ambient clock exactly as far as one whole step', () => {
+    const rendererA = new GameRenderer(makeMockSceneManager() as any);
+    const ctxA = makeCtx();
+    ctxA.state!.timeScale = 2;
+    ctxA.state!.isPaused = false;
+    rendererA.syncFromContext(ctxA);
+    rendererA.update(0.2);
+
+    const rendererB = new GameRenderer(makeMockSceneManager() as any);
+    const ctxB = makeCtx();
+    ctxB.state!.timeScale = 2;
+    ctxB.state!.isPaused = false;
+    rendererB.syncFromContext(ctxB);
+    rendererB.update(0.1);
+    rendererB.update(0.1);
+
+    expect(rendererA.ambientClockSeconds).toBeCloseTo(rendererB.ambientClockSeconds, 10);
+  });
+
+  it('pausing mid-run freezes the ambient clock; resuming continues without a catch-up jump', () => {
+    const renderer = new GameRenderer(makeMockSceneManager() as any);
+    const ctx = makeCtx();
+    ctx.state!.timeScale = 2;
+    ctx.state!.isPaused = false;
+    renderer.syncFromContext(ctx);
+
+    for (let i = 0; i < 3; i++) renderer.update(0.1);
+    const beforePause = renderer.ambientClockSeconds;
+
+    ctx.state!.isPaused = true;
+    renderer.syncFromContext(ctx);
+    for (let i = 0; i < 5; i++) renderer.update(0.1);
+    expect(renderer.ambientClockSeconds).toBe(beforePause);
+
+    ctx.state!.isPaused = false;
+    renderer.syncFromContext(ctx);
+    renderer.update(0.1);
+
+    expect(renderer.ambientClockSeconds - beforePause).toBeCloseTo(0.1 * 2, 10);
+  });
+
+  it('dt = 0 leaves the ambient clock unchanged', () => {
+    const renderer = new GameRenderer(makeMockSceneManager() as any);
+    const ctx = makeCtx();
+    ctx.state!.timeScale = 3;
+    ctx.state!.isPaused = false;
+    renderer.syncFromContext(ctx);
+
+    renderer.update(0.1);
+    const before = renderer.ambientClockSeconds;
+    renderer.update(0);
+
+    expect(renderer.ambientClockSeconds).toBe(before);
+  });
+
+  it('a capped-but-large per-frame dt at max timeScale scales linearly, no secondary clamp', () => {
+    const renderer = new GameRenderer(makeMockSceneManager() as any);
+    const ctx = makeCtx();
+    ctx.state!.timeScale = 8;
+    ctx.state!.isPaused = false;
+    renderer.syncFromContext(ctx);
+
+    renderer.update(0.1);
+
+    expect(renderer.ambientClockSeconds).toBeCloseTo(0.8, 10);
+  });
+});


### PR DESCRIPTION
Closes #490

## Summary

Decorative ambient renderer motion — wind, clouds, birds, chimney smoke, water surface, dust devils, fireflies, and vegetation sway (via the shared `ambientUniforms.uTime` shader clock) — now advances on **game time** instead of raw wall-clock frame delta.

`GameRenderer.update(dt)` derives one `gameDt` value at the top of the method:

```ts
const gameDt = this.lastState && !this.lastState.isPaused
  ? dt * this.lastState.timeScale
  : 0;
```

and feeds it to every ambient module. A comment at that exact point documents the boundary: fragment collapse playback, skybox, blast effects, characters, ghosts, border wall, and vehicles stay on raw wall-clock `dt` deliberately, so the next change to this method doesn't have to re-derive which clock applies where.

A new `GameRenderer.ambientClockSeconds` getter exposes the cumulative ambient game-time clock (mirrors `ambientUniforms.uTime.value`), surfaced through `window.__gameState().ambientClockSeconds` for scenario/test inspection.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run. None are material to gameplay, economy, or a player-facing default (all are implementation-detail defaults on a rendering-timing mechanism), so no `decision-review` follow-up issue was filed.

- **What was open:** whether `gameDt` needs its own clamp for a very large per-frame `dt` (backgrounded tab), independent of `SceneManager`'s existing `Math.min(dt, 0.1)` cap.
  **Chosen:** no additional clamp — `dt` is already capped at 0.1s and `timeScale` capped at 8, so `gameDt` never exceeds 0.8s in one frame.
  **Why:** the sim's own tick loop (`main.ts`) has no special large-gap handling either. A second, ambient-only clamp would introduce behavior the tick path doesn't have, undermining the "same clock" fix.
  **If reversed:** add a `MAX_AMBIENT_DT` constant at the `gameDt` computation line in `GameRenderer.update()`; no other call site moves.

- **What was open:** whether a `timeScale` change takes effect immediately on the next frame or blends across the frame it changed in.
  **Chosen:** instant — `gameDt` reads `this.lastState.timeScale` fresh every `update()` call, matching how `main.ts`'s tick loop reads `state.timeScale` fresh every iteration.
  **Why:** no interpolation window exists anywhere else in the codebase for a speed change; matches the existing convention.
  **If reversed:** introduce a `speedTransitionSeconds` easing constant and interpolate the multiplier toward the new `timeScale` over that window.

- **What was open:** field name/location for exposing the ambient game-clock to the scenario/visual harness.
  **Chosen:** `ambientClockSeconds`, on `GameRenderer` and mirrored into `window.__gameState()`.
  **Why:** `uTime` is already the one linear, unthrottled accumulator every ambient/vegetation shader shares — cheapest possible signal, no new state to maintain.
  **If reversed:** rename the getter/field; two call sites move.

## Verification

- **static** — `npm run typecheck`: clean, 0 errors.
- **logic** — `npm run test`: 7729 unit tests + 502 integration tests passed, 0 failed. Coverage 98.3% line / 94.32% branch / 85.78% function.
- **scenario** — `npm run scenarios`: 123/123 passed (command mode); `scripts/scenario-defs/ambient-timescale-sync.json` added (speed 1x → dump, speed 4x → dump, pause → dump, resume → dump).
- **visual** — `VISUAL: PASS`. Interaction-mode run of `ambient-timescale-sync` plus a supplementary scenario against a visually rich level, screenshots inspected directly:
  - Proportional speedup: ambient clock delta over matched 1s windows was ~2.22s at 1x vs ~8.96s at 4x (≈4.0x, within noise). A moving dust/haze shape in the scene visibly translates ~4x farther per unit wall-clock time at 4x vs 1x.
  - Pause freeze: ambient clock delta was exactly 0.0 across a full 1s wait while paused; three screenshots taken 500ms apart during pause are pixel-identical.
  - Resume, no jump: ambient clock continues forward smoothly from the exact frozen value on resume, no discontinuity; screenshot confirms the animated element continues from its frozen position with no teleport.
  - Frame-rate independence: not directly observable via screenshots (no mechanism to vary headless Chrome's render FPS independently); the dt-based (not frame-count-based) advance shown by the other two results is consistent with correct behavior.
- **playability** — not run: no player-facing UI flow changed (no new panel, button, or interaction path; this is a rendering-timing-only change consumed automatically by every scene already using the affected ambient modules).
- **build** — `npm run build`: success.
- Code review: security, quality, i18n, duplication, and semantic reviewers all ran in parallel and passed clean (one pre-existing, non-blocking file-size note on `GameRenderer.ts`, unrelated to this change).
- Refactor phase: reviewed, no changes needed — code already clean.

READY TO MERGE