### PR TITLE
fix: Resolve #513 — scope contract card action selectors with data-contract-id

### DIFF
--- a/scripts/scenario-defs/level1-playthrough-win.json
+++ b/scripts/scenario-defs/level1-playthrough-win.json
@@ -846,6 +846,14 @@
       "command": "contract deliver 2 amount:260",
       "interaction": [
         {
+          "type": "clickSelector",
+          "selector": "#bs-toolbar [data-panel=\"contracts\"]"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": "#bs-contract-panel [data-contract-id=\"2\"] .bs-contract-deliver"
+        },
+        {
           "type": "set",
           "selector": "#bs-contract-panel [data-contract-id=\"2\"] .bs-contract-amount",
           "value": "260"
@@ -855,7 +863,7 @@
           "selector": "#bs-contract-panel [data-contract-id=\"2\"] .bs-contract-deliver"
         }
       ],
-      "description": "#513 fix landed: ContractsPanel now sets `data-contract-id` on both offered and active cards, so the accept step above (and this deliver step) can scope selectors to the exact contract instead of always resolving to the first card in the DOM. This step converts from a bare `contract deliver` command to a real click -- `set` the amount field to 260 on contract #2's own card, then click that card's own `.bs-contract-deliver`. cash intentionally not asserted from here on: Ground rule #12 -- a real browser's game loop advances on real wall-clock time on top of any scripted `tick N`, and this step follows one. Confirmed directly: an earlier pass hard-asserted cash here and it failed in a real browser run (worked in command mode) purely from the click round-trip's real elapsed time, Finding #12's exact class (`rock-fragmenter-breaking.json`). tickCount/deathCount/employeeCount are unaffected and stay exact. One haul is enough to complete this contract outright (fragment 1208 carries 550kg, the contract needs 260kg) -- no second haul round needed this cycle.",
+      "description": "#513 fix landed: ContractsPanel now sets `data-contract-id` on both offered and active cards, so the accept step above (and this deliver step) can scope selectors to the exact contract instead of always resolving to the first card in the DOM. This step converts from a bare `contract deliver` command to a real click -- reopens the Contracts panel first (the intervening `vehicle haul` step switched the toolbar to the Fleet tab, which calls `ContractsPanel.hide()` and sets `display:none` -- without reopening here, the amount/deliver controls exist in the DOM but are hidden and unclickable), then `set` the amount field to 260 on contract #2's own card, then click that card's own `.bs-contract-deliver`. cash intentionally not asserted from here on: Ground rule #12 -- a real browser's game loop advances on real wall-clock time on top of any scripted `tick N`, and this step follows one. Confirmed directly: an earlier pass hard-asserted cash here and it failed in a real browser run (worked in command mode) purely from the click round-trip's real elapsed time, Finding #12's exact class (`rock-fragmenter-breaking.json`). tickCount/deathCount/employeeCount are unaffected and stay exact. One haul is enough to complete this contract outright (fragment 1208 carries 550kg, the contract needs 260kg) -- no second haul round needed this cycle.",
       "expect": {
         "equals": {
           "tickCount": 67,
@@ -1105,6 +1113,14 @@
       "command": "contract deliver 4 amount:60",
       "interaction": [
         {
+          "type": "clickSelector",
+          "selector": "#bs-toolbar [data-panel=\"contracts\"]"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": "#bs-contract-panel [data-contract-id=\"4\"] .bs-contract-deliver"
+        },
+        {
           "type": "set",
           "selector": "#bs-contract-panel [data-contract-id=\"4\"] .bs-contract-amount",
           "value": "60"
@@ -1114,7 +1130,7 @@
           "selector": "#bs-contract-panel [data-contract-id=\"4\"] .bs-contract-deliver"
         }
       ],
-      "description": "#513 fix landed: same as step 62 -- ContractsPanel now sets `data-contract-id` on both offered and active cards, so this step converts from a bare `contract deliver` command to a real click, scoped to contract #4's own card, instead of the old unscoped `.bs-contract-accept`/`.bs-contract-deliver` that always resolved to the first card in the DOM. Command mode's own trace here is a clean success (60 kg of dirtite against 575 kg stored, \"Contract #4 COMPLETED\"), and the scoped click now matches it. cash intentionally not asserted from here on: Ground rule #12 -- a real browser's game loop advances on real wall-clock time on top of any scripted `tick N`, and this step follows one. Confirmed directly: an earlier pass hard-asserted cash here and it failed in a real browser run (worked in command mode) purely from the click round-trip's real elapsed time, Finding #12's exact class (`rock-fragmenter-breaking.json`). tickCount/deathCount/employeeCount are unaffected and stay exact.",
+      "description": "#513 fix landed: same as the contract #2 deliver step above -- ContractsPanel now sets `data-contract-id` on both offered and active cards, so this step converts from a bare `contract deliver` command to a real click, scoped to contract #4's own card, instead of the old unscoped `.bs-contract-accept`/`.bs-contract-deliver` that always resolved to the first card in the DOM. Also reopens the Contracts panel first -- the intervening `vehicle haul` step switched to the Fleet tab, hiding it via `ContractsPanel.hide()`, same gap as the contract #2 deliver step. Command mode's own trace here is a clean success (60 kg of dirtite against 575 kg stored, \"Contract #4 COMPLETED\"), and the scoped click now matches it. cash intentionally not asserted from here on: Ground rule #12 -- a real browser's game loop advances on real wall-clock time on top of any scripted `tick N`, and this step follows one. Confirmed directly: an earlier pass hard-asserted cash here and it failed in a real browser run (worked in command mode) purely from the click round-trip's real elapsed time, Finding #12's exact class (`rock-fragmenter-breaking.json`). tickCount/deathCount/employeeCount are unaffected and stay exact.",
       "expect": {
         "equals": {
           "tickCount": 69,

--- a/scripts/scenario-defs/level1-playthrough-win.json
+++ b/scripts/scenario-defs/level1-playthrough-win.json
@@ -798,14 +798,14 @@
         },
         {
           "type": "waitForSelector",
-          "selector": "#bs-contract-panel .bs-contract-accept"
+          "selector": "#bs-contract-panel [data-contract-id=\"2\"] .bs-contract-accept"
         },
         {
           "type": "clickSelector",
-          "selector": "#bs-contract-panel .bs-contract-accept"
+          "selector": "#bs-contract-panel [data-contract-id=\"2\"] .bs-contract-accept"
         }
       ],
-      "description": "Finding #48: the Fleet panel's Haul button (`.bs-vehicle-haul-btn`) always sends the vehicle to `findReachableGroundFragment` (HaulingTask.ts) -- the NEAREST reachable, non-oversized, storage-fitting fragment -- with no regard for what ore it carries. A player cannot click their way to a SPECIFIC fragment by ore content; only command mode's explicit `fragment:N` can. So the CONTRACT must be picked to match what the vehicle will actually haul next, not the other way around -- every contract accept below is chosen by first checking what `findReachableGroundFragment` returns for this cycle, replaying the file's own exact, complete command sequence to get it (not a hand-abbreviated one -- `contract list`'s own RNG draw depends on exactly how many times it has already been called, so a shortened trace generates a different contract pool than the real file). This cycle's nearest fragment (id 1208) has empty ore content, so contract #2 (rubble disposal, materialId '') is the only one it can actually satisfy.",
+      "description": "Finding #48: the Fleet panel's Haul button (`.bs-vehicle-haul-btn`) always sends the vehicle to `findReachableGroundFragment` (HaulingTask.ts) -- the NEAREST reachable, non-oversized, storage-fitting fragment -- with no regard for what ore it carries. A player cannot click their way to a SPECIFIC fragment by ore content; only command mode's explicit `fragment:N` can. So the CONTRACT must be picked to match what the vehicle will actually haul next, not the other way around -- every contract accept below is chosen by first checking what `findReachableGroundFragment` returns for this cycle, replaying the file's own exact, complete command sequence to get it (not a hand-abbreviated one -- `contract list`'s own RNG draw depends on exactly how many times it has already been called, so a shortened trace generates a different contract pool than the real file). This cycle's nearest fragment (id 1208) has empty ore content, so contract #2 (rubble disposal, materialId '') is the only one it can actually satisfy. #513: the selector is now scoped to `[data-contract-id=\"2\"]` so it targets contract #2's own card regardless of DOM order, rather than unscoped `.bs-contract-accept` which always resolved to the first offered card.",
       "role": "player"
     },
     {
@@ -846,18 +846,24 @@
       "command": "contract deliver 2 amount:260",
       "interaction": [
         {
-          "type": "command",
-          "command": "contract deliver 2 amount:260"
+          "type": "set",
+          "selector": "#bs-contract-panel [data-contract-id=\"2\"] .bs-contract-amount",
+          "value": "260"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-contract-panel [data-contract-id=\"2\"] .bs-contract-deliver"
         }
       ],
-      "description": "CONVERSION ATTEMPTED AND REVERTED -- the blocker is upstream, at the accept step, and is a real finding. ContractsPanel renders no contract id on either an offered or an active card (no data-id, only the `#<id>` text), so `.bs-contract-accept` can only ever click the FIRST card on offer. Step 46 declares `contract accept 2` (rubble disposal, chosen because the fragment the Haul button hauls carries no ore) but the click accepts contract #1, \"Supply dirtite (bulk)\". Measured, not reasoned: at this step command mode holds 550 kg of rubble against the rubble contract and delivers it (\"Contract #2 COMPLETED! Payment: $451.97\"), while the browser holds the same 550 kg of rubble against a DIRTITE contract, so maxDeliverable is 0 and the whole deliver row is disabled -- a `set`+DELIVER conversion failed here with `\"#bs-contract-panel .bs-contract-amount\" ... is present but disabled`. No `expect.blocked` is attached either: the button's disabled state here is a symptom of the accept divergence, not of a stable game guard, and pinning it would enshrine the bug. Fix the panel first (give the cards a per-contract selector), then this step and step 63 both convert. cash intentionally not asserted from here on: Ground rule #12 -- a real browser's game loop advances on real wall-clock time on top of any scripted `tick N`, and this step follows one. Confirmed directly: an earlier pass hard-asserted cash here and it failed in a real browser run (worked in command mode) purely from the click round-trip's real elapsed time, Finding #12's exact class (`rock-fragmenter-breaking.json`). tickCount/deathCount/employeeCount are unaffected and stay exact. One haul is enough to complete this contract outright (fragment 1208 carries 550kg, the contract needs 260kg) -- no second haul round needed this cycle.",
+      "description": "#513 fix landed: ContractsPanel now sets `data-contract-id` on both offered and active cards, so the accept step above (and this deliver step) can scope selectors to the exact contract instead of always resolving to the first card in the DOM. This step converts from a bare `contract deliver` command to a real click -- `set` the amount field to 260 on contract #2's own card, then click that card's own `.bs-contract-deliver`. cash intentionally not asserted from here on: Ground rule #12 -- a real browser's game loop advances on real wall-clock time on top of any scripted `tick N`, and this step follows one. Confirmed directly: an earlier pass hard-asserted cash here and it failed in a real browser run (worked in command mode) purely from the click round-trip's real elapsed time, Finding #12's exact class (`rock-fragmenter-breaking.json`). tickCount/deathCount/employeeCount are unaffected and stay exact. One haul is enough to complete this contract outright (fragment 1208 carries 550kg, the contract needs 260kg) -- no second haul round needed this cycle.",
       "expect": {
         "equals": {
           "tickCount": 67,
           "deathCount": 1,
           "employeeCount": 8
         }
-      }
+      },
+      "role": "player"
     },
     {
       "command": "finances",
@@ -1049,14 +1055,14 @@
         },
         {
           "type": "waitForSelector",
-          "selector": "#bs-contract-panel .bs-contract-accept"
+          "selector": "#bs-contract-panel [data-contract-id=\"4\"] .bs-contract-accept"
         },
         {
           "type": "clickSelector",
-          "selector": "#bs-contract-panel .bs-contract-accept"
+          "selector": "#bs-contract-panel [data-contract-id=\"4\"] .bs-contract-accept"
         }
       ],
-      "description": "Finding #48: the Fleet panel's Haul button (`.bs-vehicle-haul-btn`) always sends the vehicle to `findReachableGroundFragment` (HaulingTask.ts) -- the NEAREST reachable, non-oversized, storage-fitting fragment -- with no regard for what ore it carries. A player cannot click their way to a SPECIFIC fragment by ore content; only command mode's explicit `fragment:N` can. So the CONTRACT must be picked to match what the vehicle will actually haul next, not the other way around -- every contract accept below is chosen by first checking what `findReachableGroundFragment` returns for this cycle, replaying the file's own exact, complete command sequence to get it (not a hand-abbreviated one -- `contract list`'s own RNG draw depends on exactly how many times it has already been called, so a shortened trace generates a different contract pool than the real file). This cycle's nearest fragment (id 1431) carries dirtite, so contract #4 (Deliver dirtite ore, 60kg) is the match.",
+      "description": "Finding #48: the Fleet panel's Haul button (`.bs-vehicle-haul-btn`) always sends the vehicle to `findReachableGroundFragment` (HaulingTask.ts) -- the NEAREST reachable, non-oversized, storage-fitting fragment -- with no regard for what ore it carries. A player cannot click their way to a SPECIFIC fragment by ore content; only command mode's explicit `fragment:N` can. So the CONTRACT must be picked to match what the vehicle will actually haul next, not the other way around -- every contract accept below is chosen by first checking what `findReachableGroundFragment` returns for this cycle, replaying the file's own exact, complete command sequence to get it (not a hand-abbreviated one -- `contract list`'s own RNG draw depends on exactly how many times it has already been called, so a shortened trace generates a different contract pool than the real file). This cycle's nearest fragment (id 1431) carries dirtite, so contract #4 (Deliver dirtite ore, 60kg) is the match. #513: the selector is now scoped to `[data-contract-id=\"4\"]` so it targets contract #4's own card regardless of DOM order, rather than unscoped `.bs-contract-accept` which always resolved to the first offered card.",
       "role": "player"
     },
     {
@@ -1099,17 +1105,23 @@
       "command": "contract deliver 4 amount:60",
       "interaction": [
         {
-          "type": "command",
-          "command": "contract deliver 4 amount:60"
+          "type": "set",
+          "selector": "#bs-contract-panel [data-contract-id=\"4\"] .bs-contract-amount",
+          "value": "60"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-contract-panel [data-contract-id=\"4\"] .bs-contract-deliver"
         }
       ],
-      "description": "Left as a command for the same reason as step 49: `.bs-contract-accept` clicks whichever card happens to be first, so step 60's declared `contract accept 4` and the click it runs accept different contracts, and the material this file hauls does not match what the browser ends up holding. Command mode's own trace here is a clean success (60 kg of dirtite against 575 kg stored, \"Contract #4 COMPLETED\"), which is exactly why the divergence is worth naming rather than papering over. cash intentionally not asserted from here on: Ground rule #12 -- a real browser's game loop advances on real wall-clock time on top of any scripted `tick N`, and this step follows one. Confirmed directly: an earlier pass hard-asserted cash here and it failed in a real browser run (worked in command mode) purely from the click round-trip's real elapsed time, Finding #12's exact class (`rock-fragmenter-breaking.json`). tickCount/deathCount/employeeCount are unaffected and stay exact.",
+      "description": "#513 fix landed: same as step 62 -- ContractsPanel now sets `data-contract-id` on both offered and active cards, so this step converts from a bare `contract deliver` command to a real click, scoped to contract #4's own card, instead of the old unscoped `.bs-contract-accept`/`.bs-contract-deliver` that always resolved to the first card in the DOM. Command mode's own trace here is a clean success (60 kg of dirtite against 575 kg stored, \"Contract #4 COMPLETED\"), and the scoped click now matches it. cash intentionally not asserted from here on: Ground rule #12 -- a real browser's game loop advances on real wall-clock time on top of any scripted `tick N`, and this step follows one. Confirmed directly: an earlier pass hard-asserted cash here and it failed in a real browser run (worked in command mode) purely from the click round-trip's real elapsed time, Finding #12's exact class (`rock-fragmenter-breaking.json`). tickCount/deathCount/employeeCount are unaffected and stay exact.",
       "expect": {
         "equals": {
           "tickCount": 69,
           "deathCount": 1
         }
-      }
+      },
+      "role": "player"
     },
     {
       "command": "finances",

--- a/scripts/scenario-defs/level1-playthrough-win.json
+++ b/scripts/scenario-defs/level1-playthrough-win.json
@@ -1093,16 +1093,16 @@
       "role": "player"
     },
     {
-      "command": "tick 2",
+      "command": "tick 29",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 2"
+          "command": "tick 29"
         }
       ],
       "expect": {
         "equals": {
-          "tickCount": 69,
+          "tickCount": 96,
           "deathCount": 1,
           "employeeCount": 8
         }
@@ -1133,7 +1133,7 @@
       "description": "#513 fix landed: same as the contract #2 deliver step above -- ContractsPanel now sets `data-contract-id` on both offered and active cards, so this step converts from a bare `contract deliver` command to a real click, scoped to contract #4's own card, instead of the old unscoped `.bs-contract-accept`/`.bs-contract-deliver` that always resolved to the first card in the DOM. Also reopens the Contracts panel first -- the intervening `vehicle haul` step switched to the Fleet tab, hiding it via `ContractsPanel.hide()`, same gap as the contract #2 deliver step. Command mode's own trace here is a clean success (60 kg of dirtite against 575 kg stored, \"Contract #4 COMPLETED\"), and the scoped click now matches it. cash intentionally not asserted from here on: Ground rule #12 -- a real browser's game loop advances on real wall-clock time on top of any scripted `tick N`, and this step follows one. Confirmed directly: an earlier pass hard-asserted cash here and it failed in a real browser run (worked in command mode) purely from the click round-trip's real elapsed time, Finding #12's exact class (`rock-fragmenter-breaking.json`). tickCount/deathCount/employeeCount are unaffected and stay exact.",
       "expect": {
         "equals": {
-          "tickCount": 69,
+          "tickCount": 96,
           "deathCount": 1
         }
       },
@@ -1159,10 +1159,10 @@
       ],
       "expect": {
         "equals": {
-          "safety": 1.5499999999999956,
-          "wellBeing": 96.38125000000032,
-          "ecology": 41.269999999999996,
-          "nuisance": 28.025
+          "safety": 2.899999999999993,
+          "wellBeing": 99.95,
+          "ecology": 42.61999999999992,
+          "nuisance": 29.375000000000018
         }
       },
       "role": "observe"
@@ -1188,7 +1188,7 @@
       "description": "Finding #50: a 3rd blast cycle was cut from this file after discovering a real divergence between command mode and a real browser: `contract deliver` clears `storedMassKg` to exactly 0 in command mode regardless of the delivered amount (confirmed directly -- a 260kg rubble delivery against a 550kg-mass fragment, and separately a 60kg ore delivery against a 528kg-mass fragment, both left `storedMassKg` at 0, not the undelivered remainder), but in a real browser run `storedMassKg` was still 550 after the equivalent point -- the leftover mass from cycle 1's haul was never cleared. By the time a 3rd cycle's haul was attempted, this accumulated leftover left too little room for `findReachableGroundFragment` (HaulingTask.ts's `mass > roomKg` eligibility check) to consider the next fragment reachable at all in the browser, so the Fleet panel's Haul button never rendered and the step timed out waiting for a control that was never coming -- not a scenario-authoring problem, a real gap between the two execution paths. Out of scope to fix here (`docs/plans/scenario-assertions-and-playtest-removal.md`'s ground rules: a real bug with wide blast radius is a finding, not a drive-by fix) -- flagged in the plan doc's findings log for separate investigation. 2 blast cycles, with 2 different contract types (rubble disposal and ore-specific), already prove the drilling/blasting/hauling/contract-fulfillment loop end-to-end twice over, so the file ends here rather than force a 3rd cycle through a real, unrelated bug. Finding #51: `activeContractCount` was also dropped from this step's assertions after a real browser run consistently reported it as 2 (both cycle 1 and cycle 2's contracts still counted active) at this exact point, even though command mode reports 0 and the deliveries' cash income is genuinely received in both modes -- reproduced identically across two separate interaction-mode runs, so not flaky. Same family as Finding #50 (a `contract deliver` side effect that fully applies in command mode but not in a real browser), but broader: it affects every contract cycle in this file, not only a 3rd one blocked by leftover mass. Left for the same separate investigation.",
       "expect": {
         "equals": {
-          "tickCount": 69,
+          "tickCount": 96,
           "deathCount": 1,
           "employeeCount": 8,
           "bankrupt": false,

--- a/scripts/scenario-defs/money-surfaces-visual.json
+++ b/scripts/scenario-defs/money-surfaces-visual.json
@@ -137,21 +137,30 @@
     {
       "command": "contract accept id:2",
       "timeout": 30,
-      "description": "BLOCKED FINDING, left unconverted deliberately: offered-contract rows carry no id-scoped selector, so negotiating contract 1 and accepting contract 2 specifically can't be expressed as a reliable click — only \"the first offer\" resolves unambiguously (proven in contract-panel-visual.json). A click here risks acting on the wrong contract, which is worse than staying a command.",
+      "description": "#513 fix landed: offered-contract cards now carry `data-contract-id`, so negotiating contract 1 and accepting contract 2 specifically is a reliable, scoped click instead of only ever reaching \"the first offer\". Converted from three commands to real clicks: open the contracts panel, negotiate on card 1's own `[data-action=\"negotiate\"]`, then accept on card 2's own `.bs-contract-accept`.",
       "interaction": [
         {
-          "type": "command",
-          "command": "contract list"
+          "type": "clickSelector",
+          "selector": "#bs-toolbar [data-panel=\"contracts\"]"
         },
         {
-          "type": "command",
-          "command": "contract negotiate id:1"
+          "type": "waitForSelector",
+          "selector": "#bs-contract-panel [data-contract-id=\"1\"] [data-action=\"negotiate\"]"
         },
         {
-          "type": "command",
-          "command": "contract accept id:2"
+          "type": "clickSelector",
+          "selector": "#bs-contract-panel [data-contract-id=\"1\"] [data-action=\"negotiate\"]"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": "#bs-contract-panel [data-contract-id=\"2\"] .bs-contract-accept"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-contract-panel [data-contract-id=\"2\"] .bs-contract-accept"
         }
-      ]
+      ],
+      "role": "player"
     },
     {
       "command": "state",

--- a/src/ui/panels/ContractsPanel.ts
+++ b/src/ui/panels/ContractsPanel.ts
@@ -255,8 +255,9 @@ export class ContractsPanel {
       attrs: { style: 'font:400 10px/1 var(--bsx-font-ui);color:var(--bsx-text-micro)' },
     });
 
-    // TODO: implement — capture returned card element and set cardEl.dataset['contractId'] = String(c.id) (#513)
-    return card([headRow, progressBar(pct, color), progressLine, deliverRow, storedNote]);
+    const cardEl = card([headRow, progressBar(pct, color), progressLine, deliverRow, storedNote]);
+    cardEl.dataset['contractId'] = String(c.id);
+    return cardEl;
   }
 
   // ── Offered ──
@@ -330,8 +331,9 @@ export class ContractsPanel {
     btnRow.style.cssText = 'display:flex;gap:6px';
     btnRow.append(acceptBtn, negotiateBtn, declineBtn);
 
-    // TODO: implement — capture returned card element and set cardEl.dataset['contractId'] = String(c.id) (#513)
-    return card([headRow, statRow, haveRow, termsRow, negBox, btnRow]);
+    const cardEl = card([headRow, statRow, haveRow, termsRow, negBox, btnRow]);
+    cardEl.dataset['contractId'] = String(c.id);
+    return cardEl;
   }
 
   private miniStat(label: string, value: string, color?: string, last = false): HTMLElement {

--- a/src/ui/panels/ContractsPanel.ts
+++ b/src/ui/panels/ContractsPanel.ts
@@ -255,6 +255,7 @@ export class ContractsPanel {
       attrs: { style: 'font:400 10px/1 var(--bsx-font-ui);color:var(--bsx-text-micro)' },
     });
 
+    // TODO: implement — capture returned card element and set cardEl.dataset['contractId'] = String(c.id) (#513)
     return card([headRow, progressBar(pct, color), progressLine, deliverRow, storedNote]);
   }
 
@@ -329,6 +330,7 @@ export class ContractsPanel {
     btnRow.style.cssText = 'display:flex;gap:6px';
     btnRow.append(acceptBtn, negotiateBtn, declineBtn);
 
+    // TODO: implement — capture returned card element and set cardEl.dataset['contractId'] = String(c.id) (#513)
     return card([headRow, statRow, haveRow, termsRow, negBox, btnRow]);
   }
 

--- a/tests/unit/ui/panels/ContractsPanel.test.ts
+++ b/tests/unit/ui/panels/ContractsPanel.test.ts
@@ -189,4 +189,70 @@ describe('ContractsPanel', () => {
     panel.dispose();
     expect(container.contains(panel.root)).toBe(false);
   });
+
+  // ── #513: cards must carry data-contract-id so per-card action selectors scope correctly ──
+
+  it('offered card carries data-contract-id matching its contract', () => {
+    const { panel } = makePanel();
+    const state = makeState();
+    state.contracts.available.push(makeContract({ id: 7 }));
+    panel.show();
+    panel.update(state);
+
+    expect(panel.root.querySelector('[data-contract-id="7"]')).not.toBeNull();
+  });
+
+  it('active card carries data-contract-id matching its contract', () => {
+    const { panel } = makePanel();
+    const state = makeState();
+    state.collectedOre['dirtite'] = 40;
+    state.contracts.active.push(makeContract({ id: 5, quantityKg: 100, deliveredKg: 0 }));
+    panel.show();
+    panel.update(state);
+
+    expect(panel.root.querySelector('[data-contract-id="5"]')).not.toBeNull();
+  });
+
+  it('Accept on a specific offered card dispatches contract accept for that card only, with two offers present', () => {
+    const { panel, gameConsole } = makePanel();
+    const state = makeState();
+    state.contracts.available.push(makeContract({ id: 3 }), makeContract({ id: 9 }));
+    panel.show();
+    panel.update(state);
+
+    (panel.root.querySelector('[data-contract-id="9"] .bs-contract-accept') as HTMLButtonElement).click();
+
+    expect(gameConsole).toHaveBeenCalledWith('contract accept id:9');
+    expect(gameConsole).not.toHaveBeenCalledWith('contract accept id:3');
+  });
+
+  it('Accept on the other offered card dispatches contract accept for that id, with two offers present', () => {
+    const { panel, gameConsole } = makePanel();
+    const state = makeState();
+    state.contracts.available.push(makeContract({ id: 3 }), makeContract({ id: 9 }));
+    panel.show();
+    panel.update(state);
+
+    (panel.root.querySelector('[data-contract-id="3"] .bs-contract-accept') as HTMLButtonElement).click();
+
+    expect(gameConsole).toHaveBeenCalledWith('contract accept id:3');
+    expect(gameConsole).not.toHaveBeenCalledWith('contract accept id:9');
+  });
+
+  it('Deliver on a specific active card dispatches contract deliver for that card only, with two active contracts present', () => {
+    const { panel, gameConsole } = makePanel();
+    const state = makeState();
+    state.collectedOre['dirtite'] = 100;
+    state.contracts.active.push(
+      makeContract({ id: 5, quantityKg: 100, deliveredKg: 0 }),
+      makeContract({ id: 8, quantityKg: 60, deliveredKg: 0 }),
+    );
+    panel.show();
+    panel.update(state);
+
+    (panel.root.querySelector('[data-contract-id="8"] .bs-contract-deliver') as HTMLButtonElement).click();
+
+    expect(gameConsole).toHaveBeenCalledWith('contract deliver 8 amount:60');
+    expect(gameConsole).not.toHaveBeenCalledWith(expect.stringMatching(/^contract deliver 5 /));
+  });
 });


### PR DESCRIPTION
Closes #513

## Problem

`ContractsPanel` rendered each offer/active-contract card with no id-bearing DOM attribute, so `.bs-contract-accept` / `.bs-contract-deliver` were unscoped selectors that always resolved to the FIRST card in the DOM regardless of which offer/contract was actually clicked. Converting `contract accept`/`contract deliver` scenario steps to real clicks silently accepted/delivered against the wrong contract in interaction (browser) mode while command mode did the right thing — the two verification channels were silently testing different game states.

## Fix

- `ContractsPanel.makeOfferedCard` and `makeActiveCard` (`src/ui/panels/ContractsPanel.ts`) now set `cardEl.dataset['contractId'] = String(c.id)` on the card wrapper element, mirroring the existing `data-vehicle-id` (`FleetPanel.ts`) / `data-hole` (`Sequence.ts`) precedent.
- `scripts/scenario-defs/level1-playthrough-win.json`: `contract accept 2` / `contract accept 4` now use real clicks scoped to `[data-contract-id="N"] .bs-contract-accept`; `contract deliver 2 amount:260` / `contract deliver 4 amount:60` converted from command-only steps to real `set` + `clickSelector` interactions, each reopening the Contracts panel first (an intervening `vehicle haul` step switches tabs and hides the panel) and, for contract #4, padded to `tick 29` (was `tick 2`) so the haul genuinely completes before the deliver click — all downstream `expect.equals.tickCount` and score values recomputed from an actual command-mode run.
- `scripts/scenario-defs/money-surfaces-visual.json`: `contract accept id:2` (with its preceding negotiate) converted to real scoped clicks.
- `tests/unit/ui/panels/ContractsPanel.test.ts`: 5 new tests — id-attribute presence on both card types, and multi-card scoping tests proving a click on one card's button dispatches only that card's command, never another's (these fail against the pre-fix panel, pass against the fix).

## Decisions taken

Defaulted under `agentic-decision-autonomy`:

- **What was open:** the issue asked to add an id attribute to "each offer card"; whether the active/deliver-side card gets the same treatment was unspecified.
  **Chosen:** apply `data-contract-id` to `makeActiveCard` too, scoping the deliver-side controls identically.
  **Why:** identical unscoped-selector shape as the accept bug; leaving it unscoped would reintroduce the same bug class the moment two active contracts coexist and a real click-based deliver scenario exercises it.
  **If reversed:** delete the `dataset['contractId']` assignment in `makeActiveCard`; no scenario step currently depends on it being absent.

- **What was open:** whether any of the 23 standing `expect.blocked` `contract deliver` no-op steps (in other scenario files) convert to real deliveries now that this fix lands.
  **Chosen:** none convert.
  **Why:** each was traced to a genuine 0kg-in-storage guard (those scenario files never haul material into storage at all) — unrelated to which contract card gets clicked. Converting an accept click to be correctly scoped doesn't change what's in storage.
  **If reversed:** re-run the trace for a specific file if its setup steps change; the `expect.blocked` assertion self-flags by failing once `maxDeliverable > 0`.

## Verification

- `static` (`npm run typecheck`) — PASS, 0 errors
- `logic` (`npm run test`) — PASS, 298 files / 8711 tests (5 new, all others unaffected)
- `scenario` (`npm run scenarios`, command mode) — PASS, 127/127
- `build` (`npm run build`) — PASS
- `visual` (`npm run scenario -- --scenario level1-playthrough-win --mode interaction --screenshots`, run in this session) — PASS after 3 iterations: round 1 found the panel-reopen gap (step 49), round 2 found insufficient tick padding for contract #4's haul (step 63), round 3 completed all 68 steps clean. Screenshots inspected confirm contract #2 (rubble) and contract #4 (dirtite) are each accepted and delivered correctly, command mode and interaction mode now hold the same game state throughout (`tickCount: 96`, `deathCount: 1`, `employeeCount: 8` match on both sides). `npm run a11y` and `npm run validate:state` also clean.
- `playability`/interaction-mode scenario suite — covered by CI under `full-ci` (issue #513 carried this label; transferred to this PR).
- Code review — security, quality, i18n, duplication, semantic reviewers all PASS, no blocking findings.

READY TO MERGE