### PR TITLE
fix: Resolve #512 — Fleet panel vehicle row selection

### DIFF
--- a/scripts/scenario-defs/vehicle-traffic-routing-visual.json
+++ b/scripts/scenario-defs/vehicle-traffic-routing-visual.json
@@ -259,31 +259,103 @@
       "command": "vehicle move 2 to:37,33",
       "interaction": [
         {
-          "type": "command",
-          "command": "vehicle move 2 to:37,33"
+          "type": "clickSelector",
+          "selector": "#bs-vehicle-panel [data-vehicle-id=\"2\"]"
+        },
+        {
+          "type": "awaitUsable",
+          "selector": "#bs-selection-bar [data-action=\"move_here\"]"
+        },
+        {
+          "type": "cameraFocus",
+          "x": 37.5,
+          "z": 33.5,
+          "distance": 25
+        },
+        {
+          "type": "mousemove",
+          "x": 640,
+          "y": 360
+        },
+        {
+          "type": "wait",
+          "durationMs": 300
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-selection-bar [data-action=\"move_here\"]"
         }
       ],
-      "description": "Left as a command, and this is a defect report rather than a closed exception. MOVE HERE exists and works -- the `vehicle move 1` step above clicks it for real -- but no mouse can select haulers #2, #3 or #4 here: all four spawn on ONE tile. `vehicle buy` staggers the raw spawn point by fleet index, then NavGrid.findNearestReachableCell snaps every one of them back to the same reachable cell, (82,34) on this level. Verified in a real browser: clickEntity for vehicle 2, 3 and 4 each raycast onto hauler #1 and the selection bar reads \"Debris Hauler #1\" every time, and nothing in src/ui calls ScenePicking.select, so no panel row offers a way round it. Converting this step would silently re-order hauler #1 instead of #2. The fix is in the game (de-stack the spawn snap, or give FleetPanel a per-vehicle select), not in this file."
+      "role": "player",
+      "description": "Fixed by issue #512: all four haulers spawn on ONE tile (vehicle buy stagger gets undone by NavGrid.findNearestReachableCell snapping every one of them to the same reachable cell), so scene-raycast clickEntity could only ever pick hauler #1 -- clickEntity for #2/#3/#4 always raycast onto #1 instead, with the selection bar reading \"Debris Hauler #1\" every time. FleetPanel rows are clickable now, so hauler #2 gets selected by clicking its Fleet panel row (`#bs-vehicle-panel [data-vehicle-id=\"2\"]`), routed through ScenePicking.select(), then MOVE HERE drives the same `vehicle move` command as the hauler #1 step above."
     },
     {
       "command": "vehicle move 3 to:37,33",
       "interaction": [
         {
-          "type": "command",
-          "command": "vehicle move 3 to:37,33"
+          "type": "clickSelector",
+          "selector": "#bs-vehicle-panel [data-vehicle-id=\"3\"]"
+        },
+        {
+          "type": "awaitUsable",
+          "selector": "#bs-selection-bar [data-action=\"move_here\"]"
+        },
+        {
+          "type": "cameraFocus",
+          "x": 37.5,
+          "z": 33.5,
+          "distance": 25
+        },
+        {
+          "type": "mousemove",
+          "x": 640,
+          "y": 360
+        },
+        {
+          "type": "wait",
+          "durationMs": 300
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-selection-bar [data-action=\"move_here\"]"
         }
       ],
-      "description": "Left as a command, and this is a defect report rather than a closed exception. MOVE HERE exists and works -- the `vehicle move 1` step above clicks it for real -- but no mouse can select haulers #2, #3 or #4 here: all four spawn on ONE tile. `vehicle buy` staggers the raw spawn point by fleet index, then NavGrid.findNearestReachableCell snaps every one of them back to the same reachable cell, (82,34) on this level. Verified in a real browser: clickEntity for vehicle 2, 3 and 4 each raycast onto hauler #1 and the selection bar reads \"Debris Hauler #1\" every time, and nothing in src/ui calls ScenePicking.select, so no panel row offers a way round it. Converting this step would silently re-order hauler #1 instead of #2. The fix is in the game (de-stack the spawn snap, or give FleetPanel a per-vehicle select), not in this file."
+      "role": "player",
+      "description": "Fixed by issue #512, same fix as hauler #2 above: hauler #3 gets selected via its Fleet panel row (`#bs-vehicle-panel [data-vehicle-id=\"3\"]`) instead of the scene raycast that could only ever hit hauler #1."
     },
     {
       "command": "vehicle move 4 to:37,33",
       "interaction": [
         {
-          "type": "command",
-          "command": "vehicle move 4 to:37,33"
+          "type": "clickSelector",
+          "selector": "#bs-vehicle-panel [data-vehicle-id=\"4\"]"
+        },
+        {
+          "type": "awaitUsable",
+          "selector": "#bs-selection-bar [data-action=\"move_here\"]"
+        },
+        {
+          "type": "cameraFocus",
+          "x": 37.5,
+          "z": 33.5,
+          "distance": 25
+        },
+        {
+          "type": "mousemove",
+          "x": 640,
+          "y": 360
+        },
+        {
+          "type": "wait",
+          "durationMs": 300
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-selection-bar [data-action=\"move_here\"]"
         }
       ],
-      "description": "Left as a command, and this is a defect report rather than a closed exception. MOVE HERE exists and works -- the `vehicle move 1` step above clicks it for real -- but no mouse can select haulers #2, #3 or #4 here: all four spawn on ONE tile. `vehicle buy` staggers the raw spawn point by fleet index, then NavGrid.findNearestReachableCell snaps every one of them back to the same reachable cell, (82,34) on this level. Verified in a real browser: clickEntity for vehicle 2, 3 and 4 each raycast onto hauler #1 and the selection bar reads \"Debris Hauler #1\" every time, and nothing in src/ui calls ScenePicking.select, so no panel row offers a way round it. Converting this step would silently re-order hauler #1 instead of #2. The fix is in the game (de-stack the spawn snap, or give FleetPanel a per-vehicle select), not in this file."
+      "role": "player",
+      "description": "Fixed by issue #512, same fix as haulers #2/#3 above: hauler #4 gets selected via its Fleet panel row (`#bs-vehicle-panel [data-vehicle-id=\"4\"]`) instead of the scene raycast that could only ever hit hauler #1."
     },
     {
       "command": "tick 6",

--- a/scripts/scenario-defs/vehicle-traffic.json
+++ b/scripts/scenario-defs/vehicle-traffic.json
@@ -223,31 +223,103 @@
       "command": "vehicle move 2 to:21,20",
       "interaction": [
         {
-          "type": "command",
-          "command": "vehicle move 2 to:21,20"
+          "type": "clickSelector",
+          "selector": "#bs-vehicle-panel [data-vehicle-id=\"2\"]"
+        },
+        {
+          "type": "awaitUsable",
+          "selector": "#bs-selection-bar [data-action=\"move_here\"]"
+        },
+        {
+          "type": "cameraFocus",
+          "x": 21.5,
+          "z": 20.5,
+          "distance": 25
+        },
+        {
+          "type": "mousemove",
+          "x": 640,
+          "y": 360
+        },
+        {
+          "type": "wait",
+          "durationMs": 300
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-selection-bar [data-action=\"move_here\"]"
         }
       ],
-      "description": "Left as a command, and this is a defect report rather than a closed exception. The SelectionBar's MOVE HERE drives `vehicle move` for real (gap G4, usable with a mouse since 47f4fef latched the aim), but every move in this file targets hauler #2, #3 or #4 and no mouse can select those: all four spawn on ONE tile. `vehicle buy` staggers the raw spawn point by fleet index, then NavGrid.findNearestReachableCell snaps every one of them back to the same reachable cell, (82,34) on this level -- the file's own `vehicle list` step shows all four there. Verified in a real browser: clickEntity for vehicle 2, 3 and 4 each raycast onto hauler #1 and the selection bar reads \"Debris Hauler #1\" every time, and nothing in src/ui calls ScenePicking.select, so no panel row offers a way round it. Converting would silently re-order hauler #1 and destroy the convergence this file exists to set up. The fix is in the game (de-stack the spawn snap, or give FleetPanel a per-vehicle select), not in this file."
+      "role": "player",
+      "description": "Fixed by issue #512: all four haulers spawn on ONE tile (vehicle buy stagger gets undone by NavGrid.findNearestReachableCell snapping every one of them to the same reachable cell), so scene-raycast clickEntity could only ever pick hauler #1 -- clickEntity for #2/#3/#4 always raycast onto #1 instead. FleetPanel rows are clickable now, so hauler #2 gets selected by clicking its Fleet panel row (`#bs-vehicle-panel [data-vehicle-id=\"2\"]`), routed through ScenePicking.select(), then MOVE HERE drives the same `vehicle move` command as the hauler #1 step above."
     },
     {
       "command": "vehicle move 3 to:20,21",
       "interaction": [
         {
-          "type": "command",
-          "command": "vehicle move 3 to:20,21"
+          "type": "clickSelector",
+          "selector": "#bs-vehicle-panel [data-vehicle-id=\"3\"]"
+        },
+        {
+          "type": "awaitUsable",
+          "selector": "#bs-selection-bar [data-action=\"move_here\"]"
+        },
+        {
+          "type": "cameraFocus",
+          "x": 20.5,
+          "z": 21.5,
+          "distance": 25
+        },
+        {
+          "type": "mousemove",
+          "x": 640,
+          "y": 360
+        },
+        {
+          "type": "wait",
+          "durationMs": 300
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-selection-bar [data-action=\"move_here\"]"
         }
       ],
-      "description": "Left as a command, and this is a defect report rather than a closed exception. The SelectionBar's MOVE HERE drives `vehicle move` for real (gap G4, usable with a mouse since 47f4fef latched the aim), but every move in this file targets hauler #2, #3 or #4 and no mouse can select those: all four spawn on ONE tile. `vehicle buy` staggers the raw spawn point by fleet index, then NavGrid.findNearestReachableCell snaps every one of them back to the same reachable cell, (82,34) on this level -- the file's own `vehicle list` step shows all four there. Verified in a real browser: clickEntity for vehicle 2, 3 and 4 each raycast onto hauler #1 and the selection bar reads \"Debris Hauler #1\" every time, and nothing in src/ui calls ScenePicking.select, so no panel row offers a way round it. Converting would silently re-order hauler #1 and destroy the convergence this file exists to set up. The fix is in the game (de-stack the spawn snap, or give FleetPanel a per-vehicle select), not in this file."
+      "role": "player",
+      "description": "Fixed by issue #512, same fix as hauler #2 above: hauler #3 gets selected via its Fleet panel row (`#bs-vehicle-panel [data-vehicle-id=\"3\"]`) instead of the scene raycast that could only ever hit hauler #1."
     },
     {
       "command": "vehicle move 4 to:19,20",
       "interaction": [
         {
-          "type": "command",
-          "command": "vehicle move 4 to:19,20"
+          "type": "clickSelector",
+          "selector": "#bs-vehicle-panel [data-vehicle-id=\"4\"]"
+        },
+        {
+          "type": "awaitUsable",
+          "selector": "#bs-selection-bar [data-action=\"move_here\"]"
+        },
+        {
+          "type": "cameraFocus",
+          "x": 19.5,
+          "z": 20.5,
+          "distance": 25
+        },
+        {
+          "type": "mousemove",
+          "x": 640,
+          "y": 360
+        },
+        {
+          "type": "wait",
+          "durationMs": 300
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-selection-bar [data-action=\"move_here\"]"
         }
       ],
-      "description": "Left as a command, and this is a defect report rather than a closed exception. The SelectionBar's MOVE HERE drives `vehicle move` for real (gap G4, usable with a mouse since 47f4fef latched the aim), but every move in this file targets hauler #2, #3 or #4 and no mouse can select those: all four spawn on ONE tile. `vehicle buy` staggers the raw spawn point by fleet index, then NavGrid.findNearestReachableCell snaps every one of them back to the same reachable cell, (82,34) on this level -- the file's own `vehicle list` step shows all four there. Verified in a real browser: clickEntity for vehicle 2, 3 and 4 each raycast onto hauler #1 and the selection bar reads \"Debris Hauler #1\" every time, and nothing in src/ui calls ScenePicking.select, so no panel row offers a way round it. Converting would silently re-order hauler #1 and destroy the convergence this file exists to set up. The fix is in the game (de-stack the spawn snap, or give FleetPanel a per-vehicle select), not in this file."
+      "role": "player",
+      "description": "Fixed by issue #512, same fix as haulers #2/#3 above: hauler #4 gets selected via its Fleet panel row (`#bs-vehicle-panel [data-vehicle-id=\"4\"]`) instead of the scene raycast that could only ever hit hauler #1."
     },
     {
       "command": "tick 5",
@@ -263,31 +335,103 @@
       "command": "vehicle move 2 to:20,20",
       "interaction": [
         {
-          "type": "command",
-          "command": "vehicle move 2 to:20,20"
+          "type": "clickSelector",
+          "selector": "#bs-vehicle-panel [data-vehicle-id=\"2\"]"
+        },
+        {
+          "type": "awaitUsable",
+          "selector": "#bs-selection-bar [data-action=\"move_here\"]"
+        },
+        {
+          "type": "cameraFocus",
+          "x": 20.5,
+          "z": 20.5,
+          "distance": 25
+        },
+        {
+          "type": "mousemove",
+          "x": 640,
+          "y": 360
+        },
+        {
+          "type": "wait",
+          "durationMs": 300
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-selection-bar [data-action=\"move_here\"]"
         }
       ],
-      "description": "Left as a command, and this is a defect report rather than a closed exception. The SelectionBar's MOVE HERE drives `vehicle move` for real (gap G4, usable with a mouse since 47f4fef latched the aim), but every move in this file targets hauler #2, #3 or #4 and no mouse can select those: all four spawn on ONE tile. `vehicle buy` staggers the raw spawn point by fleet index, then NavGrid.findNearestReachableCell snaps every one of them back to the same reachable cell, (82,34) on this level -- the file's own `vehicle list` step shows all four there. Verified in a real browser: clickEntity for vehicle 2, 3 and 4 each raycast onto hauler #1 and the selection bar reads \"Debris Hauler #1\" every time, and nothing in src/ui calls ScenePicking.select, so no panel row offers a way round it. Converting would silently re-order hauler #1 and destroy the convergence this file exists to set up. The fix is in the game (de-stack the spawn snap, or give FleetPanel a per-vehicle select), not in this file."
+      "role": "player",
+      "description": "Fixed by issue #512, second round of convergence at (20,20): hauler #2 gets selected via its Fleet panel row instead of the scene raycast that could only ever hit hauler #1."
     },
     {
       "command": "vehicle move 3 to:20,20",
       "interaction": [
         {
-          "type": "command",
-          "command": "vehicle move 3 to:20,20"
+          "type": "clickSelector",
+          "selector": "#bs-vehicle-panel [data-vehicle-id=\"3\"]"
+        },
+        {
+          "type": "awaitUsable",
+          "selector": "#bs-selection-bar [data-action=\"move_here\"]"
+        },
+        {
+          "type": "cameraFocus",
+          "x": 20.5,
+          "z": 20.5,
+          "distance": 25
+        },
+        {
+          "type": "mousemove",
+          "x": 640,
+          "y": 360
+        },
+        {
+          "type": "wait",
+          "durationMs": 300
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-selection-bar [data-action=\"move_here\"]"
         }
       ],
-      "description": "Left as a command, and this is a defect report rather than a closed exception. The SelectionBar's MOVE HERE drives `vehicle move` for real (gap G4, usable with a mouse since 47f4fef latched the aim), but every move in this file targets hauler #2, #3 or #4 and no mouse can select those: all four spawn on ONE tile. `vehicle buy` staggers the raw spawn point by fleet index, then NavGrid.findNearestReachableCell snaps every one of them back to the same reachable cell, (82,34) on this level -- the file's own `vehicle list` step shows all four there. Verified in a real browser: clickEntity for vehicle 2, 3 and 4 each raycast onto hauler #1 and the selection bar reads \"Debris Hauler #1\" every time, and nothing in src/ui calls ScenePicking.select, so no panel row offers a way round it. Converting would silently re-order hauler #1 and destroy the convergence this file exists to set up. The fix is in the game (de-stack the spawn snap, or give FleetPanel a per-vehicle select), not in this file."
+      "role": "player",
+      "description": "Fixed by issue #512, second round of convergence at (20,20): hauler #3 gets selected via its Fleet panel row instead of the scene raycast that could only ever hit hauler #1."
     },
     {
       "command": "vehicle move 4 to:20,20",
       "interaction": [
         {
-          "type": "command",
-          "command": "vehicle move 4 to:20,20"
+          "type": "clickSelector",
+          "selector": "#bs-vehicle-panel [data-vehicle-id=\"4\"]"
+        },
+        {
+          "type": "awaitUsable",
+          "selector": "#bs-selection-bar [data-action=\"move_here\"]"
+        },
+        {
+          "type": "cameraFocus",
+          "x": 20.5,
+          "z": 20.5,
+          "distance": 25
+        },
+        {
+          "type": "mousemove",
+          "x": 640,
+          "y": 360
+        },
+        {
+          "type": "wait",
+          "durationMs": 300
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-selection-bar [data-action=\"move_here\"]"
         }
       ],
-      "description": "Left as a command, and this is a defect report rather than a closed exception. The SelectionBar's MOVE HERE drives `vehicle move` for real (gap G4, usable with a mouse since 47f4fef latched the aim), but every move in this file targets hauler #2, #3 or #4 and no mouse can select those: all four spawn on ONE tile. `vehicle buy` staggers the raw spawn point by fleet index, then NavGrid.findNearestReachableCell snaps every one of them back to the same reachable cell, (82,34) on this level -- the file's own `vehicle list` step shows all four there. Verified in a real browser: clickEntity for vehicle 2, 3 and 4 each raycast onto hauler #1 and the selection bar reads \"Debris Hauler #1\" every time, and nothing in src/ui calls ScenePicking.select, so no panel row offers a way round it. Converting would silently re-order hauler #1 and destroy the convergence this file exists to set up. The fix is in the game (de-stack the spawn snap, or give FleetPanel a per-vehicle select), not in this file."
+      "role": "player",
+      "description": "Fixed by issue #512, second round of convergence at (20,20): hauler #4 gets selected via its Fleet panel row instead of the scene raycast that could only ever hit hauler #1."
     },
     {
       "command": "vehicle list",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 // BlastSimulator2026 — Browser entry point
 // Initializes the 3D scene, UI, audio, save system, and exposes the console bridge.
 
+import * as THREE from 'three';
 import { SceneManager } from './renderer/SceneManager.js';
 import { GameRenderer } from './renderer/GameRenderer.js';
 import { UIManager } from './ui/UIManager.js';
@@ -818,6 +819,9 @@ uiManager.setSiteMapHandler(() => {
 uiManager.setOpenSavesHandler(() => savesModal.show());
 uiManager.setMapFocusHandler((x, z) => {
   scene.cameraController.focus(x, gameRenderer.surfaceYAt(x, z), z, 60);
+});
+uiManager.setSelectVehicleHandler((vehicleId) => {
+  scenePicking.select({ kind: 'vehicle', id: vehicleId, point: new THREE.Vector3(), distance: 0 });
 });
 
 // --- Scene picking wiring (redesign P2) ---

--- a/src/ui/UIManager.ts
+++ b/src/ui/UIManager.ts
@@ -276,6 +276,11 @@ export class UIManager {
     this.miniMap.setFocusHandler(cb);
   }
 
+  /** Wire the Fleet panel's per-row click-to-select (main.ts owns ScenePicking). */
+  setSelectVehicleHandler(cb: (vehicleId: number) => void): void {
+    this.fleetPanel.setSelectVehicleHandler(cb);
+  }
+
   /** Register a notification: appears as a toast now, stays in the activity log. */
   notify(input: NotifyInput): void {
     this.notificationCenter.notify(input);

--- a/src/ui/panels/FleetPanel.ts
+++ b/src/ui/panels/FleetPanel.ts
@@ -70,11 +70,6 @@ export class FleetPanel {
 
     this.el.append(header, this.bodyEl);
     container.appendChild(this.el);
-
-    // Skeleton-phase placeholder read: implementer wires this into the
-    // vehicle card's click listener (makeVehicleCard). Keeps noUnusedLocals
-    // green until that wiring lands.
-    void this.onSelectVehicleCb;
   }
 
   get root(): HTMLElement { return this.el; }
@@ -277,6 +272,12 @@ export class FleetPanel {
 
     const wrap = card(rows);
     wrap.dataset['vehicleId'] = String(v.id);
+    wrap.style.cursor = 'pointer';
+    wrap.addEventListener('click', (e) => {
+      const target = e.target as HTMLElement;
+      if (target.closest('button, select, input, a')) return;
+      this.onSelectVehicleCb?.(v.id);
+    });
     return wrap;
   }
 

--- a/src/ui/panels/FleetPanel.ts
+++ b/src/ui/panels/FleetPanel.ts
@@ -36,6 +36,7 @@ export class FleetPanel {
   private onNavigateCb?: (panel: 'crew') => void;
   private gameConsole?: GameConsoleFn;
   private onConfirmRequestCb?: (config: ConfirmModalConfig) => void;
+  private onSelectVehicleCb?: (vehicleId: number) => void;
   private lastSignature = '';
   private lastState: GameState | null = null;
   private readonly locale = new LocaleTextRegistry();
@@ -69,6 +70,11 @@ export class FleetPanel {
 
     this.el.append(header, this.bodyEl);
     container.appendChild(this.el);
+
+    // Skeleton-phase placeholder read: implementer wires this into the
+    // vehicle card's click listener (makeVehicleCard). Keeps noUnusedLocals
+    // green until that wiring lands.
+    void this.onSelectVehicleCb;
   }
 
   get root(): HTMLElement { return this.el; }
@@ -76,6 +82,9 @@ export class FleetPanel {
   setNavigateHandler(cb: (panel: 'crew') => void): void { this.onNavigateCb = cb; }
   setGameConsole(fn: GameConsoleFn): void { this.gameConsole = fn; }
   setConfirmHandler(cb: (config: ConfirmModalConfig) => void): void { this.onConfirmRequestCb = cb; }
+
+  /** Register a callback fired when a vehicle's Fleet panel row is clicked to select it. */
+  setSelectVehicleHandler(cb: (vehicleId: number) => void): void { this.onSelectVehicleCb = cb; }
 
   show(): void { this.el.style.display = 'flex'; }
   hide(): void { this.el.style.display = 'none'; }

--- a/tests/unit/ui/UIManager.test.ts
+++ b/tests/unit/ui/UIManager.test.ts
@@ -16,6 +16,7 @@ import { NavGrid } from '../../../src/core/nav/NavGrid.js';
 import { VoxelGrid } from '../../../src/core/world/VoxelGrid.js';
 import { t, setLocale, getLocale } from '../../../src/core/i18n/I18n.js';
 import type { BlastReport } from '../../../src/core/mining/BlastExecution.js';
+import type { Vehicle } from '../../../src/core/entities/Vehicle.js';
 
 function makeState() {
   const state = createGame({ seed: 1, mineType: 'desert' });
@@ -403,5 +404,58 @@ describe('UIManager — closeStaleLevelOverlays (#504)', () => {
     expect(() => uiManager.closeStaleLevelOverlays()).not.toThrow();
 
     expect(uiManager.blastReportModalVisible).toBe(false);
+  });
+});
+
+// ── Fleet panel vehicle-select delegation (#512) ────────────────────────────
+//
+// A 3+ vehicle fleet gets snapped onto the same NavGrid cell by `vehicle
+// buy`, so scene-raycast selection can only ever hit one of them.
+// setSelectVehicleHandler delegates to FleetPanel, whose rows are clickable
+// and route through ScenePicking.select() (main.ts owns that wiring). This
+// only proves UIManager's own delegation plumbing — FleetPanel's click
+// behavior itself is covered by FleetPanel.test.ts.
+
+function makeVehicle(id: number): Vehicle {
+  return {
+    id, type: 'debris_hauler', tier: 1, x: 5, z: 5, hp: 100, task: 'idle',
+    targetX: 5, targetZ: 5, driverId: null, state: 'idle', payloadKg: 0,
+    waitingTicks: 0, moveConsecutiveFailures: 0, isMoveStuck: false,
+    haulingFragmentId: null, haulingPhase: null, haulingDepotBuildingId: null,
+  };
+}
+
+describe('UIManager — Fleet panel vehicle-select delegation (#512)', () => {
+  let container: HTMLDivElement;
+  let uiManager: UIManager;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    uiManager?.dispose();
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it('setSelectVehicleHandler(cb) + a real click on a Fleet panel vehicle row invokes cb with that vehicle\'s real id', () => {
+    vi.spyOn(MiniMap.prototype, 'update').mockImplementation(() => {});
+    uiManager = new UIManager(container);
+    const cb = vi.fn();
+    uiManager.setSelectVehicleHandler(cb);
+    uiManager.showPanel('vehicles');
+
+    const state = createGame({ seed: 1, mineType: 'desert' });
+    state.vehicles.vehicles = [makeVehicle(1), makeVehicle(2), makeVehicle(3)];
+    state.vehicles.nextId = 4;
+    uiManager.update(state);
+
+    const row = container.querySelector('#bs-vehicle-panel [data-vehicle-id="2"]') as HTMLElement;
+    expect(row).not.toBeNull();
+    row.click();
+
+    expect(cb).toHaveBeenCalledWith(2);
   });
 });

--- a/tests/unit/ui/panels/FleetPanel.test.ts
+++ b/tests/unit/ui/panels/FleetPanel.test.ts
@@ -246,4 +246,73 @@ describe('FleetPanel', () => {
     panel.dispose();
     expect(container.contains(panel.root)).toBe(false);
   });
+
+  // ── vehicle selection via Fleet panel row click (issue #512) ──────────────
+  //
+  // A 3+ vehicle fleet gets snapped onto the same NavGrid cell by `vehicle
+  // buy`, so scene-raycast selection can only ever hit one of them. Fleet
+  // panel rows become clickable instead, routing through ScenePicking.select()
+  // (wired by UIManager/main.ts) — these tests cover only FleetPanel's own
+  // click-to-handler plumbing.
+
+  it('clicking a rendered vehicle card fires the select handler with the real vehicle id', () => {
+    const { panel } = makePanel();
+    let selectedId: number | null = null;
+    panel.setSelectVehicleHandler(id => { selectedId = id; });
+    panel.update(makeState([makeVehicle({ id: 3 })]));
+
+    const card = panel.root.querySelector('[data-vehicle-id="3"]') as HTMLElement;
+    expect(card).not.toBeNull();
+    card.click();
+
+    expect(selectedId).toBe(3);
+  });
+
+  it('clicking a nested interactive control inside the card does not also fire the select handler', () => {
+    const { panel } = makePanel();
+    let selectedId: number | null = null;
+    panel.setSelectVehicleHandler(id => { selectedId = id; });
+    panel.setConfirmHandler(config => config.onConfirm());
+    panel.update(makeState([makeVehicle({ id: 4, type: 'debris_hauler', tier: 1, hp: 100 })]));
+
+    const scrapBtn = panel.root.querySelector('button[title="Scrap"]') as HTMLButtonElement;
+    expect(scrapBtn).not.toBeNull();
+    scrapBtn.click();
+
+    expect(selectedId).toBeNull();
+  });
+
+  it('clicking the driver-assign select control does not fire the select handler', () => {
+    const { panel } = makePanel();
+    let selectedId: number | null = null;
+    panel.setSelectVehicleHandler(id => { selectedId = id; });
+    const eligible = makeEmployee({ id: 6, name: 'Dorian Kask', qualifications: [{ category: 'driving.truck', proficiencyLevel: 1, xp: 0 }] });
+    panel.update(makeState([makeVehicle({ id: 2, type: 'debris_hauler' })], [eligible]));
+
+    const select = panel.root.querySelector('select') as HTMLSelectElement;
+    expect(select).not.toBeNull();
+    select.click();
+
+    expect(selectedId).toBeNull();
+  });
+
+  it('clicking a vehicle card does not throw when no select handler is registered', () => {
+    const { panel } = makePanel();
+    panel.update(makeState([makeVehicle({ id: 7 })]));
+
+    const card = panel.root.querySelector('[data-vehicle-id="7"]') as HTMLElement;
+    expect(() => card.click()).not.toThrow();
+  });
+
+  it('two different vehicle cards fire the select handler with two different, correct ids', () => {
+    const { panel } = makePanel();
+    const selected: number[] = [];
+    panel.setSelectVehicleHandler(id => { selected.push(id); });
+    panel.update(makeState([makeVehicle({ id: 2 }), makeVehicle({ id: 3 })]));
+
+    (panel.root.querySelector('[data-vehicle-id="2"]') as HTMLElement).click();
+    (panel.root.querySelector('[data-vehicle-id="3"]') as HTMLElement).click();
+
+    expect(selected).toEqual([2, 3]);
+  });
 });


### PR DESCRIPTION
Closes #512

## Summary

A fleet's vehicles (haulers, etc.) all spawn staggered by `vehicle buy`, but `NavGrid.findNearestReachableCell` snaps every one of them back onto the same tile. Any click there — scene raycast or a scenario's `clickEntity` — always resolved to vehicle #1, so a player with a 3+ vehicle fleet could never select vehicle #2/#3/#4 by clicking. Several `vehicle move` scenario steps were stuck as console commands because of it.

Fix: Fleet panel vehicle rows are now clickable and select the specific vehicle via `ScenePicking.select()` — the escape hatch already documented on `ScenePicking.ts` for exactly this case ("Select an entity directly, e.g. clicking its row in a panel, without a scene click"). No change to `NavGrid`, spawn/navigation logic, or `vehicle buy` — the issue's own "likely fix directions" flagged this as the smaller, lower-risk option, and investigation during planning confirmed it alone fully unblocks every currently-blocked scenario step (`MOVE HERE` reads scene aim, not how the vehicle got selected, and offers `move_here` for any selected vehicle unconditionally).

- `src/ui/panels/FleetPanel.ts` — vehicle card click → `onSelectVehicleCb(v.id)`, guarded so clicks on nested Haul/Break/Scrap/driver-assign controls don't also trigger selection.
- `src/ui/UIManager.ts` — `setSelectVehicleHandler` delegation, matching the existing `setXHandler` pattern.
- `src/main.ts` — wires the handler to `scenePicking.select({kind:'vehicle', id, ...})`.
- `scripts/scenario-defs/vehicle-traffic.json`, `scripts/scenario-defs/vehicle-traffic-routing-visual.json` — 9 previously-blocked `vehicle move 2/3/4` steps converted from bare console commands to real Fleet-panel-row clicks + `move_here` clicks, matching the shape of the existing working `vehicle move 1` step in each file.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** the issue offered two fix directions (de-stack spawn positions, or Fleet panel row selection) and asked the implementer to pick one.
  **Chosen:** Fleet panel row selection only; `NavGrid`/spawn logic untouched.
  **Why:** the issue itself flagged this as "probably the smaller, lower-risk change," and planning-time investigation confirmed `move_here` is selection-origin-agnostic, so this alone fully unblocks all 9 blocked scenario steps.
  **If reversed:** implement the spawn-destacking separately in `vehicle buy` (`src/console/commands/vehicle.ts`), e.g. teaching `NavGrid.findNearestReachableCell` an excluded-cells set from already-occupied vehicle tiles — orthogonal to this change, not required by it.

- **What was open:** what DOM element is clickable to select a vehicle.
  **Chosen:** the whole vehicle card, excluding nested `button`/`select`/`input`/`a` elements.
  **Why:** matches the issue's own wording ("select a specific vehicle by clicking its row") and reuses the `data-vehicle-id` attribute the card already carries.

## Verification

- `static` — `npm run typecheck`: clean.
- `logic` — `npm run test`: 8706/8706 passing (298 files), including new `FleetPanel`/`UIManager` regression tests for click-to-select and the nested-control non-interference guard.
- `scenario` — `npm run scenarios` (command mode): 127/127 scenarios passing, including both converted files.
- `visual` — `npm run scenario -- --scenario vehicle-traffic --mode interaction --screenshots` and same for `vehicle-traffic-routing-visual`: screenshots inspected directly. SelectionBar reads "Debris Hauler #2", "#3", "#4" correctly after clicking each vehicle's Fleet panel row — never "#1" regardless of which vehicle was clicked, which was the bug. `npm run a11y` and `npm run validate:state` both pass on the captured run.
- `playability` — no playtest definition drives a Fleet-panel vehicle-row-click or `vehicle move` flow (`tutorial.json`/`training.json` only click Assign/Haul buttons on the panel, explicitly excluded by this fix's click guard; `scene-picking.json` selects an employee, not a vehicle). The touched code (`ScenePicking.select()`'s new caller, the new `FleetPanel` listener) is scoped to vehicle selection, not shared scenario/rendering/picking machinery every definition runs through — so `full-ci` is not applied. The `visual` channel above is the stronger, targeted evidence for this specific control.

8706 tests — all passing

READY TO MERGE