### PR TITLE
fix: Resolve #519 — sanitize corrupt command cost override against negative/NaN values

### DIFF
--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -485,7 +485,8 @@ export function corruptCommand(
     return { success: false, output: `Invalid target. Valid: ${validTargets.join(', ')}` };
   }
 
-  const cost = named['cost'] ? parseInt(named['cost'], 10) : undefined;
+  const rawCost = named['cost'] ? parseInt(named['cost'], 10) : undefined;
+  const cost = rawCost !== undefined && Number.isFinite(rawCost) && rawCost >= 0 ? rawCost : undefined;
   const resolvedCost = cost ?? TARGET_COSTS[target];
   if (state.cash < resolvedCost) {
     return {

--- a/src/core/economy/Corruption.ts
+++ b/src/core/economy/Corruption.ts
@@ -65,7 +65,9 @@ export function attemptCorruption(
   rng: Random,
   customCost?: number,
 ): CorruptionResult {
-  const cost = customCost ?? TARGET_COSTS[target];
+  const cost = customCost !== undefined && Number.isFinite(customCost) && customCost >= 0
+    ? customCost
+    : TARGET_COSTS[target];
   const successRate = Math.max(0.1,
     BASE_SUCCESS_RATE - state.attempts.length * HISTORY_PENALTY,
   );

--- a/tests/unit/console/insufficient-funds-guards.test.ts
+++ b/tests/unit/console/insufficient-funds-guards.test.ts
@@ -439,6 +439,88 @@ describe('corrupt — insufficient funds guard', () => {
   });
 });
 
+// ── corrupt — invalid cost override sanitization (#519) ──
+//
+// `corrupt target:<t> cost:<n>` lets a player override the default bribe
+// cost. Two unsanitized inputs break that: a negative cost passes the funds
+// guard (which only rejects cash < cost) and then *increases* cash via
+// `state.cash -= result.cost`; a non-numeric cost produces NaN, which
+// `?? TARGET_COSTS[target]` does not catch (nullish coalescing only replaces
+// null/undefined), poisoning state.cash with NaN for the rest of the session
+// — every later `cash < X` guard is false because any NaN comparison is
+// false. The fix sanitizes with `Number.isFinite(cost) && cost >= 0`,
+// falling back to TARGET_COSTS[target] silently otherwise (same convention
+// as `set_policy` and `new_game`'s optional numeric overrides).
+
+describe('corrupt — invalid cost override sanitization (#519)', () => {
+  const WITNESS_COST = TARGET_COSTS.witness;
+
+  it('refuses a negative cost override when cash is below the real target cost', () => {
+    const ctx = makeCtx(WITNESS_COST - 1);
+    const before = ctx.state!.cash;
+    const result = corruptCommand(ctx, [], { target: 'witness', cost: '-1000000' });
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('Insufficient funds');
+    expect(ctx.state!.cash).toBe(before);
+  });
+
+  it('charges the real target cost, never the negative override, when cash covers it', () => {
+    const ctx = makeCtx(WITNESS_COST);
+    const before = ctx.state!.cash;
+    corruptCommand(ctx, [], { target: 'witness', cost: '-1000000' });
+    expect(ctx.state!.cash).toBe(before - WITNESS_COST);
+    expect(ctx.state!.cash).not.toBeGreaterThan(before);
+  });
+
+  it('never leaves cash as NaN after a non-numeric cost override', () => {
+    const ctx = makeCtx(WITNESS_COST);
+    corruptCommand(ctx, [], { target: 'witness', cost: 'notanumber' });
+    expect(Number.isFinite(ctx.state!.cash)).toBe(true);
+  });
+
+  it('does not permanently disable funds guards after a negative cost override', () => {
+    const ctx = makeCtx(WITNESS_COST);
+    corruptCommand(ctx, [], { target: 'witness', cost: '-1000000' });
+    expect(ctx.state!.cash).toBe(0);
+    const buildResult = buildCommand(ctx, ['management_office'], { at: '0,0' });
+    expect(buildResult.success).toBe(false);
+    expect(buildResult.output).toContain('Insufficient funds');
+  });
+
+  it('does not permanently disable funds guards after a non-numeric cost override', () => {
+    const ctx = makeCtx(WITNESS_COST);
+    corruptCommand(ctx, [], { target: 'witness', cost: 'notanumber' });
+    expect(ctx.state!.cash).toBe(0);
+    const buildResult = buildCommand(ctx, ['management_office'], { at: '0,0' });
+    expect(buildResult.success).toBe(false);
+    expect(buildResult.output).toContain('Insufficient funds');
+  });
+
+  it('accepts cost:0 as a valid override — zero is not negative', () => {
+    const ctx = makeCtx(0);
+    const result = corruptCommand(ctx, [], { target: 'witness', cost: '0' });
+    expect(result.success).toBe(true);
+    expect(result.output).not.toContain('Insufficient funds');
+    expect(ctx.state!.cash).toBe(0);
+  });
+
+  it('rejects cost:-1 and falls back to the default target cost (boundary)', () => {
+    const ctx = makeCtx(WITNESS_COST - 1);
+    const result = corruptCommand(ctx, [], { target: 'witness', cost: '-1' });
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('Insufficient funds');
+    expect(ctx.state!.cash).toBe(WITNESS_COST - 1);
+  });
+
+  it('still honors a legitimate positive cost override below the default target cost', () => {
+    const ctx = makeCtx(WITNESS_COST);
+    const before = ctx.state!.cash;
+    const result = corruptCommand(ctx, [], { target: 'witness', cost: '5000' });
+    expect(result.success).toBe(true);
+    expect(ctx.state!.cash).toBe(before - 5000);
+  });
+});
+
 // ── mafia accident — issue #511 ──
 
 describe('mafia accident — insufficient funds guard', () => {

--- a/tests/unit/economy/Corruption.test.ts
+++ b/tests/unit/economy/Corruption.test.ts
@@ -7,6 +7,7 @@ import {
   isMafiaUnlocked,
   getSuccessRate,
   MAFIA_THRESHOLD,
+  TARGET_COSTS,
 } from '../../../src/core/economy/Corruption.js';
 
 describe('Corruption system', () => {
@@ -78,5 +79,34 @@ describe('Corruption system', () => {
       }
     }
     expect.unreachable('Mafia never unlocked');
+  });
+});
+
+// ── customCost sanitization (#519) ──
+//
+// `customCost` is caller-supplied (console `corrupt` command's `cost:` arg).
+// `cost = customCost ?? TARGET_COSTS[target]` only rejects null/undefined —
+// a negative number or NaN both pass straight through, letting a negative
+// cost invert `state.cash -= result.cost` into a cash increase and a NaN
+// cost poison state.cash for the rest of the session. The fix mirrors
+// Logistics.ts's `consumeStoredOre` validation: only accept customCost when
+// `Number.isFinite(customCost) && customCost >= 0`.
+describe('Corruption system — customCost sanitization (#519)', () => {
+  it('falls back to TARGET_COSTS[target] for a negative customCost', () => {
+    const state = createCorruptionState();
+    const result = attemptCorruption(state, 'inspector', 1, new Random(42), -5000);
+    expect(result.cost).toBe(TARGET_COSTS.inspector);
+  });
+
+  it('falls back to TARGET_COSTS[target] for a NaN customCost', () => {
+    const state = createCorruptionState();
+    const result = attemptCorruption(state, 'inspector', 1, new Random(42), NaN);
+    expect(result.cost).toBe(TARGET_COSTS.inspector);
+  });
+
+  it('accepts customCost of 0 as a valid override (boundary)', () => {
+    const state = createCorruptionState();
+    const result = attemptCorruption(state, 'inspector', 1, new Random(42), 0);
+    expect(result.cost).toBe(0);
   });
 });


### PR DESCRIPTION
Closes #519

## Summary

`corruptCommand`'s console-only `cost:` override was never validated before use, enabling two exploits:

1. **Negative cost mints cash.** `corrupt target:witness cost:-1000000` passed the `cash < resolvedCost` funds check (a negative cost is always less than non-negative cash), then `state.cash -= result.cost` with a negative `result.cost` *increased* cash.
2. **Non-numeric cost permanently disables every funds guard.** `corrupt target:witness cost:abc` → `parseInt` → `NaN`. Nullish coalescing (`??`) does not catch `NaN`, only `null`/`undefined`, so `NaN ?? TARGET_COSTS[target]` evaluated to `NaN`. Every subsequent `cash < X` comparison anywhere in the game session became `false` (any comparison against `NaN` is `false`), silently disabling every funds guard — build destroy/upgrade/move, corrupt, mafia accident/frame, employee hire, vehicle buy — for the rest of the session, with `state.cash` itself becoming `NaN`.

## Fix

Both layers now only accept a numeric override when it is finite and non-negative (`Number.isFinite(x) && x >= 0`), otherwise silently fall back to `TARGET_COSTS[target]` — no error output, matching the codebase's existing convention for optional numeric console params.

- `src/console/commands/events.ts` (`corruptCommand`) — sanitizes the parsed `cost:` override before it reaches the funds check or `attemptCorruption`.
- `src/core/economy/Corruption.ts` (`attemptCorruption`) — defends its own `customCost` parameter independently, since it's an exported function within the module and any future caller could hit the same footgun (mirrors the existing `Number.isFinite` precedent in `Logistics.ts`'s `consumeStoredOre`).

11 new tests (8 console-layer, 3 core-layer) cover both exploits, the `cost:0`/`cost:-1` boundary, that a legitimate positive override still works, and that funds guards aren't left globally disabled after an invalid-cost call. All fail against the pre-fix code, all pass against the fix.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** whether an invalid/negative `cost:` override should be rejected with an error message or silently fall back to `TARGET_COSTS[target]`.
  **Chosen:** silent fallback, no error message — same as `cost:` not being passed at all.
  **Why:** matches this codebase's existing convention for optional numeric console overrides (`set_policy`'s `hunger:`/`fatigue:`/`social:`, `start_level`'s `cash:`) — invalid input silently keeps the default, no command-level rejection.
  **If reversed:** change the ternary in `corruptCommand` to `return { success: false, output: '...' }` when the guard fails.

- **What was open:** whether `attemptCorruption`'s `customCost` parameter should defensively validate independently of the console-layer guard.
  **Chosen:** yes — sanitize inline in `attemptCorruption` too, falling back to `TARGET_COSTS[target]`.
  **Why:** `consumeStoredOre` (`src/core/economy/Logistics.ts`) is the existing precedent for a core economy function validating a caller-supplied numeric parameter rather than trusting its caller. `attemptCorruption` is exported; a one-line defensive fallback closes the footgun for any future caller, not just `corruptCommand`.
  **If reversed:** remove the `Number.isFinite(customCost) && customCost >= 0` conjunction in `Corruption.ts`, restoring `customCost ?? TARGET_COSTS[target]` — the console-layer guard alone still closes both exploits in #519.

Neither decision is gameplay/economy/player-facing: `cost:` is a console-only debug override the UI never sends (confirmed — `ShadyPanel.ts` calls `corrupt target:<id>` with no `cost:` arg), so no `decision-review` follow-up issue was filed.

## Verification

- **static** (`npm run typecheck`): PASS — 0 type errors.
- **logic** (`npm run test`): PASS — 8671/8671 tests, 299 files, including 11 new regression tests (verified to fail against pre-fix code, pass against the fix).
- **scenario** (`npm run scenarios`): PASS — 127/127, command mode.
- **build** (`npm run build`): PASS.
- **visual**: not applicable — console-command-only fix, no `src/renderer/` or `src/ui/` touched; confirmed by i18n/security review that the UI never sends a `cost:` override.

## Also found, out of scope for this PR

Security review surfaced two pre-existing instances of the same unvalidated-numeric-override pattern elsewhere in the console layer, reaching the identical "funds guard permanently disabled via NaN" end state:
- `employee raise <id> amount:<n>` (`src/console/commands/employees.ts`) — `amount <= 0` guard doesn't catch `NaN` from `parseFloat`, poisons `emp.salary` then `state.cash` via the payroll cycle.
- `new_game cash:<n>` (`src/console/commands/world.ts`) — unguarded `parseInt` feeds `startingCash` directly, `NaN ?? ...` doesn't catch it.

Filing a follow-up issue for these.

5 parallel specialist reviews (security, quality, i18n, duplication, semantic) all PASS — no blocking findings.

READY TO MERGE