### PR TITLE
fix: Resolve #527 — console createCharge stemming-floor validation parity with UI

### DIFF
--- a/scripts/scenario-defs/scores-display-visual.json
+++ b/scripts/scenario-defs/scores-display-visual.json
@@ -185,14 +185,14 @@
       }
     },
     {
-      "command": "charge hole:* explosive:boomite amount:8 stemming:0",
+      "command": "charge hole:* explosive:boomite amount:8 stemming:0.5",
       "interaction": [
         {
           "type": "command",
-          "command": "charge hole:* explosive:boomite amount:8 stemming:0"
+          "command": "charge hole:* explosive:boomite amount:8 stemming:0.5"
         }
       ],
-      "description": "role: bootstrap (issue #515): `stemming:0` is below the Charge panel's own floor \u2014 `adjustStemming` clamps at `Math.max(0.5, ...)` (Charge.ts) \u2014 so no click sequence can ever reach it while `createCharge` (ChargePlan.ts) itself has no lower bound and accepts 0 freely. A real, narrow UI/console gap, not a missing selector.",
+      "description": "role: bootstrap (issue #515): `stemming:0.5` is the Charge panel's own floor \u2014 `adjustStemming` clamps at `Math.max(0.5, ...)` (Charge.ts) \u2014 the minimal stemming value reachable by any click sequence. `createCharge` (ChargePlan.ts) now enforces the same MIN_STEMMING_M floor (#527), so this step stays a `bootstrap` role for its `hole:*` batch shorthand, not to reach a value a player could not.",
       "expect": {
         "equals": {
           "chargedCount": 4

--- a/scripts/shared/interaction-executor.ts
+++ b/scripts/shared/interaction-executor.ts
@@ -243,11 +243,13 @@ export const BOOTSTRAP_COMMAND_ALLOWLIST: readonly string[] = [
   // (`computeDangerZone`), never a player-typed one, so a literal rectangle
   // override has no UI equivalent and no business having one.
   'zone clear',
-  // scores-display-visual.json: `stemming:0` is below the Charge panel's own
-  // floor — `adjustStemming` clamps at `Math.max(0.5, ...)` (Charge.ts) — so
-  // no click sequence can ever reach it, while `createCharge` (ChargePlan.ts)
-  // has no lower bound and accepts 0 freely. A real, narrow UI/console gap.
-  'charge hole:* explosive:boomite amount:8 stemming:0',
+  // scores-display-visual.json: `stemming:0.5` is the Charge panel's own
+  // floor — `adjustStemming` clamps at `Math.max(0.5, ...)` (Charge.ts) —
+  // the minimal value reachable by any click sequence. Kept as `bootstrap`
+  // for its `hole:*` batch shorthand rather than driving the individual
+  // amount/stemming steppers for real (see blast-execution-visual.json for
+  // the player-role version of this same charge).
+  'charge hole:* explosive:boomite amount:8 stemming:0.5',
   // blast-fire/preview/sequence-step-visual.json: the Charge step right
   // after each of these is the Blast panel's own designated first-open
   // (`#bs-toolbar [data-panel="blast"]` is a toggle) — giving the drill

--- a/src/console/commands/mining.ts
+++ b/src/console/commands/mining.ts
@@ -9,6 +9,7 @@ import { setDelay, autoVPattern } from '../../core/mining/Sequence.js';
 import { assembleBlastPlan, validateBlastPlan } from '../../core/mining/BlastPlan.js';
 import { executeBlast, buildBlastReport } from '../../core/mining/BlastExecution.js';
 import { getExplosive } from '../../core/world/ExplosiveCatalog.js';
+import { MIN_STEMMING_M } from '../../core/config/balance.js';
 import { addBlastFragments, syncLogisticsCapacity } from '../../core/economy/Logistics.js';
 import { addExpense } from '../../core/economy/Finance.js';
 import { processProjections } from '../../core/entities/Damage.js';
@@ -190,7 +191,7 @@ export function chargeCommand(
   const holeSpec = named['hole'] ?? '';
   const explosiveId = named['explosive'] ?? '';
   const amount = parseFloat((named['amount'] ?? '0').replace('kg', ''));
-  const stemming = parseFloat((named['stemming'] ?? '0').replace('m', ''));
+  const stemming = parseFloat((named['stemming'] ?? String(MIN_STEMMING_M)).replace('m', ''));
 
   if (!explosiveId) return { success: false, output: 'Missing explosive. Usage: charge hole:1 explosive:boomite amount:5kg stemming:2m' };
 

--- a/src/core/config/balance.ts
+++ b/src/core/config/balance.ts
@@ -220,6 +220,11 @@ export const TRANSMISSION_LOSS_POROSITY_SCALE = 0.40;
  *  of pushing harder on the same voxel. */
 export const CHARGE_KG_PER_METRE = 2.0;
 
+/** Minimum stemming column (m) a charge can carry. Matches the Charge
+ *  panel's own floor (Charge.ts adjustStemming) so a console charge can
+ *  never under-stem what a player could ever click. */
+export const MIN_STEMMING_M = 0.5;
+
 /** Converts catalog `energyPerKg` into the energy units voxel absorption thresholds
  *  are written in. The catalog numbers were tuned against an inverse-square field
  *  whose epsilon amplified them at close range; propagation conserves energy instead,

--- a/src/core/mining/ChargePlan.ts
+++ b/src/core/mining/ChargePlan.ts
@@ -2,6 +2,7 @@
 // Assigns explosives and stemming to each hole in the drill plan.
 
 import { getExplosive } from '../world/ExplosiveCatalog.js';
+import { MIN_STEMMING_M } from '../config/balance.js';
 
 export interface HoleCharge {
   explosiveId: string;
@@ -29,6 +30,9 @@ export function createCharge(
     return {
       error: `Amount ${amountKg}kg out of range [${explosive.minChargeKg}–${explosive.maxChargeKg}kg] for ${explosiveId}`,
     };
+  }
+  if (stemmingM < MIN_STEMMING_M) {
+    return { error: `Stemming ${stemmingM}m below minimum ${MIN_STEMMING_M}m` };
   }
   if (stemmingM > holeDepth) {
     return { error: `Stemming ${stemmingM}m exceeds hole depth ${holeDepth}m` };

--- a/src/core/mining/ChargePlan.ts
+++ b/src/core/mining/ChargePlan.ts
@@ -31,7 +31,7 @@ export function createCharge(
       error: `Amount ${amountKg}kg out of range [${explosive.minChargeKg}–${explosive.maxChargeKg}kg] for ${explosiveId}`,
     };
   }
-  if (stemmingM < MIN_STEMMING_M) {
+  if (!Number.isFinite(stemmingM) || stemmingM < MIN_STEMMING_M) {
     return { error: `Stemming ${stemmingM}m below minimum ${MIN_STEMMING_M}m` };
   }
   if (stemmingM > holeDepth) {

--- a/src/core/mining/ChargePlan.ts
+++ b/src/core/mining/ChargePlan.ts
@@ -26,7 +26,7 @@ export function createCharge(
   if (!explosive) {
     return { error: `Unknown explosive: "${explosiveId}"` };
   }
-  if (amountKg < explosive.minChargeKg || amountKg > explosive.maxChargeKg) {
+  if (!Number.isFinite(amountKg) || amountKg < explosive.minChargeKg || amountKg > explosive.maxChargeKg) {
     return {
       error: `Amount ${amountKg}kg out of range [${explosive.minChargeKg}–${explosive.maxChargeKg}kg] for ${explosiveId}`,
     };

--- a/src/ui/panels/blastSteps/Charge.ts
+++ b/src/ui/panels/blastSteps/Charge.ts
@@ -31,6 +31,7 @@ import { ChargeHoleList, holeChargeSignature } from './ChargeHoleList.js';
 import { getAllExplosives, getExplosive, type ExplosiveType } from '../../../core/world/ExplosiveCatalog.js';
 import { wetHoles } from '../../../core/mining/WetHoles.js';
 import { TUBING_COST } from '../../../core/mining/Tubing.js';
+import { MIN_STEMMING_M } from '../../../core/config/balance.js';
 import { formatMoney } from '../../../core/economy/formatMoney.js';
 import type { GameState } from '../../../core/state/GameState.js';
 import type { WeatherState } from '../../../core/weather/WeatherCycle.js';
@@ -304,7 +305,7 @@ export class ChargeStep {
   }
 
   private adjustStemming(delta: number): void {
-    this.stemmingM = Math.max(0.5, +(this.stemmingM + delta).toFixed(1));
+    this.stemmingM = Math.max(MIN_STEMMING_M, +(this.stemmingM + delta).toFixed(1));
     this.stemmingValueEl.textContent = `${this.stemmingM.toFixed(1)} m`;
     this.lastSignature = '';
   }

--- a/tests/integration/blast-balance-matrix.integration.test.ts
+++ b/tests/integration/blast-balance-matrix.integration.test.ts
@@ -89,8 +89,8 @@ describe('Blast balance — more explosive does more', () => {
 });
 
 describe('Blast balance — stemming decides whether rock is thrown', () => {
-  it('an unstemmed hole throws rock further than a stemmed one', () => {
-    expect(fire({ stemming: 0 }).maxThrowDistance)
+  it('a minimally stemmed hole throws rock further than a stemmed one', () => {
+    expect(fire({ stemming: 0.5 }).maxThrowDistance)
       .toBeGreaterThan(fire({ stemming: 3 }).maxThrowDistance);
   });
 
@@ -98,12 +98,12 @@ describe('Blast balance — stemming decides whether rock is thrown', () => {
     expect(fire({ stemming: 3 }).projectionCount).toBe(0);
   });
 
-  it('an unstemmed overcharge does', () => {
-    expect(fire({ stemming: 0, kg: 8 }).projectionCount).toBeGreaterThan(0);
+  it('a minimally stemmed overcharge does', () => {
+    expect(fire({ stemming: 0.5, kg: 8 }).projectionCount).toBeGreaterThan(0);
   });
 
   it('and is rated worse for it', () => {
-    const careless = fire({ stemming: 0, kg: 8 });
+    const careless = fire({ stemming: 0.5, kg: 8 });
     const careful = fire({ stemming: 3, kg: 8 });
 
     expect(['bad', 'catastrophic']).toContain(careless.rating);
@@ -113,7 +113,7 @@ describe('Blast balance — stemming decides whether rock is thrown', () => {
   it('stemming does not cost breakage — the careful shot still moves rock', () => {
     // The stemmed shot keeps its energy in the rock, so it must break at least
     // as much as the one that vented up the hole.
-    expect(fire({ stemming: 3 }).clearedVoxels).toBeGreaterThanOrEqual(fire({ stemming: 0 }).clearedVoxels);
+    expect(fire({ stemming: 3 }).clearedVoxels).toBeGreaterThanOrEqual(fire({ stemming: 0.5 }).clearedVoxels);
   });
 });
 
@@ -173,7 +173,7 @@ describe('Blast balance — the pipeline stays coherent', () => {
   });
 
   it('never flies more projectiles than fragments', () => {
-    const r = fire({ stemming: 0, kg: 8 });
+    const r = fire({ stemming: 0.5, kg: 8 });
     expect(r.projectileCount).toBeLessThanOrEqual(r.fragmentCount);
   });
 
@@ -186,7 +186,7 @@ describe('Blast balance — the pipeline stays coherent', () => {
     // The one failure the other channels cannot see: a fragment whose resting
     // place has nothing under it. It reads as a floating boulder on screen and
     // as a perfectly ordinary blast in every number the report carries.
-    for (const shot of [{ kg: 8 }, { kg: 8, stemming: 0 }, { kg: 20, stemming: 0, explosive: 'dynatomics' }]) {
+    for (const shot of [{ kg: 8 }, { kg: 8, stemming: 0.5 }, { kg: 20, stemming: 0.5, explosive: 'dynatomics' }]) {
       const { result, grid } = fireOnto(shot);
       const pile = summariseMuckPile(result.fragments, grid);
 

--- a/tests/integration/blast-flyrock-danger.integration.test.ts
+++ b/tests/integration/blast-flyrock-danger.integration.test.ts
@@ -66,7 +66,7 @@ const aliveCount = (ctx: MiningContext, ids: number[]): number =>
 beforeEach(() => resetHoleIds());
 
 describe('Blast flyrock — danger reaches the crew', () => {
-  it('an unstemmed overcharge throws rock that hurts people standing nearby', () => {
+  it('a minimally stemmed overcharge throws rock that hurts people standing nearby', () => {
     const ctx = makeCtx();
     const crew = crewBesideTheBlast(ctx);
     const before = aliveCount(ctx, crew);
@@ -74,7 +74,7 @@ describe('Blast flyrock — danger reaches the crew', () => {
     blastAt(ctx, '0.5');
 
     expect(before).toBeGreaterThan(0);
-    expect(aliveCount(ctx, crew), 'unstemmed flyrock hurt nobody').toBeLessThan(before);
+    expect(aliveCount(ctx, crew), 'minimally stemmed flyrock hurt nobody').toBeLessThan(before);
     expect(ctx.state!.damage.accidents.length).toBeGreaterThan(0);
   });
 

--- a/tests/integration/blast-flyrock-danger.integration.test.ts
+++ b/tests/integration/blast-flyrock-danger.integration.test.ts
@@ -45,13 +45,16 @@ function blastAt(ctx: MiningContext, stemming: string): void {
 
 /**
  * Stand a crew just outside the pattern — holes span x=15..21, z=15..21, so
- * this is clear of the ground that disappears but well inside the throw.
+ * this is clear of the ground that disappears (at every stemming this suite
+ * fires, including the well-stemmed '2' case, which clears *more* ground than
+ * a poorly-stemmed shot since more of its energy goes down instead of up) but
+ * well inside a minimally-stemmed (0.5m, the createCharge floor) shot's throw.
  */
 function crewBesideTheBlast(ctx: MiningContext, count = 12): number[] {
   const rng = new Random(7);
   const ids: number[] = [];
   for (let i = 0; i < count; i++) {
-    const hire = hireEmployee(ctx.state!.employees, 'driller', rng, 25 + (i % 4), 16 + Math.floor(i / 4));
+    const hire = hireEmployee(ctx.state!.employees, 'driller', rng, 24 + (i % 4), 14 + Math.floor(i / 4));
     if (hire.employee) ids.push(hire.employee.id);
   }
   return ids;
@@ -68,7 +71,7 @@ describe('Blast flyrock — danger reaches the crew', () => {
     const crew = crewBesideTheBlast(ctx);
     const before = aliveCount(ctx, crew);
 
-    blastAt(ctx, '0');
+    blastAt(ctx, '0.5');
 
     expect(before).toBeGreaterThan(0);
     expect(aliveCount(ctx, crew), 'unstemmed flyrock hurt nobody').toBeLessThan(before);
@@ -89,7 +92,7 @@ describe('Blast flyrock — danger reaches the crew', () => {
     const ctx = makeCtx();
     crewBesideTheBlast(ctx);
 
-    blastAt(ctx, '0');
+    blastAt(ctx, '0.5');
 
     const casualties = ctx.state!.damage.accidents.filter(a => a.type === 'death' || a.type === 'injury');
     expect(casualties.length).toBeGreaterThan(0);
@@ -102,7 +105,7 @@ describe('Blast flyrock — danger reaches the crew', () => {
   it('a blast with nobody around hurts nobody', () => {
     const ctx = makeCtx();
 
-    blastAt(ctx, '0');
+    blastAt(ctx, '0.5');
 
     expect(ctx.state!.damage.accidents.filter(a => a.type === 'death').length).toBe(0);
     expect(ctx.state!.damage.deathCount).toBe(0);
@@ -135,7 +138,7 @@ describe('Blast flyrock — danger reaches the crew', () => {
     const rng = new Random(11);
     const farAway = hireEmployee(ctx.state!.employees, 'driller', rng, 44, 44).employee;
 
-    blastAt(ctx, '0');
+    blastAt(ctx, '0.5');
 
     expect(farAway.alive).toBe(true);
     expect(farAway.injured).toBe(false);
@@ -143,14 +146,14 @@ describe('Blast flyrock — danger reaches the crew', () => {
 
   it('reports how far the rock was thrown, and rates the blast on it', () => {
     const reckless = makeCtx();
-    blastAt(reckless, '0');
+    blastAt(reckless, '0.5');
     const careful = makeCtx();
     blastAt(careful, '2');
 
     // Both reports exist; the reckless one threw rock further and rates worse.
     resetHoleIds();
     drillPlanCommand(reckless, ['grid'], { rows: '1', cols: '1', spacing: '3', depth: '8', start: '30,30' });
-    chargeCommand(reckless, [], { hole: '*', explosive: 'boomite', amount: '8', stemming: '0' });
+    chargeCommand(reckless, [], { hole: '*', explosive: 'boomite', amount: '8', stemming: '0.5' });
     sequenceCommand(reckless, ['auto'], {});
     const output = blastCommand(reckless, [], {}).output;
 

--- a/tests/unit/console/mining-commands.test.ts
+++ b/tests/unit/console/mining-commands.test.ts
@@ -968,6 +968,17 @@ describe('chargeCommand — stemming floor', () => {
     expect(result.output.toLowerCase()).toContain('stemming');
     expect(Object.keys(ctx.state!.chargesByHole).length).toBe(0);
   });
+
+  it('omitting the stemming: argument entirely defaults to MIN_STEMMING_M and succeeds', () => {
+    const ctx = makeMiningContext();
+    drillPlanCommand(ctx, ['grid'], { rows: '1', cols: '1', spacing: '3', depth: '8' });
+
+    const result = chargeCommand(ctx, [], { hole: 'H1', explosive: 'boomite', amount: '5kg' });
+
+    expect(result.success).toBe(true);
+    expect(ctx.state!.chargesByHole['H1']).toBeDefined();
+    expect(ctx.state!.chargesByHole['H1']!.stemmingM).toBe(MIN_STEMMING_M);
+  });
 });
 
 describe('buildRampCommand', () => {

--- a/tests/unit/console/mining-commands.test.ts
+++ b/tests/unit/console/mining-commands.test.ts
@@ -21,6 +21,7 @@ import * as SurveyCalcModule from '../../../src/core/mining/SurveyCalc.js';
 import * as EventEngineModule from '../../../src/core/events/EventEngine.js';
 import { RAMP_COST_PER_METER } from '../../../src/core/mining/Ramp.js';
 import { TUBING_COST } from '../../../src/core/mining/Tubing.js';
+import { MIN_STEMMING_M } from '../../../src/core/config/balance.js';
 
 function makeMiningContext(): MiningContext {
   const ctx: MiningContext = {
@@ -918,6 +919,54 @@ describe('surveyCommand — ore_report subcommand', () => {
     const result = surveyCommand(ctx, ['ore_report'], {});
     expect(result.success).toBe(false);
     expect(result.output).toContain('No game loaded');
+  });
+});
+
+// ── chargeCommand — stemming floor (#527) ───────────────────────────────────
+// Mirrors the UI's existing 0.5m stemming floor (Charge.ts adjustStemming) so
+// a console `charge` command can never under-stem what a player could ever click.
+
+describe('chargeCommand — stemming floor', () => {
+  it('a single-hole charge below MIN_STEMMING_M returns success:false and names the refusal', () => {
+    const ctx = makeMiningContext();
+    drillPlanCommand(ctx, ['grid'], { rows: '1', cols: '1', spacing: '3', depth: '8' });
+
+    const result = chargeCommand(ctx, [], { hole: 'H1', explosive: 'boomite', amount: '5kg', stemming: '0.2m' });
+
+    expect(result.success).toBe(false);
+    expect(result.output.toLowerCase()).toContain('stemming');
+    expect(result.output.toLowerCase()).toContain('minimum');
+  });
+
+  it('does not write a charge to state for the refused hole', () => {
+    const ctx = makeMiningContext();
+    drillPlanCommand(ctx, ['grid'], { rows: '1', cols: '1', spacing: '3', depth: '8' });
+
+    chargeCommand(ctx, [], { hole: 'H1', explosive: 'boomite', amount: '5kg', stemming: '0.2m' });
+
+    expect(ctx.state!.chargesByHole['H1']).toBeUndefined();
+  });
+
+  it('a stemming value exactly at MIN_STEMMING_M is accepted (boundary)', () => {
+    const ctx = makeMiningContext();
+    drillPlanCommand(ctx, ['grid'], { rows: '1', cols: '1', spacing: '3', depth: '8' });
+
+    const result = chargeCommand(ctx, [], { hole: 'H1', explosive: 'boomite', amount: '5kg', stemming: `${MIN_STEMMING_M}m` });
+
+    expect(result.success).toBe(true);
+    expect(ctx.state!.chargesByHole['H1']).toBeDefined();
+    expect(ctx.state!.chargesByHole['H1']!.stemmingM).toBe(MIN_STEMMING_M);
+  });
+
+  it('a batch charge (hole:*) below MIN_STEMMING_M refuses and writes no charges', () => {
+    const ctx = makeMiningContext();
+    drillPlanCommand(ctx, ['grid'], { rows: '1', cols: '2', spacing: '3', depth: '8' });
+
+    const result = chargeCommand(ctx, [], { hole: '*', explosive: 'boomite', amount: '5kg', stemming: '0.2m' });
+
+    expect(result.success).toBe(false);
+    expect(result.output.toLowerCase()).toContain('stemming');
+    expect(Object.keys(ctx.state!.chargesByHole).length).toBe(0);
   });
 });
 

--- a/tests/unit/mining/ChargePlan.test.ts
+++ b/tests/unit/mining/ChargePlan.test.ts
@@ -56,6 +56,18 @@ describe('ChargePlan', () => {
     }
   });
 
+  it('non-finite stemming (NaN) returns an error, not a charge', () => {
+    const result = createCharge('pop_rock', 2, NaN, 8);
+    expect('error' in result).toBe(true);
+    expect('charge' in result).toBe(false);
+  });
+
+  it('non-finite amount (NaN) returns an error, not a charge', () => {
+    const result = createCharge('pop_rock', NaN, 1, 8);
+    expect('error' in result).toBe(true);
+    expect('charge' in result).toBe(false);
+  });
+
   it('batchCharge surfaces the stemming-floor error per affected hole, not a silent skip', () => {
     const holeIds = ['H1', 'H2', 'H3'];
     const depths: Record<string, number> = { H1: 8, H2: 8, H3: 8 };

--- a/tests/unit/mining/ChargePlan.test.ts
+++ b/tests/unit/mining/ChargePlan.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createCharge, batchCharge } from '../../../src/core/mining/ChargePlan.js';
+import { MIN_STEMMING_M } from '../../../src/core/config/balance.js';
 
 describe('ChargePlan', () => {
   it('charging a hole stores explosive type and amount', () => {
@@ -35,5 +36,35 @@ describe('ChargePlan', () => {
   it('stemming exceeding hole depth returns error', () => {
     const result = createCharge('pop_rock', 2, 10, 8);
     expect('error' in result).toBe(true);
+  });
+
+  // ── stemming floor (#527) ──────────────────────────────────────────────────
+  // Mirrors the UI's existing 0.5m stemming floor (Charge.ts adjustStemming) so
+  // a console charge can never under-stem what a player could ever click.
+
+  it('stemming below MIN_STEMMING_M returns an error, not a charge', () => {
+    const result = createCharge('pop_rock', 2, 0.2, 8);
+    expect('error' in result).toBe(true);
+    expect('charge' in result).toBe(false);
+  });
+
+  it('stemming exactly at MIN_STEMMING_M succeeds (boundary, not off-by-one)', () => {
+    const result = createCharge('pop_rock', 2, MIN_STEMMING_M, 8);
+    expect('charge' in result).toBe(true);
+    if ('charge' in result) {
+      expect(result.charge.stemmingM).toBe(MIN_STEMMING_M);
+    }
+  });
+
+  it('batchCharge surfaces the stemming-floor error per affected hole, not a silent skip', () => {
+    const holeIds = ['H1', 'H2', 'H3'];
+    const depths: Record<string, number> = { H1: 8, H2: 8, H3: 8 };
+    const { charges, errors } = batchCharge(holeIds, depths, 'pop_rock', 2, 0.2);
+    expect(Object.keys(charges).length).toBe(0);
+    expect(errors.length).toBe(3);
+    expect(errors.map(e => e.holeId).sort()).toEqual(['H1', 'H2', 'H3']);
+    for (const e of errors) {
+      expect(e.message.toLowerCase()).toContain('stemming');
+    }
   });
 });


### PR DESCRIPTION
Closes #527

## Summary

Console `createCharge` (`src/core/mining/ChargePlan.ts`) accepted any stemming value with no floor check, while the UI's Charge panel already clamped stemming to a 0.5m minimum in `adjustStemming`. This meant a command-mode scenario or console command could create a charge state (stemming below 0.5m) a player could never actually create by clicking through the UI — the same command↔UI parity gap this project's ongoing audit (#510-#515) has been surfacing.

- Added `MIN_STEMMING_M = 0.5` to `src/core/config/balance.ts`, the single source of truth now shared by both `ChargePlan.ts` (validation) and `Charge.ts` (UI clamp) — no more duplicated magic number.
- `createCharge` now **refuses** (returns `{ error }`, does not clamp) any `stemmingM < MIN_STEMMING_M`, mirroring the function's existing `amountKg` range-refusal pattern and the funds-guard refusal convention elsewhere in the console.
- Corrected `scripts/scenario-defs/scores-display-visual.json`'s `stemming:0` step to `stemming:0.5` (the floor value, preserving the step's original minimal-stemming intent).
- Left `scripts/scenario-defs/level3-playthrough-ecology.json` untouched — its `amount:12`/`amount:15` steps are deliberately testing the pre-existing, already-working amount-range rejection and are load-bearing for that file's `ecological_shutdown` campaign ending.
- Code review (5 parallel specialist passes, 2 rounds) surfaced and closed two related gaps introduced by this same change: a `NaN` stemming value (from a malformed `stemming:abc` console input) silently bypassed the new floor check, and omitting `stemming:` entirely from a console `charge` command now always failed instead of defaulting sensibly. Both fixed, both covered by new regression tests, and the same `NaN` guard was mirrored onto the sibling `amountKg` check for consistency within the same function.
- Fixed a resulting regression in two pre-existing integration tests (`blast-flyrock-danger`, `blast-balance-matrix`) that used `stemming: 0` directly via `chargeCommand` to model unstemmed/dangerous blasts — updated to the new `0.5` floor, with one test's crew repositioned (documented in-file) since 0.5m stemming throws rock less far than true zero.

## Decisions taken

- **What was open:** the issue said to add "the same range validation" for both amount and stemming, describing both as currently unvalidated.
  **Chosen:** amount range validation already existed in `createCharge` (`amountKg < explosive.minChargeKg || amountKg > explosive.maxChargeKg`, present since the file's original commit) and was left functionally as-is; only the stemming floor was new. Only the `NaN`-bypass gap found in code review was mirrored onto it.
  **Why:** direct inspection showed the amount check already refuses out-of-range values; `level3-playthrough-ecology.json`'s own step descriptions document its amount-range rejection as deliberate and load-bearing.
  **If reversed:** no action needed — the amount check remains correct and untouched beyond the NaN guard.

- **What was open:** "pick one, document the choice" — should `createCharge` CLAMP the stemming value (matching a silent-clamp UI) or REFUSE it (matching the funds-guard refusal pattern)?
  **Chosen:** REFUSE (`{ error }`), not clamp.
  **Why:** `createCharge` already returns a `Result`-shaped `{ charge } | { error }` for every other validation in the function (amount range, hole-depth ceiling) — clamping only stemming would be the sole silent substitution in an otherwise all-refuse function. A live UI stepper can clamp safely because the player watches it change interactively; a one-shot console/scenario command has no such feedback loop, so a silent substitution would be invisible to whoever typed the command.
  **If reversed:** replace the `stemmingM < MIN_STEMMING_M` branch's `return { error }` with `stemmingM = Math.max(MIN_STEMMING_M, stemmingM)`; no caller signature changes.

- **What was open:** the pre-existing `blast-flyrock-danger.integration.test.ts` used `stemming: '0'` to model "unstemmed" danger; the new floor makes literal zero unreachable through the console, breaking 11 tests.
  **Chosen:** update the test's reckless-case stemming to `'0.5'` (the new floor, still meaningfully dangerous per `gameplay-blast-system`'s own documented figures — 0m → 30 m/s flyrock, 2m → 11 m/s safe heave), reposition the test's crew placement to a spot still reachable by 0.5m-stemmed flyrock but outside the (larger) crater at 2m stemming, and reword "unstemmed" → "minimally stemmed" throughout for accuracy.
  **Why:** `createCharge` is the single chokepoint shared by UI, console, and scenario-defs; there's no clean way to split "player-command" validation from "core" validation, and no other in-game pathway (sabotage/corruption/negligent AI) produces sub-floor stemming that would need a carve-out. The floor correctly belongs in `createCharge` for every caller.
  **If reversed:** if a future mechanic needs true zero-stemming (e.g. a scripted sabotage event), it would need a separate lower-level entry point that bypasses `createCharge`'s validation — not a change to this floor.

## Verification

- **static** (`npm run typecheck`): PASS — 0 type errors.
- **logic** (`npx vitest run`): PASS — 8717/8717 tests, 301 files.
- **scenario** (`npm run scenarios`): PASS — 127/127, command mode. `scores-display-visual` passes with the corrected `stemming:0.5` step; `level3-playthrough-ecology.json` confirmed untouched.
- **build** (`npm run build`): PASS — production bundle succeeds, no build-config files touched.
- **visual**: not applicable — no player-visible change. `Charge.ts`'s `adjustStemming` clamp behavior is byte-for-byte unchanged (same 0.5 value, now sourced from the shared constant instead of a literal).

5 specialist code-review passes (security, quality, i18n, duplication, semantic) ran twice — round 1 found the NaN-bypass and default-arg gaps above plus a stale test-naming issue; round 2, after fixes, reported clean on every channel.

READY TO MERGE