### PR TITLE
fix: Resolve #510 — surface CommandResult output in ShadyPanel

### DIFF
--- a/src/ui/panels/ShadyPanel.ts
+++ b/src/ui/panels/ShadyPanel.ts
@@ -134,8 +134,10 @@ export class ShadyPanel {
   hide(): void { this.el.style.display = 'none'; }
   get visible(): boolean { return this.el.style.display !== 'none'; }
 
-  // TODO: implement in TDD green phase
-  setStatus(_msg: string): void { /* TODO: implement in TDD green phase */ }
+  setStatus(msg: string): void {
+    this.statusEl.textContent = msg;
+    setTimeout(() => { if (this.statusEl.textContent === msg) this.statusEl.textContent = ''; }, 3000);
+  }
 
   refreshLocale(): void {
     this.locale.refresh();
@@ -207,7 +209,10 @@ export class ShadyPanel {
         title: t('ui.shady.confirm_title'),
         body: t('ui.shady.confirm_body', { target: t(target.nameKey), cost: cost.toLocaleString('en-US'), rate }),
         confirmLabel: t('ui.shady.make_the_call'),
-        onConfirm: () => this.gameConsole?.(`corrupt target:${target.id}`),
+        onConfirm: () => {
+          const cmdResult = this.gameConsole?.(`corrupt target:${target.id}`);
+          this.setStatus(cmdResult?.output ?? '');
+        },
       });
     });
     const footRow = el('div', { attrs: { style: 'display:flex;align-items:center;gap:8px' }, children: [
@@ -253,7 +258,10 @@ export class ShadyPanel {
       { dataAction: 'mafia-smuggle' },
     );
     toggleBtn.style.width = '100%';
-    toggleBtn.addEventListener('click', () => this.gameConsole?.('mafia smuggle'));
+    toggleBtn.addEventListener('click', () => {
+      const cmdResult = this.gameConsole?.('mafia smuggle');
+      this.setStatus(cmdResult?.output ?? '');
+    });
     return card([headRow, note, toggleBtn]);
   }
 
@@ -276,7 +284,10 @@ export class ShadyPanel {
         title: t('ui.shady.accident_confirm_title'),
         body: t('ui.shady.accident_confirm_body', { name: emp.name, cost: ACCIDENT_COST.toLocaleString('en-US'), rate: successRate }),
         confirmLabel: t('ui.shady.accident_button'),
-        onConfirm: () => this.gameConsole?.(`mafia accident employee:${emp.id}`),
+        onConfirm: () => {
+          const cmdResult = this.gameConsole?.(`mafia accident employee:${emp.id}`);
+          this.setStatus(cmdResult?.output ?? '');
+        },
       });
     });
     const row = el('div', { attrs: { style: 'display:flex;gap:6px' }, children: [select, goBtn] });
@@ -310,7 +321,10 @@ export class ShadyPanel {
             title: t('ui.shady.frame_complete_confirm_title'),
             body: t('ui.shady.frame_complete_confirm_body', { name: emp.name, rate: successRate }),
             confirmLabel: t('ui.shady.frame_complete_button'),
-            onConfirm: () => this.gameConsole?.(`mafia frame employee:${emp.id}`),
+            onConfirm: () => {
+              const cmdResult = this.gameConsole?.(`mafia frame employee:${emp.id}`);
+              this.setStatus(cmdResult?.output ?? '');
+            },
           });
         });
         row.appendChild(useBtn);
@@ -338,7 +352,10 @@ export class ShadyPanel {
         title: t('ui.shady.frame_start_confirm_title'),
         body: t('ui.shady.frame_start_confirm_body', { name: emp.name, cost: FRAME_COST.toLocaleString('en-US'), ticks: FRAME_EVIDENCE_TICKS }),
         confirmLabel: t('ui.shady.frame_start_button'),
-        onConfirm: () => this.gameConsole?.(`mafia frame employee:${emp.id}`),
+        onConfirm: () => {
+          const cmdResult = this.gameConsole?.(`mafia frame employee:${emp.id}`);
+          this.setStatus(cmdResult?.output ?? '');
+        },
       });
     });
     children.push(el('div', { attrs: { style: 'display:flex;gap:6px' }, children: [select, startBtn] }));

--- a/src/ui/panels/ShadyPanel.ts
+++ b/src/ui/panels/ShadyPanel.ts
@@ -39,6 +39,7 @@ export class ShadyPanel {
   private readonly exposureCard: HTMLElement;
   private readonly exposureValueEl: HTMLElement;
   private readonly exposureBarEl: HTMLElement;
+  private readonly statusEl: HTMLElement;
 
   private onCloseCb?: () => void;
   private gameConsole?: GameConsoleFn;
@@ -115,7 +116,11 @@ export class ShadyPanel {
     );
     this.exposureCard = card([exposureHeadRow, exposureTrack, exposureNote]);
 
-    this.bodyEl.append(introEl, influenceCard, arrangementsHeader, this.targetsEl, servicesHeader, this.servicesEl);
+    this.statusEl = el('div', {
+      attrs: { id: 'bs-shady-status', style: 'font:400 10px/1.4 var(--bsx-font-ui);color:var(--bsx-text-micro);min-height:14px' },
+    });
+
+    this.bodyEl.append(introEl, influenceCard, arrangementsHeader, this.targetsEl, servicesHeader, this.servicesEl, this.statusEl);
     this.el.append(header, this.bodyEl);
     container.appendChild(this.el);
   }
@@ -128,6 +133,9 @@ export class ShadyPanel {
   show(): void { this.el.style.display = 'flex'; }
   hide(): void { this.el.style.display = 'none'; }
   get visible(): boolean { return this.el.style.display !== 'none'; }
+
+  // TODO: implement in TDD green phase
+  setStatus(_msg: string): void { /* TODO: implement in TDD green phase */ }
 
   refreshLocale(): void {
     this.locale.refresh();

--- a/tests/unit/ui/panels/ShadyPanel.test.ts
+++ b/tests/unit/ui/panels/ShadyPanel.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { ShadyPanel } from '../../../../src/ui/panels/ShadyPanel.js';
 import { createGame } from '../../../../src/core/state/GameState.js';
 import type { GameState } from '../../../../src/core/state/GameState.js';
@@ -27,7 +27,7 @@ function stateWithMafiaUnlocked(): GameState {
 }
 
 describe('ShadyPanel', () => {
-  afterEach(() => { setLocale('en'); });
+  afterEach(() => { setLocale('en'); vi.useRealTimers(); });
 
   it('carries a stable root id and is hidden by default', () => {
     const { container, panel } = mount();
@@ -394,6 +394,149 @@ describe('ShadyPanel', () => {
       useBtn!.click();
       requested!.onConfirm();
       expect(calls).toEqual([`mafia frame employee:${b.id}`]);
+      panel.dispose();
+    });
+  });
+
+  // The 5 handlers below discard the CommandResult returned by
+  // this.gameConsole?.(...) — a refused/failed attempt (e.g. the judge says
+  // no) is silent to the player today. These assert the real cmdResult.output
+  // lands in #bs-shady-status, matching BuildMenu's setStatus(cmdResult.output) wiring.
+  describe('status wiring (#510)', () => {
+    it('a successful corrupt attempt surfaces cmdResult.output in the status area', () => {
+      const { container, panel } = mount();
+      const state = createGame({ seed: 1, mineType: 'desert' });
+      panel.update(state);
+      panel.show();
+
+      let requested: ConfirmModalConfig | null = null;
+      panel.setConfirmHandler((config) => { requested = config; });
+      panel.setGameConsole(() => ({ success: true, output: 'Judge takes the bribe. Corruption level rises.' }));
+
+      const btn = container.querySelector<HTMLButtonElement>('#bs-shady-panel [data-target="judge"] [data-action="corrupt"]');
+      btn!.click();
+      requested!.onConfirm();
+
+      expect(container.querySelector('#bs-shady-status')!.textContent).toBe('Judge takes the bribe. Corruption level rises.');
+      panel.dispose();
+    });
+
+    it('a failed/refused corrupt attempt also surfaces cmdResult.output in the status area (today silent)', () => {
+      const { container, panel } = mount();
+      const state = createGame({ seed: 1, mineType: 'desert' });
+      panel.update(state);
+      panel.show();
+
+      let requested: ConfirmModalConfig | null = null;
+      panel.setConfirmHandler((config) => { requested = config; });
+      panel.setGameConsole(() => ({ success: false, output: 'The judge refused the bribe.' }));
+
+      const btn = container.querySelector<HTMLButtonElement>('#bs-shady-panel [data-target="judge"] [data-action="corrupt"]');
+      btn!.click();
+      requested!.onConfirm();
+
+      expect(container.querySelector('#bs-shady-status')!.textContent).toBe('The judge refused the bribe.');
+      panel.dispose();
+    });
+
+    it('the mafia-smuggle toggle surfaces cmdResult.output in the status area on click', () => {
+      const { container, panel } = mount();
+      panel.update(stateWithMafiaUnlocked());
+      panel.show();
+      panel.setGameConsole(() => ({ success: true, output: 'Smuggling operation started.' }));
+
+      const btn = container.querySelector<HTMLButtonElement>('#bs-shady-panel [data-action="mafia-smuggle"]');
+      btn!.click();
+
+      expect(container.querySelector('#bs-shady-status')!.textContent).toBe('Smuggling operation started.');
+      panel.dispose();
+    });
+
+    it('confirming a mafia-accident arrangement surfaces cmdResult.output', () => {
+      const { container, panel } = mount();
+      const state = stateWithMafiaUnlocked();
+      const { employee } = hireEmployee(state.employees, 'driller', new Random(1));
+      panel.update(state);
+      panel.show();
+
+      let requested: ConfirmModalConfig | null = null;
+      panel.setConfirmHandler((config) => { requested = config; });
+      panel.setGameConsole(() => ({ success: true, output: 'An unfortunate accident has been arranged.' }));
+
+      const select = container.querySelector<HTMLSelectElement>('#bs-shady-panel [data-action="mafia-accident-employee"]');
+      select!.value = String(employee.id);
+      const goBtn = container.querySelector<HTMLButtonElement>('#bs-shady-panel [data-action="mafia-accident"]');
+      goBtn!.click();
+      requested!.onConfirm();
+
+      expect(container.querySelector('#bs-shady-status')!.textContent).toBe('An unfortunate accident has been arranged.');
+      panel.dispose();
+    });
+
+    it('confirming a mafia-frame start surfaces cmdResult.output', () => {
+      const { container, panel } = mount();
+      const state = stateWithMafiaUnlocked();
+      const { employee } = hireEmployee(state.employees, 'driller', new Random(1));
+      panel.update(state);
+      panel.show();
+
+      let requested: ConfirmModalConfig | null = null;
+      panel.setConfirmHandler((config) => { requested = config; });
+      panel.setGameConsole(() => ({ success: true, output: 'Evidence is being planted.' }));
+
+      const select = container.querySelector<HTMLSelectElement>('#bs-shady-panel [data-action="mafia-frame-employee"]');
+      select!.value = String(employee.id);
+      container.querySelector<HTMLButtonElement>('#bs-shady-panel [data-action="mafia-frame-start"]')!.click();
+      requested!.onConfirm();
+
+      expect(container.querySelector('#bs-shady-status')!.textContent).toBe('Evidence is being planted.');
+      panel.dispose();
+    });
+
+    it('confirming a mafia-frame complete ("use the evidence") surfaces cmdResult.output', () => {
+      const { container, panel } = mount();
+      const state = stateWithMafiaUnlocked();
+      const { employee } = hireEmployee(state.employees, 'driller', new Random(1));
+      state.tickCount = 20;
+      state.mafia.pendingFrames = [{ employeeId: employee.id, startTick: 5, readyTick: 15 }];
+      panel.update(state);
+      panel.show();
+
+      let requested: ConfirmModalConfig | null = null;
+      panel.setConfirmHandler((config) => { requested = config; });
+      panel.setGameConsole(() => ({ success: true, output: 'The frame is complete. The employee is arrested.' }));
+
+      const useBtn = container.querySelector<HTMLButtonElement>(
+        `#bs-shady-panel [data-frame-id="${employee.id}"] [data-action="mafia-frame-complete"]`,
+      );
+      useBtn!.click();
+      requested!.onConfirm();
+
+      expect(container.querySelector('#bs-shady-status')!.textContent).toBe('The frame is complete. The employee is arrested.');
+      panel.dispose();
+    });
+
+    it('setStatus auto-clears after ~3000ms, and a fresher call is not clobbered by a stale timeout', () => {
+      vi.useFakeTimers();
+      const { container, panel } = mount();
+      const statusText = () => container.querySelector('#bs-shady-status')!.textContent;
+
+      panel.setStatus('first message');
+      expect(statusText()).toBe('first message');
+
+      vi.advanceTimersByTime(1000);
+      panel.setStatus('second message');
+      expect(statusText()).toBe('second message');
+
+      // first message's own 3000ms timeout fires here (1000 + 2000 = 3000ms after it
+      // was set) — it must recognize the text has moved on and do nothing.
+      vi.advanceTimersByTime(2000);
+      expect(statusText()).toBe('second message');
+
+      // second message's own timeout, 3000ms after it was set, clears it.
+      vi.advanceTimersByTime(1000);
+      expect(statusText()).toBe('');
+
       panel.dispose();
     });
   });


### PR DESCRIPTION
Closes #510

`ShadyPanel.ts`'s button handlers (`corrupt target:<t>`, `mafia accident employee:<id>`, `mafia frame employee:<id>` — both the start and complete-evidence entry points — and the `mafia smuggle` toggle) called `this.gameConsole?.(...)` and discarded the returned `CommandResult`. A refused bribe, botched accident, or detected frame produced no visible feedback — the game appeared to silently ignore the click.

Adopts the same pattern `BuildMenu.ts` already uses: a `statusEl` DOM node (`id="bs-shady-status"`) and a `setStatus(msg)` method (guarded 3s auto-clear, mirroring `BuildMenu.setStatus` exactly) now surface every `CommandResult.output` — success or failure — at all 5 call sites.

29 tests — all passing (22 pre-existing + 7 new, `tests/unit/ui/panels/ShadyPanel.test.ts`).

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** whether success and failure status messages should be styled differently.
  **Chosen:** no color/style differentiation — one plain status row, matching `BuildMenu.statusEl`.
  **Why:** `BuildMenu` is the pattern the issue explicitly says to adopt, and it doesn't differentiate; the outcome is already legible in the message text itself ("CORRUPTION FAILED — SCANDAL!" vs "CORRUPTION SUCCESSFUL.").
  **If reversed:** add a `success` param to `setStatus(msg, success)` and set `statusEl.style.color` conditionally; call sites already have `cmdResult.success` available.

- **What was open:** whether to show `cmdResult.output` raw or map it through translated i18n keys (as `BuildMenu.queueResearch` does via a `code` field).
  **Chosen:** raw `cmdResult.output`, matching `BuildMenu`'s majority (5 of its 6 handlers).
  **Why:** traced every corrupt/mafia command path (`src/console/commands/events.ts`, `src/core/events/MafiaActions.ts`) — none sets a `code`, and no i18n keys exist for these messages today; inventing them is a larger scope than this bug fix, and `BuildMenu`'s 5 non-research handlers already show raw output un-translated, so this is precedent-consistent, not a new gap.
  **If reversed:** add `code` fields to the relevant result shapes, add i18n keys, switch the 5 call sites to a keyed lookup mirroring `BuildMenu.RESEARCH_FAILURE_KEYS`.

- **What was open:** whether the new status element needs a stable DOM hook.
  **Chosen:** `id="bs-shady-status"`.
  **Why:** `ShadyPanel.ts`'s own convention already gives every dynamic control an addressable hook (`data-target`, `data-action`, `data-frame-id`); extending that to the new element keeps tests off `container.textContent` scans.
  **If reversed:** drop the `id`, fall back to `container.textContent` assertions.

- **What was open:** whether `tests/unit/lint/UiCommandsAreRegistered.test.ts` should be extended to also catch "wired correctly, result discarded" (the issue names this half of the bug class as currently unguarded).
  **Chosen:** out of scope for this issue — not extended here.
  **Why:** generalizing that lint check to "every `gameConsole?.()` result reaches user feedback" is a materially broader static-analysis task (needs an allowlist for legitimate fire-and-forget commands) with real false-positive risk; bundling it risks blocking this fix, which a companion funds-gate issue depends on landing cleanly.
  **If reversed:** file a follow-up issue scoped to defining a "drained" lint rule and its allowlist mechanism.

None of the above changes gameplay, economy, or a player-facing default — no `decision-review` follow-up filed.

## Verification

- **static** (`npm run typecheck`): PASS, 0 errors.
- **logic** (`npm run test`): PASS, 298 files / 8637 tests, no regressions.
- **scenario** (`npm run scenarios`, command mode): PASS, 126/126.
- **visual**: PASS — screenshot of the failure path (`CORRUPTION FAILED — SCANDAL! Cost: $8000 A scandal has erupted. Expect consequences.`) inspected directly; `#bs-shady-status` DOM content confirmed byte-for-byte against the command's `output`. Full method in review thread.
- **qualimetry** (jscpd, changed files): reported only within the new test file's per-scenario setup boilerplate (5 near-identical button-handler tests); no `src/` duplication. Not blocking.
- **playability** / interaction-mode `scenario`: owed to CI under the `full-ci` label (carried over from issue #510, which already had it) — no playtest definition in `scripts/playtests/` currently drives the shady/mafia/corruption panel, so this session's `visual` channel is the direct evidence for the UI; `full-ci` runs the browser-driven suites for the wider machinery.

Code review: security, quality, i18n, duplication, and semantic reviewers all PASS (suggestions only — file-length and a pre-existing unextracted `setStatus`-pattern duplication across 3 panels, both non-blocking and out of scope here).

READY TO MERGE