### PR TITLE
fix: Resolve #539 — Infinity-overflow guard bypass in set_policy hunger/fatigue/social thresholds

### DIFF
--- a/src/console/commands/policy.ts
+++ b/src/console/commands/policy.ts
@@ -31,6 +31,7 @@ export function setPolicyCommand(
 
   state.sitePolicy.shiftMode = mode;
 
+  // #539: guards below must reject non-finite parseInt results (NaN and Infinity)
   if (named['hunger'] !== undefined) {
     const v = parseInt(named['hunger'], 10);
     if (!isNaN(v)) state.sitePolicy.hungerRestThreshold = v;

--- a/src/console/commands/policy.ts
+++ b/src/console/commands/policy.ts
@@ -34,15 +34,15 @@ export function setPolicyCommand(
   // #539: guards below must reject non-finite parseInt results (NaN and Infinity)
   if (named['hunger'] !== undefined) {
     const v = parseInt(named['hunger'], 10);
-    if (!isNaN(v)) state.sitePolicy.hungerRestThreshold = v;
+    if (Number.isFinite(v)) state.sitePolicy.hungerRestThreshold = v;
   }
   if (named['fatigue'] !== undefined) {
     const v = parseInt(named['fatigue'], 10);
-    if (!isNaN(v)) state.sitePolicy.fatigueRestThreshold = v;
+    if (Number.isFinite(v)) state.sitePolicy.fatigueRestThreshold = v;
   }
   if (named['social'] !== undefined) {
     const v = parseInt(named['social'], 10);
-    if (!isNaN(v)) state.sitePolicy.socialBreakThreshold = v;
+    if (Number.isFinite(v)) state.sitePolicy.socialBreakThreshold = v;
   }
 
   // Bumped even when every value is unchanged: applying the policy already in

--- a/tests/unit/console/policy-threshold-guards.test.ts
+++ b/tests/unit/console/policy-threshold-guards.test.ts
@@ -1,0 +1,116 @@
+// BlastSimulator2026 — set_policy threshold guards (#539)
+//
+// `set_policy hunger:<n> fatigue:<n> social:<n>` parses each override with
+// `parseInt(v, 10)` and guards it with a bare `isNaN(v)`. `isNaN` only
+// catches `NaN` — it does not catch `Infinity`. A digit string long enough
+// to overflow `parseInt` (e.g. `'1' + '0'.repeat(400)`) parses to `Infinity`,
+// and `isNaN(Infinity)` is `false`, so the guard never fires: the bare check
+// lets a non-finite value get written straight into
+// `state.sitePolicy.hungerRestThreshold` / `fatigueRestThreshold` /
+// `socialBreakThreshold`. Same bug class as #519's `corrupt cost:` and
+// #534's `employee raise amount:` / `new_game cash:` / `start_level cash:`
+// sites — the fix replaces `isNaN(v)` with `Number.isFinite(v)` in all three
+// guards. Control flow is unchanged: a rejected override is silently
+// skipped (the command still returns `success: true`), and `revision` still
+// bumps unconditionally.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { type GameContext, newGameCommand } from '../../../src/console/commands/world.js';
+import { setPolicyCommand } from '../../../src/console/commands/policy.js';
+import { EventEmitter } from '../../../src/core/state/EventEmitter.js';
+
+function makeCtx(): GameContext {
+  const ctx: GameContext = { state: null, grid: null, emitter: new EventEmitter() };
+  newGameCommand(ctx, [], { mine_type: 'desert', seed: '42', size: '24' });
+  return ctx;
+}
+
+// A digit string long enough that parseInt(str, 10) overflows to Infinity.
+const OVERFLOW_DIGITS = '1' + '0'.repeat(400);
+
+type Field = 'hunger' | 'fatigue' | 'social';
+type ThresholdKey = 'hungerRestThreshold' | 'fatigueRestThreshold' | 'socialBreakThreshold';
+
+const FIELDS: { field: Field; key: ThresholdKey }[] = [
+  { field: 'hunger', key: 'hungerRestThreshold' },
+  { field: 'fatigue', key: 'fatigueRestThreshold' },
+  { field: 'social', key: 'socialBreakThreshold' },
+];
+
+describe('set_policy threshold guards (#539)', () => {
+  let ctx: GameContext;
+
+  beforeEach(() => {
+    ctx = makeCtx();
+  });
+
+  // Sanity check on the premise, same as the #534 start_level test.
+  it('parseInt overflows the digit fixture to Infinity, and isNaN does not catch it', () => {
+    expect(parseInt(OVERFLOW_DIGITS, 10)).toBe(Infinity);
+    expect(isNaN(Infinity)).toBe(false);
+  });
+
+  for (const { field, key } of FIELDS) {
+    describe(`${field}: → sitePolicy.${key}`, () => {
+      it(`rejects ${field}:notanumber, leaving the threshold unchanged (NaN case — already correct pre-fix)`, () => {
+        const before = ctx.state!.sitePolicy[key];
+        const result = setPolicyCommand(ctx, [], { mode: 'shift_8h', [field]: 'notanumber' });
+
+        expect(result.success).toBe(true);
+        expect(ctx.state!.sitePolicy[key]).toBe(before);
+        expect(Number.isFinite(ctx.state!.sitePolicy[key])).toBe(true);
+      });
+
+      it(`rejects ${field}:<overflow digit string>, leaving the threshold unchanged and finite — reproduces #539`, () => {
+        const before = ctx.state!.sitePolicy[key];
+        const result = setPolicyCommand(ctx, [], { mode: 'shift_8h', [field]: OVERFLOW_DIGITS });
+
+        expect(result.success).toBe(true);
+        // This is the assertion that fails against the buggy bare isNaN(v)
+        // guard: it lets Infinity through, so the threshold becomes Infinity
+        // instead of staying at its pre-call value.
+        expect(Number.isFinite(ctx.state!.sitePolicy[key])).toBe(true);
+        expect(ctx.state!.sitePolicy[key]).toBe(before);
+        expect(ctx.state!.sitePolicy[key]).not.toBe(Infinity);
+      });
+
+      it(`applies a legitimate ${field}:<n> override exactly (regression guard — fix must not over-reject valid input)`, () => {
+        const result = setPolicyCommand(ctx, [], { mode: 'shift_8h', [field]: '33' });
+
+        expect(result.success).toBe(true);
+        expect(ctx.state!.sitePolicy[key]).toBe(33);
+      });
+    });
+  }
+
+  it('bumps the revision unconditionally even when an overflowing override is rejected', () => {
+    const before = ctx.state!.sitePolicy.revision;
+    const result = setPolicyCommand(ctx, [], { mode: 'shift_8h', hunger: OVERFLOW_DIGITS });
+
+    expect(result.success).toBe(true);
+    expect(ctx.state!.sitePolicy.revision).toBe(before + 1);
+  });
+
+  it('rejects an overflowing override on one field without disturbing a valid override on another', () => {
+    const result = setPolicyCommand(ctx, [], {
+      mode: 'shift_8h',
+      hunger: OVERFLOW_DIGITS,
+      fatigue: '20',
+    });
+
+    expect(result.success).toBe(true);
+    expect(Number.isFinite(ctx.state!.sitePolicy.hungerRestThreshold)).toBe(true);
+    expect(ctx.state!.sitePolicy.hungerRestThreshold).not.toBe(Infinity);
+    expect(ctx.state!.sitePolicy.fatigueRestThreshold).toBe(20);
+  });
+
+  it('does not poison sitePolicy thresholds for the rest of the session after a rejected overflow override', () => {
+    setPolicyCommand(ctx, [], { mode: 'shift_8h', hunger: OVERFLOW_DIGITS });
+    expect(Number.isFinite(ctx.state!.sitePolicy.hungerRestThreshold)).toBe(true);
+
+    // A later, legitimate call must still apply cleanly.
+    const result = setPolicyCommand(ctx, [], { mode: 'shift_8h', hunger: '45' });
+    expect(result.success).toBe(true);
+    expect(ctx.state!.sitePolicy.hungerRestThreshold).toBe(45);
+  });
+});


### PR DESCRIPTION
Closes #539

## Summary
`src/console/commands/policy.ts`'s `set_policy` command guarded its parsed `hunger:`/`fatigue:`/`social:` numeric overrides with a bare `isNaN(v)` check. `isNaN` does not catch `Infinity`, and `parseInt` on a sufficiently long digit string overflows to `Infinity` — so a non-finite value could be written into `state.sitePolicy.hungerRestThreshold`/`fatigueRestThreshold`/`socialBreakThreshold`, poisoning per-tick threshold comparisons for every employee. Same root-cause pattern already fixed on funds-related fields in #519/#533/#534/#538/#541.

Fix: replaced `!isNaN(v)` with `Number.isFinite(v)` in all three guards, matching the idiom already used in `src/console/commands/employees.ts`, `world.ts`, `campaign.ts`, `economy.ts`, `events.ts`. Pure predicate swap — no control-flow change: a rejected override is still silently skipped, `revision` still bumps unconditionally.

8748 tests — all passing (13 new, in `tests/unit/console/policy-threshold-guards.test.ts`).

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run, none material to gameplay/economy.

- **What was open:** issue said "in place of, or in addition to" the existing `isNaN` check.
  **Chosen:** replace (`isNaN(v)` → `Number.isFinite(v)`), not both.
  **Why:** matches the exact idiom of the cited sibling fix in `campaign.ts` (#534); `Number.isFinite` already rejects `NaN` and both `Infinity` signs, so a combined check would be redundant.
  **If reversed:** change the three `Number.isFinite(v)` back to `!isNaN(v)` (or add a second clause) in `src/console/commands/policy.ts`.

- **What was open:** whether a rejected override should fail the command (`success: false`) or silently skip the field.
  **Chosen:** keep silent skip / `success: true` — only the predicate changed, not control flow.
  **Why:** matches existing behavior of the pre-fix `isNaN` branch and the sibling `cash:` guard in `campaign.ts`, which also falls back silently rather than rejecting the whole command.
  **If reversed:** wrap each `if (Number.isFinite(v))` in an `else return { success: false, ... }`.

- **What was open:** issue said `tests/unit/console/` — modify existing file or create new.
  **Chosen:** new file `tests/unit/console/policy-threshold-guards.test.ts`, not appended to `insufficient-funds-guards.test.ts`.
  **Why:** that file's own header comment scopes it to cash/funds guards specifically; this bug's fields never touch `state.cash`.
  **If reversed:** move the `describe` block into `insufficient-funds-guards.test.ts`.

## Verification
- **static** — `npm run typecheck`: 0 errors.
- **logic** — `npm run test`: 302 files, 8748 passed, 0 failed.
- **scenario** — `npm run scenarios`: 127/127 passed.
- **build** — `npx vite build`: success.
- **visual** — not applicable; diff confined to `src/console/commands/policy.ts` (console command, no renderer/UI/player-facing surface) and its test file.

READY TO MERGE
