### PR TITLE
fix: Resolve #534 — NaN/Infinity funds-guard bypass in employee raise, new_game cash, start_level cash

### DIFF
--- a/src/console/commands/campaign.ts
+++ b/src/console/commands/campaign.ts
@@ -111,7 +111,7 @@ export function campaignStartCommand(
   // new_game's, and deliberately applied to both the flat field and the
   // ledger so they cannot disagree (Finding #36's class).
   const cashOverride = named['cash'] !== undefined ? parseInt(named['cash'], 10) : NaN;
-  if (!isNaN(cashOverride)) {
+  if (Number.isFinite(cashOverride)) {
     ctx.state.cash = cashOverride;
     ctx.state.finances.cash = cashOverride;
   }

--- a/src/console/commands/employees.ts
+++ b/src/console/commands/employees.ts
@@ -100,6 +100,8 @@ export function employeeCommand(
     case 'raise': {
       const id = parseInt(args[1] ?? named['id'] ?? '', 10);
       const amount = parseFloat(named['amount'] ?? '0');
+      // guard fix incoming (#534): non-numeric amount ("abc") parses to NaN,
+      // and NaN <= 0 is false, so it slips past this check and poisons salary.
       if (isNaN(id) || amount <= 0) {
         return { success: false, output: 'Usage: employee raise <id> amount:500' };
       }

--- a/src/console/commands/employees.ts
+++ b/src/console/commands/employees.ts
@@ -100,9 +100,7 @@ export function employeeCommand(
     case 'raise': {
       const id = parseInt(args[1] ?? named['id'] ?? '', 10);
       const amount = parseFloat(named['amount'] ?? '0');
-      // guard fix incoming (#534): non-numeric amount ("abc") parses to NaN,
-      // and NaN <= 0 is false, so it slips past this check and poisons salary.
-      if (isNaN(id) || amount <= 0) {
+      if (isNaN(id) || !Number.isFinite(amount) || amount <= 0) {
         return { success: false, output: 'Usage: employee raise <id> amount:500' };
       }
       if (!giveRaise(state.employees, id, amount)) {

--- a/src/console/commands/world.ts
+++ b/src/console/commands/world.ts
@@ -206,11 +206,11 @@ export function newGameCommand(
   // the larger campaign sizes (#458 T6.1/D13) are not cubic, and console
   // testing at those aspect ratios shouldn't require a same-sized cube.
   const sizeY = named['size_y'] ? parseInt(named['size_y'], 10) : size;
-  // guard fix incoming (#534): non-numeric cash:abc parses to NaN, which is
-  // truthy-guarded here but still gets spread in and poisons state.cash.
+  const parsedCash = named['cash'] ? parseInt(named['cash'], 10) : undefined;
+  const startingCash = parsedCash !== undefined && Number.isFinite(parsedCash) ? parsedCash : undefined;
   ctx.state = createGame({
     seed, mineType,
-    ...(named['cash'] ? { startingCash: parseInt(named['cash'], 10) } : {}),
+    ...(startingCash !== undefined ? { startingCash } : {}),
   });
   ctx.state.world = createWorldState(size, sizeY, size, true);
   regenerateGrid(ctx, { seed, climateBias: biome.climateCenter, sizeX: size, sizeY, sizeZ: size });

--- a/src/console/commands/world.ts
+++ b/src/console/commands/world.ts
@@ -206,6 +206,8 @@ export function newGameCommand(
   // the larger campaign sizes (#458 T6.1/D13) are not cubic, and console
   // testing at those aspect ratios shouldn't require a same-sized cube.
   const sizeY = named['size_y'] ? parseInt(named['size_y'], 10) : size;
+  // guard fix incoming (#534): non-numeric cash:abc parses to NaN, which is
+  // truthy-guarded here but still gets spread in and poisons state.cash.
   ctx.state = createGame({
     seed, mineType,
     ...(named['cash'] ? { startingCash: parseInt(named['cash'], 10) } : {}),

--- a/tests/unit/console/insufficient-funds-guards.test.ts
+++ b/tests/unit/console/insufficient-funds-guards.test.ts
@@ -36,6 +36,7 @@ import {
 import { TARGET_COSTS, MAFIA_THRESHOLD } from '../../../src/core/economy/Corruption.js';
 import { ACCIDENT_COST, FRAME_COST, FRAME_EVIDENCE_TICKS } from '../../../src/core/events/MafiaActions.js';
 import { Random } from '../../../src/core/math/Random.js';
+import { STARTING_CASH } from '../../../src/core/config/balance.js';
 
 function makeCtx(cash: number): MiningContext {
   const ctx: MiningContext = {
@@ -585,5 +586,150 @@ describe('mafia frame — insufficient funds guard', () => {
     expect(completeResult.success).toBe(true);
     expect(completeResult.output).not.toContain('Insufficient funds');
     expect(ctx.state!.cash).toBe(0);
+  });
+});
+
+// ── employee raise — invalid amount override sanitization (#534) ──
+//
+// `employee raise <id> amount:<n>` guards with `isNaN(id) || amount <= 0`.
+// A non-numeric amount (`parseFloat('notanumber')` → `NaN`) slips past that:
+// `NaN <= 0` is `false`, so the guard never fires, giveRaise runs, and
+// `emp.salary += NaN` poisons the employee's salary permanently — later
+// picked up by payroll and spread into `state.cash`. `amount:Infinity` is
+// the sharper case: `parseFloat('Infinity')` is a legitimate finite-looking
+// number to `isNaN` (`isNaN(Infinity)` is `false`) and `Infinity > 0`, so a
+// naive `isNaN`-only fix would still let it through — only
+// `Number.isFinite(amount) && amount > 0` rejects it. The fix mirrors #519's
+// `corrupt cost:` sanitization.
+
+describe('employee raise — invalid amount override sanitization (#534)', () => {
+  function hireTestEmployee(ctx: MiningContext) {
+    const { employee } = hireEmployee(ctx.state!.employees, 'driller', new Random(1));
+    return employee;
+  }
+
+  it('refuses amount:notanumber, leaving salary and cash untouched', () => {
+    const ctx = makeCtx(100_000);
+    const emp = hireTestEmployee(ctx);
+    const salaryBefore = emp.salary;
+    const cashBefore = ctx.state!.cash;
+    const result = employeeCommand(ctx, ['raise', String(emp.id)], { amount: 'notanumber' });
+    expect(result.success).toBe(false);
+    expect(result.output).toBe('Usage: employee raise <id> amount:500');
+    expect(emp.salary).toBe(salaryBefore);
+    expect(ctx.state!.cash).toBe(cashBefore);
+  });
+
+  it('refuses amount:Infinity — Infinity > 0 passes the naive amount <= 0 check', () => {
+    const ctx = makeCtx(100_000);
+    const emp = hireTestEmployee(ctx);
+    const salaryBefore = emp.salary;
+    const cashBefore = ctx.state!.cash;
+    const result = employeeCommand(ctx, ['raise', String(emp.id)], { amount: 'Infinity' });
+    expect(result.success).toBe(false);
+    expect(result.output).toBe('Usage: employee raise <id> amount:500');
+    expect(emp.salary).toBe(salaryBefore);
+    expect(ctx.state!.cash).toBe(cashBefore);
+  });
+
+  it('refuses amount:NaN (literal string), same path as notanumber', () => {
+    const ctx = makeCtx(100_000);
+    const emp = hireTestEmployee(ctx);
+    const salaryBefore = emp.salary;
+    const result = employeeCommand(ctx, ['raise', String(emp.id)], { amount: 'NaN' });
+    expect(result.success).toBe(false);
+    expect(result.output).toBe('Usage: employee raise <id> amount:500');
+    expect(emp.salary).toBe(salaryBefore);
+  });
+
+  it('rejects amount:-5 (boundary, already correct pre-fix — must stay correct)', () => {
+    const ctx = makeCtx(100_000);
+    const emp = hireTestEmployee(ctx);
+    const salaryBefore = emp.salary;
+    const result = employeeCommand(ctx, ['raise', String(emp.id)], { amount: '-5' });
+    expect(result.success).toBe(false);
+    expect(emp.salary).toBe(salaryBefore);
+  });
+
+  it('rejects amount:0 (boundary, already correct pre-fix — must stay correct)', () => {
+    const ctx = makeCtx(100_000);
+    const emp = hireTestEmployee(ctx);
+    const salaryBefore = emp.salary;
+    const result = employeeCommand(ctx, ['raise', String(emp.id)], { amount: '0' });
+    expect(result.success).toBe(false);
+    expect(emp.salary).toBe(salaryBefore);
+  });
+
+  it('accepts amount:500 on a valid id — salary increases by exactly 500 and stays finite', () => {
+    const ctx = makeCtx(100_000);
+    const emp = hireTestEmployee(ctx);
+    const salaryBefore = emp.salary;
+    const result = employeeCommand(ctx, ['raise', String(emp.id)], { amount: '500' });
+    expect(result.success).toBe(true);
+    expect(emp.salary).toBe(salaryBefore + 500);
+    expect(Number.isFinite(emp.salary)).toBe(true);
+  });
+
+  it('does not permanently disable funds guards after a rejected non-numeric raise', () => {
+    const ctx = makeCtx(0);
+    const emp = hireTestEmployee(ctx);
+    employeeCommand(ctx, ['raise', String(emp.id)], { amount: 'notanumber' });
+    expect(Number.isFinite(ctx.state!.cash)).toBe(true);
+    const buildResult = buildCommand(ctx, ['management_office'], { at: '0,0' });
+    expect(buildResult.success).toBe(false);
+    expect(buildResult.output).toContain('Insufficient funds');
+  });
+});
+
+// ── new_game cash: — invalid cash override sanitization (#534) ──
+//
+// `new_game cash:<n>` gates the override with `named['cash'] ? {...} : {}` —
+// a truthy *string* still applies even when `parseInt` on it is `NaN`, so
+// `new_game cash:notanumber` spreads `{ startingCash: NaN }` into
+// `createGame`, and `NaN ?? STARTING_CASH` keeps the `NaN` (nullish
+// coalescing only replaces `null`/`undefined`) — `state.cash` starts the
+// session poisoned. Same root cause and fix shape as #519/#533's `corrupt
+// cost:` and this file's `employee raise amount:` sanitization above.
+
+describe('new_game cash: — invalid cash override sanitization (#534)', () => {
+  function freshCtx(): MiningContext {
+    return { state: null, grid: null, emitter: new EventEmitter() };
+  }
+
+  it('falls back to STARTING_CASH for cash:notanumber', () => {
+    const ctx = freshCtx();
+    const result = newGameCommand(ctx, [], { mine_type: 'desert', seed: '1', size: '32', cash: 'notanumber' });
+    expect(result.success).toBe(true);
+    expect(ctx.state!.cash).toBe(STARTING_CASH);
+    expect(Number.isFinite(ctx.state!.cash)).toBe(true);
+  });
+
+  it('falls back to STARTING_CASH for cash:Infinity — parseInt("Infinity", 10) is NaN, same path as notanumber', () => {
+    const ctx = freshCtx();
+    const result = newGameCommand(ctx, [], { mine_type: 'desert', seed: '1', size: '32', cash: 'Infinity' });
+    expect(result.success).toBe(true);
+    expect(ctx.state!.cash).toBe(STARTING_CASH);
+    expect(Number.isFinite(ctx.state!.cash)).toBe(true);
+  });
+
+  it('honors a legitimate cash:50000 override exactly (must not regress)', () => {
+    const ctx = freshCtx();
+    const result = newGameCommand(ctx, [], { mine_type: 'desert', seed: '1', size: '32', cash: '50000' });
+    expect(result.success).toBe(true);
+    expect(ctx.state!.cash).toBe(50000);
+  });
+
+  it('honors cash:0 as a legitimate override, distinct from absent (must not regress)', () => {
+    const ctx = freshCtx();
+    const result = newGameCommand(ctx, [], { mine_type: 'desert', seed: '1', size: '32', cash: '0' });
+    expect(result.success).toBe(true);
+    expect(ctx.state!.cash).toBe(0);
+  });
+
+  it('falls back to STARTING_CASH when cash: is present but empty (pre-existing behavior, must not regress)', () => {
+    const ctx = freshCtx();
+    const result = newGameCommand(ctx, [], { mine_type: 'desert', seed: '1', size: '32', cash: '' });
+    expect(result.success).toBe(true);
+    expect(ctx.state!.cash).toBe(STARTING_CASH);
   });
 });

--- a/tests/unit/console/insufficient-funds-guards.test.ts
+++ b/tests/unit/console/insufficient-funds-guards.test.ts
@@ -24,6 +24,8 @@ import { newGameCommand } from '../../../src/console/commands/world.js';
 import { employeeCommand, buildCommand } from '../../../src/console/commands/entities.js';
 import { vehicleCommand } from '../../../src/console/commands/vehicle.js';
 import { corruptCommand, mafiaCommand } from '../../../src/console/commands/events.js';
+import { campaignStartCommand } from '../../../src/console/commands/campaign.js';
+import { getLevel } from '../../../src/core/campaign/Level.js';
 import type { MiningContext } from '../../../src/console/commands/mining.js';
 import { HIRING_COSTS, hireEmployee } from '../../../src/core/entities/Employee.js';
 import { getVehicleDefByTier } from '../../../src/core/entities/Vehicle.js';
@@ -731,5 +733,79 @@ describe('new_game cash: — invalid cash override sanitization (#534)', () => {
     const result = newGameCommand(ctx, [], { mine_type: 'desert', seed: '1', size: '32', cash: '' });
     expect(result.success).toBe(true);
     expect(ctx.state!.cash).toBe(STARTING_CASH);
+  });
+});
+
+// ── start_level — invalid cash override sanitization (#534 campaign.ts) ──
+//
+// `campaign start level:<id> cash:<n>` guards its override with
+// `parseInt(named['cash'], 10)` fed through `isNaN(cashOverride)`. Its own
+// issue claimed this "already guards correctly" — wrong, same bug class as
+// the other two #534 sites: `isNaN` only catches `NaN`, not `Infinity`, and
+// `parseInt` returns `Infinity` for a numeric digit string long enough to
+// overflow (e.g. `parseInt('1' + '0'.repeat(400), 10) === Infinity`).
+// `isNaN(Infinity)` is `false`, so `!isNaN(cashOverride)` is `true` and the
+// guard never fires — `ctx.state.cash` and `ctx.state.finances.cash` both get
+// set to `Infinity`, disabling every later `cash < X` funds guard for the
+// rest of the session, same end state as the `employee raise` and `new_game
+// cash:` sites already covered above. The fix (not made here) replaces
+// `!isNaN(cashOverride)` with `Number.isFinite(cashOverride)`.
+
+describe('start_level — invalid cash override sanitization (#534 campaign.ts)', () => {
+  const TUTORIAL_START_CASH = getLevel('tutorial_pit')!.startingCash;
+
+  function freshCtx(): MiningContext {
+    return { state: null, grid: null, emitter: new EventEmitter() };
+  }
+
+  it('does not set cash to Infinity for a cash override that overflows parseInt', () => {
+    const overflowDigits = '1' + '0'.repeat(400);
+    expect(parseInt(overflowDigits, 10)).toBe(Infinity); // sanity check on the premise
+
+    const ctx = freshCtx();
+    const result = campaignStartCommand(ctx, [], { level: 'tutorial_pit', cash: overflowDigits });
+
+    expect(result.success).toBe(true);
+    expect(ctx.state!.cash).not.toBe(Infinity);
+    expect(Number.isFinite(ctx.state!.cash)).toBe(true);
+    expect(ctx.state!.finances.cash).not.toBe(Infinity);
+    expect(Number.isFinite(ctx.state!.finances.cash)).toBe(true);
+    // Rejected override falls back to the level's own starting cash, same as
+    // the non-numeric case below and the sibling #534 sites.
+    expect(ctx.state!.cash).toBe(TUTORIAL_START_CASH);
+    expect(ctx.state!.finances.cash).toBe(TUTORIAL_START_CASH);
+  });
+
+  it('falls back to the level default for cash:notanumber (regression boundary, already correct pre-fix)', () => {
+    const ctx = freshCtx();
+    const result = campaignStartCommand(ctx, [], { level: 'tutorial_pit', cash: 'notanumber' });
+
+    expect(result.success).toBe(true);
+    expect(ctx.state!.cash).toBe(TUTORIAL_START_CASH);
+    expect(ctx.state!.finances.cash).toBe(TUTORIAL_START_CASH);
+    expect(Number.isFinite(ctx.state!.cash)).toBe(true);
+  });
+
+  it('still honors a legitimate cash:50000 override exactly (must not regress)', () => {
+    const ctx = freshCtx();
+    const result = campaignStartCommand(ctx, [], { level: 'tutorial_pit', cash: '50000' });
+
+    expect(result.success).toBe(true);
+    expect(ctx.state!.cash).toBe(50000);
+    expect(ctx.state!.finances.cash).toBe(50000);
+  });
+
+  it('does not permanently disable funds guards after an Infinity-overflowing cash override', () => {
+    const ctx = freshCtx();
+    campaignStartCommand(ctx, [], { level: 'tutorial_pit', cash: '1' + '0'.repeat(400) });
+    expect(Number.isFinite(ctx.state!.cash)).toBe(true);
+
+    const buildResult = buildCommand(ctx, ['management_office'], { at: '0,0' });
+    // A guard poisoned to Infinity would let any purchase through; a sane
+    // guard still enforces affordability against the real (finite) balance.
+    if (ctx.state!.cash < getBuildingDef('management_office', 1).constructionCost) {
+      expect(buildResult.success).toBe(false);
+      expect(buildResult.output).toContain('Insufficient funds');
+    }
   });
 });


### PR DESCRIPTION
Closes #534

## Summary

Same unvalidated-numeric-override → NaN funds-guard-bypass pattern as #519/#533, found by @security-reviewer in two more console commands, plus a third site found during this run's own security review:

1. **`employee raise <id> amount:<n>`** (`src/console/commands/employees.ts`) — `parseFloat` on bad input yields `NaN`, and `NaN <= 0` is `false`, so the guard didn't reject it. `giveRaise` then set `emp.salary` to `NaN`, which propagated to `state.cash` via the next payroll cycle, permanently disabling every funds guard in the session.
2. **`new_game cash:<n>`** (`src/console/commands/world.ts`) — non-numeric `cash:` parses to `NaN`, which isn't `null`/`undefined` so `??` doesn't fall back — `state.cash` started the session as `NaN`.
3. **`start_level cash:<n>`** (`src/console/commands/campaign.ts`) — **not in the original issue's scope**, but this run's own security-reviewer pass found the issue's claim that this command "already guards correctly" was wrong: `parseInt` can return `Infinity` from a sufficiently long numeric digit string, `isNaN(Infinity)` is `false`, so the existing `!isNaN(cashOverride)` guard let `Infinity` through into `ctx.state.cash`/`ctx.state.finances.cash`. Same bug class, same end state. Fixed in this PR since it's the identical bug family this issue is about, found while fixing it — see `agentic-decision-autonomy`'s "scope beyond framing" rule.

Fix: `Number.isFinite(...)` guards, matching the precedent already established in `contract deliver` (`src/console/commands/economy.ts`) and the `corrupt` command fix from #519/#533.

`employee raise` and `contract deliver`-style commands hard-reject a non-finite required argument. `new_game cash:` and `start_level cash:` are optional debug/scenario-setup knobs, so both silently fall back to the existing default rather than rejecting the whole command — matching `corrupt`'s `cost:` sanitization precedent.

## Decisions taken

Defaulted under `agentic-decision-autonomy`:

- **What was open:** the issue didn't specify whether `new_game cash:`'s invalid-override handling should hard-reject (like `employee raise`) or silently fall back to the default.
  **Chosen:** silent fallback to `STARTING_CASH`, matching `corrupt`'s `cost:` sanitization (#519/#533) and `start_level`'s existing `cash:` knob.
  **Why:** both are optional debug/scenario-setup overrides that should degrade gracefully, not block the whole command — unlike `employee raise`'s `amount`, which is a required argument to the action itself.
  **If reversed:** swap the silent fallback for an explicit `{ success: false, output: 'Usage: ...' }` branch in `newGameCommand`.

- **What was open:** whether to also reject negative `cash:` overrides.
  **Chosen:** no — only reject non-finite values (`NaN`/`Infinity`); negative and zero pass through unchanged.
  **Why:** `start_level`'s own `cash:` knob already accepts negative values unguarded, and the issue scoped the fix to "validate the parsed value is finite," not sign.
  **If reversed:** add `&& parsedCash >= 0` to the `Number.isFinite` checks in both `world.ts` and `campaign.ts`.

- **What was open:** whether to harden `giveRaise` (`src/core/entities/Employee.ts`) and `createGame`/`GameState.ts` at the core layer too, matching #519/#533's defense-in-depth on `attemptCorruption`.
  **Chosen:** console-layer guard only.
  **Why:** `giveRaise` has exactly one call site (`employees.ts`) and `config.startingCash` is fed only by `newGameCommand` among console commands — closing the one entry point fully closes the vulnerability, unlike `attemptCorruption`'s `customCost`, which had no such single-call-site guarantee.
  **If reversed:** add the same `Number.isFinite` clamp inside `giveRaise` and inside `createGame`'s config normalization.

- **What was open (found during this run, not in the original issue):** `start_level cash:<n>` — the issue explicitly said this was "already correct," but security review found the same `Infinity`-bypass bug via `parseInt` overflow.
  **Chosen:** fixed in this PR (`!isNaN(cashOverride)` → `Number.isFinite(cashOverride)`), same guard idiom as the rest of this fix.
  **Why:** identical bug class, in the same file family, discovered while fixing this exact issue — correct fix beats leaving a known-bad claim in place. Filed no separate issue for this one since it's directly in the fix's own scope.
  **If reversed:** revert `src/console/commands/campaign.ts`'s guard back to `!isNaN(...)` (not recommended — reopens the bypass).

Two additional findings, out of this PR's scope, filed as follow-ups:
- #539 — `set_policy hunger:/fatigue:/social:` has the identical `isNaN`-only gap (non-funds field, lower severity).
- #540 — non-blocking suggestion to extract a shared finite-override-parsing helper into `commandUtils.ts`, now that the pattern repeats 5 times.

## Verification

- `static` — `npm run typecheck`: PASS, 0 errors.
- `logic` — `npm run test`: PASS, 8735/8735 tests (301 files), including 60 tests in `tests/unit/console/insufficient-funds-guards.test.ts` covering all three fixed sites (NaN, Infinity-overflow, and legitimate-override boundary cases for each).
- `scenario` — `npm run scenarios` (command mode): PASS, 127/127.
- `visual` — not applicable. Pure `src/console/` logic fix, nothing rendered or player-facing changed.

Five specialist reviewers (security, quality, i18n, duplication, semantic) ran in two rounds — first round caught the `start_level` gap (security), both rounds otherwise clean. Full re-review after the fix: all PASS.

READY TO MERGE