### PR TITLE
fix: Resolve #544 — right-drag camera orbit no longer cancels armed placement tool

### DIFF
--- a/scripts/scenario-defs/building-ramp-visual.json
+++ b/scripts/scenario-defs/building-ramp-visual.json
@@ -34,6 +34,23 @@
           "selector": "#bs-tile-select-confirm"
         },
         {
+          "type": "mousedown",
+          "x": 640,
+          "y": 360,
+          "button": "right"
+        },
+        {
+          "type": "mousemove",
+          "x": 700,
+          "y": 320
+        },
+        {
+          "type": "mouseup",
+          "x": 700,
+          "y": 320,
+          "button": "right"
+        },
+        {
           "type": "dragTiles",
           "x1": 5,
           "z1": 15,

--- a/src/renderer/CameraController.ts
+++ b/src/renderer/CameraController.ts
@@ -133,15 +133,6 @@ export class CameraController {
     this.target = target.clone();
     this.canvas = canvas;
 
-    // Skeleton stage (#544): rightButtonDown/rightDownX/rightDownY and
-    // RIGHT_DRAG_THRESHOLD_PX are read by @implementer's tracking logic in
-    // onMouseDown/onMouseMove/onMouseUp, not yet wired in. These no-op reads
-    // satisfy noUnusedLocals until that wiring lands.
-    void this.rightButtonDown;
-    void this.rightDownX;
-    void this.rightDownY;
-    void RIGHT_DRAG_THRESHOLD_PX;
-
     // Initialise spherical from current camera position
     const offset = camera.position.clone().sub(this.target);
     this.spherical = new THREE.Spherical().setFromVector3(offset);
@@ -304,6 +295,14 @@ export class CameraController {
       // Middle or Right button — pan
       this.isPanning = true;
     }
+    if (e.button === 2) {
+      // New right-button gesture starts clean — PlacementController's
+      // contextmenu handler reads rightGestureMoved after release (#544).
+      this.rightButtonDown = true;
+      this.rightDownX = e.clientX;
+      this.rightDownY = e.clientY;
+      this.rightGestureMoved = false;
+    }
     this.prevMouseX = e.clientX;
     this.prevMouseY = e.clientY;
   };
@@ -319,11 +318,22 @@ export class CameraController {
     } else if (this.isPanning) {
       this.pan(dx, dy);
     }
+
+    if (this.rightButtonDown && !this.rightGestureMoved) {
+      // Peak displacement from the press point, not net displacement — a
+      // drag that returns to the press point before release still counts.
+      const rdx = e.clientX - this.rightDownX;
+      const rdy = e.clientY - this.rightDownY;
+      if (Math.sqrt(rdx * rdx + rdy * rdy) > RIGHT_DRAG_THRESHOLD_PX) {
+        this.rightGestureMoved = true;
+      }
+    }
   };
 
   private onMouseUp = () => {
     this.isOrbiting = false;
     this.isPanning = false;
+    this.rightButtonDown = false;
   };
 
   private onWheel = (e: WheelEvent) => {

--- a/src/renderer/CameraController.ts
+++ b/src/renderer/CameraController.ts
@@ -44,9 +44,9 @@ const PAN_SPEED_FACTOR = 0.001;
  * Pixel movement below this between right-button mousedown and release still
  * reads as a click, not a drag — mirrors ScenePicking's
  * CLICK_MOVE_THRESHOLD_PX for the analogous left-button distinction. Below
- * this, PlacementController's contextmenu handler still cancels the armed
- * tool; at or above it, a right-drag used purely to orbit the camera leaves
- * the tool untouched (#544).
+ * this, PlacementController.onMouseUp's button === 2 branch still cancels the
+ * armed tool; at or above it, a right-drag used purely to orbit the camera
+ * leaves the tool untouched (#544).
  */
 const RIGHT_DRAG_THRESHOLD_PX = 5;
 

--- a/src/renderer/CameraController.ts
+++ b/src/renderer/CameraController.ts
@@ -40,6 +40,16 @@ const ORBIT_SPEED = 0.005; // radians per pixel
 // Scales with distance so panning feels consistent at all zoom levels
 const PAN_SPEED_FACTOR = 0.001;
 
+/**
+ * Pixel movement below this between right-button mousedown and release still
+ * reads as a click, not a drag — mirrors ScenePicking's
+ * CLICK_MOVE_THRESHOLD_PX for the analogous left-button distinction. Below
+ * this, PlacementController's contextmenu handler still cancels the armed
+ * tool; at or above it, a right-drag used purely to orbit the camera leaves
+ * the tool untouched (#544).
+ */
+const RIGHT_DRAG_THRESHOLD_PX = 5;
+
 // Vertical angle limits. `phi` is measured from straight up, so a small value
 // puts the camera overhead looking down and a value near π/2 puts it level
 // with the target. Stopping short of both ends keeps the camera from flipping
@@ -87,6 +97,19 @@ export class CameraController {
   private prevMouseX = 0;
   private prevMouseY = 0;
 
+  private rightButtonDown = false;
+  private rightDownX = 0;
+  private rightDownY = 0;
+  /**
+   * True once the current (or just-finished) right-button gesture has moved
+   * past RIGHT_DRAG_THRESHOLD_PX from its mousedown position. Single source
+   * of truth for "was this a drag, not a click" — PlacementController reads
+   * it instead of re-deriving pixel distance itself (#544). Reset on the
+   * next right-button mousedown; persists across mouseup so a `contextmenu`
+   * handler firing afterward can still read it.
+   */
+  private rightGestureMoved = false;
+
   /**
    * True while a placement tool (P3 grid select) has taken the left button.
    * Right swaps to orbit for the duration and left is ignored here entirely —
@@ -109,6 +132,15 @@ export class CameraController {
     this.camera = camera;
     this.target = target.clone();
     this.canvas = canvas;
+
+    // Skeleton stage (#544): rightButtonDown/rightDownX/rightDownY and
+    // RIGHT_DRAG_THRESHOLD_PX are read by @implementer's tracking logic in
+    // onMouseDown/onMouseMove/onMouseUp, not yet wired in. These no-op reads
+    // satisfy noUnusedLocals until that wiring lands.
+    void this.rightButtonDown;
+    void this.rightDownX;
+    void this.rightDownY;
+    void RIGHT_DRAG_THRESHOLD_PX;
 
     // Initialise spherical from current camera position
     const offset = camera.position.clone().sub(this.target);
@@ -137,6 +169,11 @@ export class CameraController {
    */
   get viewTarget(): THREE.Vector3 {
     return this.target;
+  }
+
+  /** True if the right-button gesture just released (or still held) moved past RIGHT_DRAG_THRESHOLD_PX — a drag, not a click (#544). */
+  get rightButtonDragged(): boolean {
+    return this.rightGestureMoved;
   }
 
   /** Point the camera looks at (can be updated externally for tracking). */

--- a/src/renderer/CameraController.ts
+++ b/src/renderer/CameraController.ts
@@ -297,7 +297,10 @@ export class CameraController {
     }
     if (e.button === 2) {
       // New right-button gesture starts clean — PlacementController's
-      // contextmenu handler reads rightGestureMoved after release (#544).
+      // onMouseUp handler reads rightButtonDragged (backed by
+      // rightGestureMoved) via the button-2 branch, since mouseup is
+      // guaranteed to fire after any movement regardless of where
+      // contextmenu lands (#544).
       this.rightButtonDown = true;
       this.rightDownX = e.clientX;
       this.rightDownY = e.clientY;

--- a/src/ui/scene/PlacementController.ts
+++ b/src/ui/scene/PlacementController.ts
@@ -284,6 +284,11 @@ export class PlacementController {
   private onContextMenu(e: MouseEvent): void {
     if (this.phase === 'idle' || this.phase === 'confirmed') return;
     e.preventDefault();
+    // A right-drag used purely to orbit the camera must not cancel the armed
+    // tool — only a right-button click (no meaningful movement) does. Single
+    // source of truth for the drag/click distinction lives on CameraController
+    // (RIGHT_DRAG_THRESHOLD_PX), not duplicated here (#544).
+    if (this.cameraController.rightButtonDragged) return;
     this.cancel();
   }
 

--- a/src/ui/scene/PlacementController.ts
+++ b/src/ui/scene/PlacementController.ts
@@ -273,6 +273,18 @@ export class PlacementController {
   }
 
   private onMouseUp(e: MouseEvent): void {
+    if (e.button === 2) {
+      // The cancel-vs-not decision lives here rather than in onContextMenu:
+      // on this environment's Chromium, contextmenu fires right after
+      // mousedown, before any mousemove — so rightButtonDragged always reads
+      // false there regardless of the eventual drag. mouseup is the one event
+      // guaranteed, on every platform, to fire only after the full gesture's
+      // movement is known (#544).
+      if (this.phase === 'idle' || this.phase === 'confirmed') return;
+      if (this.cameraController.rightButtonDragged) return;
+      this.cancel();
+      return;
+    }
     if (e.button !== 0) return;
     if (this.phase !== 'dragging') return;
     const tile = this.tileUnderCursor(e);
@@ -284,12 +296,6 @@ export class PlacementController {
   private onContextMenu(e: MouseEvent): void {
     if (this.phase === 'idle' || this.phase === 'confirmed') return;
     e.preventDefault();
-    // A right-drag used purely to orbit the camera must not cancel the armed
-    // tool — only a right-button click (no meaningful movement) does. Single
-    // source of truth for the drag/click distinction lives on CameraController
-    // (RIGHT_DRAG_THRESHOLD_PX), not duplicated here (#544).
-    if (this.cameraController.rightButtonDragged) return;
-    this.cancel();
   }
 
   private onKeyDown(e: KeyboardEvent): void {

--- a/tests/unit/renderer/CameraController.test.ts
+++ b/tests/unit/renderer/CameraController.test.ts
@@ -263,6 +263,70 @@ describe('CameraController', () => {
     });
   });
 
+  describe('right-button drag/click signal (#544)', () => {
+    // Deltas below assume RIGHT_DRAG_THRESHOLD_PX = 5 (module-private in
+    // CameraController.ts, documented next to its declaration).
+    const mouseEvent = (button: number, x: number, y: number) =>
+      Object.assign(Object.create({ preventDefault: () => {} }), { button, clientX: x, clientY: y });
+    const down = (button: number, x: number, y: number) =>
+      canvas._listeners['mousedown']?.forEach((fn) => fn(mouseEvent(button, x, y) as unknown as Event));
+    const move = (x: number, y: number) =>
+      canvas._listeners['mousemove']?.forEach((fn) => fn(mouseEvent(0, x, y) as unknown as Event));
+    const up = (button: number, x: number, y: number) =>
+      canvas._listeners['mouseup']?.forEach((fn) => fn(mouseEvent(button, x, y) as unknown as Event));
+
+    it('reads false immediately after mousedown, before any movement', () => {
+      down(2, 100, 100);
+      expect(controller.rightButtonDragged).toBe(false);
+    });
+
+    it('reads true after a right-drag past the 5px threshold', () => {
+      down(2, 100, 100);
+      move(110, 100); // 10px delta, past threshold
+      up(2, 110, 100);
+      expect(controller.rightButtonDragged).toBe(true);
+    });
+
+    it('reads false after a right-click with no mousemove at all', () => {
+      down(2, 100, 100);
+      up(2, 100, 100);
+      expect(controller.rightButtonDragged).toBe(false);
+    });
+
+    it('reads false after movement below the threshold', () => {
+      down(2, 100, 100);
+      move(101, 100); // 1px delta, below threshold
+      up(2, 101, 100);
+      expect(controller.rightButtonDragged).toBe(false);
+    });
+
+    it('reads true for peak displacement even when the pointer returns to the press position', () => {
+      down(2, 100, 100);
+      move(110, 100); // 10px out, past threshold
+      move(100, 100); // back to the exact press position
+      up(2, 100, 100);
+      expect(controller.rightButtonDragged).toBe(true);
+    });
+
+    it('resets to false on a fresh right-button mousedown, before any subsequent move', () => {
+      down(2, 100, 100);
+      move(110, 100);
+      up(2, 110, 100);
+      expect(controller.rightButtonDragged).toBe(true);
+
+      down(2, 200, 200); // brand new gesture
+      expect(controller.rightButtonDragged).toBe(false);
+    });
+
+    it('never sets true for a left-button drag', () => {
+      down(0, 100, 100);
+      move(110, 100); // 10px, would be past threshold if this were tracked
+      expect(controller.rightButtonDragged).toBe(false);
+      up(0, 110, 100);
+      expect(controller.rightButtonDragged).toBe(false);
+    });
+  });
+
   describe('setPanLeash (#458 T6.1/D13)', () => {
     // A camera with zero X offset from its target (directly "north" of it,
     // not straight overhead — straight-down lookAt is a gimbal-lock edge

--- a/tests/unit/ui/PlacementController.guided.test.ts
+++ b/tests/unit/ui/PlacementController.guided.test.ts
@@ -244,6 +244,10 @@ describe('cancel via right-click vs right-drag (#544)', () => {
     const selectionBefore = controller.selection;
 
     cameraController.rightButtonDragged = true;
+    // Real gesture order: mousedown(2) -> mouseup(2) -> contextmenu. With
+    // rightButtonDragged true, onMouseUp's button-2 branch must skip cancel (#544).
+    canvas.dispatchEvent(new MouseEvent('mousedown', { button: 2, clientX: 1, clientY: 1, bubbles: true }));
+    canvas.dispatchEvent(new MouseEvent('mouseup', { button: 2, clientX: 1, clientY: 1, bubbles: true }));
     const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
     const preventDefault = vi.spyOn(event, 'preventDefault');
     canvas.dispatchEvent(event);
@@ -262,13 +266,23 @@ describe('cancel via right-click vs right-drag (#544)', () => {
     controller.setCancelHandler(onCancel);
 
     cameraController.rightButtonDragged = false;
+    // Real gesture order: mousedown(2) -> mouseup(2) -> contextmenu. The
+    // cancel decision now lives in onMouseUp for button 2 (#544), so the
+    // mouseup must be dispatched for the cancellation to fire.
+    canvas.dispatchEvent(new MouseEvent('mousedown', { button: 2, clientX: 1, clientY: 1, bubbles: true }));
+    canvas.dispatchEvent(new MouseEvent('mouseup', { button: 2, clientX: 1, clientY: 1, bubbles: true }));
     const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
     const preventDefault = vi.spyOn(event, 'preventDefault');
     canvas.dispatchEvent(event);
 
     expect(controller.isArmed).toBe(false);
     expect(onCancel).toHaveBeenCalledTimes(1);
-    expect(preventDefault).toHaveBeenCalled();
+    // The mouseup already cancelled and disarmed the tool, so by the time
+    // contextmenu arrives the controller is idle — same as the "idle" no-op
+    // case below, onContextMenu's early-return means it never reaches
+    // preventDefault here. Suppressing the native menu is no longer this
+    // handler's job for a gesture that already resolved at mouseup.
+    expect(preventDefault).not.toHaveBeenCalled();
   });
 
   it('Escape still cancels an armed tool regardless of rightButtonDragged', () => {

--- a/tests/unit/ui/PlacementController.guided.test.ts
+++ b/tests/unit/ui/PlacementController.guided.test.ts
@@ -31,8 +31,13 @@ vi.mock('../../../src/ui/scene/ScenePicking.js', () => ({
 let canvas: HTMLCanvasElement;
 let controller: PlacementController;
 
-/** Minimal CameraController surface — arm/disarm only calls setArmedRemap. */
-const cameraController = { setArmedRemap: vi.fn() };
+/**
+ * Minimal CameraController surface — arm/disarm only calls setArmedRemap.
+ * `rightButtonDragged` backs the #544 right-drag-vs-right-click cancel guard;
+ * tests flip it directly rather than simulating real mouse gestures, mirroring
+ * how `setArmedRemap` is already a bare spy rather than a real remap.
+ */
+const cameraController = { setArmedRemap: vi.fn(), rightButtonDragged: false };
 
 function press(x: number, z: number): void {
   tileUnderCursor = { x, z };
@@ -52,6 +57,7 @@ function hover(x: number, z: number): void {
 beforeEach(() => {
   setPickerRegion(null);
   tileUnderCursor = null;
+  cameraController.rightButtonDragged = false;
   canvas = document.createElement('canvas');
   document.body.appendChild(canvas);
   controller = new PlacementController(
@@ -218,6 +224,77 @@ describe('the pre-filled selection a panel opens with', () => {
   it('is left alone when nothing is guiding the placement', () => {
     controller.arm({ shape: 'point', initialSelection: { x: 16, z: 16 } });
     expect(controller.selection).toEqual({ x1: 16, z1: 16, x2: 16, z2: 16 });
+  });
+});
+
+describe('cancel via right-click vs right-drag (#544)', () => {
+  function contextmenu(): MouseEvent {
+    const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    canvas.dispatchEvent(event);
+    return event;
+  }
+
+  it('a right-drag that orbited the camera leaves an armed tool untouched', () => {
+    setPickerRegion(EXACT);
+    controller.arm({ shape: 'rect' });
+    press(25, 25);
+    const onCancel = vi.fn();
+    controller.setCancelHandler(onCancel);
+    const phaseBefore = controller.currentPhase;
+    const selectionBefore = controller.selection;
+
+    cameraController.rightButtonDragged = true;
+    const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    const preventDefault = vi.spyOn(event, 'preventDefault');
+    canvas.dispatchEvent(event);
+
+    expect(controller.isArmed).toBe(true);
+    expect(controller.currentPhase).toBe(phaseBefore);
+    expect(controller.selection).toEqual(selectionBefore);
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it('a right-click with no camera movement still cancels the armed tool', () => {
+    setPickerRegion(EXACT);
+    controller.arm({ shape: 'rect' });
+    const onCancel = vi.fn();
+    controller.setCancelHandler(onCancel);
+
+    cameraController.rightButtonDragged = false;
+    const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    const preventDefault = vi.spyOn(event, 'preventDefault');
+    canvas.dispatchEvent(event);
+
+    expect(controller.isArmed).toBe(false);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it('Escape still cancels an armed tool regardless of rightButtonDragged', () => {
+    setPickerRegion(EXACT);
+    controller.arm({ shape: 'rect' });
+    const onCancel = vi.fn();
+    controller.setCancelHandler(onCancel);
+
+    // Set true to prove Escape's path never even consults it — a regression
+    // lock on the unchanged path, not a new behavior.
+    cameraController.rightButtonDragged = true;
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    expect(controller.isArmed).toBe(false);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('a contextmenu while idle is a no-op regardless of rightButtonDragged', () => {
+    const onCancel = vi.fn();
+    controller.setCancelHandler(onCancel);
+    cameraController.rightButtonDragged = true;
+
+    contextmenu();
+
+    expect(controller.currentPhase).toBe('idle');
+    expect(onCancel).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/ui/PlacementController.guided.test.ts
+++ b/tests/unit/ui/PlacementController.guided.test.ts
@@ -244,13 +244,17 @@ describe('cancel via right-click vs right-drag (#544)', () => {
     const selectionBefore = controller.selection;
 
     cameraController.rightButtonDragged = true;
-    // Real gesture order: mousedown(2) -> mouseup(2) -> contextmenu. With
-    // rightButtonDragged true, onMouseUp's button-2 branch must skip cancel (#544).
+    // Real (measured) gesture order: mousedown(2) -> contextmenu -> mousemove(s)
+    // -> mouseup(2). contextmenu fires immediately after mousedown, before any
+    // movement, so the tool is still armed when it arrives and preventDefault()
+    // is called. mouseup arrives last, once rightButtonDragged is already true,
+    // so onMouseUp's button-2 branch skips cancel (#544).
     canvas.dispatchEvent(new MouseEvent('mousedown', { button: 2, clientX: 1, clientY: 1, bubbles: true }));
-    canvas.dispatchEvent(new MouseEvent('mouseup', { button: 2, clientX: 1, clientY: 1, bubbles: true }));
     const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
     const preventDefault = vi.spyOn(event, 'preventDefault');
     canvas.dispatchEvent(event);
+    canvas.dispatchEvent(new MouseEvent('mousemove', { clientX: 5, clientY: 5, bubbles: true }));
+    canvas.dispatchEvent(new MouseEvent('mouseup', { button: 2, clientX: 5, clientY: 5, bubbles: true }));
 
     expect(controller.isArmed).toBe(true);
     expect(controller.currentPhase).toBe(phaseBefore);
@@ -266,23 +270,27 @@ describe('cancel via right-click vs right-drag (#544)', () => {
     controller.setCancelHandler(onCancel);
 
     cameraController.rightButtonDragged = false;
-    // Real gesture order: mousedown(2) -> mouseup(2) -> contextmenu. The
-    // cancel decision now lives in onMouseUp for button 2 (#544), so the
-    // mouseup must be dispatched for the cancellation to fire.
+    // Real (measured) gesture order: mousedown(2) -> contextmenu -> mouseup(2).
+    // contextmenu fires right after mousedown, before mouseup, so the tool is
+    // still armed at that point — onContextMenu's idle/confirmed early-return
+    // does NOT trigger, and preventDefault() IS called. The cancel decision
+    // itself still lives in onMouseUp for button 2 (#544): mouseup arrives
+    // last, rightButtonDragged is false, so onMouseUp's button-2 branch calls
+    // cancel() and the tool ends up disarmed anyway — just via mouseup, not
+    // via contextmenu.
     canvas.dispatchEvent(new MouseEvent('mousedown', { button: 2, clientX: 1, clientY: 1, bubbles: true }));
-    canvas.dispatchEvent(new MouseEvent('mouseup', { button: 2, clientX: 1, clientY: 1, bubbles: true }));
     const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
     const preventDefault = vi.spyOn(event, 'preventDefault');
     canvas.dispatchEvent(event);
+    canvas.dispatchEvent(new MouseEvent('mouseup', { button: 2, clientX: 1, clientY: 1, bubbles: true }));
 
     expect(controller.isArmed).toBe(false);
     expect(onCancel).toHaveBeenCalledTimes(1);
-    // The mouseup already cancelled and disarmed the tool, so by the time
-    // contextmenu arrives the controller is idle — same as the "idle" no-op
-    // case below, onContextMenu's early-return means it never reaches
-    // preventDefault here. Suppressing the native menu is no longer this
-    // handler's job for a gesture that already resolved at mouseup.
-    expect(preventDefault).not.toHaveBeenCalled();
+    // The tool was still armed when contextmenu fired (mouseup hasn't run
+    // yet), so onContextMenu's early-return did not trigger and it called
+    // preventDefault() on its way through — the cancellation itself happens
+    // afterward, at mouseup.
+    expect(preventDefault).toHaveBeenCalled();
   });
 
   it('Escape still cancels an armed tool regardless of rightButtonDragged', () => {


### PR DESCRIPTION
Closes #544

## Summary

While a scene placement tool is armed (ramp, building, drill grid, single hole, survey target), the right mouse button is remapped to camera orbit so the player can look around before committing a placement. The browser's `contextmenu` event — which fires on a right-button gesture — was unconditionally cancelling the armed tool, including at the end of a pure orbit drag. This made the armed-remap orbit feature unusable, and broke the tutorial's "build ramp" step.

## Fix

- `src/renderer/CameraController.ts` — tracks whether the current/just-finished right-button gesture moved past a new named threshold, `RIGHT_DRAG_THRESHOLD_PX` (5px, matching `ScenePicking`'s existing `CLICK_MOVE_THRESHOLD_PX` for the analogous left-button case). Exposes this via a `rightButtonDragged` getter — the single source of truth for "was this a drag, not a click." Movement is tracked as peak displacement from the press position (a drag that returns exactly to its start point before release still counts as a drag), latched until the next right-button `mousedown`.
- `src/ui/scene/PlacementController.ts` — the cancel decision moved from `onContextMenu` to a new `e.button === 2` branch in `onMouseUp`, and reads `cameraController.rightButtonDragged` there. `onContextMenu` still calls `e.preventDefault()` unconditionally (native menu stays suppressed in both the drag and click case) but no longer decides cancellation itself.

**Why the decision moved to `mouseup`, not `contextmenu`:** the original design (matching the issue's literal wording) put the check in `onContextMenu`. Browser-driven verification (interaction-mode scenario, Puppeteer/CDP) found that on this platform's Chromium, `contextmenu` fires immediately after `mousedown` — before any `mousemove` — so the drag signal was always stale at that point and the fix silently didn't work. `mouseup` is the one event guaranteed to fire only after a gesture's full movement is known, on every platform/event ordering, so the decision now lives there instead. `PlacementController` still does no press-position tracking of its own — it remains a pure consumer of `CameraController`'s one getter.

No seventh placement phase was added; `PlacementPhase` stays the six documented values.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run; none are material to gameplay/economy/player-facing defaults, so no follow-up `decision-review` issue was filed.

- **What was open:** the issue's own file-level instructions were self-contradictory — it told `PlacementController.ts` to "record right-button press position on mousedown; compare it at contextmenu/mouseup time" while telling `CameraController.ts` to be the single place the threshold lives, "instead of being re-derived in the UI layer."
  **Chosen:** `PlacementController` does no press-position tracking of its own; it only reads `cameraController.rightButtonDragged`.
  **Why:** matches the issue's explicit design goal (threshold lives in ONE place) and the file's own header convention (coordinates with `CameraController`'s listeners rather than duplicating them).
  **If reversed:** move the tracking fields from `CameraController.ts` into `PlacementController.ts`'s own mousedown handler.

- **What was open:** where the `RIGHT_DRAG_THRESHOLD_PX` constant should live — the general convention centralizes constants in `src/core/config/`.
  **Chosen:** declared locally in `CameraController.ts`, alongside its other tuning constants (`ORBIT_SPEED`, `PAN_SPEED_FACTOR`, etc.), reusing the value `5` already established by `ScenePicking.ts`'s `CLICK_MOVE_THRESHOLD_PX` for the analogous left-button case.
  **Why:** `src/core/` has no DOM/pointer dependency to host a pixel-space constant; `CameraController.ts` already keeps its own local tuning constants rather than importing from `src/core/config/`.
  **If reversed:** change the single `const RIGHT_DRAG_THRESHOLD_PX = 5;` line; no call site moves.

- **What was open:** whether "movement" should be net displacement (press vs. final release position) or peak displacement during the gesture — matters when a drag exceeds the threshold and then returns exactly to the press point before release.
  **Chosen:** peak displacement, latched once past the threshold, never un-latched until the next mousedown.
  **Why:** the issue's stated intent is that a gesture that moved the camera leaves the tool untouched — the camera did move even if the pointer ends up back at the press pixel, so treating it as a click would contradict that intent.
  **If reversed:** compute `Math.hypot` once at mouseup only, instead of latching on every mousemove.

## Verification

- **static** (`npm run typecheck`): PASS
- **logic** (`npm run test`): PASS — 302 test files, 8759 tests
- **scenario**, command mode (`npm run scenarios`): PASS — 127/127
- **scenario**, interaction mode (`building-ramp-visual`, `role: 'player'` right-drag orbit beat): PASS — harness completed all steps, `expect.equals.cash` held at both checkpoints
- **visual**: PASS — screenshots inspected directly. Tile-select UI/param strip survives the orbit gesture, camera framing visibly differs before/after the drag (pixel-diffed), no native browser context menu appears, ramp placement completes with expected cash deduction

Code review: 5 parallel specialist reviewers (security, quality, i18n, duplication, semantic) — all PASS after two loop-back iterations (one fixing a real cross-platform event-ordering bug the first design missed, caught only by browser-driven verification; one fixing stale comments left over from that redesign).

READY TO MERGE