### PR TITLE
ci: gate Production build behind a build-check label

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -83,11 +83,14 @@ The game's own simulation is not the cost — turning ticking off changes the fr
 
 | Run | Where |
 |-----|-------|
-| `typecheck`, `test`, `scenarios` (command mode), `build` | Either. CI runs all four on every push and PR. |
+| `typecheck`, `test`, `scenarios` (command mode) | Either. CI runs all three on every push and PR. |
 | `screenshot`, one named scenario in interaction mode | Your session — this is the visual channel's working loop. |
+| `build` (production bundle) | CI job `Production build` on push/schedule/dispatch, or PRs labeled `build-check` or `full-ci`. |
 | All scenarios in interaction mode | CI job `Scenarios (interaction mode)` (label the PR `full-ci`). |
 
 The interaction-mode job is gated behind the `full-ci` label because the terrain material costs ~6.4 s/frame without a GPU (#475): the harness waits on the render loop for every probe, so one beat costs minutes. It adds ~30 minutes to the merge path, so the label goes on a PR whose change an interaction-mode scenario actually drives, or which touches machinery every scenario runs through — not on every diff that a player can see. `agentic-pipeline-pr-management` holds the test and the cost.
+
+The `Production build` job is gated behind `build-check` (or `full-ci`, which already implies it) because it doesn't need proving on every diff — `typecheck` already catches what would break the bundle far more often than a Vite-specific build failure does. Apply `build-check` when a change touches build config (`vite.config.ts`, `tsconfig*.json`, `package.json`'s dependencies) or anything about bundling/chunking itself.
 
 Push, then read the CI job — its result *is* the channel's result, and its artifacts carry the FAIL screenshots. Locally, run one named definition you are actively debugging, never the whole suite.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,9 +88,18 @@ jobs:
           name: test-results
           path: test-results/
 
+  # Runs the production build check. Runs only on:
+  #   - Push to main (catches build breakage after merge)
+  #   - Schedule (weekly full scan)
+  #   - workflow_dispatch (manual trigger)
+  #   - PRs labeled "build-check" or "full-ci" (opts in when the build itself is worth proving)
   build:
     name: Production build
     runs-on: ubuntu-latest
+    if: |
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'build-check') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     needs:
       - typecheck
       - test


### PR DESCRIPTION
Adds a `build-check` label so the `Production build` CI job (`npm run build` → artifact upload) only runs on pull requests when explicitly requested — mirrors the existing `full-ci` pattern exactly:

- Always runs on `push` to `main`, `schedule`, `workflow_dispatch` (unchanged).
- On `pull_request`, only runs when the PR carries `build-check` or `full-ci` (a thorough PR should get the build check too, not just the browser suite).

Rationale: `typecheck` already catches the overwhelming majority of what would break the bundle. The build job doesn't need to prove itself on every trivial PR the way type checking and tests do — reserve it for changes that actually touch build config or bundling.

Also updated `.claude/CLAUDE.md`'s "Claude Code only" job-placement table, which claimed all of `typecheck`/`test`/`scenarios`/`build` run on every push and PR — no longer true for `build` after this change.

## Verification

- `static` — `npm run typecheck`: pass (unaffected, no source change)
- YAML structure validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- This is a CI-config-only change; no `src/`/`scripts/` behavior touched, so `logic`/`scenario`/`visual` don't apply.

## Note on the label itself

I don't have a tool that creates GitHub label objects (repo labels) directly — only `get_label` (read) is available to me, no create/list. I've applied `build-check` to this PR to test whether the underlying API auto-creates it; if that fails, the label needs to be created once via Settings → Labels (or on first use from the PR label picker, which lets you type a new name and create it inline).

---
_Generated by [Claude Code](https://claude.ai/code/session_011V2gkuCaXE5LEqpVqbVCZm)_