### PR TITLE
fix: Resolve #511 — funds-guard parity for build destroy/upgrade/move, corrupt/mafia accident/frame

### DIFF
--- a/scripts/scenario-defs/insufficient-funds-guards-visual.json
+++ b/scripts/scenario-defs/insufficient-funds-guards-visual.json
@@ -1,0 +1,199 @@
+{
+  "name": "insufficient-funds-guards-visual",
+  "description": "Issue #511: build destroy/upgrade/move and corrupt/mafia accident/frame must refuse an unaffordable action and disable their button the same way employee hire, vehicle buy, and build place already do. Cash is driven down to $1,500 — below every one of the six real costs (demolish $2,000, move $4,000, corrupt(witness) $10,000, mafia accident $10,000, mafia frame $5,000, upgrade $22,000) — then each action is attempted once, real console-mode refusal proven by expect.equals, and the corresponding UI control proven unreachable by expect.blocked.",
+  "shots": [
+    {
+      "name": "overview",
+      "yaw": 0,
+      "pitch": 45,
+      "target": [5, 5],
+      "distance": 15
+    }
+  ],
+  "steps": [
+    {
+      "command": "new_game seed:42 mine_type:desert size:32 cash:200000",
+      "timeout": 30,
+      "role": "setup",
+      "interaction": [
+        { "type": "command", "command": "new_game seed:42 mine_type:desert size:32 cash:200000" }
+      ],
+      "expect": {
+        "equals": { "cash": 200000, "buildingCount": 0, "employeeCount": 0 }
+      }
+    },
+    {
+      "command": "build management_office at:5,5",
+      "description": "Placed by clicking the real Build panel — the building destroy/upgrade/move guards below all act on this one (#1). getBuildingDef('management_office', 1).constructionCost is 8000.",
+      "role": "player",
+      "interaction": [
+        { "type": "clickSelector", "selector": "#bs-toolbar [data-panel=\"build\"]" },
+        { "type": "clickSelector", "selector": "#bs-build-panel [data-build-type=\"management_office\"] .bs-build-buy-btn" },
+        { "type": "waitForSelector", "selector": "#bs-tile-select-confirm" },
+        { "type": "pickTile", "x": 5, "z": 5 },
+        { "type": "wait", "durationMs": 200 },
+        { "type": "clickSelector", "selector": "#bs-tile-select-confirm" },
+        { "type": "wait", "durationMs": 500 }
+      ],
+      "expect": {
+        "equals": { "cash": 192000, "buildingCount": 1 }
+      }
+    },
+    {
+      "command": "employee hire role:driller",
+      "description": "Hired by clicking the real Crew panel — the mafia accident/frame guards below target this one employee. HIRING_COSTS.driller is 1000 (balance.ts).",
+      "role": "player",
+      "interaction": [
+        { "type": "clickSelector", "selector": "#bs-toolbar [data-panel=\"employees\"]" },
+        { "type": "waitForSelector", "selector": "#bs-employee-panel [data-role=\"driller\"]" },
+        { "type": "clickSelector", "selector": "#bs-employee-panel [data-role=\"driller\"]" }
+      ],
+      "expect": {
+        "equals": { "cash": 191000, "employeeCount": 1 }
+      }
+    },
+    {
+      "command": "corrupt target:witness",
+      "description": "1/3 — unlocking the mafia (MAFIA_UNLOCK_THRESHOLD=3, Corruption.ts) requires 3 corrupt attempts, and corruption.level rises on both a success and a failure so this is deterministic. The Shady panel only reveals itself once corruption.level>0 (ToolRail.ts) — before that first attempt there is no button to click at all, so this is left a console command rather than a click that cannot land, same convention as the vehicle-buy BLOCKED FINDING in crew-fleet-panels-visual.json.",
+      "interaction": [
+        { "type": "command", "command": "corrupt target:witness" }
+      ],
+      "expect": {
+        "equals": { "cash": 181000 }
+      }
+    },
+    {
+      "command": "corrupt target:witness",
+      "description": "2/3.",
+      "interaction": [
+        { "type": "command", "command": "corrupt target:witness" }
+      ],
+      "expect": {
+        "equals": { "cash": 171000 }
+      }
+    },
+    {
+      "command": "corrupt target:witness",
+      "description": "3/3 — corruption.level now reaches MAFIA_UNLOCK_THRESHOLD; mafiaUnlocked flips true, and the Shady panel's accident/frame cards become reachable.",
+      "interaction": [
+        { "type": "command", "command": "corrupt target:witness" }
+      ],
+      "expect": {
+        "equals": { "cash": 161000 }
+      }
+    },
+    {
+      "command": "corrupt target:witness cost:159500",
+      "description": "Setup, not the guard under test: drains cash to $1,500 via the same named cost:<amount> override attemptCorruption already accepts, landing below every one of the six real costs checked below.",
+      "interaction": [
+        { "type": "command", "command": "corrupt target:witness cost:159500" }
+      ],
+      "expect": {
+        "equals": { "cash": 1500 }
+      }
+    },
+    {
+      "command": "build destroy 1",
+      "description": "$1,500 < demolishCost $2,000 — refused, and the Build panel's Demolish button on building #1's row must be disabled, not merely present.",
+      "interaction": [
+        { "type": "command", "command": "build destroy 1" }
+      ],
+      "expect": {
+        "equals": { "cash": 1500, "buildingCount": 1 },
+        "blocked": "#bs-build-panel [data-building-id=\"1\"] .bs-build-demolish-btn",
+        "note": "issue #511 — build destroy funds guard"
+      }
+    },
+    {
+      "command": "build upgrade 1",
+      "description": "$1,500 < upgradeCost $22,000 (demolishCost T1 $2,000 + constructionCost T2 $20,000) — refused, and the Upgrade button on building #1's row must be disabled.",
+      "interaction": [
+        { "type": "command", "command": "build upgrade 1" }
+      ],
+      "expect": {
+        "equals": { "cash": 1500, "buildingCount": 1 },
+        "blocked": "#bs-build-panel [data-building-id=\"1\"] .bs-build-upgrade-btn",
+        "note": "issue #511 — build upgrade funds guard"
+      }
+    },
+    {
+      "command": "build move 1 to:10,10",
+      "description": "$1,500 < moveCost $4,000 (round(constructionCost T1 8000 * 0.5)) — refused, and the Move button on building #1's row must be disabled.",
+      "interaction": [
+        { "type": "command", "command": "build move 1 to:10,10" }
+      ],
+      "expect": {
+        "equals": { "cash": 1500, "buildingCount": 1 },
+        "blocked": "#bs-build-panel [data-building-id=\"1\"] .bs-build-move-btn",
+        "note": "issue #511 — build move funds guard"
+      }
+    },
+    {
+      "command": "state",
+      "description": "Opens the now-revealed Shady panel (corruption.level>0 since step 3, ToolRail.ts) by clicking the real toolbar entry, so the call button is on screen for the next step's blocked check — present but disabled, not merely hidden behind a closed panel.",
+      "role": "player",
+      "interaction": [
+        { "type": "clickSelector", "selector": "#bs-toolbar [data-panel=\"shady\"]" },
+        { "type": "wait", "durationMs": 300 }
+      ]
+    },
+    {
+      "command": "corrupt target:witness",
+      "description": "$1,500 < TARGET_COSTS.witness $10,000 — refused, and the call button on the (now open) Shady panel must be disabled.",
+      "interaction": [
+        { "type": "command", "command": "corrupt target:witness" }
+      ],
+      "expect": {
+        "equals": { "cash": 1500 },
+        "blocked": "#bs-shady-panel [data-target=\"witness\"] [data-action=\"corrupt\"]",
+        "note": "issue #511 — corrupt funds guard"
+      }
+    },
+    {
+      "command": "mafia accident employee:1",
+      "description": "$1,500 < ACCIDENT_COST $10,000 — refused, and the accident GO button must be disabled. employeeCount unchanged proves the guard ran ahead of arrangeAccident, not just that the roll happened to miss.",
+      "interaction": [
+        { "type": "command", "command": "mafia accident employee:1" }
+      ],
+      "expect": {
+        "equals": { "cash": 1500, "employeeCount": 1 },
+        "blocked": "#bs-shady-panel [data-action=\"mafia-accident\"]",
+        "note": "issue #511 — mafia accident funds guard"
+      }
+    },
+    {
+      "command": "mafia frame employee:1",
+      "description": "$1,500 < FRAME_COST $5,000 — refused on the start path, and the frame start button must be disabled. Only the start path is gated; a ready pending frame's completion is always free and is covered by the console unit tests, not repeated here.",
+      "interaction": [
+        { "type": "command", "command": "mafia frame employee:1" }
+      ],
+      "expect": {
+        "equals": { "cash": 1500, "employeeCount": 1 },
+        "blocked": "#bs-shady-panel [data-action=\"mafia-frame-start\"]",
+        "note": "issue #511 — mafia frame funds guard"
+      }
+    },
+    {
+      "command": "state",
+      "description": "Final state dump for visual inspection of the Build panel's disabled row buttons.",
+      "role": "observe",
+      "interaction": [
+        { "type": "command", "command": "state" },
+        { "type": "clickSelector", "selector": "#bs-toolbar [data-panel=\"build\"]" },
+        { "type": "wait", "durationMs": 300 },
+        { "type": "screenshot" }
+      ]
+    },
+    {
+      "command": "state",
+      "description": "Final state dump for visual inspection of the Shady panel's disabled action buttons.",
+      "role": "observe",
+      "interaction": [
+        { "type": "command", "command": "state" },
+        { "type": "clickSelector", "selector": "#bs-toolbar [data-panel=\"shady\"]" },
+        { "type": "wait", "durationMs": 300 },
+        { "type": "screenshot" }
+      ]
+    }
+  ]
+}

--- a/src/console/commands/entities.ts
+++ b/src/console/commands/entities.ts
@@ -10,6 +10,8 @@ import {
   getBuildingDef,
   getDefSize,
   getMoveCost,
+  getDemolishCost,
+  getUpgradeCost,
   isPlacementBlockedByResearch,
   getStorageCapacity,
   type BuildingType,
@@ -88,14 +90,15 @@ export function buildCommand(
       const toDestroy = state.buildings.buildings.find(b => b.id === id);
       if (!toDestroy) return { success: false, output: `Building #${id} not found.` };
       const destroyDef = getBuildingDef(toDestroy.type, toDestroy.tier);
-      if (state.cash < destroyDef.demolishCost) {
+      const demolishCost = getDemolishCost(toDestroy);
+      if (state.cash < demolishCost) {
         return {
           success: false,
-          output: `Insufficient funds: need $${formatMoney(destroyDef.demolishCost)}, have $${formatMoney(state.cash)}`,
+          output: `Insufficient funds: need $${formatMoney(demolishCost)}, have $${formatMoney(state.cash)}`,
         };
       }
-      state.cash -= destroyDef.demolishCost;
-      addExpense(state.finances, destroyDef.demolishCost, 'construction', `Demolish ${toDestroy.type} #${id}`, state.tickCount);
+      state.cash -= demolishCost;
+      addExpense(state.finances, demolishCost, 'construction', `Demolish ${toDestroy.type} #${id}`, state.tickCount);
       destroyBuilding(state.buildings, id);
       refreshLogisticsCapacity(state);
       // Patch NavGrid for removed building footprint
@@ -103,7 +106,7 @@ export function buildCommand(
         const { sizeX, sizeZ } = getDefSize(destroyDef);
         patchNavGrid(state, ctx.grid, makeFootprintRegion(toDestroy.x, toDestroy.z, sizeX, sizeZ));
       }
-      return { success: true, output: `Building #${id} demolished. Cost: $${destroyDef.demolishCost}` };
+      return { success: true, output: `Building #${id} demolished. Cost: $${demolishCost}` };
     }
     case 'upgrade': {
       const id = parseInt(args[1] ?? '', 10);
@@ -117,7 +120,7 @@ export function buildCommand(
       }
       const oldDef = getBuildingDef(toUpgrade.type, toUpgrade.tier);
       const newDef = getBuildingDef(toUpgrade.type, nextTier);
-      const totalCost = oldDef.demolishCost + newDef.constructionCost;
+      const totalCost = getUpgradeCost(toUpgrade, nextTier);
       if (state.cash < totalCost) {
         return {
           success: false,

--- a/src/console/commands/entities.ts
+++ b/src/console/commands/entities.ts
@@ -9,6 +9,7 @@ import {
   getAllBuildingTypes,
   getBuildingDef,
   getDefSize,
+  getMoveCost,
   isPlacementBlockedByResearch,
   getStorageCapacity,
   type BuildingType,
@@ -87,6 +88,12 @@ export function buildCommand(
       const toDestroy = state.buildings.buildings.find(b => b.id === id);
       if (!toDestroy) return { success: false, output: `Building #${id} not found.` };
       const destroyDef = getBuildingDef(toDestroy.type, toDestroy.tier);
+      if (state.cash < destroyDef.demolishCost) {
+        return {
+          success: false,
+          output: `Insufficient funds: need $${formatMoney(destroyDef.demolishCost)}, have $${formatMoney(state.cash)}`,
+        };
+      }
       state.cash -= destroyDef.demolishCost;
       addExpense(state.finances, destroyDef.demolishCost, 'construction', `Demolish ${toDestroy.type} #${id}`, state.tickCount);
       destroyBuilding(state.buildings, id);
@@ -111,6 +118,12 @@ export function buildCommand(
       const oldDef = getBuildingDef(toUpgrade.type, toUpgrade.tier);
       const newDef = getBuildingDef(toUpgrade.type, nextTier);
       const totalCost = oldDef.demolishCost + newDef.constructionCost;
+      if (state.cash < totalCost) {
+        return {
+          success: false,
+          output: `Insufficient funds: need $${formatMoney(totalCost)}, have $${formatMoney(state.cash)}`,
+        };
+      }
       const { x, z, type: upgradeType } = toUpgrade;
       destroyBuilding(state.buildings, id);
       const upBounds = siteBounds(ctx);
@@ -145,6 +158,13 @@ export function buildCommand(
       if (!building) return { success: false, output: `Building #${id} not found.` };
       const moveDef = getBuildingDef(building.type, building.tier);
       const { sizeX, sizeZ } = getDefSize(moveDef);
+      const moveCost = getMoveCost(building);
+      if (state.cash < moveCost) {
+        return {
+          success: false,
+          output: `Insufficient funds: need $${formatMoney(moveCost)}, have $${formatMoney(state.cash)}`,
+        };
+      }
       const oldX = building.x;
       const oldZ = building.z;
       const moveClaim = claimForAction(

--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -12,9 +12,11 @@ import {
   attemptCorruption,
   getCorruptionLevel,
   getSuccessRate,
+  TARGET_COSTS,
   type CorruptionTarget,
 } from '../../core/economy/Corruption.js';
 import { addExpense, addIncome, type ExpenseCategory } from '../../core/economy/Finance.js';
+import { formatMoney } from '../../core/economy/formatMoney.js';
 import { processPayCycle } from '../../core/entities/Employee.js';
 import { tickTraining } from '../../core/entities/EmployeeTraining.js';
 import { tickResearch, getTotalOperatingCost } from '../../core/entities/Building.js';
@@ -41,6 +43,8 @@ import {
   toggleSmuggling,
   processSmuggling,
   isExposed,
+  ACCIDENT_COST,
+  FRAME_COST,
 } from '../../core/events/MafiaActions.js';
 import { requireGame } from './commandUtils.js';
 import type { GameState } from '../../core/state/GameState.js';
@@ -482,6 +486,13 @@ export function corruptCommand(
   }
 
   const cost = named['cost'] ? parseInt(named['cost'], 10) : undefined;
+  const resolvedCost = cost ?? TARGET_COSTS[target];
+  if (state.cash < resolvedCost) {
+    return {
+      success: false,
+      output: `Insufficient funds: need $${formatMoney(resolvedCost)}, have $${formatMoney(state.cash)}`,
+    };
+  }
   const rng = new Random(state.seed + state.tickCount);
   const result = attemptCorruption(state.corruption, target, state.tickCount, rng, cost);
 
@@ -534,6 +545,12 @@ export function mafiaCommand(
     case 'accident': {
       const empId = parseInt(named['employee'] ?? '', 10);
       if (isNaN(empId)) return { success: false, output: 'Usage: mafia accident employee:<id>' };
+      if (state.cash < ACCIDENT_COST) {
+        return {
+          success: false,
+          output: `Insufficient funds: need $${formatMoney(ACCIDENT_COST)}, have $${formatMoney(state.cash)}`,
+        };
+      }
       const result = arrangeAccident(state.mafia, state.employees, state.corruption, empId, rng);
       state.cash -= result.cost;
       addExpense(state.finances, result.cost, 'mafia', 'Arranged accident', state.tickCount);
@@ -553,6 +570,12 @@ export function mafiaCommand(
         return { success: true, output: result.message };
       }
 
+      if (state.cash < FRAME_COST) {
+        return {
+          success: false,
+          output: `Insufficient funds: need $${formatMoney(FRAME_COST)}, have $${formatMoney(state.cash)}`,
+        };
+      }
       const result = startFraming(state.mafia, state.employees, empId, state.tickCount);
       state.cash -= result.cost;
       addExpense(state.finances, result.cost, 'mafia', 'Frame job', state.tickCount);

--- a/src/core/entities/Building.ts
+++ b/src/core/entities/Building.ts
@@ -253,32 +253,23 @@ export function demolishBuilding(state: BuildingState, buildingId: number): Demo
   return { success: true, freedCells };
 }
 
-/**
- * Cost to demolish a building ($). Stub — see `demolishBuildingResult.cost`
- * wiring, not yet consumed by `demolishBuilding`.
- */
+/** Cost to demolish a building ($): the demolish cost of its current type/tier. */
 export function getDemolishCost(building: Building): number {
-  void building;
-  return 0;
+  return getBuildingDef(building.type, building.tier).demolishCost;
 }
 
 /**
- * Cost to upgrade a building to `nextTier` ($). Stub — not yet consumed by
- * any upgrade command.
+ * Cost to upgrade a building to `nextTier` ($): demolishing the current tier
+ * plus constructing the next one.
  */
 export function getUpgradeCost(building: Building, nextTier: BuildingTier): number {
-  void building;
-  void nextTier;
-  return 0;
+  return getBuildingDef(building.type, building.tier).demolishCost
+    + getBuildingDef(building.type, nextTier).constructionCost;
 }
 
-/**
- * Cost to relocate a building ($). Stub — mirrors the 50%-of-construction
- * calculation inlined in `moveBuilding` today; not yet consumed there.
- */
+/** Cost to relocate a building ($): 50% of its construction cost. */
 export function getMoveCost(building: Building): number {
-  void building;
-  return 0;
+  return Math.round(getBuildingDef(building.type, building.tier).constructionCost * 0.5);
 }
 
 /** Move a building to new coordinates. Returns relocation cost (50% of construction). */
@@ -308,8 +299,7 @@ export function moveBuilding(
 
   building.x = newX;
   building.z = newZ;
-  const relocCost = Math.round(def.constructionCost * 0.5);
-  return { success: true, building, cost: relocCost };
+  return { success: true, building, cost: getMoveCost(building) };
 }
 
 /** Calculate total operating cost for all active buildings. */

--- a/src/core/entities/Building.ts
+++ b/src/core/entities/Building.ts
@@ -253,6 +253,34 @@ export function demolishBuilding(state: BuildingState, buildingId: number): Demo
   return { success: true, freedCells };
 }
 
+/**
+ * Cost to demolish a building ($). Stub — see `demolishBuildingResult.cost`
+ * wiring, not yet consumed by `demolishBuilding`.
+ */
+export function getDemolishCost(building: Building): number {
+  void building;
+  return 0;
+}
+
+/**
+ * Cost to upgrade a building to `nextTier` ($). Stub — not yet consumed by
+ * any upgrade command.
+ */
+export function getUpgradeCost(building: Building, nextTier: BuildingTier): number {
+  void building;
+  void nextTier;
+  return 0;
+}
+
+/**
+ * Cost to relocate a building ($). Stub — mirrors the 50%-of-construction
+ * calculation inlined in `moveBuilding` today; not yet consumed there.
+ */
+export function getMoveCost(building: Building): number {
+  void building;
+  return 0;
+}
+
 /** Move a building to new coordinates. Returns relocation cost (50% of construction). */
 export function moveBuilding(
   state: BuildingState,

--- a/src/ui/BuildMenu.ts
+++ b/src/ui/BuildMenu.ts
@@ -123,6 +123,9 @@ export class BuildMenu {
     container.appendChild(this.el);
 
     this.buildCatalog();
+    // Skeleton-phase reference only — keeps noUnusedLocals quiet until the
+    // implementer wires this into update()/refreshPlacedList().
+    void this.refreshPlacedButtons;
   }
 
   get root(): HTMLElement { return this.el; }
@@ -382,6 +385,16 @@ export class BuildMenu {
   private updateCostDisplay(target: HTMLElement, type: BuildingType, tier: BuildingTier): void {
     const def = getBuildingDef(type, tier);
     target.textContent = t('ui.build.cost', { cost: String(def.constructionCost) });
+  }
+
+  /**
+   * Stub — will disable/enable move/upgrade/demolish buttons on placed rows
+   * per affordability, mirroring `refreshCatalogButtons`. Not yet wired into
+   * `update()`.
+   */
+  private refreshPlacedButtons(cash: number): void {
+    void cash;
+    // TODO: implement
   }
 
   private refreshCatalogButtons(cash: number): void {

--- a/src/ui/BuildMenu.ts
+++ b/src/ui/BuildMenu.ts
@@ -34,6 +34,9 @@ import type { GameState } from '../core/state/GameState.js';
 import {
   getAllBuildingTypes,
   getBuildingDef,
+  getDemolishCost,
+  getUpgradeCost,
+  getMoveCost,
   isTierUnlocked,
   isResearchQueued,
   type BuildingType,
@@ -123,9 +126,6 @@ export class BuildMenu {
     container.appendChild(this.el);
 
     this.buildCatalog();
-    // Skeleton-phase reference only — keeps noUnusedLocals quiet until the
-    // implementer wires this into update()/refreshPlacedList().
-    void this.refreshPlacedButtons;
   }
 
   get root(): HTMLElement { return this.el; }
@@ -152,6 +152,7 @@ export class BuildMenu {
     if (state.cash !== this.lastCash) {
       this.lastCash = state.cash;
       this.refreshCatalogButtons(state.cash);
+      this.refreshPlacedButtons(state.cash);
     }
     const placedSig = state.buildings.buildings.map((b) => `${b.id}:${b.tier}`).join(',');
     const unlockedSig = JSON.stringify(state.buildings.unlockedTiers);
@@ -388,13 +389,30 @@ export class BuildMenu {
   }
 
   /**
-   * Stub — will disable/enable move/upgrade/demolish buttons on placed rows
-   * per affordability, mirroring `refreshCatalogButtons`. Not yet wired into
-   * `update()`.
+   * Re-apply move/upgrade/demolish disabled state on already-rendered placed
+   * rows per affordability, mirroring `refreshCatalogButtons`. Does not
+   * rebuild the list — only toggles `disabled` on existing DOM buttons.
    */
   private refreshPlacedButtons(cash: number): void {
-    void cash;
-    // TODO: implement
+    const buildings = this.lastState?.buildings.buildings ?? [];
+    for (const row of Array.from(this.placedEl.children) as HTMLElement[]) {
+      const idStr = row.dataset['buildingId'];
+      if (!idStr) continue;
+      const b = buildings.find((bb) => bb.id === Number(idStr));
+      if (!b) continue;
+
+      const moveBtn = row.querySelector<HTMLButtonElement>('.bs-build-move-btn');
+      if (moveBtn) moveBtn.disabled = cash < getMoveCost(b);
+
+      const demolishBtn = row.querySelector<HTMLButtonElement>('.bs-build-demolish-btn');
+      if (demolishBtn) demolishBtn.disabled = cash < getDemolishCost(b);
+
+      const upgradeBtn = row.querySelector<HTMLButtonElement>('.bs-build-upgrade-btn');
+      if (upgradeBtn) {
+        const nextTier = b.tier < 3 ? ((b.tier + 1) as BuildingTier) : null;
+        upgradeBtn.disabled = nextTier === null || cash < getUpgradeCost(b, nextTier);
+      }
+    }
   }
 
   private refreshCatalogButtons(cash: number): void {
@@ -440,6 +458,8 @@ export class BuildMenu {
     moveBtn.className = 'bsx-btn bs-build-move-btn';
     moveBtn.style.cssText = 'padding:1px 5px;font-size:9px;flex:0 1 auto;white-space:normal;min-width:0;height:auto';
     moveBtn.textContent = t('ui.build.move');
+    moveBtn.title = `$${getMoveCost(b)}`;
+    moveBtn.disabled = this.lastCash < getMoveCost(b);
     moveBtn.addEventListener('click', () => {
       this.armBuildingPointTool(b.type, b.tier, `${t('ui.build.move')} #${b.id}`, (x, z) => {
         const cmdResult = this.gameConsole?.(`build move ${b.id} to:${x},${z}`);
@@ -457,8 +477,9 @@ export class BuildMenu {
     upgradeBtn.textContent = t('ui.build.upgrade');
     upgradeBtn.disabled = nextTier === null;
     if (nextTier !== null) {
-      const nextDef = getBuildingDef(b.type, nextTier);
-      upgradeBtn.title = `$${def.demolishCost + nextDef.constructionCost}`;
+      const upgradeCost = getUpgradeCost(b, nextTier);
+      upgradeBtn.title = `$${upgradeCost}`;
+      upgradeBtn.disabled = this.lastCash < upgradeCost;
     }
     upgradeBtn.addEventListener('click', () => {
       if (nextTier !== null && nextLocked) {
@@ -483,6 +504,7 @@ export class BuildMenu {
     demolishBtn.style.cssText = 'padding:1px 5px;font-size:9px;flex:0 1 auto;white-space:normal;min-width:0;height:auto';
     demolishBtn.textContent = t('ui.build.demolish');
     demolishBtn.title = `$${def.demolishCost}`;
+    demolishBtn.disabled = this.lastCash < getDemolishCost(b);
     demolishBtn.addEventListener('click', () => {
       const cmdResult = this.gameConsole?.(`build destroy ${b.id}`);
       this.setStatus(cmdResult?.success ? t('ui.build.demolished') : (cmdResult?.output ?? ''));

--- a/src/ui/panels/ShadyPanel.ts
+++ b/src/ui/panels/ShadyPanel.ts
@@ -123,6 +123,9 @@ export class ShadyPanel {
     this.bodyEl.append(introEl, influenceCard, arrangementsHeader, this.targetsEl, servicesHeader, this.servicesEl, this.statusEl);
     this.el.append(header, this.bodyEl);
     container.appendChild(this.el);
+    // Skeleton-phase reference only — keeps noUnusedLocals quiet until the
+    // implementer wires this into update()/render().
+    void this.refreshAffordability;
   }
 
   get root(): HTMLElement { return this.el; }
@@ -155,6 +158,16 @@ export class ShadyPanel {
     if (signature === this.lastSignature) return;
     this.lastSignature = signature;
     this.render(state);
+  }
+
+  /**
+   * Stub — will disable/enable the corrupt/accident/frame action buttons per
+   * affordability, mirroring BuildMenu's cost-gating pattern. Not yet wired
+   * into `update()`.
+   */
+  private refreshAffordability(cash: number): void {
+    void cash;
+    // TODO: implement
   }
 
   /** Cheap per-tick refresh: the exposure meter climbs continuously while smuggling runs. */

--- a/src/ui/panels/ShadyPanel.ts
+++ b/src/ui/panels/ShadyPanel.ts
@@ -46,6 +46,8 @@ export class ShadyPanel {
   private onConfirmRequestCb?: (config: ConfirmModalConfig) => void;
   private lastSignature = '';
   private lastState: GameState | null = null;
+  /** Last cash value used for button affordability refresh. */
+  private lastCash = -1;
   private readonly locale = new LocaleTextRegistry();
 
   constructor(container: HTMLElement) {
@@ -123,9 +125,6 @@ export class ShadyPanel {
     this.bodyEl.append(introEl, influenceCard, arrangementsHeader, this.targetsEl, servicesHeader, this.servicesEl, this.statusEl);
     this.el.append(header, this.bodyEl);
     container.appendChild(this.el);
-    // Skeleton-phase reference only — keeps noUnusedLocals quiet until the
-    // implementer wires this into update()/render().
-    void this.refreshAffordability;
   }
 
   get root(): HTMLElement { return this.el; }
@@ -154,6 +153,11 @@ export class ShadyPanel {
     this.lastState = state;
     this.refreshDynamic(state);
 
+    if (state.cash !== this.lastCash) {
+      this.lastCash = state.cash;
+      this.refreshAffordability(state.cash);
+    }
+
     const signature = this.computeSignature(state);
     if (signature === this.lastSignature) return;
     this.lastSignature = signature;
@@ -161,13 +165,32 @@ export class ShadyPanel {
   }
 
   /**
-   * Stub — will disable/enable the corrupt/accident/frame action buttons per
-   * affordability, mirroring BuildMenu's cost-gating pattern. Not yet wired
-   * into `update()`.
+   * Disable/enable the corrupt/accident/frame-start action buttons per
+   * affordability, mirroring BuildMenu's cost-gating pattern. Reapplies to
+   * already-rendered DOM without a full rebuild. The frame-complete button
+   * is never gated — completing a pending frame costs 0.
    */
   private refreshAffordability(cash: number): void {
-    void cash;
-    // TODO: implement
+    for (const targetEl of Array.from(this.targetsEl.children) as HTMLElement[]) {
+      const targetId = targetEl.dataset['target'] as CorruptionTarget | undefined;
+      if (!targetId) continue;
+      const btn = targetEl.querySelector<HTMLButtonElement>('[data-action="corrupt"]');
+      if (btn) btn.disabled = cash < TARGET_COSTS[targetId];
+    }
+
+    const accidentBtn = this.servicesEl.querySelector<HTMLButtonElement>('[data-action="mafia-accident"]');
+    if (accidentBtn) {
+      const select = this.servicesEl.querySelector<HTMLSelectElement>('[data-action="mafia-accident-employee"]');
+      const noEligible = !select || select.disabled;
+      accidentBtn.disabled = noEligible || cash < ACCIDENT_COST;
+    }
+
+    const frameStartBtn = this.servicesEl.querySelector<HTMLButtonElement>('[data-action="mafia-frame-start"]');
+    if (frameStartBtn) {
+      const select = this.servicesEl.querySelector<HTMLSelectElement>('[data-action="mafia-frame-employee"]');
+      const noEligible = !select || select.disabled;
+      frameStartBtn.disabled = noEligible || cash < FRAME_COST;
+    }
   }
 
   /** Cheap per-tick refresh: the exposure meter climbs continuously while smuggling runs. */
@@ -199,14 +222,14 @@ export class ShadyPanel {
     this.influenceNoteEl.textContent = t('ui.shady.influence_note', { threshold: MAFIA_THRESHOLD });
 
     const rate = Math.round(getSuccessRate(state.corruption) * 100);
-    this.targetsEl.replaceChildren(...TARGETS.map(target => this.targetCard(target, rate)));
+    this.targetsEl.replaceChildren(...TARGETS.map(target => this.targetCard(target, rate, state.cash)));
 
     this.servicesEl.replaceChildren(
       state.corruption.mafiaUnlocked ? this.unlockedServices(state) : this.lockedServicesTeaser(),
     );
   }
 
-  private targetCard(target: { id: CorruptionTarget; nameKey: string; noteKey: string }, rate: number): HTMLElement {
+  private targetCard(target: { id: CorruptionTarget; nameKey: string; noteKey: string }, rate: number, cash: number): HTMLElement {
     const cost = TARGET_COSTS[target.id];
     const headRow = el('div', { attrs: { style: 'display:flex;align-items:center;gap:8px' }, children: [
       iconEl('person', 13, 0.6),
@@ -216,6 +239,7 @@ export class ShadyPanel {
     const noteEl = el('span', { text: t(target.noteKey), attrs: { style: 'font:400 10px/1.4 var(--bsx-font-ui);color:var(--bsx-text-muted)' } });
     const callBtn = button('ghost', t('ui.shady.make_the_call'), { dataAction: 'corrupt' });
     callBtn.style.cssText = 'margin-left:auto;border-color:rgba(169,140,255,.4);background:rgba(169,140,255,.1);color:#c4aeff';
+    callBtn.disabled = cash < cost;
     callBtn.addEventListener('click', () => {
       this.onConfirmRequestCb?.({
         icon: 'shady',
@@ -252,7 +276,7 @@ export class ShadyPanel {
 
   private unlockedServices(state: GameState): HTMLElement {
     const wrap = el('div', { attrs: { style: 'display:flex;flex-direction:column;gap:8px' } });
-    wrap.append(this.exposureCard, this.smugglingCard(state), this.accidentCard(state), this.frameCard(state));
+    wrap.append(this.exposureCard, this.smugglingCard(state), this.accidentCard(state, state.cash), this.frameCard(state, state.cash));
     return wrap;
   }
 
@@ -278,7 +302,7 @@ export class ShadyPanel {
     return card([headRow, note, toggleBtn]);
   }
 
-  private accidentCard(state: GameState): HTMLElement {
+  private accidentCard(state: GameState, cash: number): HTMLElement {
     const successRate = Math.round(ACCIDENT_SUCCESS_RATE * 100);
     const label = el('span', { text: t('ui.shady.accident_label'), attrs: { style: 'font:600 10px/1 var(--bsx-font-ui);letter-spacing:.14em;color:var(--bsx-text-muted)' } });
     const note = el('span', { text: t('ui.shady.accident_note', { rate: successRate }), attrs: { style: 'font:400 10px/1.4 var(--bsx-font-ui);color:var(--bsx-text-muted)' } });
@@ -287,7 +311,7 @@ export class ShadyPanel {
     select.dataset['action'] = 'mafia-accident-employee';
     const goBtn = button('ghost', t('ui.shady.accident_button'), { dataAction: 'mafia-accident' });
     goBtn.style.cssText = 'border-color:rgba(255,91,76,.35);color:var(--bsx-critical-text)';
-    goBtn.disabled = alive.length === 0;
+    goBtn.disabled = alive.length === 0 || cash < ACCIDENT_COST;
     goBtn.addEventListener('click', () => {
       const empId = Number(select.value);
       const emp = alive.find(e => e.id === empId);
@@ -307,7 +331,7 @@ export class ShadyPanel {
     return card([label, note, row]);
   }
 
-  private frameCard(state: GameState): HTMLElement {
+  private frameCard(state: GameState, cash: number): HTMLElement {
     const successRate = Math.round(FRAME_SUCCESS_RATE * 100);
     const label = el('span', { text: t('ui.shady.frame_label'), attrs: { style: 'font:600 10px/1 var(--bsx-font-ui);letter-spacing:.14em;color:var(--bsx-text-muted)' } });
     const note = el('span', {
@@ -355,7 +379,7 @@ export class ShadyPanel {
     const select = this.employeeSelect(eligible);
     select.dataset['action'] = 'mafia-frame-employee';
     const startBtn = button('ghost', t('ui.shady.frame_start_button'), { dataAction: 'mafia-frame-start' });
-    startBtn.disabled = eligible.length === 0;
+    startBtn.disabled = eligible.length === 0 || cash < FRAME_COST;
     startBtn.addEventListener('click', () => {
       const empId = Number(select.value);
       const emp = eligible.find(e => e.id === empId);

--- a/tests/unit/console/build-commands.test.ts
+++ b/tests/unit/console/build-commands.test.ts
@@ -98,6 +98,9 @@ describe('build command — upgrade', () => {
     // Research-gated: unlock tiers 2 and 3 so the setup upgrades (T1→T2→T3)
     // succeed, leaving only the max-tier rejection under test.
     ctx.state!.buildings.unlockedTiers['management_office'] = 3;
+    // Fund the two setup upgrades (funds-guarded, #511) so only the max-tier
+    // rejection is under test here, not affordability.
+    ctx.state!.cash += 100000;
     // upgrade to T2 then T3
     const id1 = ctx.state!.buildings.buildings[0]!.id;
     buildCommand(ctx, ['upgrade', String(id1)], {});

--- a/tests/unit/console/insufficient-funds-guards.test.ts
+++ b/tests/unit/console/insufficient-funds-guards.test.ts
@@ -23,10 +23,19 @@ import { EventEmitter } from '../../../src/core/state/EventEmitter.js';
 import { newGameCommand } from '../../../src/console/commands/world.js';
 import { employeeCommand, buildCommand } from '../../../src/console/commands/entities.js';
 import { vehicleCommand } from '../../../src/console/commands/vehicle.js';
+import { corruptCommand, mafiaCommand } from '../../../src/console/commands/events.js';
 import type { MiningContext } from '../../../src/console/commands/mining.js';
-import { HIRING_COSTS } from '../../../src/core/entities/Employee.js';
+import { HIRING_COSTS, hireEmployee } from '../../../src/core/entities/Employee.js';
 import { getVehicleDefByTier } from '../../../src/core/entities/Vehicle.js';
-import { getBuildingDef } from '../../../src/core/entities/Building.js';
+import {
+  getBuildingDef,
+  placeBuilding,
+  type BuildingType,
+  type BuildingTier,
+} from '../../../src/core/entities/Building.js';
+import { TARGET_COSTS, MAFIA_THRESHOLD } from '../../../src/core/economy/Corruption.js';
+import { ACCIDENT_COST, FRAME_COST, FRAME_EVIDENCE_TICKS } from '../../../src/core/events/MafiaActions.js';
+import { Random } from '../../../src/core/math/Random.js';
 
 function makeCtx(cash: number): MiningContext {
   const ctx: MiningContext = {
@@ -59,7 +68,44 @@ function snapshot(ctx: MiningContext): Record<string, unknown> {
     vehicleNextId: s.vehicles.nextId,
     buildings: s.buildings.buildings.length,
     buildingNextId: s.buildings.nextId,
+    // The build destroy/upgrade/move and corrupt/mafia guards below all sit
+    // in front of state that mutates *before* today's unguarded cost
+    // deduction — attemptCorruption pushes an attempt record unconditionally,
+    // and arrangeAccident/startFraming/completeFrame raise mafia exposure
+    // risk even when the underlying action fails internally. A refusal that
+    // still moved one of these would pass the fields above by accident.
+    mafiaExposureRisk: s.mafia.exposureRisk,
+    mafiaPendingFrames: s.mafia.pendingFrames.length,
+    corruptionLevel: s.corruption.level,
+    corruptionAttempts: s.corruption.attempts.length,
   };
+}
+
+/**
+ * Place a building directly through the core `placeBuilding` — bypasses the
+ * console layer entirely, so setting up a building to destroy/upgrade/move
+ * never touches the cash balance a guard test is trying to control.
+ */
+function placeTestBuilding(ctx: MiningContext, type: BuildingType = 'management_office', tier: BuildingTier = 1): number {
+  const grid = ctx.grid!;
+  const result = placeBuilding(ctx.state!.buildings, type, 0, 0, grid.sizeX, grid.sizeZ, tier, grid.minX, grid.minZ);
+  if (!result.success) throw new Error(`setup: failed to place test building — ${result.error}`);
+  return result.building!.id;
+}
+
+/**
+ * Unlock the mafia deterministically: `attemptCorruption` bumps
+ * `corruption.level` by 1 on both a success and a failure, so 3 calls always
+ * clears `MAFIA_UNLOCK_THRESHOLD` regardless of the RNG roll. Cash is bumped
+ * for the duration and restored — this is setup, not the guard under test.
+ */
+function unlockMafia(ctx: MiningContext): void {
+  const prevCash = ctx.state!.cash;
+  setCash(ctx, 10_000_000);
+  for (let i = 0; i < MAFIA_THRESHOLD; i++) {
+    corruptCommand(ctx, [], { target: 'witness' });
+  }
+  setCash(ctx, prevCash);
 }
 
 // ── employee hire ──
@@ -224,5 +270,238 @@ describe('build <type> at: — insufficient funds guard', () => {
     expect(snapshot(ctx)).toEqual(before);
     expect({ minX: ctx.grid!.minX, maxX: ctx.grid!.maxX, minZ: ctx.grid!.minZ, maxZ: ctx.grid!.maxZ })
       .toEqual(boundsBefore);
+  });
+});
+
+// ── build destroy — issue #511 ──
+
+describe('build destroy — insufficient funds guard', () => {
+  const DEMOLISH_COST = getBuildingDef('management_office', 1).demolishCost;
+
+  it('refuses when cash is one dollar short', () => {
+    const ctx = makeCtx(DEMOLISH_COST - 1);
+    const id = placeTestBuilding(ctx);
+    const result = buildCommand(ctx, ['destroy', String(id)], {});
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('Insufficient funds');
+  });
+
+  it('changes nothing at all when it refuses', () => {
+    const ctx = makeCtx(DEMOLISH_COST - 1);
+    const id = placeTestBuilding(ctx);
+    const before = snapshot(ctx);
+    buildCommand(ctx, ['destroy', String(id)], {});
+    expect(snapshot(ctx)).toEqual(before);
+    expect(ctx.state!.buildings.buildings).toHaveLength(1);
+    expect(ctx.state!.buildings.buildings[0]!.id).toBe(id);
+  });
+
+  it('demolishes when cash exactly equals the demolish cost', () => {
+    const ctx = makeCtx(DEMOLISH_COST);
+    const id = placeTestBuilding(ctx);
+    const result = buildCommand(ctx, ['destroy', String(id)], {});
+    expect(result.success).toBe(true);
+    expect(ctx.state!.buildings.buildings).toHaveLength(0);
+    expect(ctx.state!.cash).toBe(0);
+  });
+});
+
+// ── build upgrade — issue #511 ──
+
+describe('build upgrade — insufficient funds guard', () => {
+  const OLD_DEF = getBuildingDef('management_office', 1);
+  const NEW_DEF = getBuildingDef('management_office', 2);
+  const UPGRADE_COST = OLD_DEF.demolishCost + NEW_DEF.constructionCost;
+
+  function unlockTier2(ctx: MiningContext): void {
+    ctx.state!.buildings.unlockedTiers['management_office'] = 3;
+  }
+
+  it('refuses when cash is one dollar short', () => {
+    const ctx = makeCtx(UPGRADE_COST - 1);
+    unlockTier2(ctx);
+    const id = placeTestBuilding(ctx);
+    const result = buildCommand(ctx, ['upgrade', String(id)], {});
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('Insufficient funds');
+  });
+
+  it('changes nothing at all when it refuses — original building untouched, destroyBuilding never ran', () => {
+    const ctx = makeCtx(UPGRADE_COST - 1);
+    unlockTier2(ctx);
+    const id = placeTestBuilding(ctx);
+    const before = snapshot(ctx);
+    buildCommand(ctx, ['upgrade', String(id)], {});
+    expect(snapshot(ctx)).toEqual(before);
+    expect(ctx.state!.buildings.buildings).toHaveLength(1);
+    const building = ctx.state!.buildings.buildings[0]!;
+    expect(building.id).toBe(id);
+    expect(building.tier).toBe(1);
+  });
+
+  it('upgrades when cash exactly equals the upgrade cost', () => {
+    const ctx = makeCtx(UPGRADE_COST);
+    unlockTier2(ctx);
+    const id = placeTestBuilding(ctx);
+    const result = buildCommand(ctx, ['upgrade', String(id)], {});
+    expect(result.success).toBe(true);
+    expect(ctx.state!.buildings.buildings).toHaveLength(1);
+    expect(ctx.state!.buildings.buildings[0]!.tier).toBe(2);
+    expect(ctx.state!.cash).toBe(0);
+  });
+
+  it('refuses a max-tier building for the tier-bound reason, not cost — even at cash 0', () => {
+    // Edge case: the pre-existing tier>=3 check must keep running ahead of
+    // the new funds guard, not get shadowed by it.
+    const ctx = makeCtx(0);
+    unlockTier2(ctx); // also unlocks T3 — placeTestBuilding's own placeBuilding() re-checks the research gate
+    const id = placeTestBuilding(ctx, 'management_office', 3);
+    const result = buildCommand(ctx, ['upgrade', String(id)], {});
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('already at max tier');
+    expect(result.output).not.toContain('Insufficient funds');
+  });
+});
+
+// ── build move — issue #511 ──
+
+describe('build move — insufficient funds guard', () => {
+  const MOVE_COST = Math.round(getBuildingDef('management_office', 1).constructionCost * 0.5);
+
+  it('refuses when cash is one dollar short', () => {
+    const ctx = makeCtx(MOVE_COST - 1);
+    const id = placeTestBuilding(ctx);
+    const result = buildCommand(ctx, ['move', String(id)], { to: '5,5' });
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('Insufficient funds');
+  });
+
+  it('changes nothing at all when it refuses — building keeps its original position', () => {
+    const ctx = makeCtx(MOVE_COST - 1);
+    const id = placeTestBuilding(ctx);
+    const before = snapshot(ctx);
+    buildCommand(ctx, ['move', String(id)], { to: '5,5' });
+    expect(snapshot(ctx)).toEqual(before);
+    const building = ctx.state!.buildings.buildings.find(b => b.id === id)!;
+    expect(building.x).toBe(0);
+    expect(building.z).toBe(0);
+  });
+
+  it('moves when cash exactly equals the move cost', () => {
+    const ctx = makeCtx(MOVE_COST);
+    const id = placeTestBuilding(ctx);
+    const result = buildCommand(ctx, ['move', String(id)], { to: '5,5' });
+    expect(result.success).toBe(true);
+    const building = ctx.state!.buildings.buildings.find(b => b.id === id)!;
+    expect(building.x).toBe(5);
+    expect(building.z).toBe(5);
+    expect(ctx.state!.cash).toBe(0);
+  });
+});
+
+// ── corrupt — issue #511 ──
+
+describe('corrupt — insufficient funds guard', () => {
+  const WITNESS_COST = TARGET_COSTS.witness;
+
+  it('refuses when cash is one dollar short', () => {
+    const ctx = makeCtx(WITNESS_COST - 1);
+    const result = corruptCommand(ctx, [], { target: 'witness' });
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('Insufficient funds');
+  });
+
+  it('leaves no phantom attempt record on refusal — attemptCorruption today pushes one unconditionally', () => {
+    const ctx = makeCtx(WITNESS_COST - 1);
+    const before = snapshot(ctx);
+    corruptCommand(ctx, [], { target: 'witness' });
+    expect(snapshot(ctx)).toEqual(before);
+    expect(ctx.state!.corruption.attempts).toHaveLength(0);
+    expect(ctx.state!.corruption.level).toBe(0);
+    expect(ctx.state!.corruption.mafiaUnlocked).toBe(false);
+  });
+
+  it('attempts corruption when cash exactly equals the target cost', () => {
+    const ctx = makeCtx(WITNESS_COST);
+    const result = corruptCommand(ctx, [], { target: 'witness' });
+    expect(result.success).toBe(true);
+    expect(ctx.state!.cash).toBe(0);
+    expect(ctx.state!.corruption.attempts).toHaveLength(1);
+  });
+
+  it('refuses the expensive target at a balance that affords the cheap one', () => {
+    const cheapCost = TARGET_COSTS.inspector;
+    const expensiveCost = TARGET_COSTS.judge;
+    expect(expensiveCost).toBeGreaterThan(cheapCost);
+    const ctx = makeCtx(expensiveCost - 1);
+    expect(corruptCommand(ctx, [], { target: 'judge' }).success).toBe(false);
+    expect(corruptCommand(ctx, [], { target: 'inspector' }).success).toBe(true);
+  });
+});
+
+// ── mafia accident — issue #511 ──
+
+describe('mafia accident — insufficient funds guard', () => {
+  it('refuses when cash is one dollar short', () => {
+    const ctx = makeCtx(ACCIDENT_COST - 1);
+    unlockMafia(ctx);
+    const { employee } = hireEmployee(ctx.state!.employees, 'driller', new Random(1));
+    const before = snapshot(ctx);
+    const result = mafiaCommand(ctx, ['accident'], { employee: String(employee.id) });
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('Insufficient funds');
+    expect(snapshot(ctx)).toEqual(before);
+    expect(ctx.state!.employees.employees.find(e => e.id === employee.id)!.alive).toBe(true);
+  });
+
+  it('arranges the accident when cash exactly equals the accident cost', () => {
+    const ctx = makeCtx(ACCIDENT_COST);
+    unlockMafia(ctx);
+    const { employee } = hireEmployee(ctx.state!.employees, 'driller', new Random(1));
+    const result = mafiaCommand(ctx, ['accident'], { employee: String(employee.id) });
+    expect(result.success).toBe(true);
+    expect(ctx.state!.cash).toBe(0);
+  });
+});
+
+// ── mafia frame — issue #511 ──
+
+describe('mafia frame — insufficient funds guard', () => {
+  it('refuses the start path when cash is one dollar short', () => {
+    const ctx = makeCtx(FRAME_COST - 1);
+    unlockMafia(ctx);
+    const { employee } = hireEmployee(ctx.state!.employees, 'driller', new Random(1));
+    const before = snapshot(ctx);
+    const result = mafiaCommand(ctx, ['frame'], { employee: String(employee.id) });
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('Insufficient funds');
+    expect(snapshot(ctx)).toEqual(before);
+    expect(ctx.state!.mafia.pendingFrames).toHaveLength(0);
+  });
+
+  it('starts framing when cash exactly equals the frame cost', () => {
+    const ctx = makeCtx(FRAME_COST);
+    unlockMafia(ctx);
+    const { employee } = hireEmployee(ctx.state!.employees, 'driller', new Random(1));
+    const result = mafiaCommand(ctx, ['frame'], { employee: String(employee.id) });
+    expect(result.success).toBe(true);
+    expect(ctx.state!.cash).toBe(0);
+    expect(ctx.state!.mafia.pendingFrames).toHaveLength(1);
+  });
+
+  it('completes a ready pending frame even at cash === 0 — the complete path must never be gated', () => {
+    const ctx = makeCtx(FRAME_COST);
+    unlockMafia(ctx);
+    const { employee } = hireEmployee(ctx.state!.employees, 'driller', new Random(1));
+    const startResult = mafiaCommand(ctx, ['frame'], { employee: String(employee.id) });
+    expect(startResult.success).toBe(true);
+    expect(ctx.state!.mafia.pendingFrames).toHaveLength(1);
+
+    ctx.state!.tickCount += FRAME_EVIDENCE_TICKS;
+    setCash(ctx, 0);
+    const completeResult = mafiaCommand(ctx, ['frame'], { employee: String(employee.id) });
+    expect(completeResult.success).toBe(true);
+    expect(completeResult.output).not.toContain('Insufficient funds');
+    expect(ctx.state!.cash).toBe(0);
   });
 });

--- a/tests/unit/entities/Building.test.ts
+++ b/tests/unit/entities/Building.test.ts
@@ -13,7 +13,13 @@ import {
   tickResearch,
   isTierUnlocked,
   findNearestActiveBuildingOfType,
+  getDemolishCost,
+  getUpgradeCost,
+  getMoveCost,
+  moveBuilding,
+  BUILDING_DEFS,
 } from '../../../src/core/entities/Building.js';
+import type { Building } from '../../../src/core/entities/Building.js';
 
 describe('Building system', () => {
   it('placing a building deducts cost and adds it to state', () => {
@@ -312,5 +318,83 @@ describe('findNearestActiveBuildingOfType', () => {
     const state = createBuildingState();
     const result = findNearestActiveBuildingOfType(state, 'freight_warehouse', 0, 0);
     expect(result).toBeNull();
+  });
+});
+
+// ── getDemolishCost / getUpgradeCost / getMoveCost (#511 — direct coverage) ──
+
+describe('getDemolishCost()', () => {
+  it('equals the demolish cost of the building def for its type and tier', () => {
+    const building: Building = { id: 1, type: 'management_office', tier: 1, x: 0, z: 0, hp: 100, active: true };
+    expect(getDemolishCost(building)).toBe(getBuildingDef('management_office', 1).demolishCost);
+  });
+
+  it('uses the tier-specific demolish cost, not tier 1, for an upgraded building', () => {
+    const building: Building = { id: 2, type: 'freight_warehouse', tier: 3, x: 0, z: 0, hp: 100, active: true };
+    expect(getDemolishCost(building)).toBe(getBuildingDef('freight_warehouse', 3).demolishCost);
+    expect(getDemolishCost(building)).not.toBe(getBuildingDef('freight_warehouse', 1).demolishCost);
+  });
+});
+
+describe('getUpgradeCost()', () => {
+  it('is the sum of the current tier demolish cost and the next tier construction cost', () => {
+    const building: Building = { id: 1, type: 'living_quarters', tier: 1, x: 0, z: 0, hp: 100, active: true };
+    const currentDemolish = getBuildingDef('living_quarters', 1).demolishCost;
+    const nextConstruction = getBuildingDef('living_quarters', 2).constructionCost;
+
+    expect(getUpgradeCost(building, 2)).toBe(currentDemolish + nextConstruction);
+    // Not just the next tier's construction cost alone...
+    expect(getUpgradeCost(building, 2)).not.toBe(nextConstruction);
+    // ...and not just the current tier's demolish cost alone.
+    expect(getUpgradeCost(building, 2)).not.toBe(currentDemolish);
+  });
+
+  it('computes the same demolish-plus-construction sum for a tier-2 to tier-3 upgrade', () => {
+    const building: Building = { id: 2, type: 'vehicle_depot', tier: 2, x: 0, z: 0, hp: 100, active: true };
+    const expected = getBuildingDef('vehicle_depot', 2).demolishCost + getBuildingDef('vehicle_depot', 3).constructionCost;
+
+    expect(getUpgradeCost(building, 3)).toBe(expected);
+  });
+});
+
+describe('getMoveCost()', () => {
+  it('is 50% of the construction cost for the building type and tier', () => {
+    const building: Building = { id: 1, type: 'geology_lab', tier: 1, x: 0, z: 0, hp: 100, active: true };
+    expect(getMoveCost(building)).toBe(Math.round(getBuildingDef('geology_lab', 1).constructionCost * 0.5));
+    expect(getMoveCost(building)).toBe(6000);
+  });
+
+  it('scales with tier via the tier-specific construction cost', () => {
+    const building: Building = { id: 2, type: 'freight_warehouse', tier: 3, x: 0, z: 0, hp: 100, active: true };
+    expect(getMoveCost(building)).toBe(Math.round(getBuildingDef('freight_warehouse', 3).constructionCost * 0.5));
+    expect(getMoveCost(building)).toBe(36000);
+  });
+
+  it('rounds a fractional raw product instead of truncating or leaving it unrounded', () => {
+    // Every real catalog constructionCost is a multiple of 500 (even), so halving
+    // never lands on a fraction. Nudge one entry's cost odd for this case only,
+    // to prove Math.round — not truncation, not a no-op — is what runs.
+    const original = BUILDING_DEFS.management_office[1].constructionCost;
+    const building: Building = { id: 3, type: 'management_office', tier: 1, x: 0, z: 0, hp: 100, active: true };
+    try {
+      BUILDING_DEFS.management_office[1].constructionCost = 8001; // raw product: 4000.5
+      expect(getMoveCost(building)).toBe(4001); // Math.round(4000.5) === 4001, not 4000
+    } finally {
+      BUILDING_DEFS.management_office[1].constructionCost = original;
+    }
+  });
+});
+
+describe('moveBuilding() cost matches getMoveCost()', () => {
+  it('deducts exactly getMoveCost(building) as the relocation cost', () => {
+    const state = createBuildingState();
+    placeBuilding(state, 'management_office', 0, 0, 64, 64);
+    const building = state.buildings[0]!;
+    const expectedCost = getMoveCost(building);
+
+    const result = moveBuilding(state, building.id, 10, 10, 64, 64);
+
+    expect(result.success).toBe(true);
+    expect(result.cost).toBe(expectedCost);
   });
 });

--- a/tests/unit/scenario-defs.test.ts
+++ b/tests/unit/scenario-defs.test.ts
@@ -146,6 +146,7 @@ const VISUAL_SCENARIO_NAMES = [
   'tutorial-interactive',
   'scene-picking-visual',
   'landscape-continuity-visual',
+  'insufficient-funds-guards-visual',
 ] as const;
 
 /**

--- a/tests/unit/ui/BuildMenu.test.ts
+++ b/tests/unit/ui/BuildMenu.test.ts
@@ -16,7 +16,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { BuildMenu } from '../../../src/ui/BuildMenu.js';
 import { createGame } from '../../../src/core/state/GameState.js';
 import type { GameState } from '../../../src/core/state/GameState.js';
-import type { Building } from '../../../src/core/entities/Building.js';
+import { getBuildingDef, type Building } from '../../../src/core/entities/Building.js';
 
 /** Minimal GameState that won't crash the panel update loop. */
 function makeMockState(overrides?: Partial<GameState>): GameState {
@@ -142,5 +142,71 @@ describe('BuildMenu — placed-row layout does not collapse the label column (is
       expect(btn!.style.flex).toBe('0 1 auto');
       expect(btn!.style.whiteSpace).toBe('normal');
     }
+  });
+});
+
+describe('BuildMenu — placed-row affordability guard (issue #511)', () => {
+  let container: HTMLDivElement;
+  let menu: BuildMenu;
+
+  beforeEach(() => {
+    ({ container, menu } = setupMenu());
+  });
+
+  afterEach(() => {
+    menu.dispose();
+    container.remove();
+  });
+
+  it('.bs-build-demolish-btn / .bs-build-upgrade-btn / .bs-build-move-btn disable when cash is short of their real cost, and re-enable on a cash-only update() that never rebuilds the row', () => {
+    const building = makeBuilding({ id: 1, type: 'management_office', tier: 1 });
+    const state = makeMockState();
+    state.buildings.buildings = [building];
+    // Tier 2 researched so only the funds guard — not the research gate — is
+    // under test here; the tier-locked case is covered by BuildMenu's own
+    // pre-existing nextTier===null disabling, not this guard.
+    state.buildings.unlockedTiers['management_office'] = 2;
+
+    const oldDef = getBuildingDef('management_office', 1);
+    const newDef = getBuildingDef('management_office', 2);
+    const demolishCost = oldDef.demolishCost;
+    const moveCost = Math.round(oldDef.constructionCost * 0.5);
+    const upgradeCost = oldDef.demolishCost + newDef.constructionCost;
+    const maxCost = Math.max(demolishCost, moveCost, upgradeCost);
+
+    state.cash = maxCost - 1;
+    menu.update(state);
+    const row = findPlacedRow(container, 1);
+    expect(row.querySelector<HTMLButtonElement>('.bs-build-demolish-btn')!.disabled).toBe(demolishCost > state.cash);
+    expect(row.querySelector<HTMLButtonElement>('.bs-build-upgrade-btn')!.disabled).toBe(upgradeCost > state.cash);
+    expect(row.querySelector<HTMLButtonElement>('.bs-build-move-btn')!.disabled).toBe(moveCost > state.cash);
+
+    // Cash-only change: building id/tier, unlockedTiers, and researchQueue are
+    // all unchanged, so `update()` must not trigger `refreshPlacedList()` — the
+    // row's own DOM node must survive, proving the cash refresh is the cheap
+    // per-tick path, not a full placed-list rebuild.
+    state.cash = maxCost;
+    menu.update(state);
+    const rowAfter = findPlacedRow(container, 1);
+    expect(rowAfter).toBe(row);
+    expect(rowAfter.querySelector<HTMLButtonElement>('.bs-build-demolish-btn')!.disabled).toBe(false);
+    expect(rowAfter.querySelector<HTMLButtonElement>('.bs-build-upgrade-btn')!.disabled).toBe(false);
+    expect(rowAfter.querySelector<HTMLButtonElement>('.bs-build-move-btn')!.disabled).toBe(false);
+  });
+
+  it('re-disables on a cash-only update() that drops the balance back below cost', () => {
+    const building = makeBuilding({ id: 2, type: 'management_office', tier: 1 });
+    const state = makeMockState();
+    state.buildings.buildings = [building];
+    state.buildings.unlockedTiers['management_office'] = 2;
+    const demolishCost = getBuildingDef('management_office', 1).demolishCost;
+
+    state.cash = demolishCost;
+    menu.update(state);
+    expect(findPlacedRow(container, 2).querySelector<HTMLButtonElement>('.bs-build-demolish-btn')!.disabled).toBe(false);
+
+    state.cash = demolishCost - 1;
+    menu.update(state);
+    expect(findPlacedRow(container, 2).querySelector<HTMLButtonElement>('.bs-build-demolish-btn')!.disabled).toBe(true);
   });
 });

--- a/tests/unit/ui/panels/ShadyPanel.test.ts
+++ b/tests/unit/ui/panels/ShadyPanel.test.ts
@@ -7,6 +7,8 @@ import { hireEmployee } from '../../../../src/core/entities/Employee.js';
 import { Random } from '../../../../src/core/math/Random.js';
 import { t, setLocale } from '../../../../src/core/i18n/I18n.js';
 import type { ConfirmModalConfig } from '../../../../src/ui/panels/ConfirmModal.js';
+import { TARGET_COSTS } from '../../../../src/core/economy/Corruption.js';
+import { ACCIDENT_COST, FRAME_COST } from '../../../../src/core/events/MafiaActions.js';
 
 function mount(): { container: HTMLDivElement; panel: ShadyPanel } {
   const container = document.createElement('div');
@@ -537,6 +539,107 @@ describe('ShadyPanel', () => {
       vi.advanceTimersByTime(1000);
       expect(statusText()).toBe('');
 
+      panel.dispose();
+    });
+  });
+
+  // Funds-guard parity (issue #511): a control that spends cash must refuse
+  // an unaffordable action the same way employee hire / vehicle buy / build
+  // already do, on both the console guard and the button's disabled state.
+  // These cover the button side; the console side lives in
+  // tests/unit/console/insufficient-funds-guards.test.ts.
+  describe('affordability guard (#511)', () => {
+    // Scoped to `panel.root` rather than `container.querySelector('#bs-shady-panel ...')`:
+    // a red-phase assertion failure below skips the trailing `panel.dispose()`,
+    // and jsdom resolves id selectors against the whole document rather than
+    // the query root (same gotcha BuildMenu.test.ts documents for #462), so a
+    // prior test's undisposed panel can shadow this one's #bs-shady-panel.
+    // `panel.root` is the exact element, immune to that collision regardless
+    // of cleanup order.
+
+    it('disables the corrupt call button when cash is short of the target cost, and re-enables on a cash-only update()', () => {
+      const { panel } = mount();
+      const state = createGame({ seed: 1, mineType: 'desert' });
+      state.cash = TARGET_COSTS.witness - 1;
+      panel.update(state);
+      panel.show();
+
+      const witnessBtn = panel.root.querySelector<HTMLButtonElement>('[data-target="witness"] [data-action="corrupt"]')!;
+      expect(witnessBtn.disabled).toBe(true);
+
+      // Cash-only change: no roster/frame/level/smuggling change, so the
+      // signature-gated render() must not need to fire for this to update.
+      state.cash = TARGET_COSTS.witness;
+      panel.update(state);
+      const witnessBtnAfter = panel.root.querySelector<HTMLButtonElement>('[data-target="witness"] [data-action="corrupt"]')!;
+      expect(witnessBtnAfter.disabled).toBe(false);
+      panel.dispose();
+    });
+
+    it('a cheap target stays clickable while an expensive one is disabled at the same balance', () => {
+      const { panel } = mount();
+      const state = createGame({ seed: 1, mineType: 'desert' });
+      state.cash = TARGET_COSTS.judge - 1; // affords every target except judge
+      panel.update(state);
+      panel.show();
+
+      const judgeBtn = panel.root.querySelector<HTMLButtonElement>('[data-target="judge"] [data-action="corrupt"]')!;
+      const witnessBtn = panel.root.querySelector<HTMLButtonElement>('[data-target="witness"] [data-action="corrupt"]')!;
+      expect(judgeBtn.disabled).toBe(true);
+      expect(witnessBtn.disabled).toBe(false);
+      panel.dispose();
+    });
+
+    it('disables the accident button when cash is short of the accident cost — distinct from the no-employees disable case', () => {
+      const { panel } = mount();
+      const state = stateWithMafiaUnlocked();
+      hireEmployee(state.employees, 'driller', new Random(1));
+      state.cash = ACCIDENT_COST - 1;
+      panel.update(state);
+      panel.show();
+
+      const goBtn = panel.root.querySelector<HTMLButtonElement>('[data-action="mafia-accident"]')!;
+      expect(goBtn.disabled).toBe(true);
+
+      state.cash = ACCIDENT_COST;
+      panel.update(state);
+      const goBtnAfter = panel.root.querySelector<HTMLButtonElement>('[data-action="mafia-accident"]')!;
+      expect(goBtnAfter.disabled).toBe(false);
+      panel.dispose();
+    });
+
+    it('disables the frame start button when cash is short of the frame cost, and re-enables on a cash-only update()', () => {
+      const { panel } = mount();
+      const state = stateWithMafiaUnlocked();
+      hireEmployee(state.employees, 'driller', new Random(1));
+      state.cash = FRAME_COST - 1;
+      panel.update(state);
+      panel.show();
+
+      const startBtn = panel.root.querySelector<HTMLButtonElement>('[data-action="mafia-frame-start"]')!;
+      expect(startBtn.disabled).toBe(true);
+
+      state.cash = FRAME_COST;
+      panel.update(state);
+      const startBtnAfter = panel.root.querySelector<HTMLButtonElement>('[data-action="mafia-frame-start"]')!;
+      expect(startBtnAfter.disabled).toBe(false);
+      panel.dispose();
+    });
+
+    it('keeps the frame complete button enabled regardless of cash — completing a ready frame is always free', () => {
+      const { panel } = mount();
+      const state = stateWithMafiaUnlocked();
+      const { employee } = hireEmployee(state.employees, 'driller', new Random(1));
+      state.tickCount = 20;
+      state.mafia.pendingFrames = [{ employeeId: employee.id, startTick: 5, readyTick: 15 }];
+      state.cash = 0;
+      panel.update(state);
+      panel.show();
+
+      const useBtn = panel.root.querySelector<HTMLButtonElement>(
+        `[data-frame-id="${employee.id}"] [data-action="mafia-frame-complete"]`,
+      )!;
+      expect(useBtn.disabled).toBe(false);
       panel.dispose();
     });
   });


### PR DESCRIPTION
Closes #511

## Summary

`build destroy`/`build upgrade`/`build move` (`src/console/commands/entities.ts`) and `corrupt`/`mafia accident`/`mafia frame` (`src/console/commands/events.ts`) all deduct cash but neither console nor UI (`BuildMenu.ts`, `ShadyPanel.ts`) previously refused when unaffordable — the one pair of command groups the earlier funds-guard pass (`employee hire`/`vehicle buy`/`build <type> at:`) deliberately left alone. This PR closes that gap on both sides, mirroring the existing guard pattern.

- Added pure cost helpers `getDemolishCost`, `getUpgradeCost`, `getMoveCost` to `src/core/entities/Building.ts` — single source of truth shared by console guards and UI disabled-state checks. `moveBuilding` itself now calls `getMoveCost` instead of duplicating the formula.
- Console: `build destroy`/`build upgrade`/`build move`, `corrupt`, `mafia accident`, `mafia frame` (start branch only — completing a pending frame stays free) all refuse with `Insufficient funds: need $X, have $Y` before any state mutation. `cash === cost` (exact) is allowed, matching every existing guard.
- UI: `BuildMenu.ts`'s placed-row Destroy/Upgrade/Move buttons and `ShadyPanel.ts`'s corrupt/accident/frame-start buttons now disable exactly when unaffordable, refreshed on cash-only state updates without a full rebuild.
- Extended `tests/unit/console/insufficient-funds-guards.test.ts`'s snapshot to also cover `mafia.exposureRisk`, `mafia.pendingFrames`, `corruption.level`/`attempts` — the newly-guarded actions mutate these unconditionally today, so a refusal that let one through would have passed the old snapshot by accident.
- New scenario `scripts/scenario-defs/insufficient-funds-guards-visual.json` drives all six actions one dollar short and asserts refusal + a disabled control, plus exact-cost success per action.
- Added direct unit tests for the three new `Building.ts` helpers (`tests/unit/entities/Building.test.ts`), including a rounding-proof case for `getMoveCost`.

## Verification

- **static**: `npm run typecheck` — clean, 0 errors.
- **logic**: `npm run test` — 298 files / 8700 tests passing (unit + integration), no regressions.
- **scenario**: `npm run scenarios` (command mode) — 127/127 passing, including the new scenario.
- **visual**: ran in this session — `insufficient-funds-guards-visual` in interaction mode with screenshots, all 16 steps passed, screenshots inspected directly (disabled controls visibly dimmed at guarded cash, `npm run a11y` still 87/87 AA-compliant, `npm run validate:state` 16/16 clean).
- **playability**: no `scripts/playtests/` definition drives build destroy/upgrade/move or corrupt/mafia — these are controls on existing panels (Build panel, Shady panel), not a new goal-reaching flow, so per `agentic-pipeline-pr-management` this is covered by the visual channel above rather than the `full-ci`-labeled playtest job. No new playtest definition or label added.
- `npm run validate` (typecheck → coverage → integration → scenario defs → build) passed in full.

## Decisions taken

Defaulted under `agentic-decision-autonomy`:

- **What was open:** no shared cost-lookup helper existed for building demolish/upgrade/move cost before this change; the issue asked what predicate a UI check and console guard "could share."
  **Chosen:** added `getDemolishCost`/`getUpgradeCost`/`getMoveCost` to `src/core/entities/Building.ts`, with `moveBuilding` itself calling `getMoveCost` internally.
  **Why:** every other guarded action in the codebase (`HIRING_COSTS`, vehicle purchase cost, `TARGET_COSTS`) already reads from one named source both console and UI share; building costs were the only gap.
  **If reversed:** inline the three formulas back into their call sites, delete the helpers.

- **What was open:** whether to extract the 9 now-near-identical `if (cash < cost) return {...}` guard clauses (3 pre-existing + 6 new) across `entities.ts`/`events.ts`/`employees.ts`/`vehicle.ts` into a shared helper (a duplication-reviewer suggestion).
  **Chosen:** left them inline, unextracted.
  **Why:** the issue explicitly asked to mirror the existing per-command guard style already used by `employee hire`/`vehicle buy`/`build <type> at:`, none of which are extracted either — introducing a new shared helper here would deviate from both the issue's own instruction and the established convention.
  **If reversed:** add `guardAffordability(cash, cost): CommandResult | null` to `src/console/commands/commandUtils.ts`, replace all 9 call sites.

- **What was open:** whether `full-ci` (the browser-driven playtest/interaction-mode CI job) should be applied, since building/panel changes are listed as playability-owed in the verification gate.
  **Chosen:** not applied — no `scripts/playtests/` definition drives build destroy/upgrade/move or corrupt/mafia, and this is a control added to an existing panel rather than a new goal-reaching flow.
  **Why:** per `agentic-pipeline-pr-management`, that shape is covered by the visual channel (run in this session, see Verification above), not by paying the ~50-minute `full-ci` cost to replay flows the diff never touched.
  **If reversed:** add `full-ci` label; CI's `Scenarios (interaction mode)` and `Playtest (playability)` jobs then also report on this PR.

## Note — pre-existing issue found, not fixed here

Security review surfaced that `corrupt target:<t> cost:<override>` accepts an unvalidated `named['cost']`: a negative value bypasses the new funds guard and *increases* cash on refund; a non-numeric value produces `NaN`, which permanently corrupts `state.cash` to `NaN` (every subsequent `cash < X` guard in the game — including the ones added here — becomes unconditionally false from then on). Confirmed via `git show origin/main` that this predates this PR (`corruptCommand`'s `parseInt`, `attemptCorruption`'s `customCost ?? TARGET_COSTS[target]` defaulting) and is not introduced or worsened by it — `named['cost']` is a console-only override never sent by the UI. Left out of scope per the issue's own framing; filing a follow-up issue.

READY TO MERGE