### PR TITLE
fix: Resolve #514 — convert last 3 un-converted scenario steps to real clicks

### DIFF
--- a/scripts/scenario-defs/blast-preview-step-visual.json
+++ b/scripts/scenario-defs/blast-preview-step-visual.json
@@ -51,13 +51,34 @@
     {
       "command": "charge hole:* explosive:boomite amount:5kg stemming:2m",
       "timeout": 30,
-      "description": "Setup, matching the drill/sequence steps around it: the Blast Workshop is not opened until the step below (switching straight to the Preview step), so charging here still happens off-panel via command rather than a real Charge All click.",
+      "description": "Declared boomite/5kg/2m is exactly what the Charge panel shows on a fresh page (DEFAULT_EXPLOSIVE/DEFAULT_AMOUNT_KG/DEFAULT_STEMMING_M, Charge.ts), so Charge All commits the declared values with no stepper click at all — asserted rather than assumed. The Blast Workshop is opened here (same shape as blast-fire-step-visual.json's charge step); the step below no longer needs its own panel-open click since the panel is already open by then.",
       "interaction": [
         {
-          "type": "command",
-          "command": "charge hole:* explosive:boomite amount:5kg stemming:2m"
+          "type": "clickSelector",
+          "selector": "#bs-toolbar [data-panel=\"blast\"]"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": "#bs-blast-panel [data-action=\"charge-all\"]"
+        },
+        {
+          "type": "assert",
+          "selector": "#bs-blast-panel [data-field=\"amount\"] .bsx-stepper-value",
+          "property": "textContent",
+          "expectedValue": "5 kg"
+        },
+        {
+          "type": "assert",
+          "selector": "#bs-blast-panel [data-field=\"stemming\"] .bsx-stepper-value",
+          "property": "textContent",
+          "expectedValue": "2.0 m"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-blast-panel [data-action=\"charge-all\"]"
         }
       ],
+      "role": "player",
       "expect": {
         "equals": {
           "chargedCount": 1
@@ -83,12 +104,8 @@
     {
       "command": "state",
       "timeout": 30,
-      "description": "Opening the Blast Workshop and switching to step 4 (Preview) shows the Analysis Suite: T1 buyable, T2-4 not yet, and Predicted showing 'run analysis to see predictions' since none has run",
+      "description": "Switching to step 4 (Preview) shows the Analysis Suite: T1 buyable, T2-4 not yet, and Predicted showing 'run analysis to see predictions' since none has run. The panel is already open (opened by the charge step above), so no panel-open click here — #bs-toolbar [data-panel=\"blast\"] is a toggle (UIManager.togglePanel), so clicking it again would have closed it.",
       "interaction": [
-        {
-          "type": "clickSelector",
-          "selector": "#bs-toolbar [data-panel=\"blast\"]"
-        },
         {
           "type": "wait",
           "durationMs": 300

--- a/scripts/scenario-defs/blast-sequence-step-visual.json
+++ b/scripts/scenario-defs/blast-sequence-step-visual.json
@@ -51,13 +51,34 @@
     {
       "command": "charge hole:* explosive:boomite amount:5kg stemming:2m",
       "timeout": 30,
-      "description": "Setup, matching the drill step above: the Blast Workshop is not opened until the step below (it auto-lands on Sequence once drilling/charging are done), so charging here still happens off-panel via command rather than a real Charge All click.",
+      "description": "Declared boomite/5kg/2m is exactly what the Charge panel shows on a fresh page (DEFAULT_EXPLOSIVE/DEFAULT_AMOUNT_KG/DEFAULT_STEMMING_M, Charge.ts), so Charge All commits the declared values with no stepper click at all — asserted rather than assumed. The Blast Workshop is opened here (same shape as blast-fire-step-visual.json's charge step); the step below no longer needs its own panel-open click since the panel is already open by then.",
       "interaction": [
         {
-          "type": "command",
-          "command": "charge hole:* explosive:boomite amount:5kg stemming:2m"
+          "type": "clickSelector",
+          "selector": "#bs-toolbar [data-panel=\"blast\"]"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": "#bs-blast-panel [data-action=\"charge-all\"]"
+        },
+        {
+          "type": "assert",
+          "selector": "#bs-blast-panel [data-field=\"amount\"] .bsx-stepper-value",
+          "property": "textContent",
+          "expectedValue": "5 kg"
+        },
+        {
+          "type": "assert",
+          "selector": "#bs-blast-panel [data-field=\"stemming\"] .bsx-stepper-value",
+          "property": "textContent",
+          "expectedValue": "2.0 m"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-blast-panel [data-action=\"charge-all\"]"
         }
       ],
+      "role": "player",
       "expect": {
         "equals": {
           "chargedCount": 4,
@@ -68,12 +89,8 @@
     {
       "command": "state",
       "timeout": 30,
-      "description": "Opening the Blast Workshop auto-lands on step 3 (Sequence) since drilling and charging are done but nothing is sequenced — every hole row shows an unset (—) delay",
+      "description": "The already-open Blast Workshop auto-lands on step 3 (Sequence) since drilling and charging are done but nothing is sequenced — every hole row shows an unset (—) delay. The panel is already open (opened by the charge step above), so no panel-open click here — #bs-toolbar [data-panel=\"blast\"] is a toggle (UIManager.togglePanel), so clicking it again would have closed it.",
       "interaction": [
-        {
-          "type": "clickSelector",
-          "selector": "#bs-toolbar [data-panel=\"blast\"]"
-        },
         {
           "type": "wait",
           "durationMs": 300

--- a/scripts/scenario-defs/multi-deck-blast.json
+++ b/scripts/scenario-defs/multi-deck-blast.json
@@ -362,11 +362,32 @@
       "command": "blast",
       "interaction": [
         {
-          "type": "command",
-          "command": "blast"
+          "type": "clickSelector",
+          "selector": "#bs-blast-panel [data-step=\"5\"]"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-blast-panel [data-action=\"execute\"]"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": ".bs-confirm-overlay .bs-btn-danger"
+        },
+        {
+          "type": "clickSelector",
+          "selector": ".bs-confirm-overlay .bs-btn-danger"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": "[data-action=\"report-close\"]"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "[data-action=\"report-close\"]"
         }
       ],
-      "description": "blast — still a command here, but NOT for want of a button: the Fire step's Execute -> confirm -> report-close path is real and is clicked for real in sibling files (presplit-wall.json, level1-lose-ecology.json). Converting it is the blast step's own conversion, not this pass's (per-hole charging); console `blast` reuses the same validator the Execute button gates, so both modes exercise the same code.",
+      "role": "player",
+      "description": "blast — Fire step's Execute -> confirm -> report-close path, same click sequence as the sibling files (presplit-wall.json, level1-lose-ecology.json). The blast panel is already open (opened at the drill_plan step above) and stays open through every per-hole charge/sequence step, so no panel-open click is needed here.",
       "expect": {
         "equals": {
           "holeCount": 0,

--- a/tests/unit/scenario-defs.test.ts
+++ b/tests/unit/scenario-defs.test.ts
@@ -863,3 +863,79 @@ describe('Step expect field is shaped correctly when present', () => {
     });
   }
 });
+
+// ──────────────────────────────────────────────
+// 16. The 3 remaining un-converted, non-exempt player steps (issue #514).
+//
+// Issue #514 audited every untagged (no `role`) step carrying a raw console
+// `command` action and found 289 of them; all but 3 are legitimately exempt
+// (cheat/setup steps with no UI equivalent, or documented permanent
+// exceptions per .claude/rules/scenario-defs.md). These 3 are ordinary
+// player actions — a blast execution and two charge-hole steps — that were
+// simply never converted. They must become real `role: 'player'` steps
+// driven by clicks, matching every other player-facing step in the suite.
+//
+// This test intentionally does not dictate the click sequence (selectors,
+// waitForSelector targets, etc.) that the fix will use — only the
+// structural invariant: `role` must be `'player'` (or another established
+// non-exempt role) and the interaction array must not dispatch the console
+// command directly.
+// ──────────────────────────────────────────────
+describe('The 3 known un-converted player steps are converted to real UI interactions (#514)', () => {
+  const TARGETS: Array<{ file: string; stepIndex: number; expectedCommandPrefix: string }> = [
+    { file: 'multi-deck-blast', stepIndex: 7, expectedCommandPrefix: 'blast' },
+    { file: 'blast-preview-step-visual', stepIndex: 2, expectedCommandPrefix: 'charge hole:*' },
+    { file: 'blast-sequence-step-visual', stepIndex: 2, expectedCommandPrefix: 'charge hole:*' },
+  ];
+
+  for (const { file, stepIndex, expectedCommandPrefix } of TARGETS) {
+    it(`${file}.json step[${stepIndex}] — is tagged with a non-exempt role`, () => {
+      const scenario = loadScenarioDef(file, SCENARIO_DIR);
+      const step = scenario.steps[stepIndex] as ScenarioStepDef;
+      // Sanity check we're pointed at the right, still-unconverted step —
+      // fails loudly if the file is edited in a way that shifts step order
+      // before the role/interaction fix lands.
+      expect(
+        step.command.startsWith(expectedCommandPrefix),
+        `${file}.json step[${stepIndex}] command changed — expected it to start with "${expectedCommandPrefix}", got "${step.command}"`,
+      ).toBe(true);
+
+      expect(
+        step.role,
+        `${file}.json step[${stepIndex}] ("${step.command}") must carry role: "player" (or another established non-exempt role) — it is an ordinary player action, not exempt setup/observation`,
+      ).toBeDefined();
+      expect(step.role).not.toBe('setup');
+      expect(step.role).not.toBe('observe');
+    });
+
+    it(`${file}.json step[${stepIndex}] — its interaction array contains no raw "command" action`, () => {
+      const scenario = loadScenarioDef(file, SCENARIO_DIR);
+      const step = scenario.steps[stepIndex] as ScenarioStepDef;
+      expect(
+        step.interaction,
+        `${file}.json step[${stepIndex}] must have an interaction array`,
+      ).toBeDefined();
+      expect(step.interaction!.length).toBeGreaterThan(0);
+
+      const commandActions = (step.interaction ?? []).filter(a => a.type === 'command');
+      expect(
+        commandActions,
+        `${file}.json step[${stepIndex}] interaction array still dispatches the console command directly instead of real UI actions: ${JSON.stringify(commandActions)}`,
+      ).toEqual([]);
+    });
+
+    it(`${file}.json step[${stepIndex}] — a role-marked step's interaction obeys checkStepActionAllowed`, () => {
+      const scenario = loadScenarioDef(file, SCENARIO_DIR);
+      const step = scenario.steps[stepIndex] as ScenarioStepDef;
+      if (step.role === undefined) return; // covered by the role-defined assertion above
+      for (const action of step.interaction ?? []) {
+        if (action.type !== 'command') continue;
+        const violation = checkStepActionAllowed(step, action);
+        expect(
+          violation,
+          `${file}.json step[${stepIndex}] — unexpected allowed console command in a player-tagged step's interaction`,
+        ).toBeNull();
+      }
+    });
+  }
+});


### PR DESCRIPTION
Closes #514

Converts the last 3 mechanically-convertible, untagged (no `role`) scenario steps carrying a raw console `command` — found by the full audit of 289 such steps referenced in the issue — to real `role: "player"` UI click sequences, matching the established convention already used by every other converted step in the suite.

## Changes

- `scripts/scenario-defs/multi-deck-blast.json` — step 7 (`blast`): now the Fire step's real click path (Execute → confirm-danger overlay → report-close), copied from the already-proven pattern in `presplit-wall.json` and `level1-lose-ecology.json`.
- `scripts/scenario-defs/blast-preview-step-visual.json` — step 2 (`charge hole:* explosive:boomite amount:5kg stemming:2m`): now opens the Blast Workshop Charge panel, asserts the amount/stemming stepper values (5 kg / 2.0 m), and clicks Charge All — copied from the already-converted sibling step in `blast-fire-step-visual.json`. A downstream step's now-redundant `[data-panel="blast"]` toolbar click (which toggles an already-open panel closed) was removed.
- `scripts/scenario-defs/blast-sequence-step-visual.json` — step 2: same charge-step conversion and same downstream collateral fix.
- `tests/unit/scenario-defs.test.ts` — new regression test locking all 3 targets to a non-exempt `role` and a `command`-free `interaction` array, so a future edit that reintroduces a bare command on these steps fails loudly.

## Decisions taken

Defaulted under `agentic-decision-autonomy`.

- **What was open:** the issue flagged that `charge` is not on `SETUP_COMMAND_ALLOWLIST`/`TIME_COMMAND_ALLOWLIST` (`scripts/shared/playtest-types.ts`), so simply tagging the two `charge` steps `role: "setup"` would fail validation, and asked whether a scenario-init-only allowlist exception was the better fit instead of a real click.
  **Chosen:** no exception — both `charge` steps convert to real `Charge All` clicks.
  **Why:** `ChargeStep`'s own instance defaults (`Charge.ts`: `DEFAULT_EXPLOSIVE='boomite'`, `DEFAULT_AMOUNT_KG=5`, `DEFAULT_STEMMING_M=2`) already equal the declared command values, and the sibling file `blast-fire-step-visual.json` already proved the identical open-panel-then-click-Charge-All pattern for this exact step shape under #510-#513. A real click exists and is reachable; an allowlist exception would contradict the click-only mandate (`docs/plans/scenario-assertions-and-playtest-removal.md`) for a step that was only mis-sequenced, not actually blocked.
  **If reversed:** if `ChargeStep`'s defaults ever drift from 5kg/2m/boomite, add stepper-click actions to the two charge steps' `interaction` arrays rather than reaching for the allowlist.

- **What was open:** whether to fix the charge steps by inserting a new "open panel" step before them, or reordering existing steps.
  **Chosen:** neither literally — folded the panel-open click into the existing charge step's own `interaction` array, and removed the one downstream step's now-redundant (and panel-closing) duplicate panel-open click.
  **Why:** matches the structural shape already used to fix the third sibling file (`blast-fire-step-visual.json`, #510-#513) — keeps all three `blast-*-step-visual.json` files structurally identical instead of introducing a second convention.
  **If reversed:** re-add the removed `clickSelector [data-panel="blast"]` action as the first element of the downstream step's `interaction` array if this fix is ever reverted.

- **What was open:** whether the `full-ci` label (full browser-driven interaction-mode + playability CI sweep, ~50 min) is warranted.
  **Chosen:** no — verified all 3 files locally via `npm run scenario -- --scenario <name> --mode interaction --screenshots` in this session (the visual channel's normal working loop) instead.
  **Why:** the diff touches 3 named scenario-def files only, not shared rendering/input/camera/picking/harness machinery every scenario runs through, and the issue's own verification list is scoped to exactly these 3 files — which the visual channel already covered in-session, with screenshots inspected.
  **If reversed:** add `full-ci` if a reviewer wants the full suite re-run in CI anyway.

## Verification

- **static** — `npm run typecheck`: 0 errors.
- **logic** — `npm run test`: 298 files / 8720 tests passing.
- **scenario** — `npm run scenarios` (command mode): 127/127 passing, all 3 target files included — unaffected by design, since only `interaction`/`role` changed, never `command`.
- **visual** — `npm run scenario -- --scenario <name> --mode interaction --screenshots` run individually for all 3 target files: all pass end to end, no selector timeouts, expected `chargedCount`/`sequencedCount`/blast-report values all matched. Screenshots inspected with vision for all 3 runs — Blast Workshop panel, Charge/Fire tab state, and stepper values genuinely rendered as expected in every capture.
- **build** — `npm run build`: success.
- Duplication check (`npx jscpd`) on the changed test file: 9 pre-existing clones, all identical to `main`, zero new duplication from this diff's added block.
- 5 parallel code reviewers (security, quality, i18n, duplication, semantic) — all PASS. One non-blocking suggestion noted: one of the 3 new sub-assertions per target is currently vacuous under the fixed state (would still catch a regression if a `command` action were reintroduced on a `role: "player"` step) — left as-is, not worth a second round for a harmless redundancy.

READY TO MERGE