### PR TITLE
fix: Resolve #520 — smooth entity movement interpolation, no more teleporting

### DIFF
--- a/src/renderer/CharacterMesh.ts
+++ b/src/renderer/CharacterMesh.ts
@@ -127,6 +127,16 @@ export class CharacterMesh {
   }
 
   /**
+   * Correct a character's terrain-surface Y immediately, leaving x/z motion
+   * to the eased tween (#520 — GameRenderer.syncFromContext() should no
+   * longer hard-snap x/z every sync).
+   */
+  setSurfaceY(_id: number, _y: number): void {
+    // TODO: implement
+    throw new Error('not implemented');
+  }
+
+  /**
    * Mark a character as evacuating (will blink to indicate urgency).
    */
   setEvacuating(employeeId: number, evacuating: boolean): void {

--- a/src/renderer/CharacterMesh.ts
+++ b/src/renderer/CharacterMesh.ts
@@ -7,6 +7,7 @@
 import * as THREE from 'three';
 import type { Employee, EmployeeRole } from '../core/entities/Employee.js';
 import { tagPickable } from './Pickable.js';
+import { createTween, stepTween, type MovementTween } from './MovementInterpolation.js';
 
 // ---------- Role colors (bright, distinct) ----------
 // Exported for the Crew panel's roster avatars (redesign P6) — same hue as
@@ -28,9 +29,6 @@ const BODY_RADIUS   = 0.22;
 const BODY_HEIGHT   = 0.55;
 const HEAD_RADIUS   = 0.20;
 
-// ---------- Movement ----------
-const MOVE_LERP = 0.10;
-
 // ---------- Main class ----------
 
 export class CharacterMesh {
@@ -41,6 +39,7 @@ export class CharacterMesh {
     headMat: THREE.MeshPhongMaterial;
     employee: Employee;
     evacuating: boolean;
+    tween: MovementTween;
   }>();
   private time = 0;
 
@@ -79,7 +78,10 @@ export class CharacterMesh {
     group.position.set(employee.x, surfaceY, employee.z);
     tagPickable(group, 'employee', employee.id);
     this.scene.add(group);
-    this.characters.set(employee.id, { group, bodyMat, headMat, employee, evacuating: false });
+    this.characters.set(employee.id, {
+      group, bodyMat, headMat, employee, evacuating: false,
+      tween: createTween(employee.x, employee.z),
+    });
   }
 
   /**
@@ -96,9 +98,10 @@ export class CharacterMesh {
 
       entry.employee = emp;
 
-      // Lerp toward work position
-      entry.group.position.x += (emp.x - entry.group.position.x) * MOVE_LERP;
-      entry.group.position.z += (emp.z - entry.group.position.z) * MOVE_LERP;
+      // Ease toward work position (duration-aware tween, #520)
+      const eased = stepTween(entry.tween, entry.group.position.x, entry.group.position.z, emp.x, emp.z, dt);
+      entry.group.position.x = eased.x;
+      entry.group.position.z = eased.z;
 
       // Update body color for injury state
       const roleColor = ROLE_COLORS[emp.role];
@@ -123,6 +126,7 @@ export class CharacterMesh {
     const entry = this.characters.get(id);
     if (entry) {
       entry.group.position.set(x, y, z);
+      entry.tween = createTween(x, z);
     }
   }
 
@@ -131,9 +135,11 @@ export class CharacterMesh {
    * to the eased tween (#520 — GameRenderer.syncFromContext() should no
    * longer hard-snap x/z every sync).
    */
-  setSurfaceY(_id: number, _y: number): void {
-    // TODO: implement
-    throw new Error('not implemented');
+  setSurfaceY(id: number, y: number): void {
+    const entry = this.characters.get(id);
+    if (entry) {
+      entry.group.position.y = y;
+    }
   }
 
   /**

--- a/src/renderer/CharacterMesh.ts
+++ b/src/renderer/CharacterMesh.ts
@@ -120,7 +120,7 @@ export class CharacterMesh {
 
   /**
    * Snap a character to an exact position (e.g. after terrain rebuild repositions surface).
-   * Unlike the lerp-based update(), this sets the position immediately.
+   * Unlike the tween-based update(), this sets the position immediately.
    */
   snapPosition(id: number, x: number, y: number, z: number): void {
     const entry = this.characters.get(id);

--- a/src/renderer/GameRenderer.ts
+++ b/src/renderer/GameRenderer.ts
@@ -167,12 +167,11 @@ export class GameRenderer {
       (x, z) => this.getTerrainSurfaceY(x, z),
     );
 
-    // Place vehicles at terrain surface height (not buried at y=0).
-    // Also fold in the waiting-queue render offset (#411 round 2, anchored to
-    // the shared target point since round 4) — this snap runs on every sync
-    // (not just once per frame like update()'s lerp), so without it every
-    // sync would stomp fused 'waiting' vehicles back to their raw, near-
-    // identical GameState x/z.
+    // Place vehicles at terrain surface height (not buried at y=0). This
+    // corrects only the instant terrain-surface `y` value via setSurfaceY();
+    // x/z motion (including the waiting-queue render offset, #411) is left
+    // entirely to the per-frame tween inside VehicleMesh.update() (#520), so
+    // this sync never stomps a mid-glide or fused 'waiting' vehicle's x/z.
     if (this.vehicles && this.lastGrid) {
       for (const v of ctx.state.vehicles.vehicles) {
         if (this.renderedVehicleIds.has(v.id)) {

--- a/src/renderer/GameRenderer.ts
+++ b/src/renderer/GameRenderer.ts
@@ -177,8 +177,7 @@ export class GameRenderer {
       for (const v of ctx.state.vehicles.vehicles) {
         if (this.renderedVehicleIds.has(v.id)) {
           const surfaceY = this.getTerrainSurfaceY(v.x, v.z);
-          const [renderX, renderZ] = this.vehicles.waitingRenderPosition(v, ctx.state.vehicles.vehicles);
-          this.vehicles.snapPosition(v.id, renderX, surfaceY, renderZ);
+          this.vehicles.setSurfaceY(v.id, surfaceY);
         }
       }
     }
@@ -188,7 +187,7 @@ export class GameRenderer {
       for (const e of ctx.state.employees.employees) {
         if (this.renderedEmployeeIds.has(e.id)) {
           const surfaceY = this.getTerrainSurfaceY(e.x, e.z);
-          this.characters.snapPosition(e.id, e.x, surfaceY, e.z);
+          this.characters.setSurfaceY(e.id, surfaceY);
         }
       }
     }
@@ -314,7 +313,7 @@ export class GameRenderer {
     }
 
     if (this.vehicles && this.lastState) {
-      this.vehicles.update(this.lastState.vehicles.vehicles);
+      this.vehicles.update(this.lastState.vehicles.vehicles, dt);
     }
 
     if (this.ghosts) {

--- a/src/renderer/MovementInterpolation.ts
+++ b/src/renderer/MovementInterpolation.ts
@@ -5,6 +5,7 @@
 // pattern in VehicleWaitingQueue.ts.
 
 import { BASE_TICK_MS } from '../core/config/balance.js';
+import { smoothstep } from '../core/math/Smoothstep.js';
 
 export interface MovementTween {
   prevX: number;
@@ -26,17 +27,15 @@ export function createTween(x: number, z: number): MovementTween {
 }
 
 // Pure: eased position at `elapsedS` into a `durationS`-long tween from
-// (prevX,prevZ) to (targetX,targetZ). Smoothstep easing, clamped.
+// (prevX,prevZ) to (targetX,targetZ). Smoothstep easing (shared with
+// core/math/Smoothstep.ts), which already clamps to exactly 0/1 at/beyond
+// the [0,durationS] bounds, so no separate early-return is needed.
 export function computeInterpolatedPosition(
   prevX: number, prevZ: number,
   targetX: number, targetZ: number,
   elapsedS: number, durationS: number,
 ): { x: number; z: number } {
-  if (elapsedS <= 0) return { x: prevX, z: prevZ };
-  if (elapsedS >= durationS) return { x: targetX, z: targetZ };
-
-  const t = elapsedS / durationS;
-  const ease = t * t * (3 - 2 * t); // smoothstep
+  const ease = smoothstep(0, durationS, elapsedS);
   return {
     x: prevX + (targetX - prevX) * ease,
     z: prevZ + (targetZ - prevZ) * ease,

--- a/src/renderer/MovementInterpolation.ts
+++ b/src/renderer/MovementInterpolation.ts
@@ -1,9 +1,8 @@
-// BlastSimulator2026 — Movement Interpolation (skeleton, #520)
+// BlastSimulator2026 — Movement Interpolation (#520)
 // Pure per-tick position easing shared by CharacterMesh and VehicleMesh, so
 // employees/vehicles glide between GameState position updates instead of
 // snapping. No THREE import — mirrors the pure-logic-out-of-mesh-class
 // pattern in VehicleWaitingQueue.ts.
-// TODO: implement (skeleton phase — stubs only).
 
 import { BASE_TICK_MS } from '../core/config/balance.js';
 
@@ -22,20 +21,26 @@ export const MOVE_TWEEN_DURATION_S = BASE_TICK_MS / 1000;
 // (not gradual per-tick movement) and snap instead of easing.
 export const MOVE_TELEPORT_DISTANCE = 60;
 
-export function createTween(_x: number, _z: number): MovementTween {
-  // TODO: implement
-  throw new Error('not implemented');
+export function createTween(x: number, z: number): MovementTween {
+  return { prevX: x, prevZ: z, targetX: x, targetZ: z, elapsedS: 0 };
 }
 
 // Pure: eased position at `elapsedS` into a `durationS`-long tween from
 // (prevX,prevZ) to (targetX,targetZ). Smoothstep easing, clamped.
 export function computeInterpolatedPosition(
-  _prevX: number, _prevZ: number,
-  _targetX: number, _targetZ: number,
-  _elapsedS: number, _durationS: number,
+  prevX: number, prevZ: number,
+  targetX: number, targetZ: number,
+  elapsedS: number, durationS: number,
 ): { x: number; z: number } {
-  // TODO: implement
-  throw new Error('not implemented');
+  if (elapsedS <= 0) return { x: prevX, z: prevZ };
+  if (elapsedS >= durationS) return { x: targetX, z: targetZ };
+
+  const t = elapsedS / durationS;
+  const ease = t * t * (3 - 2 * t); // smoothstep
+  return {
+    x: prevX + (targetX - prevX) * ease,
+    z: prevZ + (targetZ - prevZ) * ease,
+  };
 }
 
 // Stateful per-frame step: advances `tween` by `dt` real seconds (mutates it)
@@ -44,11 +49,36 @@ export function computeInterpolatedPosition(
 // stored target. Snaps immediately when the new target is
 // >= MOVE_TELEPORT_DISTANCE away from (renderX,renderZ).
 export function stepTween(
-  _tween: MovementTween,
-  _renderX: number, _renderZ: number,
-  _targetX: number, _targetZ: number,
-  _dt: number,
+  tween: MovementTween,
+  renderX: number, renderZ: number,
+  targetX: number, targetZ: number,
+  dt: number,
 ): { x: number; z: number } {
-  // TODO: implement
-  throw new Error('not implemented');
+  // Target moved since the last step (new tick's position, a mid-glide
+  // retarget, etc.) — restart from the entity's actual current rendered
+  // position, not the tween's stale prev, or the mesh pops.
+  if (targetX !== tween.targetX || targetZ !== tween.targetZ) {
+    tween.prevX = renderX;
+    tween.prevZ = renderZ;
+    tween.targetX = targetX;
+    tween.targetZ = targetZ;
+    tween.elapsedS = 0;
+  }
+
+  // Hard reposition (zone-clear, training enrolment, etc.) — no gradual
+  // movement to glide through, so snap and mark the tween fully converged.
+  if (Math.hypot(targetX - renderX, targetZ - renderZ) >= MOVE_TELEPORT_DISTANCE) {
+    tween.prevX = targetX;
+    tween.prevZ = targetZ;
+    tween.targetX = targetX;
+    tween.targetZ = targetZ;
+    tween.elapsedS = MOVE_TWEEN_DURATION_S;
+    return { x: targetX, z: targetZ };
+  }
+
+  tween.elapsedS += dt;
+  return computeInterpolatedPosition(
+    tween.prevX, tween.prevZ, tween.targetX, tween.targetZ,
+    tween.elapsedS, MOVE_TWEEN_DURATION_S,
+  );
 }

--- a/src/renderer/MovementInterpolation.ts
+++ b/src/renderer/MovementInterpolation.ts
@@ -1,0 +1,54 @@
+// BlastSimulator2026 — Movement Interpolation (skeleton, #520)
+// Pure per-tick position easing shared by CharacterMesh and VehicleMesh, so
+// employees/vehicles glide between GameState position updates instead of
+// snapping. No THREE import — mirrors the pure-logic-out-of-mesh-class
+// pattern in VehicleWaitingQueue.ts.
+// TODO: implement (skeleton phase — stubs only).
+
+import { BASE_TICK_MS } from '../core/config/balance.js';
+
+export interface MovementTween {
+  prevX: number;
+  prevZ: number;
+  targetX: number;
+  targetZ: number;
+  elapsedS: number;
+}
+
+// Real seconds a mesh takes to ease from one GameState position update to the next.
+export const MOVE_TWEEN_DURATION_S = BASE_TICK_MS / 1000;
+
+// Position deltas at/above this many world units are treated as a hard reposition
+// (not gradual per-tick movement) and snap instead of easing.
+export const MOVE_TELEPORT_DISTANCE = 60;
+
+export function createTween(_x: number, _z: number): MovementTween {
+  // TODO: implement
+  throw new Error('not implemented');
+}
+
+// Pure: eased position at `elapsedS` into a `durationS`-long tween from
+// (prevX,prevZ) to (targetX,targetZ). Smoothstep easing, clamped.
+export function computeInterpolatedPosition(
+  _prevX: number, _prevZ: number,
+  _targetX: number, _targetZ: number,
+  _elapsedS: number, _durationS: number,
+): { x: number; z: number } {
+  // TODO: implement
+  throw new Error('not implemented');
+}
+
+// Stateful per-frame step: advances `tween` by `dt` real seconds (mutates it)
+// and returns the eased render position. Restarts the tween from
+// (renderX,renderZ) whenever (targetX,targetZ) differs from the tween's
+// stored target. Snaps immediately when the new target is
+// >= MOVE_TELEPORT_DISTANCE away from (renderX,renderZ).
+export function stepTween(
+  _tween: MovementTween,
+  _renderX: number, _renderZ: number,
+  _targetX: number, _targetZ: number,
+  _dt: number,
+): { x: number; z: number } {
+  // TODO: implement
+  throw new Error('not implemented');
+}

--- a/src/renderer/VehicleMesh.ts
+++ b/src/renderer/VehicleMesh.ts
@@ -9,12 +9,14 @@
 //   building_destroyer → low yellow box + front blade (flat box)
 //   rock_fragmenter   → yellow box body + crusher head
 //
-// Vehicles move smoothly to their target position via lerp each frame.
+// Vehicles move smoothly to their target position via a duration-aware
+// tween each frame (#520 — see MovementInterpolation.ts).
 
 import * as THREE from 'three';
 import type { Vehicle, VehicleRole, VehicleTier, VehicleOperationalState } from '../core/entities/Vehicle.js';
 import { waitingQueueOffset, waitingRenderPosition } from './VehicleWaitingQueue.js';
 import { tagPickable } from './Pickable.js';
+import { createTween, stepTween, type MovementTween } from './MovementInterpolation.js';
 
 // ---------- Colors ----------
 const YELLOW = 0xf5c518;   // Caterpillar yellow
@@ -142,15 +144,11 @@ const VEHICLE_BUILDERS: Record<VehicleRole, GroupBuilder> = {
   },
 };
 
-// ---------- Movement lerp speed ----------
-// Fraction of remaining distance covered per frame (smooth follow)
-const MOVE_LERP = 0.08;
-
 // ---------- Main class ----------
 
 export class VehicleMesh {
   private readonly scene: THREE.Scene;
-  private readonly vehicles = new Map<number, { group: THREE.Group; vehicle: Vehicle }>();
+  private readonly vehicles = new Map<number, { group: THREE.Group; vehicle: Vehicle; tween: MovementTween }>();
 
   constructor(scene: THREE.Scene) {
     this.scene = scene;
@@ -167,23 +165,25 @@ export class VehicleMesh {
     group.position.set(renderX, surfaceY, renderZ);
     tagPickable(group, 'vehicle', vehicle.id);
     this.scene.add(group);
-    this.vehicles.set(vehicle.id, { group, vehicle });
+    this.vehicles.set(vehicle.id, { group, vehicle, tween: createTween(renderX, renderZ) });
   }
 
   /**
    * Update vehicle positions. Call every frame.
-   * Lerps toward the target position to give smooth movement.
+   * Eases toward the target position (duration-aware tween, #520) to give
+   * smooth movement.
    */
-  update(vehicles: Vehicle[]): void {
+  update(vehicles: Vehicle[], dt: number): void {
     for (const v of vehicles) {
       const entry = this.vehicles.get(v.id);
       if (!entry) continue;
       // Update stored reference
       entry.vehicle = v;
-      // Lerp toward target (+ queue offset for fused 'waiting' vehicles, #411 round 2)
+      // Ease toward target (+ queue offset for fused 'waiting' vehicles, #411 round 2)
       const [targetX, targetZ] = this.waitingRenderPosition(v, vehicles);
-      entry.group.position.x += (targetX - entry.group.position.x) * MOVE_LERP;
-      entry.group.position.z += (targetZ - entry.group.position.z) * MOVE_LERP;
+      const eased = stepTween(entry.tween, entry.group.position.x, entry.group.position.z, targetX, targetZ, dt);
+      entry.group.position.x = eased.x;
+      entry.group.position.z = eased.z;
       applyStateIndicator(entry.group, v.state);
     }
   }
@@ -210,6 +210,7 @@ export class VehicleMesh {
     const entry = this.vehicles.get(vehicleId);
     if (entry) {
       entry.group.position.set(x, y, z);
+      entry.tween = createTween(x, z);
     }
   }
 
@@ -218,9 +219,11 @@ export class VehicleMesh {
    * to the eased tween (#520 — GameRenderer.syncFromContext() should no
    * longer hard-snap x/z every sync).
    */
-  setSurfaceY(_vehicleId: number, _y: number): void {
-    // TODO: implement
-    throw new Error('not implemented');
+  setSurfaceY(vehicleId: number, y: number): void {
+    const entry = this.vehicles.get(vehicleId);
+    if (entry) {
+      entry.group.position.y = y;
+    }
   }
 
   removeVehicle(vehicleId: number): void {

--- a/src/renderer/VehicleMesh.ts
+++ b/src/renderer/VehicleMesh.ts
@@ -213,6 +213,16 @@ export class VehicleMesh {
     }
   }
 
+  /**
+   * Correct a vehicle's terrain-surface Y immediately, leaving x/z motion
+   * to the eased tween (#520 — GameRenderer.syncFromContext() should no
+   * longer hard-snap x/z every sync).
+   */
+  setSurfaceY(_vehicleId: number, _y: number): void {
+    // TODO: implement
+    throw new Error('not implemented');
+  }
+
   removeVehicle(vehicleId: number): void {
     const entry = this.vehicles.get(vehicleId);
     if (entry) {

--- a/src/renderer/VehicleMesh.ts
+++ b/src/renderer/VehicleMesh.ts
@@ -205,7 +205,7 @@ export class VehicleMesh {
     return waitingRenderPosition(vehicle, pool);
   }
 
-  /** Snap a vehicle directly to its world position (no lerp — use after teleport or initial placement). */
+  /** Snap a vehicle directly to its world position (no tween — use after teleport or initial placement). */
   snapPosition(vehicleId: number, x: number, y: number, z: number): void {
     const entry = this.vehicles.get(vehicleId);
     if (entry) {

--- a/src/renderer/VehicleWaitingQueue.ts
+++ b/src/renderer/VehicleWaitingQueue.ts
@@ -17,10 +17,10 @@ import { WAITING_QUEUE_SLOT_OFFSETS } from '../core/config/balance.js';
  * vehicles sharing that target, so it stays stable frame to frame.
  *
  * Public: GameRenderer's terrain-surface-height correction (syncFromContext)
- * calls snapPosition with x/z straight from GameState every sync, which
- * would otherwise stomp this offset back to the fused raw position between
- * update()'s per-frame lerps — GameRenderer must fold this same offset into
- * the x/z it passes to snapPosition.
+ * only corrects `y` (setSurfaceY) and never touches x/z (#520) — this offset
+ * is applied every frame inside VehicleMesh's own update() call, as the
+ * target of its per-frame tween, so it survives syncs without any snap-time
+ * folding.
  *
  * Round 3 (#411 issue A): an `idle` vehicle already sitting at that exact
  * target cell (x/z equal to the target, e.g. it arrived and stopped) also

--- a/tests/unit/renderer/CharacterMesh.test.ts
+++ b/tests/unit/renderer/CharacterMesh.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect } from 'vitest';
 import * as THREE from 'three';
 import type { Employee } from '../../../src/core/entities/Employee.js';
 import { CharacterMesh } from '../../../src/renderer/CharacterMesh.js';
+import { MOVE_TWEEN_DURATION_S } from '../../../src/renderer/MovementInterpolation.js';
 
 function makeEmployee(id: number, overrides: Partial<Employee> = {}): Employee {
   return {
@@ -148,6 +149,98 @@ describe('CharacterMesh', () => {
     cm.clearAll();
     expect(scene.children.length).toBe(0);
     cm.dispose();
+  });
+
+  describe('movement interpolation (#520)', () => {
+    it('update() eases across multiple small-dt frames, passing through an intermediate point, and fully converges only once cumulative real time matches the tween duration', () => {
+      const scene = new THREE.Scene();
+      const cm = new CharacterMesh(scene);
+      const emp = makeEmployee(1, { x: 0, z: 0 });
+      cm.addEmployee(emp, 0);
+      const group = scene.children[0] as THREE.Group;
+
+      emp.x = 10;
+      emp.z = 10;
+
+      const dt = 0.05;
+      const steps = Math.ceil(MOVE_TWEEN_DURATION_S / dt) + 5;
+      let sawIntermediate = false;
+      for (let i = 0; i < steps; i++) {
+        cm.update([emp], dt);
+        if (
+          group.position.x > 0 && group.position.x < 10 &&
+          group.position.z > 0 && group.position.z < 10
+        ) {
+          sawIntermediate = true;
+        }
+      }
+
+      expect(sawIntermediate).toBe(true);
+      // Not just "greater than 0" — cumulative real time (steps * dt) now
+      // exceeds MOVE_TWEEN_DURATION_S, so a duration-aware ease must have
+      // fully arrived. A fixed-fraction-per-call lerp (duration-blind)
+      // never reaches this close after only ~1s of real time.
+      expect(group.position.x).toBeCloseTo(10);
+      expect(group.position.z).toBeCloseTo(10);
+      cm.dispose();
+    });
+
+    it('retargeting mid-glide does not produce a large single-frame jump', () => {
+      const scene = new THREE.Scene();
+      const cm = new CharacterMesh(scene);
+      const emp = makeEmployee(1, { x: 0, z: 0 });
+      cm.addEmployee(emp, 0);
+      const group = scene.children[0] as THREE.Group;
+
+      emp.x = 10;
+      emp.z = 10;
+      cm.update([emp], 0.05); // glide partway
+
+      const beforeX = group.position.x;
+      const beforeZ = group.position.z;
+
+      // Retarget completely before convergence.
+      emp.x = -20;
+      emp.z = 40;
+      cm.update([emp], 0.05);
+
+      const jump = Math.hypot(group.position.x - beforeX, group.position.z - beforeZ);
+      expect(jump).toBeLessThan(2);
+      cm.dispose();
+    });
+
+    it('a very large x/z change reaches the new position within one update() call (snap path)', () => {
+      const scene = new THREE.Scene();
+      const cm = new CharacterMesh(scene);
+      const emp = makeEmployee(1, { x: 0, z: 0 });
+      cm.addEmployee(emp, 0);
+      const group = scene.children[0] as THREE.Group;
+
+      // Magnitude far exceeding any single-tick move (teleport across the map).
+      emp.x = 500;
+      emp.z = -500;
+      cm.update([emp], 0.016);
+
+      expect(group.position.x).toBeCloseTo(500);
+      expect(group.position.z).toBeCloseTo(-500);
+      cm.dispose();
+    });
+
+    it('setSurfaceY updates only the y component, leaving x/z untouched', () => {
+      const scene = new THREE.Scene();
+      const cm = new CharacterMesh(scene);
+      cm.addEmployee(makeEmployee(1, { x: 4, z: 9 }), 0);
+      const group = scene.children[0] as THREE.Group;
+      const xBefore = group.position.x;
+      const zBefore = group.position.z;
+
+      cm.setSurfaceY(1, 7);
+
+      expect(group.position.y).toBe(7);
+      expect(group.position.x).toBe(xBefore);
+      expect(group.position.z).toBe(zBefore);
+      cm.dispose();
+    });
   });
 
   describe('scene picking (P2)', () => {

--- a/tests/unit/renderer/GameRenderer.test.ts
+++ b/tests/unit/renderer/GameRenderer.test.ts
@@ -194,6 +194,58 @@ describe('GameRenderer — ghost preview positioning (issue #406)', () => {
   });
 });
 
+describe('GameRenderer — movement interpolation, no hard-snap on sync (#520)', () => {
+  it('does not hard-snap employee x/z to the raw GameState value on sync, but instantly corrects y to the terrain surface', () => {
+    const sm = makeMockSceneManager();
+    const renderer = new GameRenderer(sm as any);
+    const ctx = makeCtx();
+    const { employee } = hireEmployee(ctx.state!.employees, 'driller', new Random(1), 5, 5);
+    renderer.syncFromContext(ctx);
+
+    // Solid column at the employee's new position so its terrain surface
+    // height differs from the flat y=0 the first sync placed it at.
+    for (let y = 0; y <= 2; y++) {
+      ctx.grid!.setVoxel(20, y, 20, { composition: { rocks: [] }, density: 1, oreDensities: {}, fractureModifier: 1 });
+    }
+    employee.x = 20;
+    employee.z = 20;
+    renderer.syncFromContext(ctx);
+
+    const pos = renderer.entityWorldPosition('employee', employee.id);
+    expect(pos).not.toBeNull();
+    // x/z must NOT be hard-snapped to the raw new GameState value on sync —
+    // that would pre-empt the mesh's own eased glide (no update() call
+    // happened between the two syncFromContext() calls here).
+    expect(pos!.x).not.toBe(20);
+    expect(pos!.z).not.toBe(20);
+    // y must still be corrected immediately, independent of the x/z glide.
+    expect(pos!.y).toBeGreaterThan(2);
+  });
+
+  it('does not hard-snap vehicle x/z to the raw GameState value on sync, but instantly corrects y to the terrain surface', () => {
+    const sm = makeMockSceneManager();
+    const renderer = new GameRenderer(sm as any);
+    const ctx = makeCtx();
+    const { vehicle } = purchaseVehicle(ctx.state!.vehicles, 'debris_hauler', 5, 5);
+    renderer.syncFromContext(ctx);
+
+    for (let y = 0; y <= 2; y++) {
+      ctx.grid!.setVoxel(20, y, 20, { composition: { rocks: [] }, density: 1, oreDensities: {}, fractureModifier: 1 });
+    }
+    vehicle.x = 20;
+    vehicle.z = 20;
+    vehicle.targetX = 20;
+    vehicle.targetZ = 20;
+    renderer.syncFromContext(ctx);
+
+    const pos = renderer.entityWorldPosition('vehicle', vehicle.id);
+    expect(pos).not.toBeNull();
+    expect(pos!.x).not.toBe(20);
+    expect(pos!.z).not.toBe(20);
+    expect(pos!.y).toBeGreaterThan(2);
+  });
+});
+
 describe('GameRenderer — camera framing', () => {
   it('frames the site on the first load, using the grid size as the span', () => {
     const sm = makeMockSceneManager();

--- a/tests/unit/renderer/MovementInterpolation.test.ts
+++ b/tests/unit/renderer/MovementInterpolation.test.ts
@@ -1,0 +1,172 @@
+// MovementInterpolation — unit tests (#520)
+// Pure per-tick position easing shared by CharacterMesh and VehicleMesh.
+
+import { describe, it, expect } from 'vitest';
+import {
+  createTween,
+  computeInterpolatedPosition,
+  stepTween,
+  MOVE_TWEEN_DURATION_S,
+  MOVE_TELEPORT_DISTANCE,
+} from '../../../src/renderer/MovementInterpolation.js';
+
+describe('MovementInterpolation', () => {
+  describe('createTween', () => {
+    it('returns a tween with prev === target === (x,z) and elapsedS === 0', () => {
+      const tween = createTween(3, 7);
+      expect(tween.prevX).toBe(3);
+      expect(tween.prevZ).toBe(7);
+      expect(tween.targetX).toBe(3);
+      expect(tween.targetZ).toBe(7);
+      expect(tween.elapsedS).toBe(0);
+    });
+
+    it('boundary: works at the origin (0,0)', () => {
+      const tween = createTween(0, 0);
+      expect(tween.prevX).toBe(0);
+      expect(tween.prevZ).toBe(0);
+      expect(tween.targetX).toBe(0);
+      expect(tween.targetZ).toBe(0);
+      expect(tween.elapsedS).toBe(0);
+    });
+  });
+
+  describe('computeInterpolatedPosition', () => {
+    const durationS = 1;
+
+    it('returns exactly the prev position at elapsedS <= 0', () => {
+      const pos = computeInterpolatedPosition(0, 0, 10, 10, 0, durationS);
+      expect(pos.x).toBe(0);
+      expect(pos.z).toBe(0);
+
+      const posNeg = computeInterpolatedPosition(0, 0, 10, 10, -0.5, durationS);
+      expect(posNeg.x).toBe(0);
+      expect(posNeg.z).toBe(0);
+    });
+
+    it('returns exactly the target position at elapsedS >= durationS', () => {
+      const pos = computeInterpolatedPosition(0, 0, 10, 10, durationS, durationS);
+      expect(pos.x).toBe(10);
+      expect(pos.z).toBe(10);
+
+      const posOver = computeInterpolatedPosition(0, 0, 10, 10, durationS * 5, durationS);
+      expect(posOver.x).toBe(10);
+      expect(posOver.z).toBe(10);
+    });
+
+    it('returns a point strictly between prev and target at the halfway point (not clamped to either endpoint)', () => {
+      const pos = computeInterpolatedPosition(0, 0, 10, 20, durationS / 2, durationS);
+      expect(pos.x).toBeGreaterThan(0);
+      expect(pos.x).toBeLessThan(10);
+      expect(pos.z).toBeGreaterThan(0);
+      expect(pos.z).toBeLessThan(20);
+    });
+
+    it('is monotonic — increasing elapsedS never moves the result away from target', () => {
+      const targetX = 10, targetZ = -30;
+      let prevDist = Infinity;
+      for (let e = 0; e <= durationS; e += durationS / 20) {
+        const pos = computeInterpolatedPosition(0, 0, targetX, targetZ, e, durationS);
+        const dist = Math.hypot(targetX - pos.x, targetZ - pos.z);
+        expect(dist).toBeLessThanOrEqual(prevDist + 1e-9);
+        prevDist = dist;
+      }
+    });
+  });
+
+  describe('stepTween', () => {
+    it('converges toward the target across several small-dt frames, passing through an intermediate point, without overshoot', () => {
+      const tween = createTween(0, 0);
+      let renderX = 0, renderZ = 0;
+      const targetX = 10, targetZ = 10; // well below MOVE_TELEPORT_DISTANCE
+      const dt = 0.05;
+      const steps = Math.ceil(MOVE_TWEEN_DURATION_S / dt) + 5;
+
+      let sawIntermediate = false;
+      for (let i = 0; i < steps; i++) {
+        const pos = stepTween(tween, renderX, renderZ, targetX, targetZ, dt);
+        // No overshoot at any point during the glide.
+        expect(pos.x).toBeLessThanOrEqual(targetX + 1e-9);
+        expect(pos.z).toBeLessThanOrEqual(targetZ + 1e-9);
+        if (pos.x > 0 && pos.x < targetX && pos.z > 0 && pos.z < targetZ) {
+          sawIntermediate = true;
+        }
+        renderX = pos.x;
+        renderZ = pos.z;
+      }
+
+      expect(sawIntermediate).toBe(true);
+      // Enough cumulative real time has passed to fully converge.
+      expect(renderX).toBeCloseTo(targetX);
+      expect(renderZ).toBeCloseTo(targetZ);
+    });
+
+    it('does not jump straight to the target in a single frame', () => {
+      const tween = createTween(0, 0);
+      const pos = stepTween(tween, 0, 0, 10, 10, 0.05);
+      expect(pos.x).toBeGreaterThan(0);
+      expect(pos.x).toBeLessThan(10);
+      expect(pos.z).toBeGreaterThan(0);
+      expect(pos.z).toBeLessThan(10);
+    });
+
+    it('continues progressing across repeated calls with an unchanged target (does not reset elapsedS)', () => {
+      const tween = createTween(0, 0);
+      let renderX = 0, renderZ = 0;
+      const targetX = 10, targetZ = 0;
+      const dt = 0.05;
+      const steps = Math.ceil(MOVE_TWEEN_DURATION_S / dt) + 5; // enough cumulative real time to fully converge
+
+      for (let i = 0; i < steps; i++) {
+        const pos = stepTween(tween, renderX, renderZ, targetX, targetZ, dt);
+        renderX = pos.x;
+        renderZ = pos.z;
+      }
+
+      // If elapsedS were reset to 0 on every call, renderX could never pass
+      // computeInterpolatedPosition(0,0,10,0,dt,duration) — it would stall
+      // partway forever, regardless of how many calls are made.
+      expect(renderX).toBeCloseTo(targetX);
+    });
+
+    it('does not pop when the target changes mid-tween — the next position stays close to the current render position', () => {
+      const tween = createTween(0, 0);
+      const dt = 0.05;
+
+      // Glide partway toward the first target.
+      const pos1 = stepTween(tween, 0, 0, 10, 10, dt);
+      const renderX = pos1.x, renderZ = pos1.z;
+
+      // Retarget completely before convergence.
+      const pos2 = stepTween(tween, renderX, renderZ, -20, 40, dt);
+
+      const jump = Math.hypot(pos2.x - renderX, pos2.z - renderZ);
+      // One small dt step of gliding should cover only a small fraction of
+      // the (now much larger) remaining distance, not pop toward it.
+      expect(jump).toBeLessThan(2);
+    });
+
+    it('snaps immediately to the target when it is >= MOVE_TELEPORT_DISTANCE away, regardless of dt', () => {
+      const targetX = MOVE_TELEPORT_DISTANCE, targetZ = 0;
+
+      const tweenZeroDt = createTween(0, 0);
+      const posZeroDt = stepTween(tweenZeroDt, 0, 0, targetX, targetZ, 0);
+      expect(posZeroDt.x).toBe(targetX);
+      expect(posZeroDt.z).toBe(targetZ);
+
+      const tweenLargeDt = createTween(0, 0);
+      const posLargeDt = stepTween(tweenLargeDt, 0, 0, targetX, targetZ, 5);
+      expect(posLargeDt.x).toBe(targetX);
+      expect(posLargeDt.z).toBe(targetZ);
+    });
+
+    it('with dt === 0, returns a position consistent with no time advancing (still approaching, not jumping)', () => {
+      const tween = createTween(0, 0);
+      const pos = stepTween(tween, 0, 0, 10, 10, 0);
+      // A tween restarted from (0,0) with elapsedS still at 0 after a
+      // zero-length step must read back the render position, not the target.
+      expect(pos.x).toBe(0);
+      expect(pos.z).toBe(0);
+    });
+  });
+});

--- a/tests/unit/renderer/VehicleMesh.test.ts
+++ b/tests/unit/renderer/VehicleMesh.test.ts
@@ -5,6 +5,7 @@ import * as THREE from 'three';
 import type { Vehicle, VehicleTier, VehicleOperationalState } from '../../../src/core/entities/Vehicle.js';
 import { VehicleMesh, STATE_COLOR_MAP, applyStateIndicator } from '../../../src/renderer/VehicleMesh.js';
 import { WAITING_QUEUE_SLOT_OFFSETS } from '../../../src/core/config/balance.js';
+import { MOVE_TWEEN_DURATION_S } from '../../../src/renderer/MovementInterpolation.js';
 
 function makeVehicle(id: number, type: Vehicle['type'], x = 0, z = 0, tier = 1 as VehicleTier): Vehicle {
   return { id, type, x, z, hp: 100, task: 'idle', state: 'idle', targetX: x, targetZ: z, tier } as Vehicle;
@@ -53,9 +54,10 @@ describe('VehicleMesh', () => {
     v.z = 100;
 
     // After a few updates, position should move toward target
-    vm.update([v]);
-    vm.update([v]);
-    vm.update([v]);
+    // (dt now required — VehicleMesh.update() must become duration-aware, #520)
+    vm.update([v], 0.1);
+    vm.update([v], 0.1);
+    vm.update([v], 0.1);
     const group = scene.children[0] as THREE.Group;
     expect(group.position.x).toBeGreaterThan(0);
     expect(group.position.z).toBeGreaterThan(0);
@@ -91,6 +93,102 @@ describe('VehicleMesh', () => {
     vm.addVehicle(makeVehicle(2, 'drill_rig'));
     vm.clearAll();
     expect(scene.children.length).toBe(0);
+    vm.dispose();
+  });
+});
+
+describe('VehicleMesh — movement interpolation (#520)', () => {
+  it('update() eases across multiple small-dt frames, passing through an intermediate point, and fully converges only once cumulative real time matches the tween duration', () => {
+    const scene = new THREE.Scene();
+    const vm = new VehicleMesh(scene);
+    const v = makeVehicle(1, 'debris_hauler', 0, 0);
+    vm.addVehicle(v);
+    const group = scene.children[0] as THREE.Group;
+
+    v.x = 10;
+    v.z = 10;
+    v.targetX = 10;
+    v.targetZ = 10;
+
+    const dt = 0.05;
+    const steps = Math.ceil(MOVE_TWEEN_DURATION_S / dt) + 5;
+    let sawIntermediate = false;
+    for (let i = 0; i < steps; i++) {
+      vm.update([v], dt);
+      if (
+        group.position.x > 0 && group.position.x < 10 &&
+        group.position.z > 0 && group.position.z < 10
+      ) {
+        sawIntermediate = true;
+      }
+    }
+
+    expect(sawIntermediate).toBe(true);
+    expect(group.position.x).toBeCloseTo(10);
+    expect(group.position.z).toBeCloseTo(10);
+    vm.dispose();
+  });
+
+  it('retargeting mid-glide does not produce a large single-frame jump', () => {
+    const scene = new THREE.Scene();
+    const vm = new VehicleMesh(scene);
+    const v = makeVehicle(1, 'debris_hauler', 0, 0);
+    vm.addVehicle(v);
+    const group = scene.children[0] as THREE.Group;
+
+    v.x = 10;
+    v.z = 10;
+    v.targetX = 10;
+    v.targetZ = 10;
+    vm.update([v], 0.05); // glide partway
+
+    const beforeX = group.position.x;
+    const beforeZ = group.position.z;
+
+    // Retarget completely before convergence.
+    v.x = -20;
+    v.z = 40;
+    v.targetX = -20;
+    v.targetZ = 40;
+    vm.update([v], 0.05);
+
+    const jump = Math.hypot(group.position.x - beforeX, group.position.z - beforeZ);
+    expect(jump).toBeLessThan(2);
+    vm.dispose();
+  });
+
+  it('a very large x/z change reaches the new position within one update() call (snap path)', () => {
+    const scene = new THREE.Scene();
+    const vm = new VehicleMesh(scene);
+    const v = makeVehicle(1, 'debris_hauler', 0, 0);
+    vm.addVehicle(v);
+    const group = scene.children[0] as THREE.Group;
+
+    // Magnitude far exceeding any single-tick move (teleport across the map).
+    v.x = 500;
+    v.z = -500;
+    v.targetX = 500;
+    v.targetZ = -500;
+    vm.update([v], 0.016);
+
+    expect(group.position.x).toBeCloseTo(500);
+    expect(group.position.z).toBeCloseTo(-500);
+    vm.dispose();
+  });
+
+  it('setSurfaceY updates only the y component, leaving x/z untouched', () => {
+    const scene = new THREE.Scene();
+    const vm = new VehicleMesh(scene);
+    vm.addVehicle(makeVehicle(1, 'debris_hauler', 4, 9));
+    const group = scene.children[0] as THREE.Group;
+    const xBefore = group.position.x;
+    const zBefore = group.position.z;
+
+    vm.setSurfaceY(1, 7);
+
+    expect(group.position.y).toBe(7);
+    expect(group.position.x).toBe(xBefore);
+    expect(group.position.z).toBe(zBefore);
     vm.dispose();
   });
 });


### PR DESCRIPTION
Closes #520

## Summary

Employees and vehicles teleported between grid positions instead of gliding smoothly. Two compounding causes:

1. `GameRenderer.syncFromContext()` hard-snapped a moved character's/vehicle's rendered x/z to the raw core `GameState` value on every sync, pre-empting any easing the mesh's own per-frame `update()` would do.
2. The old `MOVE_LERP` fixed-decay blend wasn't tied to real elapsed time or distance-to-travel (`VehicleMesh.update()` didn't even accept `dt`), so convergence speed silently depended on frame rate.

### Fix

- New pure module `src/renderer/MovementInterpolation.ts`: `createTween`, `computeInterpolatedPosition` (smoothstep easing via the existing `src/core/math/Smoothstep.ts`, clamped), `stepTween` (restarts the tween from the entity's actual current render position whenever the simulation's target changes — no pop on retarget/time-scale change/resume; snaps immediately when the new target is `>= MOVE_TELEPORT_DISTANCE` away, covering non-gradual repositioning like zone-clear evacuation or training relocation).
- `CharacterMesh.ts` / `VehicleMesh.ts`: replaced `MOVE_LERP` with per-entry `stepTween` calls; `VehicleMesh.update()` now accepts `dt`; both gained `setSurfaceY(id, y)` for instant terrain-height-only correction.
- `GameRenderer.syncFromContext()`: now calls `setSurfaceY` instead of `snapPosition` for characters/vehicles — y corrects instantly (terrain can change abruptly after a blast), x/z glides via the per-frame tween.

8693 tests — all passing (300 files). `npm run typecheck`, `npm run test`, `npm run scenarios` (127/127), and production build all pass.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** the issue asked for "the real-world duration of a tick, accounting for timeScale" as the interpolation window, but the actual tick-scheduling cadence (`main.ts`) fires the `tick` console command roughly once per real second regardless of `timeScale` — only the batch size (ticks processed per call) scales with speed.
  **Chosen:** `MOVE_TWEEN_DURATION_S = BASE_TICK_MS / 1000` (~1.0s), not divided by `timeScale`.
  **Why:** matches the actual measured real-world gap between successive GameState position updates at every speed.
  **If reversed:** change the derivation in `src/renderer/MovementInterpolation.ts`.

- **What was open:** no core event signals "this position change was an instant relocation, not gradual movement" (zone-clear evacuation, training-enrolment relocation both mutate x/z directly).
  **Chosen:** a fixed distance threshold, `MOVE_TELEPORT_DISTANCE = 60` world units, inside `stepTween` — snaps instead of easing at/above it.
  **Why:** derived from the fastest legitimate per-sync glide (tier-3 `debris_hauler` at max time-scale ≈ 43.2 units), with margin.
  **If reversed:** bump the constant in `src/renderer/MovementInterpolation.ts`, or add explicit relocation events later for precision.

- **What was open:** the issue didn't specify an easing curve.
  **Chosen:** smoothstep (reusing the existing `src/core/math/Smoothstep.ts` utility, per code review).
  **Why:** removes the velocity discontinuity a linear ease would leave at tween start/end; reuses an existing utility rather than adding a new formula.
  **If reversed:** swap the formula/import in `computeInterpolatedPosition`.

None of these change gameplay balance, economy, or a player-facing default — all three are rendering-only tuning constants for a visual bug fix, so no `decision-review` follow-up issue was opened.

## Verification

- **static** (`npm run typecheck`): PASS, 0 errors.
- **logic** (`npm run test`): PASS, 300 files / 8693 tests.
- **scenario** (`npm run scenarios`): PASS, 127/127 (sanity check — this diff touches no `src/core/` simulation state).
- **build** (`npx vite build`): PASS.
- **visual**: PASS — manual Puppeteer probe (dev server live) drove a vehicle across several tiles at 1x/2x/4x/8x time scale and across a pause-mid-move/resume sequence; 20 of 35 captured screenshots inspected directly. Vehicle mesh position sits strictly between tile centers at every sampled frame (confirmed via non-integer `vehicle list` position readout too), no jump/pop at any speed transition or at the pause/resume boundary. `full-ci` label applied so CI's interaction-mode job also exercises this shared rendering machinery (every scenario with an employee/vehicle runs through `CharacterMesh`/`VehicleMesh.update()`).

READY TO MERGE
