### PR TITLE
fix: Resolve #540 — extract sanitizeFiniteOverride helper for console-command guards

### DIFF
--- a/src/console/commands/campaign.ts
+++ b/src/console/commands/campaign.ts
@@ -11,6 +11,7 @@ import { getBiome } from '../../core/world/BiomeCatalog.js';
 import { calculateStarRating } from '../../core/campaign/SuccessTracker.js';
 import { Random } from '../../core/math/Random.js';
 import { generateContracts } from '../../core/economy/Contract.js';
+import { sanitizeFiniteOverride } from './commandUtils.js';
 // ── campaign status ──
 
 export function campaignStatusCommand(
@@ -110,8 +111,8 @@ export function campaignStartCommand(
   // cash allows has nowhere else to get it. Debug grant, same class as
   // new_game's, and deliberately applied to both the flat field and the
   // ledger so they cannot disagree (Finding #36's class).
-  const cashOverride = named['cash'] !== undefined ? parseInt(named['cash'], 10) : NaN;
-  if (Number.isFinite(cashOverride)) {
+  const cashOverride = named['cash'] !== undefined ? sanitizeFiniteOverride(parseInt(named['cash'], 10)) : undefined;
+  if (cashOverride !== undefined) {
     ctx.state.cash = cashOverride;
     ctx.state.finances.cash = cashOverride;
   }

--- a/src/console/commands/commandUtils.ts
+++ b/src/console/commands/commandUtils.ts
@@ -10,3 +10,16 @@ export function requireGame(ctx: GameContext): CommandResult | null {
   if (!ctx.state) return { success: false, output: 'No game loaded. Use new_game first.' };
   return null;
 }
+
+/**
+ * Sanitizes an already-parsed numeric console-arg override: keeps it only if
+ * finite (rejects NaN and ±Infinity) and, when `opts.min` is given, only if
+ * `>= opts.min` (inclusive). Returns undefined otherwise so the caller falls
+ * back to its own default. Takes the parsed number, not the raw string —
+ * callers keep their own `parseInt`/`parseFloat` choice.
+ */
+export function sanitizeFiniteOverride(parsed: number, opts?: { min?: number }): number | undefined {
+  void parsed;
+  void opts;
+  throw new Error('not implemented');
+}

--- a/src/console/commands/commandUtils.ts
+++ b/src/console/commands/commandUtils.ts
@@ -19,7 +19,7 @@ export function requireGame(ctx: GameContext): CommandResult | null {
  * callers keep their own `parseInt`/`parseFloat` choice.
  */
 export function sanitizeFiniteOverride(parsed: number, opts?: { min?: number }): number | undefined {
-  void parsed;
-  void opts;
-  throw new Error('not implemented');
+  if (!Number.isFinite(parsed)) return undefined;
+  if (opts?.min !== undefined && parsed < opts.min) return undefined;
+  return parsed;
 }

--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -46,7 +46,7 @@ import {
   ACCIDENT_COST,
   FRAME_COST,
 } from '../../core/events/MafiaActions.js';
-import { requireGame } from './commandUtils.js';
+import { requireGame, sanitizeFiniteOverride } from './commandUtils.js';
 import type { GameState } from '../../core/state/GameState.js';
 
 /** Deduct a cash cost and log it as a finance expense, if the cost is positive. */
@@ -485,8 +485,7 @@ export function corruptCommand(
     return { success: false, output: `Invalid target. Valid: ${validTargets.join(', ')}` };
   }
 
-  const rawCost = named['cost'] ? parseInt(named['cost'], 10) : undefined;
-  const cost = rawCost !== undefined && Number.isFinite(rawCost) && rawCost >= 0 ? rawCost : undefined;
+  const cost = named['cost'] ? sanitizeFiniteOverride(parseInt(named['cost'], 10), { min: 0 }) : undefined;
   const resolvedCost = cost ?? TARGET_COSTS[target];
   if (state.cash < resolvedCost) {
     return {

--- a/src/console/commands/world.ts
+++ b/src/console/commands/world.ts
@@ -15,6 +15,7 @@ import type { VoxelGrid } from '../../core/world/VoxelGrid.js';
 import { EventEmitter } from '../../core/state/EventEmitter.js';
 import { decodeVoxelGrid, type SerializedVoxels, type SerializedTerrainGen } from '../../core/state/VoxelGridCodec.js';
 import { DEFAULT_GRID_SIZE } from '../../core/config/balance.js';
+import { sanitizeFiniteOverride } from './commandUtils.js';
 
 /**
  * The landscape's coarse tile map plus a reusable fine-grained sampler
@@ -206,8 +207,7 @@ export function newGameCommand(
   // the larger campaign sizes (#458 T6.1/D13) are not cubic, and console
   // testing at those aspect ratios shouldn't require a same-sized cube.
   const sizeY = named['size_y'] ? parseInt(named['size_y'], 10) : size;
-  const parsedCash = named['cash'] ? parseInt(named['cash'], 10) : undefined;
-  const startingCash = parsedCash !== undefined && Number.isFinite(parsedCash) ? parsedCash : undefined;
+  const startingCash = named['cash'] ? sanitizeFiniteOverride(parseInt(named['cash'], 10)) : undefined;
   ctx.state = createGame({
     seed, mineType,
     ...(startingCash !== undefined ? { startingCash } : {}),


### PR DESCRIPTION
Closes #540

## Summary

Non-blocking duplication flagged twice by @duplication-reviewer during the #534 pipeline run: the "reject/replace non-finite numeric override" idiom repeated across 5 console-command sites. This is a pure refactor pass — zero behavior change — that extracts a shared helper where it genuinely simplifies, and leaves the rest alone where the reviewer's own differentiation held up under evaluation.

- Added `sanitizeFiniteOverride(parsed: number, opts?: { min?: number }): number | undefined` to `src/console/commands/commandUtils.ts`, alongside the existing `requireGame`/`NO_EMPLOYEES_MSG` helpers.
- Migrated 3 sites to it:
  - `world.ts` — `new_game cash:` override (no bound)
  - `events.ts` — `corrupt cost:` override (`min: 0`, matches the existing inclusive `>= 0` bound)
  - `campaign.ts` — `start_level cash:` override (no bound; replaces the NaN-sentinel idiom with the same undefined-based idiom as the other two)
- Left `employees.ts` (`employee raise amount:`) and `economy.ts` (`contract deliver amount:`) unmigrated: both combine the numeric guard with an unrelated `id` check in one `||` boolean, use an exclusive `>0` bound, and reject-with-usage-message rather than assign-a-fallback — a materially different shape a helper would obscure, not clarify. Matches the reviewer's own original assessment (only `world.ts`/`events.ts` were called structurally identical; this run additionally found `campaign.ts` migratable once the guard-only scope was drawn correctly).

No new tests: `tests/unit/console/insufficient-funds-guards.test.ts` already covered all 5 sites' NaN/Infinity/bound behavior end to end and was confirmed sufficient by the test-writer phase — it is unmodified in this diff (`git diff origin/main...HEAD -- tests/` is empty).

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** the issue's illustrative helper signature (`parseFiniteOverride(raw: string | undefined, opts?)`) parses the raw string internally, but call sites split between `parseInt` (world/events/campaign — integer cash/cost) and `parseFloat` (employees/economy — fractional amounts); baking one parse function in would either duplicate it per caller or silently diverge behavior for the other parse kind.
  **Chosen:** `sanitizeFiniteOverride(parsed: number, opts?: { min?: number })` takes the already-parsed number; each caller keeps its own `parseInt`/`parseFloat` choice.
  **Why:** the issue's hard requirement ("no behavior change") outweighs its illustrative (`e.g.`) signature; a number-sanitizing helper cannot introduce a parseInt/parseFloat divergence a string-parsing one could.
  **If reversed:** change the helper's first parameter to `raw: string | undefined` and move one `parseInt`/`parseFloat` call inside it; affects only `commandUtils.ts` and one line at each of the 3 call sites.

- **What was open:** "evaluate case-by-case" for the 3 non-identical sites, with no explicit rule for what counts as a genuine simplification.
  **Chosen:** migrate a site only when the finite/bound check is a standalone `finite [&& bound] ? value : undefined` decision, independent of any other field's validation — not when it's fused into a multi-field `||` reject branch.
  **Why:** applies the reviewer's own stated criterion ("differ in what else they validate") literally: `campaign.ts`'s dual-field assignment happens *after* the decision, so it qualifies; `employees.ts`/`economy.ts`'s `id` check is *inside* the same boolean as the amount check, so it doesn't.
  **If reversed:** none needed — a future site that separates its `id` check onto its own line would qualify under this same rule without changing it.

Neither decision affects gameplay, economy, or a player-facing default — both are internal refactor-shape choices — so no `decision-review` follow-up issue was opened.

## Verification

- **static** — `npm run typecheck`: PASS, 0 errors.
- **logic** — `npm run test`: PASS, 302 test files / 8748 tests, 0 failures. `tests/unit/console/insufficient-funds-guards.test.ts` passes unmodified.
- **scenario** — `npm run scenarios`: PASS, 127/127 (command mode).
- **build** — `npm run build`: PASS.
- Console-layer refactor only, no renderer/UI/player-facing-flow change — `visual` channel not owed per the issue's own verification list, and not applicable (no rendering, UI, or click-flow touched).
- Qualimetry (`jscpd` on changed files): 3 pre-existing clones found, confirmed identical (same line ranges, ±1 line from import addition) on `main` before this diff — no new duplication introduced.
- 5 parallel specialist reviews (security, quality, i18n, duplication, semantic) + runtime validator: all PASS, verdict APPROVE.

READY TO MERGE