### PR TITLE
fix: Resolve #525 — convert sandbox-mode scenario to real UI clicks (toolbar bug already fixed by #504)

### DIFF
--- a/scripts/scenario-defs/sandbox-mode.json
+++ b/scripts/scenario-defs/sandbox-mode.json
@@ -32,13 +32,14 @@
     {
       "command": "drill_plan grid rows:3 cols:3 spacing:4 depth:6 start:20,20",
       "interaction": [
-        {
-          "type": "command",
-          "command": "drill_plan grid rows:3 cols:3 spacing:4 depth:6 start:20,20"
-        }
+        { "type": "clickSelector", "selector": "#bs-toolbar [data-panel=\"blast\"]" },
+        { "type": "clickSelector", "selector": "#bs-blast-panel [data-action=\"grid-tool\"]" },
+        { "type": "waitForSelector", "selector": "#bs-tile-select-confirm" },
+        { "type": "clickSelector", "selector": "#bs-param-strip [data-field=\"spacing\"] .bsx-stepper-btn:last-child" },
+        { "type": "dragTiles", "x1": 20, "z1": 20, "x2": 28, "z2": 28 },
+        { "type": "clickSelector", "selector": "#bs-tile-select-confirm" }
       ],
-      "description": "role: bootstrap, temporary exception (issue #515): bootstrapping via console `sandbox start` (not `new_game`/`campaign start`) leaves #bs-toolbar with zero size -- confirmed by the first interaction-mode run failing here with exactly that. Whether the real Sandbox Mode panel flow (SandboxPanel.ts's #bs-sandbox-start) triggers a UI transition console bootstrap skips is unverified; left as a command rather than guess at a fix for a UI path this batch never drives for real (see SANDBOX_START_DESC above). Not a permanent bootstrap primitive like `employee assign_skill` -- once the #bs-toolbar zero-size bug is fixed, this step should convert to a real click.",
-      "role": "bootstrap",
+      "role": "player",
       "expect": {
         "equals": {
           "holeCount": 9,
@@ -49,13 +50,9 @@
     {
       "command": "charge hole:* explosive:boomite amount:5 stemming:2",
       "interaction": [
-        {
-          "type": "command",
-          "command": "charge hole:* explosive:boomite amount:5 stemming:2"
-        }
+        { "type": "clickSelector", "selector": "#bs-blast-panel [data-action=\"charge-all\"]" }
       ],
-      "description": "role: bootstrap, temporary exception (issue #515) -- see the preceding drill_plan step's description for the #bs-toolbar zero-size rationale.",
-      "role": "bootstrap",
+      "role": "player",
       "expect": {
         "equals": {
           "chargedCount": 9,
@@ -66,13 +63,9 @@
     {
       "command": "sequence auto delay_step:25",
       "interaction": [
-        {
-          "type": "command",
-          "command": "sequence auto delay_step:25"
-        }
+        { "type": "clickSelector", "selector": "#bs-blast-panel [data-action=\"auto-sequence\"]" }
       ],
-      "description": "role: bootstrap, temporary exception (issue #515) -- see the drill_plan step's description for the #bs-toolbar zero-size rationale.",
-      "role": "bootstrap",
+      "role": "player",
       "expect": {
         "equals": {
           "sequencedCount": 9
@@ -81,14 +74,15 @@
     },
     {
       "command": "blast",
-      "description": "role: bootstrap, temporary exception (issue #515) -- see the drill_plan step's description for the #bs-toolbar zero-size rationale.",
-      "role": "bootstrap",
+      "role": "player",
       "interaction": [
-        {
-          "type": "command",
-          "command": "blast"
-        }
+        { "type": "clickSelector", "selector": "#bs-blast-panel [data-action=\"execute\"]" },
+        { "type": "waitForSelector", "selector": ".bs-confirm-overlay .bs-btn-danger" },
+        { "type": "clickSelector", "selector": ".bs-confirm-overlay .bs-btn-danger" },
+        { "type": "waitForSelector", "selector": "[data-action=\"report-close\"]" },
+        { "type": "clickSelector", "selector": "[data-action=\"report-close\"]" }
       ],
+      "timeout": 15,
       "expect": {
         "equals": {
           "holeCount": 0,

--- a/scripts/shared/interaction-executor.ts
+++ b/scripts/shared/interaction-executor.ts
@@ -161,12 +161,6 @@ export function isObservationCommand(command: string): boolean {
  * setup a player never does. Kept as an explicit list for the same reason
  * {@link OBSERVATION_COMMANDS} is: adding an entry is a visible edit here,
  * not an accident of what a step happened to call.
- *
- * The last four (`drill_plan grid`, `sequence auto`, `blast`, `charge hole`)
- * are a documented temporary exception: `sandbox-mode.json` steps 2-5 are
- * blocked on a separate, real, undiagnosed rendering bug (`#bs-toolbar` is
- * zero-sized after a console `sandbox start` bootstrap in interaction mode).
- * These stay commands until that bug is fixed, not permanently.
  */
 export const BOOTSTRAP_COMMAND_ALLOWLIST: readonly string[] = [
   'employee assign_skill',
@@ -174,10 +168,6 @@ export const BOOTSTRAP_COMMAND_ALLOWLIST: readonly string[] = [
   'weather set',
   'weather',
   'event fire',
-  'drill_plan grid',
-  'sequence auto',
-  'blast',
-  'charge hole',
   // Broader than the others on purpose, for two independent reasons:
   //  1. `corrupt target:X cost:Y` — the scenario overrides the bribe's cost
   //     to hit an exact scripted cash delta; ShadyPanel's real "Make the


### PR DESCRIPTION
Closes #525

## Summary

Issue #525 asked to diagnose why `#bs-toolbar` renders zero-sized in interaction mode immediately after a console-driven `sandbox start`, blocking real UI-click conversion of `scripts/scenario-defs/sandbox-mode.json` steps 2-5 (`drill_plan grid`, `charge hole:*`, `sequence auto`, `blast`).

Two independent investigations this run (planner, then implementer — each reproducing the flow in a real headless browser) found **the described defect no longer exists**: it was already fixed on `main` by commit `34deccf` (PR #504, merged before this run started), which replaced a `cmdName === 'new_game'` string check with a `ctx.state` identity check in `runGameCommand` (`src/main.ts`) — making the `mainMenu.hide()` / toolbar-reveal path command-agnostic instead of hardcoded to `new_game`. `sandboxCommand` and `newGameCommand` both replace `ctx.state` with a fresh object, so both now trip the same UI-refresh path identically.

**No `src/` change was made this run.** The fix is exactly the issue's own "Test" deliverable:

- `scripts/scenario-defs/sandbox-mode.json` — steps 2-5 converted from `role: 'bootstrap'` console-command steps to `role: 'player'` steps with real `interaction` click arrays (toolbar → Blast panel → grid tool → spacing stepper → tile drag → confirm; charge-all; auto-sequence; execute → confirm → report-close), matching the click-conversion pattern from #510-#514/#515.
- `scripts/shared/interaction-executor.ts` — removed the 4 now-unused `BOOTSTRAP_COMMAND_ALLOWLIST` entries (`'drill_plan grid'`, `'sequence auto'`, `'blast'`, `'charge hole'`) and their justification comment. Verified by repo-wide grep that no other scenario file relies on these generic entries — every other match has its own separate, more specific allowlist entry, left untouched.

## Decisions taken

None — the issue's own "Test" section fully specified this deliverable (convert steps 2-5, trim the allowlist). No open requirement needed a default; the only finding beyond the issue's framing is that the "Fix" half of the task was already resolved by prior work, which is documented above rather than recorded as a decision.

## Verification

- **static** — `npm run typecheck`: 0 errors (`src/` + `scripts/`)
- **logic** — `npx vitest run`: 8693 tests passed (300 files), including `tests/unit/lint/ScenarioStepsHaveRole.test.ts` (4/4) with the converted steps now `role: 'player'`
- **scenario** (command mode) — `npm run scenarios`: 127/127 passed, `sandbox-mode` OK (7 steps) — JSON restructure still drives correctly via `command` fields
- **build** — `npx vite build`: success, 3.31s
- **visual** (interaction mode, screenshots inspected) — `npm run scenario -- --scenario sandbox-mode --mode interaction --screenshots`: all 7 steps pass, 0 failures. Screenshots opened and inspected directly: `#bs-toolbar` renders full-size (7 rail buttons, ~67×66px, not zero-sized) in every step, Blast Workshop panel opens correctly via real click, 9 drill holes place in a 3×3 grid, charge/sequence/fire complete via real clicks matching original command semantics (`PERFECT` rating, 106 cleared voxels, $115,600 ore value). `npm run a11y` PASS (WCAG AA). `npm run validate:state` 7/7 PASS.

5 parallel code reviewers (security, quality, i18n, duplication, semantic) all PASS — semantic reviewer independently verified every new CSS selector against actual DOM/source (`ToolRail.ts`, `Drill.ts`, `Charge.ts`, `Sequence.ts`, `blastFooter.ts`, `PreflightModal.ts`, `BlastReportModal.ts`, `ParamStrip.ts`).

`full-ci` label applied: this diff touches `scripts/shared/interaction-executor.ts`, the shared interaction-mode harness every `role: 'bootstrap'` scenario step runs through — qualifies as machinery every scenario exercises.

READY TO MERGE