### PR TITLE
feat: rebuild landscape as one continuous surface, fix seams and material blend (#491)

### DIFF
--- a/scripts/scenario-defs/landscape-continuity-visual.json
+++ b/scripts/scenario-defs/landscape-continuity-visual.json
@@ -8,7 +8,7 @@
   "steps": [
     {
       "command": "new_game mine_type:alpine_granite seed:11 size:48",
-      "timeout": 30,
+      "timeout": 90,
       "description": "Setup: relief terrain (alpine_granite) with several dominant rocks, big enough to have a real interior away from every edge",
       "interaction": [
         { "type": "command", "command": "new_game mine_type:alpine_granite seed:11 size:48" }
@@ -16,7 +16,7 @@
     },
     {
       "command": "terrain_info",
-      "timeout": 15,
+      "timeout": 90,
       "description": "Sanity check: the playable grid and landscape both exist before framing any of it",
       "interaction": [
         { "type": "command", "command": "terrain_info" }
@@ -24,7 +24,7 @@
     },
     {
       "command": "state",
-      "timeout": 15,
+      "timeout": 120,
       "description": "Frame a ridge in the landscape's interior — the coarse tile mesh and its slope shading, no floating shards",
       "interaction": [
         { "type": "command", "command": "state" },
@@ -35,7 +35,7 @@
     },
     {
       "command": "state",
-      "timeout": 15,
+      "timeout": 120,
       "description": "Frame a slope away from the pit edge — one continuous surface, no seam crease and no duplicated geometry",
       "interaction": [
         { "type": "command", "command": "state" },
@@ -46,7 +46,7 @@
     },
     {
       "command": "state",
-      "timeout": 15,
+      "timeout": 120,
       "description": "Frame the close pit edge (pre-blast) — the landscape's boundary quad must meet the playable mesh with no gap and no floating shard",
       "interaction": [
         { "type": "command", "command": "state" },
@@ -57,7 +57,7 @@
     },
     {
       "command": "state",
-      "timeout": 15,
+      "timeout": 120,
       "description": "Frame the far pit edge (pre-blast), the opposite side of the site from the close edge above",
       "interaction": [
         { "type": "command", "command": "state" },
@@ -68,7 +68,7 @@
     },
     {
       "command": "state",
-      "timeout": 15,
+      "timeout": 120,
       "description": "Frame a material/biome transition — adjacent landscape vertices with different dominant rocks should blend smoothly, not snap at a hard tessellation-dependent edge",
       "interaction": [
         { "type": "command", "command": "state" },
@@ -79,7 +79,7 @@
     },
     {
       "command": "drill_plan grid rows:2 cols:2 spacing:4 depth:6 start:2,22",
-      "timeout": 20,
+      "timeout": 90,
       "description": "Drill right at the close pit edge, so the following blast reshapes the live junction the landscape must track",
       "interaction": [
         { "type": "command", "command": "drill_plan grid rows:2 cols:2 spacing:4 depth:6 start:2,22" }
@@ -87,7 +87,7 @@
     },
     {
       "command": "charge hole:* explosive:boomite amount:5 stemming:2",
-      "timeout": 20,
+      "timeout": 90,
       "description": "Charge every drilled hole at the pit edge",
       "interaction": [
         { "type": "command", "command": "charge hole:* explosive:boomite amount:5 stemming:2" }
@@ -95,7 +95,7 @@
     },
     {
       "command": "sequence auto delay_step:25",
-      "timeout": 20,
+      "timeout": 90,
       "description": "Auto-sequence the charges",
       "interaction": [
         { "type": "command", "command": "sequence auto delay_step:25" }
@@ -103,7 +103,7 @@
     },
     {
       "command": "blast",
-      "timeout": 30,
+      "timeout": 240,
       "frames": 6,
       "interval": 50,
       "description": "Fire the pit-edge blast — the crater it carves is the new live boundary the landscape must match",
@@ -113,7 +113,7 @@
     },
     {
       "command": "state",
-      "timeout": 20,
+      "timeout": 120,
       "description": "Re-frame the close pit edge post-blast — the landscape's boundary nodes must track the new, lower live surface (PlayableCut.boundaryHeightAt), not the stale pre-dig height, still with no gap or overlap",
       "interaction": [
         { "type": "command", "command": "state" },
@@ -124,7 +124,7 @@
     },
     {
       "command": "terrain_info",
-      "timeout": 15,
+      "timeout": 90,
       "description": "Final inspection: playable terrain state after the pit-edge blast",
       "interaction": [
         { "type": "command", "command": "terrain_info" }

--- a/scripts/scenario-defs/landscape-continuity-visual.json
+++ b/scripts/scenario-defs/landscape-continuity-visual.json
@@ -1,0 +1,134 @@
+{
+  "name": "landscape-continuity-visual",
+  "description": "Visual regression for the landscape/playable mesh junction (#491): frames a ridge, a slope, the close and far pit edges, and a material/biome transition on relief terrain, then drills, charges, sequences and blasts right at the pit edge and re-frames it post-blast — the landscape and the crater must read as one continuous, gap-free, non-overlapping surface throughout, with no hard-edged material snap across the boundary.",
+  "shots": [
+    { "name": "overview", "yaw": 0, "pitch": 45 },
+    { "name": "birdseye", "yaw": 0, "pitch": 80 }
+  ],
+  "steps": [
+    {
+      "command": "new_game mine_type:alpine_granite seed:11 size:48",
+      "timeout": 30,
+      "description": "Setup: relief terrain (alpine_granite) with several dominant rocks, big enough to have a real interior away from every edge",
+      "interaction": [
+        { "type": "command", "command": "new_game mine_type:alpine_granite seed:11 size:48" }
+      ]
+    },
+    {
+      "command": "terrain_info",
+      "timeout": 15,
+      "description": "Sanity check: the playable grid and landscape both exist before framing any of it",
+      "interaction": [
+        { "type": "command", "command": "terrain_info" }
+      ]
+    },
+    {
+      "command": "state",
+      "timeout": 15,
+      "description": "Frame a ridge in the landscape's interior — the coarse tile mesh and its slope shading, no floating shards",
+      "interaction": [
+        { "type": "command", "command": "state" },
+        { "type": "cameraFocus", "x": 24, "z": 6, "distance": 22 },
+        { "type": "wait", "durationMs": 250 },
+        { "type": "screenshot" }
+      ]
+    },
+    {
+      "command": "state",
+      "timeout": 15,
+      "description": "Frame a slope away from the pit edge — one continuous surface, no seam crease and no duplicated geometry",
+      "interaction": [
+        { "type": "command", "command": "state" },
+        { "type": "cameraFocus", "x": 14, "z": 34, "distance": 20 },
+        { "type": "wait", "durationMs": 250 },
+        { "type": "screenshot" }
+      ]
+    },
+    {
+      "command": "state",
+      "timeout": 15,
+      "description": "Frame the close pit edge (pre-blast) — the landscape's boundary quad must meet the playable mesh with no gap and no floating shard",
+      "interaction": [
+        { "type": "command", "command": "state" },
+        { "type": "cameraFocus", "x": 2, "z": 24, "distance": 14 },
+        { "type": "wait", "durationMs": 250 },
+        { "type": "screenshot" }
+      ]
+    },
+    {
+      "command": "state",
+      "timeout": 15,
+      "description": "Frame the far pit edge (pre-blast), the opposite side of the site from the close edge above",
+      "interaction": [
+        { "type": "command", "command": "state" },
+        { "type": "cameraFocus", "x": 46, "z": 24, "distance": 14 },
+        { "type": "wait", "durationMs": 250 },
+        { "type": "screenshot" }
+      ]
+    },
+    {
+      "command": "state",
+      "timeout": 15,
+      "description": "Frame a material/biome transition — adjacent landscape vertices with different dominant rocks should blend smoothly, not snap at a hard tessellation-dependent edge",
+      "interaction": [
+        { "type": "command", "command": "state" },
+        { "type": "cameraFocus", "x": 34, "z": 14, "distance": 18 },
+        { "type": "wait", "durationMs": 250 },
+        { "type": "screenshot" }
+      ]
+    },
+    {
+      "command": "drill_plan grid rows:2 cols:2 spacing:4 depth:6 start:2,22",
+      "timeout": 20,
+      "description": "Drill right at the close pit edge, so the following blast reshapes the live junction the landscape must track",
+      "interaction": [
+        { "type": "command", "command": "drill_plan grid rows:2 cols:2 spacing:4 depth:6 start:2,22" }
+      ]
+    },
+    {
+      "command": "charge hole:* explosive:boomite amount:5 stemming:2",
+      "timeout": 20,
+      "description": "Charge every drilled hole at the pit edge",
+      "interaction": [
+        { "type": "command", "command": "charge hole:* explosive:boomite amount:5 stemming:2" }
+      ]
+    },
+    {
+      "command": "sequence auto delay_step:25",
+      "timeout": 20,
+      "description": "Auto-sequence the charges",
+      "interaction": [
+        { "type": "command", "command": "sequence auto delay_step:25" }
+      ]
+    },
+    {
+      "command": "blast",
+      "timeout": 30,
+      "frames": 6,
+      "interval": 50,
+      "description": "Fire the pit-edge blast — the crater it carves is the new live boundary the landscape must match",
+      "interaction": [
+        { "type": "command", "command": "blast" }
+      ]
+    },
+    {
+      "command": "state",
+      "timeout": 20,
+      "description": "Re-frame the close pit edge post-blast — the landscape's boundary nodes must track the new, lower live surface (PlayableCut.boundaryHeightAt), not the stale pre-dig height, still with no gap or overlap",
+      "interaction": [
+        { "type": "command", "command": "state" },
+        { "type": "cameraFocus", "x": 2, "z": 22, "distance": 14 },
+        { "type": "wait", "durationMs": 300 },
+        { "type": "screenshot" }
+      ]
+    },
+    {
+      "command": "terrain_info",
+      "timeout": 15,
+      "description": "Final inspection: playable terrain state after the pit-edge blast",
+      "interaction": [
+        { "type": "command", "command": "terrain_info" }
+      ]
+    }
+  ]
+}

--- a/src/core/world/VoxelGrid.ts
+++ b/src/core/world/VoxelGrid.ts
@@ -696,7 +696,26 @@ export function computeVoxelColumnSurfaceY(grid: VoxelGrid, x: number, z: number
  * column right now, pre- or post-blast. Returns 0 for a column with no
  * solid voxel at all.
  */
-export function computeVoxelColumnSurfaceHeight(_grid: VoxelGrid, _x: number, _z: number): number {
-  // TODO: implement
+export function computeVoxelColumnSurfaceHeight(grid: VoxelGrid, x: number, z: number): number {
+  if (grid.sizeX <= 0 || grid.sizeZ <= 0) return 0;
+
+  const cx = Math.max(grid.minX, Math.min(grid.maxX - 1, Math.floor(x)));
+  const cz = Math.max(grid.minZ, Math.min(grid.maxZ - 1, Math.floor(z)));
+  for (let y = grid.sizeY - 1; y >= 0; y--) {
+    const density0 = grid.densityAt(cx, y, cz);
+    if (density0 >= 0.5) {
+      // Same crossing interpolation as TerrainMesh's emitVertex: the voxel
+      // above a topmost-solid voxel is air-side (density < 0.5, or 0 past
+      // the grid's own top), and the fractional height along that edge is
+      // where density == 0.5. Matches marching cubes exactly.
+      const density1 = grid.densityAt(cx, y + 1, cz);
+      let t = 0.5;
+      if (Math.abs(density1 - density0) > 1e-6) {
+        t = (0.5 - density0) / (density1 - density0);
+      }
+      t = Math.max(0, Math.min(1, t));
+      return y + t;
+    }
+  }
   return 0;
 }

--- a/src/core/world/VoxelGrid.ts
+++ b/src/core/world/VoxelGrid.ts
@@ -685,3 +685,18 @@ export function computeVoxelColumnSurfaceY(grid: VoxelGrid, x: number, z: number
   }
   return -1;
 }
+
+/**
+ * Continuous height of the topmost solid-to-air crossing at column (x, z),
+ * in the same datum as heightToVoxelYContinuous. Mirrors
+ * computeVoxelColumnSurfaceY's top-down scan and clamp-to-edge-column
+ * behaviour, but returns the fractional crossing height (via densityAt
+ * interpolation between the topmost solid voxel and the one above it),
+ * matching what TerrainMesh's marching cubes actually renders at that
+ * column right now, pre- or post-blast. Returns 0 for a column with no
+ * solid voxel at all.
+ */
+export function computeVoxelColumnSurfaceHeight(_grid: VoxelGrid, _x: number, _z: number): number {
+  // TODO: implement
+  return 0;
+}

--- a/src/renderer/GameRenderer.ts
+++ b/src/renderer/GameRenderer.ts
@@ -6,7 +6,7 @@ import * as THREE from 'three';
 import type { MiningContext } from '../console/commands/mining.js';
 import { ensureLandscape, type LandscapeHandle } from '../console/commands/world.js';
 import type { GameState } from '../core/state/GameState.js';
-import { type VoxelGrid, computeVoxelColumnSurfaceY } from '../core/world/VoxelGrid.js';
+import { type VoxelGrid, computeVoxelColumnSurfaceY, computeVoxelColumnSurfaceHeight } from '../core/world/VoxelGrid.js';
 import { getBiome } from '../core/world/BiomeCatalog.js';
 import type { WeatherState } from '../core/weather/WeatherCycle.js';
 import { BIOME_GRADES, NEUTRAL_GRADE } from './post/AerialPerspectivePass.js';
@@ -654,6 +654,10 @@ export class GameRenderer {
     return {
       rect: { minX: grid.minX, minZ: grid.minZ, maxX: grid.maxX, maxZ: grid.maxZ },
       ownsColumn: (x, z) => grid.containsColumn(x, z),
+      // Live surface height, so the landscape's claim-boundary ring matches
+      // whatever the playable marching-cubes mesh renders there right now —
+      // before or after a blast — instead of the static WorldGen prediction.
+      boundaryHeightAt: (x, z) => computeVoxelColumnSurfaceHeight(grid, x, z),
     };
   }
 

--- a/src/renderer/terrain/LandscapeMesh.ts
+++ b/src/renderer/terrain/LandscapeMesh.ts
@@ -1,33 +1,31 @@
-// BlastSimulator2026 — Landscape mesher (#458 T3.2/D7/A16)
+// BlastSimulator2026 — Landscape mesher (#458 T3.2/D7/A16, #491)
 // Builds real ground geometry for LandscapeMap's tiles, replacing
 // DistantScenery's ring of unrelated decorative primitives with continuous
 // terrain that actually meets the playable voxel mesh at its edge.
 //
-// Two kinds of geometry, sharing the same material as the playable terrain:
-//   - One indexed grid Mesh per LandscapeTile, at the map's stored coarse
-//     resolution (4m by default).
-//   - One "seam" Mesh: a fine (1m) band from FINE_MARGIN outside the
-//     playable rect to OVERLAP inside it, sampled directly (the stored
-//     tiles don't have 1m resolution) so silhouette density matches the
-//     voxel mesh right at the junction, with the inside-the-rect portion
-//     lowered by OVERLAP_DROP so it sits safely under the playable mesh —
-//     no gap can open there regardless of voxelization rounding (#458 A16).
-// The deep interior (more than OVERLAP inside the rect) is skipped
-// entirely: that's the playable VoxelGrid's own marching-cubes job.
+// One indexed grid Mesh per LandscapeTile, at the map's stored coarse
+// resolution (4m by default): quads fully outside the playable rect are
+// emitted as-is, quads fully inside it are dropped (the voxel mesh owns that
+// ground), and quads straddling the boundary are subdivided down to
+// FINE_STEP (1m) by buildBoundaryQuad instead of duplicated by a second,
+// overlapping "seam" mesh (#491 — the old two-mesh overlap-and-hide-the-seam
+// design left a ~20m band where the coarse tile's loose corner-in-rect test
+// and the fine seam mesh's own placement could disagree, producing floating
+// or detached ground shards along ridges/slopes). Every boundary quad's
+// outer perimeter interpolates linearly between its PARENT coarse quad's own
+// corner heights (the "flat-edge rule") so it always meets its unsubdivided
+// coarse neighbours with no crack, while interior boundary nodes — and the
+// exact claim edge, via PlayableCut.boundaryHeightAt — read the live surface
+// so a blast never opens a gap before the next rebuild moves the boundary.
 
 import * as THREE from 'three';
 import type { LandscapeHandle } from '../../console/commands/world.js';
 import type { LandscapeTile } from '../../core/world/LandscapeMap.js';
 import type { Rect } from '../../core/world/WorldGen.js';
-import { getDominantRockId, type CompositionPalette } from '../../core/world/VoxelGrid.js';
+import { type CompositionPalette } from '../../core/world/VoxelGrid.js';
 import { rockIndexOf } from '../../core/world/RockCatalog.js';
 
-/** Metres outside the playable rect within which the seam subdivides to FINE_STEP (#458 A16). */
-const FINE_MARGIN = 24;
-/** Metres inside the playable rect the seam mesh still covers. */
-const OVERLAP = 2;
-/** The overlap strip's vertices are lowered by this much so it sits under the playable mesh, never fighting it. */
-const OVERLAP_DROP = 0.15;
+/** Sample spacing of a boundary quad's subdivision, metres — matches the old seam mesh's resolution. */
 const FINE_STEP = 1;
 
 type SampleFn = (x: number, z: number) => { height: number; biomeId: number; surfCompId: number };
@@ -91,28 +89,6 @@ export function voxelSurfaceHeight(continuousHeight: number): number {
 }
 
 /**
- * Seam vertex height.
- *
- * Both meshes now agree on the continuous height, so the seam simply follows
- * it. The strip that overlaps the playable rect is still dropped clear of the
- * mesh that owns that ground, so the two can never z-fight.
- */
-export function seamHeightAt(continuousHeight: number, insideDepth: number): number {
-  const y = voxelSurfaceHeight(continuousHeight);
-  return insideDepth > 0 ? y - OVERLAP_DROP : y;
-}
-
-/**
- * Landscape samples carry one rock (no marching-cubes blend), so both shader
- * rock slots are the same index and the blend weight is 0 — no ore data is
- * tracked in LandscapeMap, so aOre is always "none" (#458 T4.1/A18).
- */
-function rockIndexFor(palette: CompositionPalette, surfCompId: number): number {
-  const comp = palette.get(surfCompId).comp;
-  return Math.max(0, rockIndexOf(getDominantRockId(comp)));
-}
-
-/**
  * The ground the playable mesh owns, which the landscape must not overlap.
  *
  * `rect` is the site's live bounding box, and `ownsColumn` its actual claimed
@@ -138,14 +114,26 @@ function rectCut(rect: Rect): PlayableCut {
 /**
  * Two-rock blend for one sample, replacing rockIndexFor's collapse to a
  * single dominant index. `rockA`/`rockB` are shader rock-catalog indices;
- * `weight` is the blend fraction toward `rockB` (0 = pure rockA).
- *
- * TODO: implement — read the top two coefficients out of the composition
- * at surfCompId instead of only the dominant one.
+ * `weight` is the blend fraction toward `rockB` (0 = pure rockA), matching
+ * TerrainMesh.emitVertex's convention exactly (rockA/rockB/weight feed the
+ * one shared shader, which rounds each to an int per-fragment and blends
+ * their material recipes by vRockW).
  */
-export function rockBlendFor(_palette: CompositionPalette, _surfCompId: number): { rockA: number; rockB: number; weight: number } {
-  // TODO: implement
-  return { rockA: 0, rockB: 0, weight: 0 };
+export function rockBlendFor(palette: CompositionPalette, surfCompId: number): { rockA: number; rockB: number; weight: number } {
+  const rocks = palette.get(surfCompId).comp.rocks;
+  if (rocks.length === 0) return { rockA: 0, rockB: 0, weight: 0 };
+
+  const sorted = [...rocks].sort((a, b) => b.coefficient - a.coefficient);
+  const first = sorted[0]!;
+  const second = sorted[1];
+
+  const rockA = Math.max(0, rockIndexOf(first.rockId));
+  if (!second || second.coefficient <= 0) {
+    return { rockA, rockB: rockA, weight: 0 };
+  }
+  const rockB = Math.max(0, rockIndexOf(second.rockId));
+  const weight = second.coefficient / (first.coefficient + second.coefficient);
+  return { rockA, rockB, weight };
 }
 
 /**
@@ -154,46 +142,143 @@ export function rockBlendFor(_palette: CompositionPalette, _surfCompId: number):
  * as-is), fully inside it (dropped — the voxel mesh owns that ground), or
  * straddling the boundary (needs clipping/subdivision via buildBoundaryQuad
  * instead of being emitted whole).
- *
- * TODO: implement — replace buildTileMesh's current binary
- * drop-if-any-corner-inside test with this three-way classification.
  */
-export function classifyQuad(_playable: PlayableCut, _x0: number, _z0: number, _x1: number, _z1: number): 'outside' | 'inside' | 'boundary' {
-  // TODO: implement
-  return 'outside';
+export function classifyQuad(playable: PlayableCut, x0: number, z0: number, x1: number, z1: number): 'outside' | 'inside' | 'boundary' {
+  const owned = [
+    playable.ownsColumn(x0, z0),
+    playable.ownsColumn(x1, z0),
+    playable.ownsColumn(x0, z1),
+    playable.ownsColumn(x1, z1),
+  ];
+  if (owned.every(o => o)) return 'inside';
+  if (owned.every(o => !o)) return 'outside';
+  return 'boundary';
 }
 
 /**
  * Emits the clipped/subdivided geometry for one boundary quad (a coarse-tile
  * quad classifyQuad marked 'boundary') into the given output arrays, sampled
- * at fine resolution against the live claim edge so it meets the playable
- * mesh with no overlap and no gap.
+ * at fine (FINE_STEP) resolution against the live claim edge so it meets the
+ * playable mesh with no overlap and no gap.
  *
- * TODO: implement — replace the fixed OVERLAP/OVERLAP_DROP seam-mesh
- * strategy for this quad with an exact clip against `playable.ownsColumn`
- * (and `playable.boundaryHeightAt` where available).
+ * Subdivides the one coarse quad into SUBDIV×SUBDIV fine cells and keeps a
+ * cell only if at least one of its 4 corners is unowned — this is what drops
+ * the pit-side ground entirely rather than duplicating it. Every kept cell's
+ * two triangles are appended to the (growable) output arrays the caller's
+ * coarse pass already populated for its own tile.
+ *
+ * Node positions follow the flat-edge rule: a node sitting exactly on the
+ * PARENT coarse quad's own perimeter is placed by linear interpolation
+ * between that side's two coarse corner heights (never the true sampled
+ * height), so the boundary quad's outer edge always matches whatever an
+ * unsubdivided neighbouring coarse quad computes for the same edge — no
+ * T-junction crack is possible. Interior nodes use the live surface height
+ * (`playable.boundaryHeightAt`) when the caller supplies one, falling back to
+ * the theoretical WorldGen height otherwise, so the boundary ring never
+ * drifts from what the playable marching-cubes mesh renders after a blast.
  */
 export function buildBoundaryQuad(
-  _positions: number[],
-  _normals: number[],
-  _rockA: number[],
-  _rockB: number[],
-  _rockWeight: number[],
-  _ore: number[],
-  _indices: number[],
-  _x0: number, _z0: number, _x1: number, _z1: number,
-  _sampleColumn: SampleFn,
-  _palette: CompositionPalette,
-  _playable: PlayableCut,
+  positions: number[],
+  normals: number[],
+  rockA: number[],
+  rockB: number[],
+  rockWeight: number[],
+  ore: number[],
+  indices: number[],
+  x0: number, z0: number, x1: number, z1: number,
+  sampleColumn: SampleFn,
+  palette: CompositionPalette,
+  playable: PlayableCut,
 ): void {
-  // TODO: implement
+  const subdiv = Math.max(1, Math.round((x1 - x0) / FINE_STEP));
+
+  // Parent coarse corner heights, read directly (never boundary-adjusted) —
+  // the flat-edge rule's whole point is to reproduce exactly what an
+  // unsubdivided coarse neighbour would compute for this same edge.
+  const h00 = sampleColumn(x0, z0).height;
+  const h10 = sampleColumn(x1, z0).height;
+  const h01 = sampleColumn(x0, z1).height;
+  const h11 = sampleColumn(x1, z1).height;
+
+  // Slope source for shading: the live/theoretical field, never the
+  // flat-edge-adjusted position (a T-junction fix, not a slope).
+  const heightCache = new Map<string, number>();
+  const trueHeightAt = (x: number, z: number): number => {
+    const key = `${x},${z}`;
+    const cached = heightCache.get(key);
+    if (cached !== undefined) return cached;
+    const h = playable.boundaryHeightAt ? playable.boundaryHeightAt(x, z) : sampleColumn(x, z).height;
+    heightCache.set(key, h);
+    return h;
+  };
+
+  const vertexIndex = new Map<number, number>();
+
+  const emitVertex = (row: number, col: number): number => {
+    const key = row * (subdiv + 1) + col;
+    const existing = vertexIndex.get(key);
+    if (existing !== undefined) return existing;
+
+    const x = x0 + col * FINE_STEP;
+    const z = z0 + row * FINE_STEP;
+    const sample = sampleColumn(x, z);
+
+    const onXEdge = col === 0 || col === subdiv;
+    const onZEdge = row === 0 || row === subdiv;
+
+    let y: number;
+    if (onXEdge && onZEdge) {
+      y = col === 0 ? (row === 0 ? h00 : h01) : (row === 0 ? h10 : h11);
+    } else if (onZEdge) {
+      const t = col / subdiv;
+      y = row === 0 ? h00 + t * (h10 - h00) : h01 + t * (h11 - h01);
+    } else if (onXEdge) {
+      const t = row / subdiv;
+      y = col === 0 ? h00 + t * (h01 - h00) : h10 + t * (h11 - h10);
+    } else {
+      y = playable.boundaryHeightAt ? playable.boundaryHeightAt(x, z) : sample.height;
+    }
+
+    const dhdx = (trueHeightAt(x + FINE_STEP, z) - trueHeightAt(x - FINE_STEP, z)) / (2 * FINE_STEP);
+    const dhdz = (trueHeightAt(x, z + FINE_STEP) - trueHeightAt(x, z - FINE_STEP)) / (2 * FINE_STEP);
+    const normal = heightFieldNormal(dhdx, dhdz);
+
+    const idx = positions.length / 3;
+    positions.push(x, y, z);
+    normals.push(normal[0], normal[1], normal[2]);
+
+    const blend = rockBlendFor(palette, sample.surfCompId);
+    rockA.push(blend.rockA);
+    rockB.push(blend.rockB);
+    rockWeight.push(blend.weight);
+    ore.push(-1, 0); // landscape never carries ore (#458 A18)
+
+    vertexIndex.set(key, idx);
+    return idx;
+  };
+
+  for (let row = 0; row < subdiv; row++) {
+    for (let col = 0; col < subdiv; col++) {
+      const cx0 = x0 + col * FINE_STEP, cx1 = cx0 + FINE_STEP;
+      const cz0 = z0 + row * FINE_STEP, cz1 = cz0 + FINE_STEP;
+      const anyUnowned =
+        !playable.ownsColumn(cx0, cz0) || !playable.ownsColumn(cx1, cz0) ||
+        !playable.ownsColumn(cx0, cz1) || !playable.ownsColumn(cx1, cz1);
+      if (!anyUnowned) continue; // fully claimed — the playable mesh owns this cell
+
+      const i0 = emitVertex(row, col);
+      const i1 = emitVertex(row, col + 1);
+      const i2 = emitVertex(row + 1, col);
+      const i3 = emitVertex(row + 1, col + 1);
+      pushQuad(indices, i0, i1, i2, i3, row + col);
+    }
+  }
 }
 
 export class LandscapeMesh {
   private readonly scene: THREE.Scene;
   private readonly material: THREE.Material;
   private readonly tileMeshes: THREE.Mesh[] = [];
-  private seamMesh: THREE.Mesh | null = null;
   /** Tiles by grid index, so a vertex on a tile's edge can read its neighbour's samples for a slope. */
   private readonly tileIndex = new Map<string, LandscapeTile>();
 
@@ -203,9 +288,9 @@ export class LandscapeMesh {
     this.material = material;
   }
 
-  /** Total mesh count (tiles + seam, if any) — diagnostics and tests. */
+  /** Total mesh count (one per non-empty tile) — diagnostics and tests. */
   get meshCount(): number {
-    return this.tileMeshes.length + (this.seamMesh ? 1 : 0);
+    return this.tileMeshes.length;
   }
 
   /**
@@ -221,16 +306,13 @@ export class LandscapeMesh {
 
     for (const tile of handle.map.tiles) {
       const mesh = this.buildTileMesh(
-        tile, handle.map.coarseStep, handle.map.samplesPerTile, palette, playable,
+        tile, handle.map.coarseStep, handle.map.samplesPerTile, palette, playable, handle.sampleColumn,
       );
       if (mesh) {
         this.scene.add(mesh);
         this.tileMeshes.push(mesh);
       }
     }
-
-    this.seamMesh = this.buildSeamMesh(playable.rect, handle.sampleColumn, palette);
-    if (this.seamMesh) this.scene.add(this.seamMesh);
   }
 
   dispose(): void {
@@ -240,11 +322,6 @@ export class LandscapeMesh {
     }
     this.tileMeshes.length = 0;
     this.tileIndex.clear();
-    if (this.seamMesh) {
-      this.scene.remove(this.seamMesh);
-      this.seamMesh.geometry.dispose();
-      this.seamMesh = null;
-    }
   }
 
   // ---------- Internal ----------
@@ -276,16 +353,17 @@ export class LandscapeMesh {
   /**
    * Indexed grid mesh from one tile's stored samples, smooth-shaded (#458 A16).
    *
-   * Quads reaching into the playable rect are dropped. A tile spans 512 m
-   * while a playable rect is 32–160 m, so every rect sits deep inside its
-   * tiles — without this the coarse 4 m sheet blankets the whole pit at the
-   * pre-dig surface height and hides everything the voxel mesh does beneath
-   * it, craters included. The seam mesh already bridges from FINE_MARGIN
-   * outside the rect to OVERLAP inside it, so cutting the tiles back to the
-   * rect boundary opens no gap.
+   * A tile spans 512 m while a playable rect is 32–160 m, so every rect sits
+   * deep inside its tiles. Each coarse quad is classified against the live
+   * claim boundary (classifyQuad): 'inside' quads are dropped (the voxel mesh
+   * owns that ground), 'outside' quads are emitted whole exactly as before,
+   * and 'boundary' quads — the single quad-wide ring actually straddling the
+   * claim edge — are subdivided by buildBoundaryQuad instead of a second,
+   * overlapping seam mesh (#491).
    */
   private buildTileMesh(
     tile: LandscapeTile, step: number, n: number, palette: CompositionPalette, playable: PlayableCut,
+    sampleColumn: SampleFn,
   ): THREE.Mesh | null {
     if (tile.heights.length === 0) return null;
 
@@ -297,13 +375,18 @@ export class LandscapeMesh {
       tileMaxX > playable.rect.minX && tile.originX < playable.rect.maxX &&
       tileMaxZ > playable.rect.minZ && tile.originZ < playable.rect.maxZ;
 
-    const positions = new Float32Array(n * n * 3);
-    const normals = new Float32Array(n * n * 3);
-    const rockA = new Float32Array(n * n);
-    const rockB = new Float32Array(n * n);
-    const rockWeight = new Float32Array(n * n); // all zero: single-rock samples (#458 A18)
-    const ore = new Float32Array(n * n * 2); // (id, amt) pairs; landscape never carries ore (#458 A18)
-    for (let i = 0; i < n * n; i++) ore[i * 2] = -1; // id = -1 (none); amt stays 0
+    // Growable, not fixed-size: boundary quads append extra fine-grid
+    // vertices past the tile's own n*n coarse nodes.
+    const positions: number[] = [];
+    const normals: number[] = [];
+    const rockA: number[] = [];
+    const rockB: number[] = [];
+    const rockWeight: number[] = [];
+    const ore: number[] = []; // (id, amt) pairs; landscape never carries ore (#458 A18)
+
+    // Coarse nodes are pushed unconditionally, in row-major order, so index
+    // row*n+col stays valid for every 'outside' quad regardless of which
+    // quads elsewhere in the tile turn out to be 'inside'/'boundary'.
     for (let row = 0; row < n; row++) {
       const z = tile.originZ + row * step;
       for (let col = 0; col < n; col++) {
@@ -311,9 +394,7 @@ export class LandscapeMesh {
         const idx = row * n + col;
         const y = tile.heights[idx]!;
 
-        positions[idx * 3] = x;
-        positions[idx * 3 + 1] = y;
-        positions[idx * 3 + 2] = z;
+        positions.push(x, y, z);
 
         // Central differences over the sample spacing, reaching into the
         // neighbouring tile at a tile edge so the slope — and therefore the
@@ -321,13 +402,13 @@ export class LandscapeMesh {
         const dhdx = (this.nodeHeight(tile, row, col + 1, n) - this.nodeHeight(tile, row, col - 1, n)) / (2 * step);
         const dhdz = (this.nodeHeight(tile, row + 1, col, n) - this.nodeHeight(tile, row - 1, col, n)) / (2 * step);
         const normal = heightFieldNormal(dhdx, dhdz);
-        normals[idx * 3] = normal[0];
-        normals[idx * 3 + 1] = normal[1];
-        normals[idx * 3 + 2] = normal[2];
+        normals.push(normal[0], normal[1], normal[2]);
 
-        const rockIdx = rockIndexFor(palette, tile.surfCompIds[idx]!);
-        rockA[idx] = rockIdx;
-        rockB[idx] = rockIdx;
+        const blend = rockBlendFor(palette, tile.surfCompIds[idx]!);
+        rockA.push(blend.rockA);
+        rockB.push(blend.rockB);
+        rockWeight.push(blend.weight);
+        ore.push(-1, 0); // id = -1 (none); amt stays 0
       }
     }
 
@@ -337,123 +418,20 @@ export class LandscapeMesh {
       for (let col = 0; col < n - 1; col++) {
         if (touchesRect) {
           const x0 = tile.originX + col * step, x1 = x0 + step;
-          // Any corner over claimed ground means this quad overhangs what the
-          // voxel mesh owns — drop the whole quad rather than let it dip in.
-          const reachesIntoSite =
-            playable.ownsColumn(x0, z0) || playable.ownsColumn(x1, z0) ||
-            playable.ownsColumn(x0, z1) || playable.ownsColumn(x1, z1);
-          if (reachesIntoSite) continue;
+          const cls = classifyQuad(playable, x0, z0, x1, z1);
+          if (cls === 'inside') continue;
+          if (cls === 'boundary') {
+            buildBoundaryQuad(
+              positions, normals, rockA, rockB, rockWeight, ore, indices,
+              x0, z0, x1, z1, sampleColumn, palette, playable,
+            );
+            continue;
+          }
         }
         const i0 = row * n + col;
         const i1 = i0 + 1;
         const i2 = i0 + n;
         const i3 = i2 + 1;
-        pushQuad(indices, i0, i1, i2, i3, row + col);
-      }
-    }
-    if (indices.length === 0) return null;
-
-    const geometry = new THREE.BufferGeometry();
-    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-    geometry.setAttribute('aRockA', new THREE.BufferAttribute(rockA, 1));
-    geometry.setAttribute('aRockB', new THREE.BufferAttribute(rockB, 1));
-    geometry.setAttribute('aRockWeight', new THREE.BufferAttribute(rockWeight, 1));
-    geometry.setAttribute('aOre', new THREE.BufferAttribute(ore, 2));
-    geometry.setAttribute('normal', new THREE.BufferAttribute(normals, 3));
-    geometry.setIndex(indices);
-    geometry.computeBoundingSphere();
-
-    const mesh = new THREE.Mesh(geometry, this.material);
-    mesh.frustumCulled = true;
-    mesh.castShadow = true;
-    mesh.receiveShadow = true;
-    return mesh;
-  }
-
-  /**
-   * Fine (1m) band from FINE_MARGIN outside the playable rect to OVERLAP
-   * inside it, sampled directly since the stored tiles don't have this
-   * resolution. Quads whose every corner sits more than OVERLAP inside the
-   * rect are skipped — the playable mesh owns that ground.
-   */
-  private buildSeamMesh(rect: Rect, sampleColumn: SampleFn, palette: CompositionPalette): THREE.Mesh | null {
-    const outerMinX = rect.minX - FINE_MARGIN;
-    const outerMinZ = rect.minZ - FINE_MARGIN;
-    const cols = Math.round((rect.maxX + FINE_MARGIN - outerMinX) / FINE_STEP) + 1;
-    const rows = Math.round((rect.maxZ + FINE_MARGIN - outerMinZ) / FINE_STEP) + 1;
-
-    const positions: number[] = [];
-    const normals: number[] = [];
-    const rockA: number[] = [];
-    const rockB: number[] = [];
-    const rockWeight: number[] = [];
-    const ore: number[] = [];
-    const indices: number[] = [];
-    const vertexIndex = new Map<number, number>();
-
-    const worldX = (col: number) => outerMinX + col * FINE_STEP;
-    const worldZ = (row: number) => outerMinZ + row * FINE_STEP;
-
-    // Slopes need the neighbouring nodes' heights, and every node is a
-    // neighbour of four others — sampling each one once and reusing it keeps
-    // this to barely more than one sample per vertex.
-    const heightCache = new Map<number, number>();
-    const heightAtNode = (row: number, col: number): number => {
-      const key = (row + 1) * (cols + 2) + (col + 1);
-      const cached = heightCache.get(key);
-      if (cached !== undefined) return cached;
-      const h = sampleColumn(worldX(col), worldZ(row)).height;
-      heightCache.set(key, h);
-      return h;
-    };
-
-    const emitVertex = (row: number, col: number): number => {
-      const key = row * cols + col;
-      const existing = vertexIndex.get(key);
-      if (existing !== undefined) return existing;
-
-      const x = worldX(col), z = worldZ(row);
-      const sample = sampleColumn(x, z);
-      heightCache.set((row + 1) * (cols + 2) + (col + 1), sample.height);
-      const insideDepth = distanceInsideRect(rect, x, z);
-      const y = seamHeightAt(sample.height, insideDepth);
-
-      // From the sampled height field, not from the dropped seam height: the
-      // OVERLAP_DROP step is a depth-fighting trick, not a slope, and shading
-      // it as one would ring the site with a bright line.
-      const dhdx = (heightAtNode(row, col + 1) - heightAtNode(row, col - 1)) / (2 * FINE_STEP);
-      const dhdz = (heightAtNode(row + 1, col) - heightAtNode(row - 1, col)) / (2 * FINE_STEP);
-      const normal = heightFieldNormal(dhdx, dhdz);
-
-      const idx = positions.length / 3;
-      positions.push(x, y, z);
-      normals.push(normal[0], normal[1], normal[2]);
-      // Single-rock sample: both shader rock slots are the same index, blend
-      // weight 0, no ore data tracked by LandscapeMap (#458 A18).
-      const rockIdx = rockIndexFor(palette, sample.surfCompId);
-      rockA.push(rockIdx);
-      rockB.push(rockIdx);
-      rockWeight.push(0);
-      ore.push(-1, 0);
-      vertexIndex.set(key, idx);
-      return idx;
-    };
-
-    for (let row = 0; row < rows - 1; row++) {
-      const z0 = worldZ(row), z1 = worldZ(row + 1);
-      for (let col = 0; col < cols - 1; col++) {
-        const x0 = worldX(col), x1 = worldX(col + 1);
-        const allDeepInside =
-          distanceInsideRect(rect, x0, z0) > OVERLAP &&
-          distanceInsideRect(rect, x1, z0) > OVERLAP &&
-          distanceInsideRect(rect, x0, z1) > OVERLAP &&
-          distanceInsideRect(rect, x1, z1) > OVERLAP;
-        if (allDeepInside) continue; // playable mesh already covers this ground
-
-        const i0 = emitVertex(row, col);
-        const i1 = emitVertex(row, col + 1);
-        const i2 = emitVertex(row + 1, col);
-        const i3 = emitVertex(row + 1, col + 1);
         pushQuad(indices, i0, i1, i2, i3, row + col);
       }
     }

--- a/src/renderer/terrain/LandscapeMesh.ts
+++ b/src/renderer/terrain/LandscapeMesh.ts
@@ -74,21 +74,6 @@ function distanceInsideRect(rect: Rect, x: number, z: number): number {
 }
 
 /**
- * Where the playable mesh's surface actually sits for a column of this height.
- *
- * Identity, and that is the point. The playable grid used to fill voxels solid
- * up to a rounded surface, which put its iso-surface half a voxel below the
- * first air cell and left the landscape floating up to a metre above it; the
- * landscape had to quantize the same way to meet it. Generation now writes a
- * fractional density through the surface band (TerrainGen's surfaceDensityAt),
- * so marching cubes reproduces the continuous height exactly and both
- * representations read the same number with no correction at all (#458).
- */
-export function voxelSurfaceHeight(continuousHeight: number): number {
-  return continuousHeight;
-}
-
-/**
  * The ground the playable mesh owns, which the landscape must not overlap.
  *
  * `rect` is the site's live bounding box, and `ownsColumn` its actual claimed

--- a/src/renderer/terrain/LandscapeMesh.ts
+++ b/src/renderer/terrain/LandscapeMesh.ts
@@ -124,11 +124,69 @@ function rockIndexFor(palette: CompositionPalette, surfCompId: number): number {
 export interface PlayableCut {
   rect: Rect;
   ownsColumn(x: number, z: number): boolean;
+  /** Live surface height at (x, z), when known — used at the claim boundary
+   *  so the landscape's edge matches whatever the playable mesh currently
+   *  renders there. Falls back to the theoretical WorldGen height when absent. */
+  boundaryHeightAt?(x: number, z: number): number;
 }
 
 /** The pre-expansion behaviour: the site is exactly its rect. */
 function rectCut(rect: Rect): PlayableCut {
   return { rect, ownsColumn: (x, z) => distanceInsideRect(rect, x, z) > 0 };
+}
+
+/**
+ * Two-rock blend for one sample, replacing rockIndexFor's collapse to a
+ * single dominant index. `rockA`/`rockB` are shader rock-catalog indices;
+ * `weight` is the blend fraction toward `rockB` (0 = pure rockA).
+ *
+ * TODO: implement — read the top two coefficients out of the composition
+ * at surfCompId instead of only the dominant one.
+ */
+export function rockBlendFor(_palette: CompositionPalette, _surfCompId: number): { rockA: number; rockB: number; weight: number } {
+  // TODO: implement
+  return { rockA: 0, rockB: 0, weight: 0 };
+}
+
+/**
+ * Classifies one coarse-tile quad (given by its two opposite corners)
+ * against the live claim boundary: fully outside the playable rect (kept
+ * as-is), fully inside it (dropped — the voxel mesh owns that ground), or
+ * straddling the boundary (needs clipping/subdivision via buildBoundaryQuad
+ * instead of being emitted whole).
+ *
+ * TODO: implement — replace buildTileMesh's current binary
+ * drop-if-any-corner-inside test with this three-way classification.
+ */
+export function classifyQuad(_playable: PlayableCut, _x0: number, _z0: number, _x1: number, _z1: number): 'outside' | 'inside' | 'boundary' {
+  // TODO: implement
+  return 'outside';
+}
+
+/**
+ * Emits the clipped/subdivided geometry for one boundary quad (a coarse-tile
+ * quad classifyQuad marked 'boundary') into the given output arrays, sampled
+ * at fine resolution against the live claim edge so it meets the playable
+ * mesh with no overlap and no gap.
+ *
+ * TODO: implement — replace the fixed OVERLAP/OVERLAP_DROP seam-mesh
+ * strategy for this quad with an exact clip against `playable.ownsColumn`
+ * (and `playable.boundaryHeightAt` where available).
+ */
+export function buildBoundaryQuad(
+  _positions: number[],
+  _normals: number[],
+  _rockA: number[],
+  _rockB: number[],
+  _rockWeight: number[],
+  _ore: number[],
+  _indices: number[],
+  _x0: number, _z0: number, _x1: number, _z1: number,
+  _sampleColumn: SampleFn,
+  _palette: CompositionPalette,
+  _playable: PlayableCut,
+): void {
+  // TODO: implement
 }
 
 export class LandscapeMesh {

--- a/tests/unit/renderer/LandscapeMesh.test.ts
+++ b/tests/unit/renderer/LandscapeMesh.test.ts
@@ -4,7 +4,15 @@ import { CompositionPalette } from '../../../src/core/world/VoxelGrid.js';
 import type { LandscapeMap, LandscapeTile } from '../../../src/core/world/LandscapeMap.js';
 import type { Rect } from '../../../src/core/world/WorldGen.js';
 import type { LandscapeHandle } from '../../../src/console/commands/world.js';
-import { LandscapeMesh, seamHeightAt, voxelSurfaceHeight } from '../../../src/renderer/terrain/LandscapeMesh.js';
+import {
+  LandscapeMesh,
+  rockBlendFor,
+  classifyQuad,
+  buildBoundaryQuad,
+  type PlayableCut,
+} from '../../../src/renderer/terrain/LandscapeMesh.js';
+import { rockIndexOf } from '../../../src/core/world/RockCatalog.js';
+import { getAllBiomes } from '../../../src/core/world/BiomeCatalog.js';
 
 function makeScene(): THREE.Scene {
   return new THREE.Scene();
@@ -45,7 +53,7 @@ function makeFakeHandle(
 }
 
 describe('LandscapeMesh', () => {
-  it('builds one Mesh per non-empty tile plus a seam mesh, all added to the scene', () => {
+  it('builds one Mesh per non-empty tile, with no separate seam mesh (#491)', () => {
     const scene = makeScene();
     const { palette, compId } = makePalette();
     const rect: Rect = { minX: 0, minZ: 0, maxX: 32, maxZ: 32 };
@@ -59,8 +67,8 @@ describe('LandscapeMesh', () => {
     const lm = new LandscapeMesh(scene, makeMaterial());
     lm.build(handle, palette);
 
-    expect(lm.meshCount).toBe(3); // 2 tiles + 1 seam
-    expect(scene.children.length).toBe(3);
+    expect(lm.meshCount).toBe(2); // 2 tiles, no seam mesh (#491 removes the seam design)
+    expect(scene.children.length).toBe(2);
     lm.dispose();
   });
 
@@ -74,7 +82,8 @@ describe('LandscapeMesh', () => {
     const lm = new LandscapeMesh(scene, makeMaterial());
     lm.build(handle, palette);
 
-    expect(lm.meshCount).toBe(1); // seam mesh only
+    expect(lm.meshCount).toBe(0); // no tile geometry, and no seam mesh to fall back on (#491)
+    expect(scene.children.length).toBe(0);
     lm.dispose();
   });
 
@@ -119,7 +128,7 @@ describe('LandscapeMesh', () => {
     lm.dispose();
   });
 
-  it('tile and seam meshes cast and receive shadows (#458 T5.1/CSM)', () => {
+  it('tile meshes cast and receive shadows (#458 T5.1/CSM)', () => {
     const scene = makeScene();
     const { palette, compId } = makePalette();
     const rect: Rect = { minX: 0, minZ: 0, maxX: 32, maxZ: 32 };
@@ -171,7 +180,7 @@ describe('LandscapeMesh', () => {
     lm.dispose();
   });
 
-  describe('tile meshes never cover the playable rect', () => {
+  describe('tile meshes never fully cover the playable claim', () => {
     // A tile spans 512m while a playable rect is 32-160m, so every rect sits
     // deep inside its tiles. Before this exclusion the coarse 4m sheet was
     // emitted straight across the pit at the pre-dig surface height, hiding
@@ -202,7 +211,12 @@ describe('LandscapeMesh', () => {
       return { tile: makeFakeTile(-100, -100, 40, compId), n: 40 };
     }
 
-    it('emits no triangle that reaches inside the playable rect', () => {
+    it('never emits a vertex more than one coarse step inside the claim (fine subdivision stays within its own boundary quad)', () => {
+      // Under the fixed design a coarse quad classified 'inside' (every corner
+      // owned) is dropped whole, but a 'boundary' quad's fine subdivision keeps
+      // any fine cell with at least one unowned corner — so geometry can still
+      // reach up to one coarse-tile step (4m, the default coarseStep here) past
+      // the claim edge, never further.
       const scene = makeScene();
       const { palette, compId } = makePalette();
       const { tile, n } = tileCoveringRect(compId);
@@ -218,7 +232,7 @@ describe('LandscapeMesh', () => {
 
       for (const tri of triangles(tileMesh)) {
         for (const [x, z] of tri) {
-          expect(insideDepth(x, z)).toBeLessThanOrEqual(0);
+          expect(insideDepth(x, z)).toBeLessThanOrEqual(4 + 1e-6);
         }
       }
       lm.dispose();
@@ -259,7 +273,7 @@ describe('LandscapeMesh', () => {
       lm.dispose();
     });
 
-    it('drops the tile entirely when every one of its quads is inside the rect', () => {
+    it('drops the tile entirely when every one of its quads is inside the rect (no double coverage of the claim)', () => {
       const scene = makeScene();
       const { palette, compId } = makePalette();
       const big: Rect = { minX: -1000, minZ: -1000, maxX: 1000, maxZ: 1000 };
@@ -277,126 +291,290 @@ describe('LandscapeMesh', () => {
     });
   });
 
-  describe('seam mesh (#458 A16 anti-gap overlap)', () => {
-    it('locks seam height to the playable mesh at the rect edge, easing out to the true height', () => {
-      // The two representations quantize differently: the landscape samples a
-      // continuous height, while the voxel grid rounds to a voxel and marching
-      // cubes lands the iso-surface half a voxel below the first air cell.
-      // Left alone the seam floats up to a metre above the playable mesh — a
-      // lip right round the site.
+  describe('no landscape vertex sits above the sampled height field (#491)', () => {
+    it('every emitted vertex matches a linear ground-truth field exactly, at every (x,z) it emits (interior and flat-edge nodes both interpolate exactly for a linear field)', () => {
       const scene = makeScene();
       const { palette, compId } = makePalette();
-      const rect: Rect = { minX: 0, minZ: 0, maxX: 32, maxZ: 32 };
-      // A flat, deliberately non-integer height isolates the quantization.
-      const H = 50.4;
-      const handle = makeFakeHandle(rect, [], 4, compId, () => ({ height: H, biomeId: 0, surfCompId: compId }));
-
-      const lm = new LandscapeMesh(scene, makeMaterial());
-      lm.build(handle, palette);
-
-      const seamMesh = scene.children[0] as THREE.Mesh;
-      const positions = seamMesh.geometry.getAttribute('position').array as Float32Array;
-      const matched = voxelSurfaceHeight(H); // the playable mesh's own surface — now the same 50.4
-
-      let sawInside = false, sawFarOutside = false;
-      for (let i = 0; i < positions.length; i += 3) {
-        const x = positions[i]!, y = positions[i + 1]!, z = positions[i + 2]!;
-        const dx = Math.min(x - rect.minX, rect.maxX - x);
-        const dz = Math.min(z - rect.minZ, rect.maxZ - z);
-        const insideDepth = Math.min(dx, dz);
-
-        if (insideDepth > 0) {
-          // Inside the rect: sits on the playable surface, dropped clear of it.
-          expect(y).toBeCloseTo(matched - 0.15, 5);
-          sawInside = true;
-        } else if (insideDepth <= -24) {
-          // A full margin out: back to the smooth continuous height.
-          expect(y).toBeCloseTo(H, 5);
-          sawFarOutside = true;
+      const field = (x: number, z: number) => 10 + 0.5 * x + 0.3 * z;
+      const rect: Rect = { minX: 0, minZ: 0, maxX: 20, maxZ: 20 };
+      const n = 9;
+      const tile = makeFakeTile(-20, -20, n, compId);
+      for (let row = 0; row < n; row++) {
+        for (let col = 0; col < n; col++) {
+          const x = tile.originX + col * 4; // default coarseStep in makeFakeHandle
+          const z = tile.originZ + row * 4;
+          tile.heights[row * n + col] = field(x, z);
         }
-        // Everywhere between is a blend, always within the two bounds.
-        // Positions round-trip through Float32, so allow a float32 ulp.
-        expect(y).toBeGreaterThanOrEqual(matched - 0.15 - 1e-4);
-        expect(y).toBeLessThanOrEqual(H + 1e-4);
       }
-      expect(sawInside).toBe(true);
-      expect(sawFarOutside).toBe(true);
-      lm.dispose();
-    });
-
-    it('seamHeightAt meets the voxel surface exactly at the boundary', () => {
-      for (const h of [50.4, 50.5, 49.9, 12.0, 7.25]) {
-        expect(seamHeightAt(h, 0)).toBeCloseTo(voxelSurfaceHeight(h), 6);
-      }
-    });
-
-    it('never emits a vertex more than OVERLAP + one grid step inside the playable rect', () => {
-      // A quad is included if ANY of its 4 corners is within OVERLAP — so an
-      // included quad's deepest corner can be up to OVERLAP + FINE_STEP in
-      // the worst case (the quantization slack of a discrete grid, not a
-      // bug: the playable mesh already fully covers that ground regardless).
-      const scene = makeScene();
-      const { palette, compId } = makePalette();
-      const rect: Rect = { minX: 0, minZ: 0, maxX: 32, maxZ: 32 };
-      const handle = makeFakeHandle(rect, [], 4, compId, () => ({ height: 50, biomeId: 0, surfCompId: compId }));
+      const handle = makeFakeHandle(rect, [tile], n, compId, (x, z) => ({ height: field(x, z), biomeId: 0, surfCompId: compId }));
 
       const lm = new LandscapeMesh(scene, makeMaterial());
       lm.build(handle, palette);
+      expect(scene.children.length).toBeGreaterThan(0);
 
-      const seamMesh = scene.children[0] as THREE.Mesh;
-      const positions = seamMesh.geometry.getAttribute('position').array as Float32Array;
-      for (let i = 0; i < positions.length; i += 3) {
-        const x = positions[i]!, z = positions[i + 2]!;
-        const dx = Math.min(x - rect.minX, rect.maxX - x);
-        const dz = Math.min(z - rect.minZ, rect.maxZ - z);
-        const insideDepth = Math.min(dx, dz);
-        expect(insideDepth).toBeLessThanOrEqual(2 + 1 + 1e-9);
+      for (const child of scene.children) {
+        const mesh = child as THREE.Mesh;
+        const pos = mesh.geometry.getAttribute('position').array as Float32Array;
+        for (let i = 0; i < pos.length; i += 3) {
+          const x = pos[i]!, y = pos[i + 1]!, z = pos[i + 2]!;
+          expect(y).toBeCloseTo(field(x, z), 4);
+        }
       }
       lm.dispose();
     });
+  });
 
-    it('reaches at least FINE_MARGIN (24m) outside the playable rect', () => {
-      const scene = makeScene();
+  describe('pit/landscape junction continuity via PlayableCut.boundaryHeightAt (#491)', () => {
+    function makeJunctionHandle(theoreticalHeight: number) {
       const { palette, compId } = makePalette();
-      const rect: Rect = { minX: 0, minZ: 0, maxX: 32, maxZ: 32 };
-      const handle = makeFakeHandle(rect, [], 4, compId, () => ({ height: 50, biomeId: 0, surfCompId: compId }));
+      const n = 9;
+      const tile = makeFakeTile(0, -1000, n, compId, theoreticalHeight);
+      const rect: Rect = { minX: 16, minZ: -1000, maxX: 1000, maxZ: 1000 };
+      const handle = makeFakeHandle(rect, [tile], n, compId, () => ({ height: theoreticalHeight, biomeId: 0, surfCompId: compId }));
+      return { handle, palette, rect };
+    }
+
+    /** Height of the emitted vertex nearest the claim edge (largest x still < 16). */
+    function closestUnownedVertexHeight(scene: THREE.Scene): number {
+      let bestX = -Infinity;
+      let bestY = NaN;
+      for (const child of scene.children) {
+        const mesh = child as THREE.Mesh;
+        const pos = mesh.geometry.getAttribute('position')?.array as Float32Array | undefined;
+        if (!pos) continue;
+        for (let i = 0; i < pos.length; i += 3) {
+          const x = pos[i]!;
+          if (x < 16 && x > bestX) { bestX = x; bestY = pos[i + 1]!; }
+        }
+      }
+      return bestY;
+    }
+
+    it('before a blast: boundary nodes track the live pre-dig height supplied by boundaryHeightAt', () => {
+      const scene = makeScene();
+      const { handle, palette, rect } = makeJunctionHandle(50);
+      const playable: PlayableCut = { rect, ownsColumn: (x) => x >= 16, boundaryHeightAt: () => 50 };
 
       const lm = new LandscapeMesh(scene, makeMaterial());
-      lm.build(handle, palette);
-
-      const seamMesh = scene.children[0] as THREE.Mesh;
-      const positions = seamMesh.geometry.getAttribute('position').array as Float32Array;
-      let minX = Infinity, maxX = -Infinity;
-      for (let i = 0; i < positions.length; i += 3) {
-        minX = Math.min(minX, positions[i]!);
-        maxX = Math.max(maxX, positions[i]!);
-      }
-      expect(minX).toBeLessThanOrEqual(rect.minX - 24);
-      expect(maxX).toBeGreaterThanOrEqual(rect.maxX + 24);
+      lm.build(handle, palette, playable);
+      expect(closestUnownedVertexHeight(scene)).toBeCloseTo(50, 1);
       lm.dispose();
     });
 
-    it('is deterministic for the same handle and palette', () => {
-      const { palette, compId } = makePalette();
-      const rect: Rect = { minX: 0, minZ: 0, maxX: 32, maxZ: 32 };
-      const handle = makeFakeHandle(rect, [], 4, compId);
+    it('after a blast: boundary nodes track the lower live height, not the stale WorldGen height (#491)', () => {
+      const scene = makeScene();
+      const { handle, palette, rect } = makeJunctionHandle(50); // sampleColumn/WorldGen still reports the theoretical pre-dig 50
+      const playable: PlayableCut = { rect, ownsColumn: (x) => x >= 16, boundaryHeightAt: () => 44 }; // TerrainMesh currently renders a dug crater at 44
 
-      const sceneA = makeScene();
-      const lmA = new LandscapeMesh(sceneA, makeMaterial());
-      lmA.build(handle, palette);
-      const meshA = sceneA.children[0] as THREE.Mesh; // only the seam mesh — tiles is []
-
-      const sceneB = makeScene();
-      const lmB = new LandscapeMesh(sceneB, makeMaterial());
-      lmB.build(handle, palette);
-      const meshB = sceneB.children[0] as THREE.Mesh;
-
-      expect(Array.from(meshA.geometry.getAttribute('position').array))
-        .toEqual(Array.from(meshB.geometry.getAttribute('position').array));
-
-      lmA.dispose();
-      lmB.dispose();
+      const lm = new LandscapeMesh(scene, makeMaterial());
+      lm.build(handle, palette, playable);
+      const y = closestUnownedVertexHeight(scene);
+      expect(y).toBeCloseTo(44, 1);
+      expect(Math.abs(y - 50)).toBeGreaterThan(2); // must not have fallen back to the theoretical height
+      lm.dispose();
     });
+  });
+});
+
+describe('rockBlendFor (#491)', () => {
+  it('single-rock composition: weight 0, rockA === rockB, matching the dominant rock index', () => {
+    const palette = new CompositionPalette();
+    const compId = palette.intern({ rocks: [{ rockId: 'cruite', coefficient: 1 }] });
+
+    const result = rockBlendFor(palette, compId);
+    expect(result.rockA).toBe(result.rockB);
+    expect(result.weight).toBe(0);
+    expect(result.rockA).toBe(Math.max(0, rockIndexOf('cruite')));
+  });
+
+  it('two-rock composition: dominant sorts to rockA, runner-up to rockB, weight is the runner-up fraction', () => {
+    const palette = new CompositionPalette();
+    const compId = palette.intern({ rocks: [{ rockId: 'sandite', coefficient: 0.65 }, { rockId: 'molite', coefficient: 0.35 }] });
+
+    const result = rockBlendFor(palette, compId);
+    expect(result.rockA).toBe(Math.max(0, rockIndexOf('sandite')));
+    expect(result.rockB).toBe(Math.max(0, rockIndexOf('molite')));
+    expect(result.weight).toBeCloseTo(0.35, 5);
+  });
+
+  it('sorts by coefficient magnitude, not input array order', () => {
+    const palette = new CompositionPalette();
+    // Deliberately entered with the smaller coefficient first — the palette
+    // itself re-sorts entries by rockId, not coefficient, so rockBlendFor must
+    // do its own magnitude sort rather than trusting array order.
+    const compId = palette.intern({ rocks: [{ rockId: 'molite', coefficient: 0.2 }, { rockId: 'sandite', coefficient: 0.8 }] });
+
+    const result = rockBlendFor(palette, compId);
+    expect(result.rockA).toBe(Math.max(0, rockIndexOf('sandite')));
+    expect(result.rockB).toBe(Math.max(0, rockIndexOf('molite')));
+    expect(result.weight).toBeCloseTo(0.2, 5);
+  });
+
+  it('air composition (palette index 0) resolves without throwing, weight 0', () => {
+    const palette = new CompositionPalette();
+    expect(() => rockBlendFor(palette, 0)).not.toThrow();
+    const result = rockBlendFor(palette, 0);
+    expect(result.weight).toBe(0);
+    expect(result.rockA).toBe(result.rockB);
+  });
+});
+
+describe('classifyQuad (#491)', () => {
+  function cut(owns: (x: number, z: number) => boolean): PlayableCut {
+    return { rect: { minX: 0, minZ: 0, maxX: 100, maxZ: 100 }, ownsColumn: owns };
+  }
+
+  it('outside: all four corners unowned', () => {
+    const playable = cut(() => false);
+    expect(classifyQuad(playable, 0, 0, 4, 4)).toBe('outside');
+  });
+
+  it('inside: all four corners owned', () => {
+    const playable = cut(() => true);
+    expect(classifyQuad(playable, 0, 0, 4, 4)).toBe('inside');
+  });
+
+  it('boundary: exactly one corner owned', () => {
+    const playable = cut((x, z) => x === 4 && z === 4);
+    expect(classifyQuad(playable, 0, 0, 4, 4)).toBe('boundary');
+  });
+
+  it('boundary: exactly three corners owned', () => {
+    const playable = cut((x, z) => !(x === 0 && z === 0));
+    expect(classifyQuad(playable, 0, 0, 4, 4)).toBe('boundary');
+  });
+
+  it('boundary: one full side owned (two adjacent corners)', () => {
+    const playable = cut((x) => x === 4);
+    expect(classifyQuad(playable, 0, 0, 4, 4)).toBe('boundary');
+  });
+
+  it('boundary: two diagonally-opposite corners owned', () => {
+    const playable = cut((x, z) => (x === 0 && z === 0) || (x === 4 && z === 4));
+    expect(classifyQuad(playable, 0, 0, 4, 4)).toBe('boundary');
+  });
+});
+
+describe('buildBoundaryQuad (#491)', () => {
+  const SUBDIV = 4; // documented fine-cell subdivision factor for a boundary quad
+
+  /** Deliberately non-linear in x: a flat-edge interpolation reads measurably different from the true sampled height. */
+  function makeSample(compId: number) {
+    return (x: number, z: number) => ({ height: x * x + z, biomeId: 0, surfCompId: compId });
+  }
+
+  function run(playable: PlayableCut, palette: CompositionPalette, compId: number) {
+    const positions: number[] = [];
+    const normals: number[] = [];
+    const rockA: number[] = [];
+    const rockB: number[] = [];
+    const rockWeight: number[] = [];
+    const ore: number[] = [];
+    const indices: number[] = [];
+    buildBoundaryQuad(
+      positions, normals, rockA, rockB, rockWeight, ore, indices,
+      0, 0, 4, 4,
+      makeSample(compId), palette, playable,
+    );
+    return { positions, normals, rockA, rockB, rockWeight, ore, indices };
+  }
+
+  function verticesAt(positions: number[], normals: number[], x: number, z: number) {
+    const out: { y: number; nx: number; ny: number; nz: number }[] = [];
+    for (let i = 0; i < positions.length; i += 3) {
+      if (Math.abs(positions[i]! - x) < 1e-6 && Math.abs(positions[i + 2]! - z) < 1e-6) {
+        out.push({ y: positions[i + 1]!, nx: normals[i]!, ny: normals[i + 1]!, nz: normals[i + 2]! });
+      }
+    }
+    return out;
+  }
+
+  function heightsAt(positions: number[], x: number, z: number): number[] {
+    const out: number[] = [];
+    for (let i = 0; i < positions.length; i += 3) {
+      if (Math.abs(positions[i]! - x) < 1e-6 && Math.abs(positions[i + 2]! - z) < 1e-6) out.push(positions[i + 1]!);
+    }
+    return out;
+  }
+
+  it('emits geometry for a boundary quad (coherent triangle list, non-empty)', () => {
+    const { palette, compId } = makePalette();
+    const playable: PlayableCut = { rect: { minX: 2, minZ: -100, maxX: 100, maxZ: 100 }, ownsColumn: (x) => x >= 2 };
+
+    const { indices, positions } = run(playable, palette, compId);
+    expect(indices.length).toBeGreaterThan(0);
+    expect(indices.length % 3).toBe(0);
+    expect(positions.length / 3).toBeGreaterThan(0);
+  });
+
+  it("flat-edge rule: nodes on a parent side interpolate linearly between that side's two coarse corners, not the true sampled height", () => {
+    const { palette, compId } = makePalette();
+    // Whole quad outside the claim so every fine cell survives — isolates the
+    // flat-edge behaviour from the keep/drop rule.
+    const playable: PlayableCut = { rect: { minX: 1000, minZ: 1000, maxX: 2000, maxZ: 2000 }, ownsColumn: () => false };
+    const { positions } = run(playable, palette, compId);
+
+    const sample = makeSample(compId);
+    const h00 = sample(0, 0).height; // 0
+    const h40 = sample(4, 0).height; // 16
+    const expectedEdge = h00 + (2 / 4) * (h40 - h00); // 8, linear interpolation
+    const trueSampled = sample(2, 0).height; // 4
+    expect(expectedEdge).not.toBeCloseTo(trueSampled, 3); // the field really is non-linear here
+
+    const edgeHeights = heightsAt(positions, 2, 0);
+    expect(edgeHeights.length).toBeGreaterThan(0);
+    for (const h of edgeHeights) expect(h).toBeCloseTo(expectedEdge, 4);
+  });
+
+  it('interior nodes get the true sampled height and a height-field normal (not a flat-edge interpolation)', () => {
+    const { palette, compId } = makePalette();
+    const playable: PlayableCut = { rect: { minX: 1000, minZ: 1000, maxX: 2000, maxZ: 2000 }, ownsColumn: () => false };
+    const { positions, normals } = run(playable, palette, compId);
+
+    const sample = makeSample(compId);
+    const trueSampled = sample(2, 2).height; // interior node (2,2) => 4 + 2 = 6
+    const verts = verticesAt(positions, normals, 2, 2);
+    expect(verts.length).toBeGreaterThan(0);
+
+    // Analytic gradient of height = x^2 + z at (2, 2): dhdx = 2x = 4, dhdz = 1.
+    const dhdx = 4, dhdz = 1;
+    const len = Math.hypot(dhdx, 1, dhdz);
+    for (const v of verts) {
+      expect(v.y).toBeCloseTo(trueSampled, 4);
+      expect(v.nx).toBeCloseTo(-dhdx / len, 3);
+      expect(v.ny).toBeCloseTo(1 / len, 3);
+      expect(v.nz).toBeCloseTo(-dhdz / len, 3);
+    }
+  });
+
+  it('keeps a fine cell only when at least one of its four corners is unowned', () => {
+    const { palette, compId } = makePalette();
+    // Top-right quadrant (x>=2 && z>=2) is owned by the claim — exactly the 4
+    // innermost fine cells (of SUBDIV*SUBDIV=16) have every corner owned and
+    // must be dropped; the other 12 keep at least one unowned corner.
+    const playable: PlayableCut = {
+      rect: { minX: 2, minZ: 2, maxX: 100, maxZ: 100 },
+      ownsColumn: (x, z) => x >= 2 && z >= 2,
+    };
+    const { indices } = run(playable, palette, compId);
+    const totalCells = SUBDIV * SUBDIV;
+    const fullyOwnedCells = 4;
+    const keptCells = totalCells - fullyOwnedCells;
+    expect(indices.length).toBe(keptCells * 6); // 2 triangles (6 indices) per kept cell
+  });
+
+  it('array lengths stay coherent: one rockA/rockB/rockWeight per vertex, two entries per vertex in ore', () => {
+    const { palette, compId } = makePalette();
+    const playable: PlayableCut = { rect: { minX: 1000, minZ: 1000, maxX: 2000, maxZ: 2000 }, ownsColumn: () => false };
+    const { positions, normals, rockA, rockB, rockWeight, ore } = run(playable, palette, compId);
+
+    const vertexCount = positions.length / 3;
+    expect(vertexCount).toBeGreaterThan(0);
+    expect(normals.length).toBe(positions.length);
+    expect(rockA.length).toBe(vertexCount);
+    expect(rockB.length).toBe(vertexCount);
+    expect(rockWeight.length).toBe(vertexCount);
+    expect(ore.length).toBe(vertexCount * 2);
   });
 });
 
@@ -487,6 +665,11 @@ describe('LandscapeMesh — normals come from the height field, not the triangle
     ) as THREE.Mesh[];
     expect(tileMeshes).toHaveLength(2);
 
+    const positionAt = (mesh: THREE.Mesh, row: number, col: number) => {
+      const a = mesh.geometry.getAttribute('position').array as Float32Array;
+      const i = (row * n + col) * 3;
+      return [a[i]!, a[i + 1]!, a[i + 2]!] as const;
+    };
     const normalAt = (mesh: THREE.Mesh, row: number, col: number) => {
       const a = mesh.geometry.getAttribute('normal').array as Float32Array;
       const i = (row * n + col) * 3;
@@ -499,7 +682,13 @@ describe('LandscapeMesh — normals come from the height field, not the triangle
     const dhdz = (field(edgeX, -1000 + (row + 1) * step) - field(edgeX, -1000 + (row - 1) * step)) / (2 * step);
     const len = Math.hypot(dhdx, 1, dhdz);
 
-    // Tile A's last column and tile B's first are the same world position.
+    // Tile A's last column and tile B's first are the same world position:
+    // exact position match (#491 regression) and exact normal match.
+    const [posA, posB] = [positionAt(tileMeshes[0]!, row, n - 1), positionAt(tileMeshes[1]!, row, 0)];
+    expect(posB[0]).toBeCloseTo(posA[0], 6);
+    expect(posB[1]).toBeCloseTo(posA[1], 6);
+    expect(posB[2]).toBeCloseTo(posA[2], 6);
+
     for (const [mesh, col] of [[tileMeshes[0]!, n - 1], [tileMeshes[1]!, 0]] as const) {
       const nrm = normalAt(mesh, row, col);
       expect(nrm[0]).toBeCloseTo(-dhdx / len, 5);
@@ -507,26 +696,47 @@ describe('LandscapeMesh — normals come from the height field, not the triangle
     }
     lm.dispose();
   });
+});
 
-  it('the seam mesh is shaded from the sampled height field too', () => {
-    const scene = makeScene();
-    const { palette, compId } = makePalette();
-    const rect: Rect = { minX: 0, minZ: 0, maxX: 32, maxZ: 32 };
-    // A slope steep enough that a wrong normal is unmistakable.
-    const sample = (x: number, z: number) => ({ height: 20 + x * 0.25 - z * 0.1, biomeId: 0, surfCompId: compId });
-    const handle = makeFakeHandle(rect, [], 4, compId, sample);
+describe('LandscapeMesh — per-biome coverage (#491)', () => {
+  for (const biome of getAllBiomes()) {
+    it(`${biome.id}: build() produces a continuous, blended surface with no double coverage of the claim`, () => {
+      const scene = makeScene();
+      const palette = new CompositionPalette();
+      const [primary, secondary] = biome.dominantRocks;
+      const compId = palette.intern({
+        rocks: secondary
+          ? [{ rockId: primary!, coefficient: 0.7 }, { rockId: secondary, coefficient: 0.3 }]
+          : [{ rockId: primary!, coefficient: 1 }],
+      });
+      const n = 6;
+      const rect: Rect = { minX: 0, minZ: 0, maxX: 20, maxZ: 20 };
+      const tile = makeFakeTile(-40, -40, n, compId, 12);
+      const handle = makeFakeHandle(rect, [tile], n, compId);
 
-    const lm = new LandscapeMesh(scene, makeMaterial());
-    lm.build(handle, palette);
-    const seam = scene.children[0] as THREE.Mesh;
-    const normals = seam.geometry.getAttribute('normal').array as Float32Array;
+      const lm = new LandscapeMesh(scene, makeMaterial());
+      lm.build(handle, palette);
 
-    const len = Math.hypot(0.25, 1, -0.1);
-    for (let i = 0; i < normals.length; i += 3) {
-      expect(normals[i]!).toBeCloseTo(-0.25 / len, 4);
-      expect(normals[i + 1]!).toBeCloseTo(1 / len, 4);
-      expect(normals[i + 2]!).toBeCloseTo(0.1 / len, 4);
-    }
-    lm.dispose();
-  });
+      expect(lm.meshCount).toBe(1);
+      const mesh = scene.children[0] as THREE.Mesh;
+      const geo = mesh.geometry;
+      const rockAArr = geo.getAttribute('aRockA').array as Float32Array;
+      const rockBArr = geo.getAttribute('aRockB').array as Float32Array;
+      const weightArr = geo.getAttribute('aRockWeight').array as Float32Array;
+
+      for (let i = 0; i < weightArr.length; i++) {
+        expect(weightArr[i]).toBeGreaterThanOrEqual(0);
+        expect(weightArr[i]).toBeLessThanOrEqual(1);
+      }
+
+      if (secondary) {
+        expect(rockAArr[0]).not.toBe(rockBArr[0]);
+        expect(weightArr[0]).toBeCloseTo(0.3, 5);
+      } else {
+        expect(rockAArr[0]).toBe(rockBArr[0]);
+        expect(weightArr[0]).toBe(0);
+      }
+      lm.dispose();
+    });
+  }
 });

--- a/tests/unit/renderer/LandscapeMesh.test.ts
+++ b/tests/unit/renderer/LandscapeMesh.test.ts
@@ -211,12 +211,13 @@ describe('LandscapeMesh', () => {
       return { tile: makeFakeTile(-100, -100, 40, compId), n: 40 };
     }
 
-    it('never emits a vertex more than one coarse step inside the claim (fine subdivision stays within its own boundary quad)', () => {
-      // Under the fixed design a coarse quad classified 'inside' (every corner
-      // owned) is dropped whole, but a 'boundary' quad's fine subdivision keeps
-      // any fine cell with at least one unowned corner — so geometry can still
-      // reach up to one coarse-tile step (4m, the default coarseStep here) past
-      // the claim edge, never further.
+    it('never emits a triangle deeper than one boundary-quad ring inside the playable rect (#491)', () => {
+      // Coarse quads fully inside the rect are dropped outright (classifyQuad
+      // 'inside'). Only the single quad-wide ring straddling the claim edge
+      // (classifyQuad 'boundary') is subdivided by buildBoundaryQuad, and
+      // even there a fine cell survives only with >=1 unowned corner — so no
+      // vertex can sit deeper than one diagonal fine step (FINE_STEP=1m)
+      // inside the rect, unlike the old coarse-only test's strict <= 0.
       const scene = makeScene();
       const { palette, compId } = makePalette();
       const { tile, n } = tileCoveringRect(compId);
@@ -225,14 +226,13 @@ describe('LandscapeMesh', () => {
       const lm = new LandscapeMesh(scene, makeMaterial());
       lm.build(handle, palette);
 
-      const tileMesh = scene.children.find(
-        (c) => (c as THREE.Mesh).geometry?.getAttribute('position')?.count === n * n,
-      ) as THREE.Mesh;
-      expect(tileMesh).toBeDefined();
+      expect(scene.children.length).toBe(1);
+      const tileMesh = scene.children[0] as THREE.Mesh;
 
+      const maxBoundaryReach = Math.SQRT2; // diagonal fine-cell slack
       for (const tri of triangles(tileMesh)) {
         for (const [x, z] of tri) {
-          expect(insideDepth(x, z)).toBeLessThanOrEqual(4 + 1e-6);
+          expect(insideDepth(x, z)).toBeLessThanOrEqual(maxBoundaryReach + 1e-6);
         }
       }
       lm.dispose();
@@ -247,13 +247,16 @@ describe('LandscapeMesh', () => {
       const lm = new LandscapeMesh(scene, makeMaterial());
       lm.build(handle, palette);
 
-      const tileMesh = scene.children.find(
-        (c) => (c as THREE.Mesh).geometry?.getAttribute('position')?.count === n * n,
-      ) as THREE.Mesh;
-      const kept = tileMesh.geometry.getIndex()!.count / 6;
-      const total = (n - 1) * (n - 1);
-      expect(kept).toBeGreaterThan(total * 0.8); // only the pit's few quads are gone
-      expect(kept).toBeLessThan(total);          // but some really are gone
+      const tileMesh = scene.children[0] as THREE.Mesh;
+      const triangleCount = tileMesh.geometry.getIndex()!.count / 3;
+      const fullGridTriangleCount = (n - 1) * (n - 1) * 2;
+      // Ground outside the rect is still there — the tile isn't dropped
+      // wholesale. Total count differs from a naive uncut grid either way:
+      // fully-'inside' quads are dropped outright, while 'boundary' quads
+      // are subdivided into more (smaller) triangles than the one coarse
+      // quad they replace, so the two effects don't net to a simple bound.
+      expect(triangleCount).toBeGreaterThan(0);
+      expect(triangleCount).not.toBe(fullGridTriangleCount);
       lm.dispose();
     });
 
@@ -321,6 +324,117 @@ describe('LandscapeMesh', () => {
         }
       }
       lm.dispose();
+    });
+  });
+
+  // #491: the old two-mesh design (a coarse tile sheet plus a separate,
+  // overlapping fine "seam" mesh dropped OVERLAP_DROP below it) is gone.
+  // Every tile is now the single source of ground at the claim boundary:
+  // classifyQuad + buildBoundaryQuad subdivide only the one quad-wide ring
+  // straddling the edge, in place. These tests cover the invariants the old
+  // seam mesh existed for — no crack at the boundary, and the boundary ring
+  // tracking the live playable surface — against the new design.
+  describe('claim-boundary ring (#491: no overlap, no gap, no crack)', () => {
+    it('never leaves two vertices at the same (x, z) with different heights (no T-junction crack)', () => {
+      // A non-flat field makes any mismatch between the flat-edge-interpolated
+      // boundary ring and its unsubdivided coarse neighbour visible as a
+      // height disagreement at a shared (x, z) — a flat field would hide it
+      // (every scheme agrees on a plane).
+      const scene = makeScene();
+      const { palette, compId } = makePalette();
+      const rect: Rect = { minX: 0, minZ: 0, maxX: 32, maxZ: 32 };
+      const field = (x: number, z: number) => 20 + Math.sin(x * 0.1) * 3 + Math.cos(z * 0.07) * 2;
+      const handle = makeFakeHandle(
+        rect,
+        [makeFakeTile(-100, -100, 40, compId)],
+        40,
+        compId,
+        (x, z) => ({ height: field(x, z), biomeId: 0, surfCompId: compId }),
+      );
+      // makeFakeTile ignores the sample function for its stored heights, so
+      // rebuild the tile's own samples from the same field the boundary ring
+      // reads, or the tile's flat interior would trivially disagree with a
+      // sloped boundary ring at every shared corner.
+      const n = 40;
+      const step = 4;
+      const originX = -100, originZ = -100;
+      const heights = new Float32Array(n * n);
+      for (let row = 0; row < n; row++) {
+        for (let col = 0; col < n; col++) {
+          heights[row * n + col] = field(originX + col * step, originZ + row * step);
+        }
+      }
+      handle.map.tiles[0]!.heights.set(heights);
+
+      const lm = new LandscapeMesh(scene, makeMaterial());
+      lm.build(handle, palette);
+
+      const tileMesh = scene.children[0] as THREE.Mesh;
+      const positions = tileMesh.geometry.getAttribute('position').array as Float32Array;
+
+      const heightAt = new Map<string, number>();
+      for (let i = 0; i < positions.length; i += 3) {
+        const x = positions[i]!, y = positions[i + 1]!, z = positions[i + 2]!;
+        const key = `${x.toFixed(3)},${z.toFixed(3)}`;
+        const existing = heightAt.get(key);
+        if (existing !== undefined) {
+          expect(y).toBeCloseTo(existing, 4);
+        } else {
+          heightAt.set(key, y);
+        }
+      }
+      lm.dispose();
+    });
+
+    it('uses the live boundaryHeightAt (not the theoretical WorldGen height) inside the boundary ring', () => {
+      const scene = makeScene();
+      const { palette, compId } = makePalette();
+      const rect: Rect = { minX: 0, minZ: 0, maxX: 32, maxZ: 32 };
+      const theoreticalH = 50;
+      const liveH = 12; // deliberately far off, so a fallback to the theoretical height is unmistakable
+      const handle = makeFakeHandle(
+        rect, [makeFakeTile(-100, -100, 40, compId)], 40, compId,
+        () => ({ height: theoreticalH, biomeId: 0, surfCompId: compId }),
+      );
+
+      const lm = new LandscapeMesh(scene, makeMaterial());
+      lm.build(handle, palette, {
+        rect,
+        ownsColumn: (x, z) => x > rect.minX && x < rect.maxX && z > rect.minZ && z < rect.maxZ,
+        boundaryHeightAt: () => liveH,
+      });
+
+      const tileMesh = scene.children[0] as THREE.Mesh;
+      const positions = tileMesh.geometry.getAttribute('position').array as Float32Array;
+
+      let sawLiveHeight = false;
+      for (let i = 0; i < positions.length; i += 3) {
+        if (positions[i + 1] === liveH) sawLiveHeight = true;
+      }
+      expect(sawLiveHeight).toBe(true);
+      lm.dispose();
+    });
+
+    it('is deterministic for the same handle, palette, and cut', () => {
+      const { palette, compId } = makePalette();
+      const rect: Rect = { minX: 0, minZ: 0, maxX: 32, maxZ: 32 };
+      const handle = makeFakeHandle(rect, [makeFakeTile(-100, -100, 40, compId)], 40, compId);
+
+      const sceneA = makeScene();
+      const lmA = new LandscapeMesh(sceneA, makeMaterial());
+      lmA.build(handle, palette);
+      const meshA = sceneA.children[0] as THREE.Mesh;
+
+      const sceneB = makeScene();
+      const lmB = new LandscapeMesh(sceneB, makeMaterial());
+      lmB.build(handle, palette);
+      const meshB = sceneB.children[0] as THREE.Mesh;
+
+      expect(Array.from(meshA.geometry.getAttribute('position').array))
+        .toEqual(Array.from(meshB.geometry.getAttribute('position').array));
+
+      lmA.dispose();
+      lmB.dispose();
     });
   });
 
@@ -693,6 +807,35 @@ describe('LandscapeMesh — normals come from the height field, not the triangle
       const nrm = normalAt(mesh, row, col);
       expect(nrm[0]).toBeCloseTo(-dhdx / len, 5);
       expect(nrm[2]).toBeCloseTo(-dhdz / len, 5);
+    }
+    lm.dispose();
+  });
+
+  it('boundary-ring vertices are shaded from the sampled height field too (#491)', () => {
+    // The boundary ring's fine nodes are appended past the tile's own n*n
+    // coarse nodes (buildTileMesh pushes those unconditionally first), so
+    // indices >= n*n identify them without needing to know which quads were
+    // classified 'boundary'.
+    const scene = makeScene();
+    const { palette, compId } = makePalette();
+    const rect: Rect = { minX: 0, minZ: 0, maxX: 32, maxZ: 32 };
+    const n = 40;
+    // A slope steep enough that a wrong normal is unmistakable.
+    const sample = (x: number, z: number) => ({ height: 20 + x * 0.25 - z * 0.1, biomeId: 0, surfCompId: compId });
+    const handle = makeFakeHandle(rect, [makeFakeTile(-100, -100, n, compId)], n, compId, sample);
+
+    const lm = new LandscapeMesh(scene, makeMaterial());
+    lm.build(handle, palette);
+    const tileMesh = scene.children[0] as THREE.Mesh;
+    const normals = tileMesh.geometry.getAttribute('normal').array as Float32Array;
+    const vertexCount = normals.length / 3;
+    expect(vertexCount).toBeGreaterThan(n * n); // boundary ring really did append vertices
+
+    const len = Math.hypot(0.25, 1, -0.1);
+    for (let i = n * n; i < vertexCount; i++) {
+      expect(normals[i * 3]!).toBeCloseTo(-0.25 / len, 3);
+      expect(normals[i * 3 + 1]!).toBeCloseTo(1 / len, 3);
+      expect(normals[i * 3 + 2]!).toBeCloseTo(0.1 / len, 3);
     }
     lm.dispose();
   });

--- a/tests/unit/renderer/LandscapeMesh.test.ts
+++ b/tests/unit/renderer/LandscapeMesh.test.ts
@@ -453,16 +453,23 @@ describe('LandscapeMesh', () => {
      * restricted to genuine INTERIOR boundary-quad nodes.
      *
      * buildBoundaryQuad's flat-edge rule (see LandscapeMesh.ts) routes every node
-     * on a boundary quad's Z-perimeter (row===0 or row===subdiv, i.e. z a multiple
-     * of coarseStep away from the tile's own origin) through coarse-corner
-     * interpolation ALWAYS — never through boundaryHeightAt — regardless of live
-     * grid state, specifically to avoid T-junction cracks against the neighbouring
-     * unsubdivided coarse quad. Only interior fine nodes (row strictly between 0
-     * and subdiv) are ever routed through boundaryHeightAt. A helper that doesn't
-     * exclude perimeter rows can land on a flat-edge (theoretical-height) vertex
-     * that happens to share the same x as a closer interior one, and its result
-     * would then depend on geometry emission order rather than on whether
-     * boundaryHeightAt is actually honored — so filter to interior rows only.
+     * on a boundary quad's perimeter — the Z-perimeter (row===0 or row===subdiv)
+     * AND, independently, the X-perimeter (col===0 or col===subdiv) — through
+     * coarse-corner interpolation ALWAYS — never through boundaryHeightAt —
+     * regardless of live grid state, specifically to avoid T-junction cracks
+     * against the neighbouring unsubdivided coarse quad. Only nodes strictly
+     * interior on BOTH axes (row strictly between 0 and subdiv, AND col strictly
+     * between 0 and subdiv) are ever routed through boundaryHeightAt. A helper
+     * that doesn't exclude perimeter rows can land on a flat-edge (theoretical-
+     * height) vertex that happens to share the same x as a closer interior one,
+     * and its result would then depend on geometry emission order rather than on
+     * whether boundaryHeightAt is actually honored — so filter to interior rows.
+     * This helper filters only the Z-perimeter, not the X-perimeter; that is
+     * safe for the two tests below because this fixture's PlayableCut.ownsColumn
+     * depends only on x, so an X-perimeter node here still carries a height
+     * consistent with what boundaryHeightAt would report, and doesn't produce a
+     * false pass — but it means this helper is not a general-purpose "interior
+     * boundary node" filter for fixtures where ownership varies with z too.
      */
     function closestUnownedVertexHeight(scene: THREE.Scene, originZ: number, coarseStep: number): number {
       let bestX = -Infinity;
@@ -596,7 +603,12 @@ describe('buildBoundaryQuad (#491)', () => {
     return (x: number, z: number) => ({ height: x * x + z, biomeId: 0, surfCompId: compId });
   }
 
-  function run(playable: PlayableCut, palette: CompositionPalette, compId: number) {
+  /** Deliberately non-linear in z (mirror of makeSample): isolates the onXEdge flat-edge branch, which interpolates along z. */
+  function makeSampleZ(compId: number) {
+    return (x: number, z: number) => ({ height: x + z * z, biomeId: 0, surfCompId: compId });
+  }
+
+  function run(playable: PlayableCut, palette: CompositionPalette, compId: number, sample = makeSample(compId)) {
     const positions: number[] = [];
     const normals: number[] = [];
     const rockA: number[] = [];
@@ -607,7 +619,7 @@ describe('buildBoundaryQuad (#491)', () => {
     buildBoundaryQuad(
       positions, normals, rockA, rockB, rockWeight, ore, indices,
       0, 0, 4, 4,
-      makeSample(compId), palette, playable,
+      sample, palette, playable,
     );
     return { positions, normals, rockA, rockB, rockWeight, ore, indices };
   }
@@ -655,6 +667,27 @@ describe('buildBoundaryQuad (#491)', () => {
     expect(expectedEdge).not.toBeCloseTo(trueSampled, 3); // the field really is non-linear here
 
     const edgeHeights = heightsAt(positions, 2, 0);
+    expect(edgeHeights.length).toBeGreaterThan(0);
+    for (const h of edgeHeights) expect(h).toBeCloseTo(expectedEdge, 4);
+  });
+
+  it("flat-edge rule (onXEdge): nodes on a parent left/right side interpolate linearly between that side's two coarse corners, not the true sampled height", () => {
+    const { palette, compId } = makePalette();
+    // Whole quad outside the claim so every fine cell survives — isolates the
+    // flat-edge behaviour from the keep/drop rule. Uses a field non-linear in z
+    // (mirroring the onZEdge test's field non-linear in x) so a bug that swapped
+    // which pair of corners feeds this branch would show up as a wrong value.
+    const playable: PlayableCut = { rect: { minX: 1000, minZ: 1000, maxX: 2000, maxZ: 2000 }, ownsColumn: () => false };
+    const sample = makeSampleZ(compId);
+    const { positions } = run(playable, palette, compId, sample);
+
+    const h00 = sample(0, 0).height; // 0
+    const h04 = sample(0, 4).height; // 16
+    const expectedEdge = h00 + (2 / 4) * (h04 - h00); // 8, linear interpolation along z at x=0
+    const trueSampled = sample(0, 2).height; // 4
+    expect(expectedEdge).not.toBeCloseTo(trueSampled, 3); // the field really is non-linear here
+
+    const edgeHeights = heightsAt(positions, 0, 2);
     expect(edgeHeights.length).toBeGreaterThan(0);
     for (const h of edgeHeights) expect(h).toBeCloseTo(expectedEdge, 4);
   });

--- a/tests/unit/renderer/LandscapeMesh.test.ts
+++ b/tests/unit/renderer/LandscapeMesh.test.ts
@@ -448,8 +448,23 @@ describe('LandscapeMesh', () => {
       return { handle, palette, rect };
     }
 
-    /** Height of the emitted vertex nearest the claim edge (largest x still < 16). */
-    function closestUnownedVertexHeight(scene: THREE.Scene): number {
+    /**
+     * Height of the emitted vertex nearest the claim edge (largest x still < 16),
+     * restricted to genuine INTERIOR boundary-quad nodes.
+     *
+     * buildBoundaryQuad's flat-edge rule (see LandscapeMesh.ts) routes every node
+     * on a boundary quad's Z-perimeter (row===0 or row===subdiv, i.e. z a multiple
+     * of coarseStep away from the tile's own origin) through coarse-corner
+     * interpolation ALWAYS — never through boundaryHeightAt — regardless of live
+     * grid state, specifically to avoid T-junction cracks against the neighbouring
+     * unsubdivided coarse quad. Only interior fine nodes (row strictly between 0
+     * and subdiv) are ever routed through boundaryHeightAt. A helper that doesn't
+     * exclude perimeter rows can land on a flat-edge (theoretical-height) vertex
+     * that happens to share the same x as a closer interior one, and its result
+     * would then depend on geometry emission order rather than on whether
+     * boundaryHeightAt is actually honored — so filter to interior rows only.
+     */
+    function closestUnownedVertexHeight(scene: THREE.Scene, originZ: number, coarseStep: number): number {
       let bestX = -Infinity;
       let bestY = NaN;
       for (const child of scene.children) {
@@ -458,6 +473,10 @@ describe('LandscapeMesh', () => {
         if (!pos) continue;
         for (let i = 0; i < pos.length; i += 3) {
           const x = pos[i]!;
+          const z = pos[i + 2]!;
+          const offsetFromOrigin = ((z - originZ) % coarseStep + coarseStep) % coarseStep;
+          const onZPerimeter = Math.abs(offsetFromOrigin) < 1e-6;
+          if (onZPerimeter) continue; // flat-edge rule node — never reflects boundaryHeightAt
           if (x < 16 && x > bestX) { bestX = x; bestY = pos[i + 1]!; }
         }
       }
@@ -471,7 +490,7 @@ describe('LandscapeMesh', () => {
 
       const lm = new LandscapeMesh(scene, makeMaterial());
       lm.build(handle, palette, playable);
-      expect(closestUnownedVertexHeight(scene)).toBeCloseTo(50, 1);
+      expect(closestUnownedVertexHeight(scene, -1000, handle.map.coarseStep)).toBeCloseTo(50, 1);
       lm.dispose();
     });
 
@@ -482,7 +501,7 @@ describe('LandscapeMesh', () => {
 
       const lm = new LandscapeMesh(scene, makeMaterial());
       lm.build(handle, palette, playable);
-      const y = closestUnownedVertexHeight(scene);
+      const y = closestUnownedVertexHeight(scene, -1000, handle.map.coarseStep);
       expect(y).toBeCloseTo(44, 1);
       expect(Math.abs(y - 50)).toBeGreaterThan(2); // must not have fallen back to the theoretical height
       lm.dispose();

--- a/tests/unit/renderer/TerrainMesh.test.ts
+++ b/tests/unit/renderer/TerrainMesh.test.ts
@@ -325,6 +325,62 @@ describe('TerrainMesh', () => {
     });
   });
 
+  describe('adjacent chunks share exact boundary geometry (#491)', () => {
+    it('shares exact position AND normal at the seam between two chunks, for a surface that varies along the seam', () => {
+      // A flat, uniform surface would make any implementation agree trivially.
+      // Varying the surface height by z gives the boundary several distinct
+      // vertices, each a real test that both chunks compute the identical
+      // interpolated crossing from the same shared VoxelGrid data.
+      const scene = makeScene();
+      const grid = new VoxelGrid(32, 16, 16); // 2 chunks along x (16 each), 1 along y/z
+      for (let x = 0; x < 32; x++) {
+        for (let z = 0; z < 16; z++) {
+          const surfaceY = 4 + (z % 5); // varies 4..8 with z
+          for (let y = 0; y < surfaceY; y++) grid.setVoxel(x, y, z, makeSolidVoxel());
+        }
+      }
+      const tm = new TerrainMesh(scene, grid);
+      tm.buildAll();
+
+      const mesh0 = tm.getChunkMesh(0, 0, 0);
+      const mesh1 = tm.getChunkMesh(1, 0, 0);
+      expect(mesh0).not.toBeNull();
+      expect(mesh1).not.toBeNull();
+
+      function boundaryVertices(mesh: THREE.Mesh): Map<string, { position: [number, number, number]; normal: [number, number, number] }> {
+        const pos = mesh.geometry.getAttribute('position').array as Float32Array;
+        const nrm = mesh.geometry.getAttribute('normal').array as Float32Array;
+        const out = new Map<string, { position: [number, number, number]; normal: [number, number, number] }>();
+        for (let i = 0; i < pos.length; i += 3) {
+          if (Math.abs(pos[i]! - 16) < 1e-9) {
+            const key = `${pos[i + 1]!.toFixed(4)},${pos[i + 2]!.toFixed(4)}`;
+            out.set(key, {
+              position: [pos[i]!, pos[i + 1]!, pos[i + 2]!],
+              normal: [nrm[i]!, nrm[i + 1]!, nrm[i + 2]!],
+            });
+          }
+        }
+        return out;
+      }
+
+      const b0 = boundaryVertices(mesh0!);
+      const b1 = boundaryVertices(mesh1!);
+      expect(b0.size).toBeGreaterThan(0);
+
+      for (const [key, v0] of b0) {
+        const v1 = b1.get(key);
+        expect(v1).toBeDefined();
+        expect(v1!.position[0]).toBeCloseTo(v0.position[0], 6);
+        expect(v1!.position[1]).toBeCloseTo(v0.position[1], 6);
+        expect(v1!.position[2]).toBeCloseTo(v0.position[2], 6);
+        expect(v1!.normal[0]).toBeCloseTo(v0.normal[0], 6);
+        expect(v1!.normal[1]).toBeCloseTo(v0.normal[1], 6);
+        expect(v1!.normal[2]).toBeCloseTo(v0.normal[2], 6);
+      }
+      tm.dispose();
+    });
+  });
+
   describe('meshes (P2 — scene picking raycast targets)', () => {
     it('returns every built chunk mesh', () => {
       const scene = makeScene();

--- a/tests/unit/scenario-defs.test.ts
+++ b/tests/unit/scenario-defs.test.ts
@@ -132,6 +132,7 @@ const VISUAL_SCENARIO_NAMES = [
   'survey-stale-handling',
   'tutorial-interactive',
   'scene-picking-visual',
+  'landscape-continuity-visual',
 ] as const;
 
 /**

--- a/tests/unit/world/VoxelGrid.test.ts
+++ b/tests/unit/world/VoxelGrid.test.ts
@@ -4,6 +4,7 @@ import {
   getDominantRockId,
   CompositionPalette,
   computeVoxelColumnSurfaceY,
+  computeVoxelColumnSurfaceHeight,
   setVoxelBoundsReporter,
   chunkIndexOf,
   CHUNK_SIZE,
@@ -389,6 +390,38 @@ describe('computeVoxelColumnSurfaceY', () => {
     grid.addChunk(-1, 0);
     grid.fillVoxel(-16, 2, 0, 0, undefined, 1);
     expect(computeVoxelColumnSurfaceY(grid, -99, 0)).toBe(2);
+  });
+});
+
+describe('computeVoxelColumnSurfaceHeight (#491)', () => {
+  it('matches computeVoxelColumnSurfaceY\'s column, at the half-voxel crossing for a clean solid-to-air boundary', () => {
+    const grid = new VoxelGrid(16, 8, 16);
+    grid.fillVoxel(3, 0, 3, 0, undefined, 1);
+    grid.fillVoxel(3, 4, 3, 0, undefined, 1); // topmost solid at y=4; y=5 stays air (density 0)
+    expect(computeVoxelColumnSurfaceY(grid, 3, 3)).toBe(4);
+    // t = (0.5 - 1.0) / (0.0 - 1.0) = 0.5 -> crossing at y=4.5, exactly the
+    // same half-voxel offset TerrainMesh's marching cubes places there.
+    expect(computeVoxelColumnSurfaceHeight(grid, 3, 3)).toBeCloseTo(4.5, 6);
+  });
+
+  it('interpolates a fractional (non-half) crossing height when the voxel above the topmost solid one is partially filled', () => {
+    const grid = new VoxelGrid(16, 8, 16);
+    const compId = grid.palette.intern({ rocks: [{ rockId: 'cruite', coefficient: 1 }] });
+    grid.fillVoxel(3, 4, 3, compId, undefined, 1.0);
+    grid.fillVoxel(3, 5, 3, compId, undefined, 0.3);
+    // t = (0.5 - 1.0) / (0.3 - 1.0) = 5/7 -> crossing at y = 4 + 5/7.
+    expect(computeVoxelColumnSurfaceHeight(grid, 3, 3)).toBeCloseTo(4 + 5 / 7, 6);
+  });
+
+  it('clamps to the site edge rather than the origin once the site has grown west, like computeVoxelColumnSurfaceY', () => {
+    const grid = new VoxelGrid(16, 8, 16);
+    grid.addChunk(-1, 0);
+    grid.fillVoxel(-16, 2, 0, 0, undefined, 1);
+    expect(computeVoxelColumnSurfaceHeight(grid, -99, 0)).toBeCloseTo(2.5, 6);
+  });
+
+  it('returns 0 for a column with no solid voxel at all', () => {
+    expect(computeVoxelColumnSurfaceHeight(new VoxelGrid(16, 8, 16), 3, 3)).toBe(0);
   });
 });
 


### PR DESCRIPTION
Closes #491

## Summary

Rebuilds the landscape terrain as one continuous surface, removing the two overlapping-sheet defects reported in the issue:

1. **Floating/detached faces.** `LandscapeMesh.ts` used to draw a coarse (4m) per-tile mesh cut back only where a quad *corner* fell inside the playable rect, plus a separate fine (1m) "seam" mesh spanning 24m outside the rect to 2m inside it — both sampling the same height field but disagreeing between their own grid nodes, and the seam mesh's inner 2m band was deliberately dropped 0.15m below the playable pit mesh to "avoid fighting" it. That is real overlapping/duplicate geometry, and it produced the floating shards.
   Fix: the seam mesh, `OVERLAP`, `OVERLAP_DROP`, and `FINE_MARGIN`'s old role are removed. Coarse tile quads are now exactly classified against the live claim (`classifyQuad`: outside / inside / boundary) and only quads straddling the boundary are subdivided (`buildBoundaryQuad`, one coarse-quad-wide ring, 4x4 fine cells). Perimeter nodes of a boundary quad use linear interpolation between the parent quad's own corners (the "flat-edge rule") so they always agree exactly with an unsubdivided neighbouring coarse quad — no T-junction crack is possible. Interior boundary nodes sample the true height field, and — when the live voxel grid is available — the live post-blast height via a new `computeVoxelColumnSurfaceHeight` query, so the landscape/pit junction tracks whatever `TerrainMesh` is actually rendering there, before and after a blast.

2. **Hard-edged material transitions.** `LandscapeMesh`'s `rockIndexFor` collapsed every vertex to one dominant rock id with a blend weight always 0. The shader interpolates that index as a float across each triangle and rounds it, producing a hard snap wherever two adjacent vertices picked different dominant rocks. `TerrainMaterial.ts`/`MaterialRecipesGLSL.ts` were already correct — the bug was entirely in what `LandscapeMesh` fed them.
   Fix: `rockBlendFor` replaces `rockIndexFor`, computing a genuine two-rock blend (dominant + runner-up + share) mirroring `TerrainMesh.emitVertex()`'s existing convention for the playable mesh, so both meshes now feed the shared shader a real interpolatable blend.

## Files changed

- `src/renderer/terrain/LandscapeMesh.ts` — core rewrite (see above)
- `src/core/world/VoxelGrid.ts` — new pure `computeVoxelColumnSurfaceHeight` query (side-effect-free, no renderer imports)
- `src/renderer/GameRenderer.ts` — wires `boundaryHeightAt` into `playableCut()` against the live grid
- `tests/unit/renderer/LandscapeMesh.test.ts` — rewritten: removed old seam-mesh-pinned assertions, added coverage for `rockBlendFor`, `classifyQuad`, `buildBoundaryQuad` (including both flat-edge axes), no-overlap invariant, pit/landscape junction continuity pre/post-blast, tile-to-tile exact position+normal regression, per-biome coverage
- `tests/unit/renderer/TerrainMesh.test.ts` — added internal chunk-to-chunk boundary position+normal regression
- `tests/unit/world/VoxelGrid.test.ts` — added `computeVoxelColumnSurfaceHeight` coverage
- `scripts/scenario-defs/landscape-continuity-visual.json` — new visual scenario: frames a ridge, a slope, close/far pit edge, a material transition, then drills+charges+blasts near the pit edge and re-frames it post-blast

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** the issue's Verification section asks to reproduce "the two attached player screenshots' framings," but the issue thread (`gh issue view 491 --comments`) has no image attachments anywhere.
  **Chosen:** covered by the ridge/slope/pit-edge/material-transition framings the same Verification section itself enumerates, captured in the new `landscape-continuity-visual.json` scenario and visually inspected this run (VISUAL: PASS).
  **Why:** those are the only concrete framings actually specified in the issue text; no other source of the claimed attachments exists.
  **If reversed:** if screenshots surface later, add matching camera-focus steps to `landscape-continuity-visual.json`.

- **What was open:** the old design's 24m-wide fine "seam" band existed to ramp triangle density toward marching-cubes density near the pit edge, not for correctness.
  **Chosen:** dropped it — boundary refinement is now exactly one coarse-quad ring (4m) wide.
  **Why:** the issue explicitly welcomes a cheaper surface; a wide fine band reintroduces the same coarse/fine stitching surface area the fix removes, for cosmetic-only benefit.
  **If reversed:** widen the boundary ring to N quads by applying `buildBoundaryQuad`'s classification recursively outward; the flat-edge rule generalizes unchanged.

- **What was open:** at a claim-boundary column with an overhang directly at the edge, `TerrainMesh`'s normal (true 3D density gradient) and the landscape's normal (height-field slope) use different formulas and aren't guaranteed to agree even where positions do.
  **Chosen:** accepted as a documented limitation — position continuity (no gap, no overlap) is guaranteed unconditionally; normal continuity is guaranteed for the common case (undug or gently-sloped boundary, no overhang directly at the edge).
  **Why:** full normal agreement would require merging the two meshers across the entire pit rim — far larger than this issue's scope.
  **If reversed:** sample `densityGradientNormal` directly at the nodes nearest the claim edge via a matching `boundaryNormalAt`.

- **What was open:** the issue's Test guidance suggests `tests/integration/` for per-biome invariant coverage, but `LandscapeMesh` requires `THREE.Scene`/`THREE.Material`, and this repo's testing rules keep Three.js/DOM out of `tests/integration/`.
  **Chosen:** per-biome coverage lives in `tests/unit/renderer/LandscapeMesh.test.ts` instead; `tests/integration/landscape.integration.test.ts` left untouched.
  **Why:** the narrower, path-scoped testing rule is more specific than the issue's file suggestion, which is guidance not mandate.
  **If reversed:** move the per-biome geometry checks if a headless/mock-THREE integration mode is added later.

None of these decisions change gameplay, economy, or a player-facing default — no `decision-review` follow-up filed.

## Verification

- **static** (`npm run typecheck`): PASS, 0 errors.
- **logic** (`npm run test`): PASS, 282 files / 7782 tests.
- **scenario** (`npm run scenarios`, command mode): PASS, 124/124 scenario defs, including the new `landscape-continuity-visual`.
- **visual**: PASS. Ran `landscape-continuity-visual` in interaction mode with screenshots (`npm run scenario -- --scenario landscape-continuity-visual --mode interaction --screenshots`, confirmed completing cleanly after widening its per-step timeouts — the original timeouts didn't fit `size:48` + multi-shot capture cost). Inspected ~25 screenshots at multiple distances and grazing angles across ridge, slope, close/far pit-edge, and material-transition framings, pre- and post-blast: no floating/detached/shearing faces found anywhere, material transition reads as a soft gradient with no polygon-aligned hard edge, and the pit/landscape junction shows neither gap nor doubled surface before or after the blast.
- **build** (`npx vite build`): PASS.
- `full-ci` label added — rendering change, so CI's interaction-mode and playability jobs also run against the full scenario suite.

## Process notes

- 5 parallel code reviews (security, quality, i18n, duplication, semantic) — all PASS. Refactor pass applied: removed a dead export (`voxelSurfaceHeight`), fixed a misleading test-helper doc comment, and added missing test coverage for `buildBoundaryQuad`'s X-axis flat-edge branch (self-verified against a deliberately injected bug before committing).
- One TDD-cherry-pick conflict (both test-writer and the implementer independently touched the same pre-existing test file) — resolved by merging both sides' intent; one test-helper ambiguity surfaced afterward (first-match-wins vertex selection picking a flat-edge node instead of an interior one) and was fixed by @fixer.

7782 tests — all passing

READY TO MERGE
