### PR TITLE
fix: Resolve #545 — defer blast report modal by real-time delay

### DIFF
--- a/.claude/rules/scenario-defs.md
+++ b/.claude/rules/scenario-defs.md
@@ -63,4 +63,6 @@ A step's `command` or clicks prove only that nothing threw, not that the game ac
 
 `set`/`clickLabel`/`awaitUsable`/`zoomOut`/`focusTile`/`clickEntity`/`clickIfPresent`/`resolveEventIfPending` were ported from the playability harness (issue #479) to close gaps in the click vocabulary — before them, some player steps had no click-equivalent at all and stayed console commands.
 
+`waitForSelector` resolves on DOM presence, not CSS visibility (Puppeteer's default `visible: false`) — an element that stays mounted with only its `display` toggled resolves the wait immediately, before the toggle happens (#545). To capture a screenshot after a *visibility* change (a modal that arms before it opens, a panel that shows/hides an already-mounted node), use an explicit real-time `wait` timed to the known delay, or `awaitUsable` if the element's usability is what's being probed.
+
 Adding a scenario for a feature is how that feature gets end-to-end coverage without a unit test per interaction. Runner flags, batch mode, and output layout: `dev-visual-testing` skill. Scenario inventory: `dev-testing-strategy` skill.

--- a/.claude/skills/dev-coding-conventions/SKILL.md
+++ b/.claude/skills/dev-coding-conventions/SKILL.md
@@ -67,6 +67,7 @@ Physics/rendering can use try/catch for unexpected errors. Never let game crash 
 - Marching cubes recalculation localized — only recompute chunks near blast
 - Fragment count capped per blast (max 2000) to avoid physics overload
 - Event system timers use delta-time accumulation, not setTimeout
+- A UI element that must delay by real wall-clock time (not simulation ticks — e.g. letting an animation play before a modal opens) takes its clock as an injectable constructor param defaulting to `performance.now`: `constructor(..., private readonly now: () => number = () => performance.now())`. Tests inject a fake clock instead of waiting out the real delay; production gets the real one for free. See `BlastReportModal` (#545).
 - Voxel grid operations use spatial indexing where beneficial
 
 ## Centralized Configuration

--- a/.github/skills/dev-coding-conventions/SKILL.md
+++ b/.github/skills/dev-coding-conventions/SKILL.md
@@ -67,6 +67,7 @@ Physics/rendering can use try/catch for unexpected errors. Never let game crash 
 - Marching cubes recalculation localized — only recompute chunks near blast
 - Fragment count capped per blast (max 2000) to avoid physics overload
 - Event system timers use delta-time accumulation, not setTimeout
+- A UI element that must delay by real wall-clock time (not simulation ticks — e.g. letting an animation play before a modal opens) takes its clock as an injectable constructor param defaulting to `performance.now`: `constructor(..., private readonly now: () => number = () => performance.now())`. Tests inject a fake clock instead of waiting out the real delay; production gets the real one for free. See `BlastReportModal` (#545).
 - Voxel grid operations use spatial indexing where beneficial
 
 ## Centralized Configuration

--- a/.opencode/skills/dev-coding-conventions/SKILL.md
+++ b/.opencode/skills/dev-coding-conventions/SKILL.md
@@ -67,6 +67,7 @@ Physics/rendering can use try/catch for unexpected errors. Never let game crash 
 - Marching cubes recalculation localized — only recompute chunks near blast
 - Fragment count capped per blast (max 2000) to avoid physics overload
 - Event system timers use delta-time accumulation, not setTimeout
+- A UI element that must delay by real wall-clock time (not simulation ticks — e.g. letting an animation play before a modal opens) takes its clock as an injectable constructor param defaulting to `performance.now`: `constructor(..., private readonly now: () => number = () => performance.now())`. Tests inject a fake clock instead of waiting out the real delay; production gets the real one for free. See `BlastReportModal` (#545).
 - Voxel grid operations use spatial indexing where beneficial
 
 ## Centralized Configuration

--- a/scripts/scenario-defs/blast-basic.json
+++ b/scripts/scenario-defs/blast-basic.json
@@ -94,7 +94,7 @@
     },
     {
       "command": "blast",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "clickSelector",

--- a/scripts/scenario-defs/blast-execution-effects.json
+++ b/scripts/scenario-defs/blast-execution-effects.json
@@ -98,7 +98,7 @@
     },
     {
       "command": "blast",
-      "timeout": 20,
+      "timeout": 30,
       "interaction": [
         {
           "type": "clickSelector",

--- a/scripts/scenario-defs/blast-execution-visual.json
+++ b/scripts/scenario-defs/blast-execution-visual.json
@@ -110,7 +110,7 @@
     },
     {
       "command": "blast",
-      "timeout": 20,
+      "timeout": 30,
       "frames": 6,
       "interval": 50,
       "interaction": [
@@ -258,7 +258,7 @@
     },
     {
       "command": "blast",
-      "timeout": 20,
+      "timeout": 30,
       "frames": 6,
       "interval": 50,
       "interaction": [
@@ -451,7 +451,7 @@
     },
     {
       "command": "blast",
-      "timeout": 20,
+      "timeout": 30,
       "frames": 6,
       "interval": 50,
       "interaction": [

--- a/scripts/scenario-defs/blast-report-metrics.json
+++ b/scripts/scenario-defs/blast-report-metrics.json
@@ -98,7 +98,7 @@
     },
     {
       "command": "blast",
-      "timeout": 20,
+      "timeout": 30,
       "interaction": [
         {
           "type": "clickSelector",

--- a/scripts/scenario-defs/blast-report-visual.json
+++ b/scripts/scenario-defs/blast-report-visual.json
@@ -98,7 +98,7 @@
     },
     {
       "command": "blast",
-      "timeout": 15,
+      "timeout": 30,
       "frames": 6,
       "interval": 50,
       "interaction": [
@@ -115,8 +115,18 @@
           "selector": ".bs-confirm-overlay .bs-btn-danger"
         },
         {
+          "type": "wait",
+          "durationMs": 1000
+        },
+        {
+          "type": "screenshot"
+        },
+        {
           "type": "waitForSelector",
           "selector": "[data-action=\"report-close\"]"
+        },
+        {
+          "type": "screenshot"
         },
         {
           "type": "clickSelector",

--- a/scripts/scenario-defs/blast-report-visual.json
+++ b/scripts/scenario-defs/blast-report-visual.json
@@ -122,11 +122,15 @@
           "type": "screenshot"
         },
         {
-          "type": "waitForSelector",
-          "selector": "[data-action=\"report-close\"]"
+          "type": "wait",
+          "durationMs": 2500
         },
         {
           "type": "screenshot"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": "[data-action=\"report-close\"]"
         },
         {
           "type": "clickSelector",

--- a/scripts/scenario-defs/blast-visual-full.json
+++ b/scripts/scenario-defs/blast-visual-full.json
@@ -475,7 +475,7 @@
     },
     {
       "command": "blast",
-      "timeout": 20,
+      "timeout": 30,
       "frames": 6,
       "interval": 50,
       "interaction": [

--- a/scripts/scenario-defs/blast-voxel-fragmentation-visual.json
+++ b/scripts/scenario-defs/blast-voxel-fragmentation-visual.json
@@ -104,7 +104,7 @@
     },
     {
       "command": "blast",
-      "timeout": 20,
+      "timeout": 30,
       "frames": 6,
       "interval": 50,
       "interaction": [

--- a/scripts/scenario-defs/blast-voxel-fragmentation.json
+++ b/scripts/scenario-defs/blast-voxel-fragmentation.json
@@ -116,7 +116,7 @@
     },
     {
       "command": "blast",
-      "timeout": 20,
+      "timeout": 30,
       "interaction": [
         {
           "type": "clickSelector",

--- a/scripts/scenario-defs/building-destruction-visual.json
+++ b/scripts/scenario-defs/building-destruction-visual.json
@@ -238,7 +238,7 @@
     },
     {
       "command": "blast",
-      "timeout": 20,
+      "timeout": 30,
       "frames": 6,
       "interval": 50,
       "interaction": [

--- a/scripts/scenario-defs/core-loop-visual.json
+++ b/scripts/scenario-defs/core-loop-visual.json
@@ -250,7 +250,7 @@
     },
     {
       "command": "blast",
-      "timeout": 20,
+      "timeout": 30,
       "frames": 6,
       "interval": 50,
       "interaction": [

--- a/scripts/scenario-defs/safety-projection-visual.json
+++ b/scripts/scenario-defs/safety-projection-visual.json
@@ -354,7 +354,7 @@
     },
     {
       "command": "blast",
-      "timeout": 20,
+      "timeout": 30,
       "frames": 6,
       "interval": 50,
       "interaction": [

--- a/scripts/scenario-defs/sandbox-mode.json
+++ b/scripts/scenario-defs/sandbox-mode.json
@@ -82,7 +82,7 @@
         { "type": "waitForSelector", "selector": "[data-action=\"report-close\"]" },
         { "type": "clickSelector", "selector": "[data-action=\"report-close\"]" }
       ],
-      "timeout": 15,
+      "timeout": 30,
       "expect": {
         "equals": {
           "holeCount": 0,

--- a/scripts/scenario-defs/save-load-visual.json
+++ b/scripts/scenario-defs/save-load-visual.json
@@ -231,7 +231,7 @@
     {
       "command": "blast",
       "description": "Blast a crater into the live scene after slot 1's save, so the load step below must actually regenerate terrain (not just leave the cratered grid on screen) to prove itself.",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "clickSelector",

--- a/scripts/scenario-defs/site-expansion.json
+++ b/scripts/scenario-defs/site-expansion.json
@@ -177,7 +177,7 @@
     {
       "command": "blast",
       "description": "A blast spanning both the original site and ground claimed during play.",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "clickSelector",

--- a/src/ui/UIManager.ts
+++ b/src/ui/UIManager.ts
@@ -314,6 +314,9 @@ export class UIManager {
    * transition, sandbox start) — a fresh GameState's lastBlastReport is
    * always null, so BlastReportModal.update() never re-closes itself on its
    * own (it only ever opens on a new report; see BlastReportModal#update).
+   * reset() drops both a visible report and a pending/armed-but-not-yet-open
+   * one (#545) — a report queued right before a transition must not survive
+   * into the next level's state.
    * PreflightModal/ConfirmModal are excluded on purpose: both are
    * request/response dialogs the player just triggered, never state-derived,
    * so a level transition mid-dialog is not this bug's shape. LevelEndScreen
@@ -321,7 +324,7 @@ export class UIManager {
    * state.levelEndReason reads null, which a fresh level's state always is.
    */
   closeStaleLevelOverlays(): void {
-    if (this.blastReportModal.visible) this.blastReportModal.hide();
+    this.blastReportModal.reset();
   }
 
   /** Read-only accessor for tests (#504) — whether the BlastReportModal is currently open. */
@@ -415,7 +418,7 @@ export class UIManager {
     // so it would render on top and hide the report's own Close button
     // behind it. Re-checked every tick, so the event opens itself the moment
     // the report is closed.
-    if (this.eventModal.visible || !this.blastReportModal.visible) {
+    if (this.eventModal.visible || (!this.blastReportModal.visible && !this.blastReportModal.pending)) {
       this.eventModal.update(state);
     }
   }

--- a/src/ui/UIManager.ts
+++ b/src/ui/UIManager.ts
@@ -327,6 +327,9 @@ export class UIManager {
   /** Read-only accessor for tests (#504) — whether the BlastReportModal is currently open. */
   get blastReportModalVisible(): boolean { return this.blastReportModal.visible; }
 
+  /** Read-only accessor for tests (#545) — whether a report is waiting out its open delay. */
+  get blastReportModalPending(): boolean { return this.blastReportModal.pending; }
+
   /** Re-render all owned panels' locale-dependent text after a language change. */
   refreshLocale(): void {
     this.topBar.refreshLocale();

--- a/src/ui/panels/BlastReportModal.ts
+++ b/src/ui/panels/BlastReportModal.ts
@@ -28,6 +28,10 @@ const RATING_COLOR: Record<BlastRating, string> = {
   catastrophic: 'var(--bsx-critical-text)',
 };
 
+// TODO: implement — real-time delay between a blast report becoming
+// available and the modal actually opening (#545).
+export const BLAST_REPORT_DELAY_MS = 3000;
+
 export class BlastReportModal {
   private readonly overlay: HTMLElement;
   private readonly ratingEl: HTMLElement;
@@ -38,7 +42,15 @@ export class BlastReportModal {
   private lastShownReport: BlastReport | null = null;
   private readonly locale = new LocaleTextRegistry();
 
-  constructor(container: HTMLElement) {
+  // TODO: implement — deferred-open state (#545). pendingReport holds a
+  // report that has arrived but not yet been shown; pendingDeadlineMs is
+  // the `now()` timestamp (per the injected clock) at which it should open.
+  private pendingReport: BlastReport | null = null;
+  private pendingDeadlineMs: number | null = null;
+
+  constructor(container: HTMLElement, private readonly now: () => number = () => performance.now()) {
+    // Used by the deferred-open delay logic landing with the implementer (#545).
+    void this.now;
     this.overlay = el('div', { className: 'bs-confirm-overlay' });
     this.overlay.style.display = 'none';
 
@@ -86,6 +98,18 @@ export class BlastReportModal {
 
   hide(): void { this.open = false; this.overlay.style.display = 'none'; }
   get visible(): boolean { return this.open; }
+
+  /** Whether a report has arrived but is still waiting out its open delay (#545). */
+  get pending(): boolean { return this.pendingReport !== null; }
+
+  /** Discard any in-flight deferred report and close the modal (#545). */
+  // TODO: implement — real logic lands with the implementer.
+  reset(): void {
+    this.hide();
+    this.pendingReport = null;
+    this.pendingDeadlineMs = null;
+    void this.pendingDeadlineMs;
+  }
 
   update(state: GameState): void {
     const report = state.lastBlastReport;

--- a/src/ui/panels/BlastReportModal.ts
+++ b/src/ui/panels/BlastReportModal.ts
@@ -28,8 +28,9 @@ const RATING_COLOR: Record<BlastRating, string> = {
   catastrophic: 'var(--bsx-critical-text)',
 };
 
-// TODO: implement — real-time delay between a blast report becoming
-// available and the modal actually opening (#545).
+// Real-time delay between a blast report becoming available and the modal
+// actually opening (#545), so the fragment-collapse animation plays in the
+// clear instead of being instantly covered.
 export const BLAST_REPORT_DELAY_MS = 3000;
 
 export class BlastReportModal {
@@ -42,15 +43,13 @@ export class BlastReportModal {
   private lastShownReport: BlastReport | null = null;
   private readonly locale = new LocaleTextRegistry();
 
-  // TODO: implement — deferred-open state (#545). pendingReport holds a
-  // report that has arrived but not yet been shown; pendingDeadlineMs is
-  // the `now()` timestamp (per the injected clock) at which it should open.
+  // Deferred-open state (#545). pendingReport holds a report that has
+  // arrived but not yet been shown; pendingDeadlineMs is the `now()`
+  // timestamp (per the injected clock) at which it should open.
   private pendingReport: BlastReport | null = null;
   private pendingDeadlineMs: number | null = null;
 
   constructor(container: HTMLElement, private readonly now: () => number = () => performance.now()) {
-    // Used by the deferred-open delay logic landing with the implementer (#545).
-    void this.now;
     this.overlay = el('div', { className: 'bs-confirm-overlay' });
     this.overlay.style.display = 'none';
 
@@ -103,12 +102,10 @@ export class BlastReportModal {
   get pending(): boolean { return this.pendingReport !== null; }
 
   /** Discard any in-flight deferred report and close the modal (#545). */
-  // TODO: implement — real logic lands with the implementer.
   reset(): void {
-    this.hide();
     this.pendingReport = null;
     this.pendingDeadlineMs = null;
-    void this.pendingDeadlineMs;
+    this.hide();
   }
 
   update(state: GameState): void {
@@ -120,11 +117,25 @@ export class BlastReportModal {
     // tick-equality check silently drops the second report forever (found
     // converting vibration-budget.json to real clicks, issue #479 — a
     // player who fires twice in a row would never see the second one).
-    if (!report || report === this.lastShownReport) return;
-    this.lastShownReport = report;
-    this.render(report, state);
-    this.open = true;
-    this.overlay.style.display = '';
+    //
+    // Arming replaces any not-yet-opened pending report outright (#545): a
+    // second blast inside the delay window discards the first pending
+    // report and starts its own full-length real-time window from its own
+    // arrival time. The first report is never shown.
+    if (report && report !== this.lastShownReport && report !== this.pendingReport) {
+      this.pendingReport = report;
+      this.pendingDeadlineMs = this.now() + BLAST_REPORT_DELAY_MS;
+    }
+
+    if (this.pendingReport !== null && this.pendingDeadlineMs !== null && this.now() >= this.pendingDeadlineMs) {
+      const toShow = this.pendingReport;
+      this.lastShownReport = toShow;
+      this.pendingReport = null;
+      this.pendingDeadlineMs = null;
+      this.render(toShow, state);
+      this.open = true;
+      this.overlay.style.display = '';
+    }
   }
 
   refreshLocale(): void { this.locale.refresh(); }

--- a/src/ui/panels/BlastReportModal.ts
+++ b/src/ui/panels/BlastReportModal.ts
@@ -1,10 +1,12 @@
 // BlastSimulator2026 — Blast Report Modal (redesign P4/§5.C)
-// Shows state.lastBlastReport (built in blastCommand, task P4/#17) right
-// after a blast resolves. Visibility is derived from state, not manually
-// toggled — the same pattern EventModal already uses for its own pendingEvent:
-// a report whose tick differs from the last one shown means a new blast just
-// happened, so the modal opens itself on the very next update() tick, right
-// after PreflightModal's DETONATE dispatches `blast` and closes itself.
+// Shows state.lastBlastReport (built in blastCommand, task P4/#17) once a
+// blast resolves. Visibility is derived from state, not manually toggled —
+// the same pattern EventModal already uses for its own pendingEvent: a
+// report whose identity differs from the last one shown means a new blast
+// just happened, right after PreflightModal's DETONATE dispatches `blast`
+// and closes itself. Rather than opening on that very next update() tick,
+// the modal arms and waits out BLAST_REPORT_DELAY_MS before actually
+// showing itself (#545), so the fragment-collapse animation plays first.
 //
 // Deviation from the design mock: its second footer button, "SEND HAULERS",
 // has no real backing command — only per-vehicle `vehicle haul <id>` exists,

--- a/tests/unit/ui/UIManager.test.ts
+++ b/tests/unit/ui/UIManager.test.ts
@@ -390,10 +390,19 @@ describe('UIManager — closeStaleLevelOverlays (#504)', () => {
     // the NavGrid overlay tests above do, since UIManager.update() also
     // drives the minimap.
     vi.spyOn(MiniMap.prototype, 'update').mockImplementation(() => {});
+    // Blast reports arm on first sight and only open once real time (via
+    // performance.now()) advances past BLAST_REPORT_DELAY_MS (#545) — mock
+    // the clock so this test can reach a genuinely visible modal before
+    // testing that closeStaleLevelOverlays() closes it.
+    const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(0);
     uiManager = new UIManager(container);
-    // Simulate the first site's blast report opening the modal, the way a
-    // real `blast` command's uiManager.update(state) call does.
-    uiManager.update(makeStateWithReport(10));
+    // Simulate the first site's blast report arriving, the way a real
+    // `blast` command's uiManager.update(state) call does.
+    const state = makeStateWithReport(10);
+    uiManager.update(state); // arms the report (pending)
+
+    nowSpy.mockReturnValue(BLAST_REPORT_DELAY_MS);
+    uiManager.update(state); // delay elapsed — report opens
     expect(uiManager.blastReportModalVisible).toBe(true);
 
     uiManager.closeStaleLevelOverlays();

--- a/tests/unit/ui/UIManager.test.ts
+++ b/tests/unit/ui/UIManager.test.ts
@@ -17,6 +17,10 @@ import { VoxelGrid } from '../../../src/core/world/VoxelGrid.js';
 import { t, setLocale, getLocale } from '../../../src/core/i18n/I18n.js';
 import type { BlastReport } from '../../../src/core/mining/BlastExecution.js';
 import type { Vehicle } from '../../../src/core/entities/Vehicle.js';
+import { BLAST_REPORT_DELAY_MS } from '../../../src/ui/panels/BlastReportModal.js';
+import { setupEvents } from '../../../src/core/events/index.js';
+
+setupEvents();
 
 function makeState() {
   const state = createGame({ seed: 1, mineType: 'desert' });
@@ -404,6 +408,99 @@ describe('UIManager — closeStaleLevelOverlays (#504)', () => {
     expect(() => uiManager.closeStaleLevelOverlays()).not.toThrow();
 
     expect(uiManager.blastReportModalVisible).toBe(false);
+  });
+
+  it('clears a pending (not yet opened) report too, and a fresh level state stays closed/non-pending as time advances (#545)', () => {
+    const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(0);
+    vi.spyOn(MiniMap.prototype, 'update').mockImplementation(() => {});
+    uiManager = new UIManager(container);
+    // Report has arrived but is still waiting out its real-time open delay —
+    // never actually opened the modal.
+    uiManager.update(makeStateWithReport(10));
+    expect(uiManager.blastReportModalPending).toBe(true);
+    expect(uiManager.blastReportModalVisible).toBe(false);
+
+    uiManager.closeStaleLevelOverlays();
+
+    expect(uiManager.blastReportModalPending).toBe(false);
+
+    // Level-transition semantics: a genuinely fresh GameState, whose
+    // lastBlastReport starts null (mirrors the real enteredNewLevel guard) —
+    // not a reuse of the same stale state object.
+    const freshState = createGame({ seed: 1, mineType: 'desert' });
+    nowSpy.mockReturnValue(BLAST_REPORT_DELAY_MS * 10);
+    uiManager.update(freshState);
+
+    expect(uiManager.blastReportModalPending).toBe(false);
+    expect(uiManager.blastReportModalVisible).toBe(false);
+  });
+});
+
+// ── Blast report deferral holds off the event modal (#545) ─────────────────
+//
+// Both BlastReportModal and EventModal are auto-triggered off GameState, and
+// eventModal is deferred while blastReportModal.visible is true so a
+// same-tick scripted follow-up event can't render on top of the report and
+// hide its Close button. The deferral has to key off "still on screen or
+// about to be" (pending OR visible), not just visible — otherwise a report
+// that has arrived but not yet opened (still waiting out its real-time
+// delay) lets the event modal open underneath it.
+
+function makeStateWithReportAndEvent(tick: number): GameState {
+  const state = createGame({ seed: 1, mineType: 'desert' });
+  state.lastBlastReport = makeBlastReport(tick);
+  state.events.pendingEvent = { eventId: 'tutorial_synergy_consultant', firedAtTick: tick };
+  return state;
+}
+
+describe('UIManager — blast report deferral holds the event modal (#545)', () => {
+  let container: HTMLDivElement;
+  let uiManager: UIManager;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    vi.spyOn(MiniMap.prototype, 'update').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    uiManager?.dispose();
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it('event modal stays closed while the report is pending (arrived but not yet opened)', () => {
+    vi.spyOn(performance, 'now').mockReturnValue(0);
+    uiManager = new UIManager(container);
+    const state = makeStateWithReportAndEvent(10);
+
+    uiManager.update(state);
+
+    expect(uiManager.blastReportModalPending).toBe(true);
+    expect(uiManager.blastReportModalVisible).toBe(false);
+    const eventDialog = container.querySelector('#bs-event-dialog') as HTMLElement;
+    expect(eventDialog.style.display).toBe('none');
+  });
+
+  it('event modal opens once the report is closed', () => {
+    const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(0);
+    uiManager = new UIManager(container);
+    const state = makeStateWithReportAndEvent(10);
+    uiManager.update(state); // arms the report
+
+    nowSpy.mockReturnValue(BLAST_REPORT_DELAY_MS);
+    uiManager.update(state); // report opens
+
+    expect(uiManager.blastReportModalVisible).toBe(true);
+    let eventDialog = container.querySelector('#bs-event-dialog') as HTMLElement;
+    expect(eventDialog.style.display).toBe('none');
+
+    (container.querySelector('[data-action="report-close"]') as HTMLButtonElement).click();
+    uiManager.update(state);
+
+    expect(uiManager.blastReportModalVisible).toBe(false);
+    eventDialog = container.querySelector('#bs-event-dialog') as HTMLElement;
+    expect(eventDialog.style.display).not.toBe('none');
   });
 });
 

--- a/tests/unit/ui/panels/BlastReportModal.test.ts
+++ b/tests/unit/ui/panels/BlastReportModal.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach } from 'vitest';
-import { BlastReportModal } from '../../../../src/ui/panels/BlastReportModal.js';
+import { BlastReportModal, BLAST_REPORT_DELAY_MS } from '../../../../src/ui/panels/BlastReportModal.js';
 import { createGame } from '../../../../src/core/state/GameState.js';
 import { resetHoleIds } from '../../../../src/core/mining/DrillPlan.js';
 import type { GameState } from '../../../../src/core/state/GameState.js';
@@ -10,11 +10,17 @@ function makeState(): GameState {
   return createGame({ seed: 1, mineType: 'desert' });
 }
 
-function makeModal(): { modal: BlastReportModal; container: HTMLElement } {
+/**
+ * Injects a fake, manually-advanced clock (#545) — `setNow()` drives the same
+ * `now` closure variable the modal's constructor was handed, so tests control
+ * real-time delay without a real timer.
+ */
+function makeModal(): { modal: BlastReportModal; container: HTMLElement; setNow: (v: number) => void } {
   const container = document.createElement('div');
   document.body.appendChild(container);
-  const modal = new BlastReportModal(container);
-  return { modal, container };
+  let now = 0;
+  const modal = new BlastReportModal(container, () => now);
+  return { modal, container, setNow: (v: number) => { now = v; } };
 }
 
 function makeReport(overrides: Partial<BlastReport> = {}): BlastReport {
@@ -41,14 +47,41 @@ describe('BlastReportModal', () => {
     expect(modal.visible).toBe(false);
   });
 
-  it('auto-shows and renders real stats the first time a report appears', () => {
+  it('does not open on the same update() call that first observes a report (#545)', () => {
     const { modal } = makeModal();
     const state = makeState();
     state.lastBlastReport = makeReport();
 
     modal.update(state);
 
+    expect(modal.visible).toBe(false);
+    expect(modal.pending).toBe(true);
+  });
+
+  it('stays closed just before the open delay has elapsed (#545)', () => {
+    const { modal, setNow } = makeModal();
+    const state = makeState();
+    state.lastBlastReport = makeReport();
+    modal.update(state);
+
+    setNow(BLAST_REPORT_DELAY_MS - 1);
+    modal.update(state);
+
+    expect(modal.visible).toBe(false);
+    expect(modal.pending).toBe(true);
+  });
+
+  it('opens once the delay has elapsed, rendering the held report\'s real stats (#545)', () => {
+    const { modal, setNow } = makeModal();
+    const state = makeState();
+    state.lastBlastReport = makeReport();
+    modal.update(state);
+
+    setNow(BLAST_REPORT_DELAY_MS);
+    modal.update(state);
+
     expect(modal.visible).toBe(true);
+    expect(modal.pending).toBe(false);
     expect(modal.root.textContent).toContain('1842');
     expect(modal.root.textContent).toContain('610');
     expect(modal.root.textContent).toContain('47');
@@ -57,10 +90,39 @@ describe('BlastReportModal', () => {
     expect(modal.root.textContent).toContain('Good');
   });
 
+  it('a second report inside the delay window replaces the first — only the latest is ever rendered (#545)', () => {
+    const { modal, setNow } = makeModal();
+    const state = makeState();
+    const reportA = makeReport({ fragmentCount: 47, totalOreValue: 16020 });
+    state.lastBlastReport = reportA;
+    modal.update(state); // arms A at now=0
+    expect(modal.visible).toBe(false);
+    expect(modal.root.textContent).not.toContain('16,020');
+
+    setNow(1000);
+    const reportB = makeReport({ fragmentCount: 12, totalOreValue: 12345 });
+    state.lastBlastReport = reportB;
+    modal.update(state); // B replaces A well before A's own deadline (3000)
+
+    expect(modal.visible).toBe(false); // A never opened
+    expect(modal.root.textContent).not.toContain('16,020'); // A's stat never rendered
+
+    // B's own fresh full window, counted from when B was armed (now=1000).
+    setNow(1000 + BLAST_REPORT_DELAY_MS);
+    modal.update(state);
+
+    expect(modal.visible).toBe(true);
+    expect(modal.pending).toBe(false);
+    expect(modal.root.textContent).toContain('12,345');
+    expect(modal.root.textContent).not.toContain('16,020');
+  });
+
   it('Close hides the modal', () => {
-    const { modal } = makeModal();
+    const { modal, setNow } = makeModal();
     const state = makeState();
     state.lastBlastReport = makeReport();
+    modal.update(state);
+    setNow(BLAST_REPORT_DELAY_MS);
     modal.update(state);
 
     (modal.root.querySelector('[data-action="report-close"]') as HTMLButtonElement).click();
@@ -69,25 +131,35 @@ describe('BlastReportModal', () => {
   });
 
   it('does not reopen on the next tick for the same report once closed', () => {
-    const { modal } = makeModal();
+    const { modal, setNow } = makeModal();
     const state = makeState();
     state.lastBlastReport = makeReport();
     modal.update(state);
+    setNow(BLAST_REPORT_DELAY_MS);
+    modal.update(state);
     (modal.root.querySelector('[data-action="report-close"]') as HTMLButtonElement).click();
 
-    modal.update(state); // same tick, same report object
+    modal.update(state); // same report object, time unchanged
 
     expect(modal.visible).toBe(false);
   });
 
   it('opens again for a genuinely new report (different tick)', () => {
-    const { modal } = makeModal();
+    const { modal, setNow } = makeModal();
     const state = makeState();
     state.lastBlastReport = makeReport({ tick: 100 });
     modal.update(state);
+    setNow(BLAST_REPORT_DELAY_MS);
+    modal.update(state);
     (modal.root.querySelector('[data-action="report-close"]') as HTMLButtonElement).click();
 
+    setNow(BLAST_REPORT_DELAY_MS + 1);
     state.lastBlastReport = makeReport({ tick: 200 });
+    modal.update(state); // arms the new report
+
+    expect(modal.visible).toBe(false);
+
+    setNow(BLAST_REPORT_DELAY_MS + 1 + BLAST_REPORT_DELAY_MS);
     modal.update(state);
 
     expect(modal.visible).toBe(true);
@@ -101,14 +173,22 @@ describe('BlastReportModal', () => {
     // fix compares report identity instead (buildBlastReport in mining.ts
     // always returns a fresh object, so two distinct blasts are always two
     // distinct references even when their tick matches). Issue #479.
-    const { modal } = makeModal();
+    const { modal, setNow } = makeModal();
     const state = makeState();
     state.lastBlastReport = makeReport({ tick: 100, fragmentCount: 47 });
+    modal.update(state);
+    setNow(BLAST_REPORT_DELAY_MS);
     modal.update(state);
     (modal.root.querySelector('[data-action="report-close"]') as HTMLButtonElement).click();
     expect(modal.visible).toBe(false);
 
+    setNow(BLAST_REPORT_DELAY_MS + 1);
     state.lastBlastReport = makeReport({ tick: 100, fragmentCount: 12 });
+    modal.update(state); // arms the second blast's report
+
+    expect(modal.visible).toBe(false); // still waiting out its own delay
+
+    setNow(BLAST_REPORT_DELAY_MS + 1 + BLAST_REPORT_DELAY_MS);
     modal.update(state);
 
     expect(modal.visible).toBe(true);
@@ -116,7 +196,7 @@ describe('BlastReportModal', () => {
   });
 
   it('shows the ore report card with real percentage and breakdown when a survey estimate exists', () => {
-    const { modal } = makeModal();
+    const { modal, setNow } = makeModal();
     const state = makeState();
     state.lastBlastReport = makeReport();
     state.lastOreReport = {
@@ -126,6 +206,8 @@ describe('BlastReportModal', () => {
     };
 
     modal.update(state);
+    setNow(BLAST_REPORT_DELAY_MS);
+    modal.update(state);
 
     expect(modal.root.textContent).toContain('86%');
     expect(modal.root.textContent).toContain('5220 kg');
@@ -133,7 +215,7 @@ describe('BlastReportModal', () => {
   });
 
   it('omits the ore report card when there was no survey estimate to compare against', () => {
-    const { modal } = makeModal();
+    const { modal, setNow } = makeModal();
     const state = makeState();
     state.lastBlastReport = makeReport();
     state.lastOreReport = {
@@ -142,17 +224,21 @@ describe('BlastReportModal', () => {
     };
 
     modal.update(state);
+    setNow(BLAST_REPORT_DELAY_MS);
+    modal.update(state);
 
     expect(modal.root.textContent).not.toContain('Ore Report');
   });
 
   it('shows one card per destroyed building', () => {
-    const { modal } = makeModal();
+    const { modal, setNow } = makeModal();
     const state = makeState();
     state.lastBlastReport = makeReport({
       destroyedBuildings: [{ buildingId: 3, type: 'freight_warehouse', x: 5, z: 5 }],
     });
 
+    modal.update(state);
+    setNow(BLAST_REPORT_DELAY_MS);
     modal.update(state);
 
     expect(modal.root.textContent).toContain('Freight Warehouse #3');
@@ -160,18 +246,59 @@ describe('BlastReportModal', () => {
   });
 
   it('shows the oversized-fragments hint, naming the real rock_fragmenter vehicle, only when there are any', () => {
-    const { modal: modalA } = makeModal();
+    const { modal: modalA, setNow: setNowA } = makeModal();
     const stateA = makeState();
     stateA.lastBlastReport = makeReport({ oversizedFragments: 0 });
     modalA.update(stateA);
+    setNowA(BLAST_REPORT_DELAY_MS);
+    modalA.update(stateA);
     expect(modalA.root.textContent).not.toContain('too large for standard haulers');
 
-    const { modal: modalB } = makeModal();
+    const { modal: modalB, setNow: setNowB } = makeModal();
     const stateB = makeState();
     stateB.lastBlastReport = makeReport({ oversizedFragments: 6 });
     modalB.update(stateB);
+    setNowB(BLAST_REPORT_DELAY_MS);
+    modalB.update(stateB);
     expect(modalB.root.textContent).toContain('6 fragments are too large for standard haulers');
     expect(modalB.root.textContent).toContain('Rock Fragmenter');
+  });
+
+  it('reset() clears a pending report so it never opens (#545)', () => {
+    const { modal, setNow } = makeModal();
+    const state = makeState();
+    state.lastBlastReport = makeReport();
+    modal.update(state); // arms the report at now=0
+    expect(modal.pending).toBe(true);
+
+    modal.reset();
+
+    expect(modal.pending).toBe(false);
+    expect(modal.visible).toBe(false);
+
+    // Level-transition sequence: a fresh GameState (new_game/campaign/sandbox
+    // entry), whose lastBlastReport always starts null — mirrors the real
+    // enteredNewLevel guard, not a reuse of the same stale state object.
+    const freshState = makeState();
+    setNow(BLAST_REPORT_DELAY_MS * 10);
+    modal.update(freshState);
+
+    expect(modal.visible).toBe(false);
+    expect(modal.pending).toBe(false);
+  });
+
+  it('reset() also hides an already-open modal (#545)', () => {
+    const { modal, setNow } = makeModal();
+    const state = makeState();
+    state.lastBlastReport = makeReport();
+    modal.update(state);
+    setNow(BLAST_REPORT_DELAY_MS);
+    modal.update(state);
+    expect(modal.visible).toBe(true);
+
+    modal.reset();
+
+    expect(modal.visible).toBe(false);
   });
 
   it('refreshLocale() does not throw', () => {

--- a/tests/unit/ui/panels/BlastReportModal.test.ts
+++ b/tests/unit/ui/panels/BlastReportModal.test.ts
@@ -33,6 +33,18 @@ function makeReport(overrides: Partial<BlastReport> = {}): BlastReport {
   };
 }
 
+/**
+ * Arms the modal's current `state.lastBlastReport` and forces it open by
+ * running out the full delay (#545) — the arm-then-open sequence most tests
+ * need before asserting on already-open content, factored out of the ~9
+ * call sites that repeated it verbatim.
+ */
+function openReport(modal: BlastReportModal, state: GameState, setNow: (v: number) => void): void {
+  modal.update(state);
+  setNow(BLAST_REPORT_DELAY_MS);
+  modal.update(state);
+}
+
 beforeEach(() => resetHoleIds());
 
 describe('BlastReportModal', () => {
@@ -75,10 +87,8 @@ describe('BlastReportModal', () => {
     const { modal, setNow } = makeModal();
     const state = makeState();
     state.lastBlastReport = makeReport();
-    modal.update(state);
 
-    setNow(BLAST_REPORT_DELAY_MS);
-    modal.update(state);
+    openReport(modal, state, setNow);
 
     expect(modal.visible).toBe(true);
     expect(modal.pending).toBe(false);
@@ -121,9 +131,7 @@ describe('BlastReportModal', () => {
     const { modal, setNow } = makeModal();
     const state = makeState();
     state.lastBlastReport = makeReport();
-    modal.update(state);
-    setNow(BLAST_REPORT_DELAY_MS);
-    modal.update(state);
+    openReport(modal, state, setNow);
 
     (modal.root.querySelector('[data-action="report-close"]') as HTMLButtonElement).click();
 
@@ -134,9 +142,7 @@ describe('BlastReportModal', () => {
     const { modal, setNow } = makeModal();
     const state = makeState();
     state.lastBlastReport = makeReport();
-    modal.update(state);
-    setNow(BLAST_REPORT_DELAY_MS);
-    modal.update(state);
+    openReport(modal, state, setNow);
     (modal.root.querySelector('[data-action="report-close"]') as HTMLButtonElement).click();
 
     modal.update(state); // same report object, time unchanged
@@ -148,9 +154,7 @@ describe('BlastReportModal', () => {
     const { modal, setNow } = makeModal();
     const state = makeState();
     state.lastBlastReport = makeReport({ tick: 100 });
-    modal.update(state);
-    setNow(BLAST_REPORT_DELAY_MS);
-    modal.update(state);
+    openReport(modal, state, setNow);
     (modal.root.querySelector('[data-action="report-close"]') as HTMLButtonElement).click();
 
     setNow(BLAST_REPORT_DELAY_MS + 1);
@@ -176,9 +180,7 @@ describe('BlastReportModal', () => {
     const { modal, setNow } = makeModal();
     const state = makeState();
     state.lastBlastReport = makeReport({ tick: 100, fragmentCount: 47 });
-    modal.update(state);
-    setNow(BLAST_REPORT_DELAY_MS);
-    modal.update(state);
+    openReport(modal, state, setNow);
     (modal.root.querySelector('[data-action="report-close"]') as HTMLButtonElement).click();
     expect(modal.visible).toBe(false);
 
@@ -205,9 +207,7 @@ describe('BlastReportModal', () => {
       hasTreranium: false, absurdiumFraction: 0,
     };
 
-    modal.update(state);
-    setNow(BLAST_REPORT_DELAY_MS);
-    modal.update(state);
+    openReport(modal, state, setNow);
 
     expect(modal.root.textContent).toContain('86%');
     expect(modal.root.textContent).toContain('5220 kg');
@@ -223,9 +223,7 @@ describe('BlastReportModal', () => {
       hasTreranium: false, absurdiumFraction: 0,
     };
 
-    modal.update(state);
-    setNow(BLAST_REPORT_DELAY_MS);
-    modal.update(state);
+    openReport(modal, state, setNow);
 
     expect(modal.root.textContent).not.toContain('Ore Report');
   });
@@ -237,9 +235,7 @@ describe('BlastReportModal', () => {
       destroyedBuildings: [{ buildingId: 3, type: 'freight_warehouse', x: 5, z: 5 }],
     });
 
-    modal.update(state);
-    setNow(BLAST_REPORT_DELAY_MS);
-    modal.update(state);
+    openReport(modal, state, setNow);
 
     expect(modal.root.textContent).toContain('Freight Warehouse #3');
     expect(modal.root.textContent).toContain('was destroyed');
@@ -249,17 +245,13 @@ describe('BlastReportModal', () => {
     const { modal: modalA, setNow: setNowA } = makeModal();
     const stateA = makeState();
     stateA.lastBlastReport = makeReport({ oversizedFragments: 0 });
-    modalA.update(stateA);
-    setNowA(BLAST_REPORT_DELAY_MS);
-    modalA.update(stateA);
+    openReport(modalA, stateA, setNowA);
     expect(modalA.root.textContent).not.toContain('too large for standard haulers');
 
     const { modal: modalB, setNow: setNowB } = makeModal();
     const stateB = makeState();
     stateB.lastBlastReport = makeReport({ oversizedFragments: 6 });
-    modalB.update(stateB);
-    setNowB(BLAST_REPORT_DELAY_MS);
-    modalB.update(stateB);
+    openReport(modalB, stateB, setNowB);
     expect(modalB.root.textContent).toContain('6 fragments are too large for standard haulers');
     expect(modalB.root.textContent).toContain('Rock Fragmenter');
   });
@@ -291,9 +283,7 @@ describe('BlastReportModal', () => {
     const { modal, setNow } = makeModal();
     const state = makeState();
     state.lastBlastReport = makeReport();
-    modal.update(state);
-    setNow(BLAST_REPORT_DELAY_MS);
-    modal.update(state);
+    openReport(modal, state, setNow);
     expect(modal.visible).toBe(true);
 
     modal.reset();


### PR DESCRIPTION
Closes #545

## Summary

The blast report modal used to open on the very same frame the report data landed, covering the fragment-collapse animation the moment a blast fired. This holds the report for a fixed real-time delay (`BLAST_REPORT_DELAY_MS = 3000`, `src/ui/panels/BlastReportModal.ts`) before opening it, so the collapse plays in the clear first.

- `BlastReportModal` arms a `pendingReport`/`pendingDeadlineMs` pair on a fresh report instead of opening immediately; opens only once an injectable clock (`performance.now` by default) crosses the deadline. A second report inside the window fully replaces the first — the first is never shown — and starts its own fresh delay window.
- `reset()` clears both a pending and an already-open report; `UIManager.closeStaleLevelOverlays()` now calls it unconditionally so leaving a level / starting a new game / loading a save drops any pending report instead of opening it over the new site.
- `UIManager`'s event-modal deferral now checks `pending` as well as `visible`, so a scripted follow-up event fired the same tick as the blast can't sneak open during the hold and get buried once the report opens.
- Timing is driven by real time only (never `state.tickCount`/`timeScale`), matching the same real-time convention `FragmentAnimator` already uses for the collapse itself (`.claude/rules/rendering.md`).

## Test plan

- `tests/unit/ui/panels/BlastReportModal.test.ts` — rewritten: no same-tick open, stays pending just before the deadline, opens at the deadline, second report replaces first with only the latest ever rendered, `reset()` clears pending and hides a visible report.
- `tests/unit/ui/UIManager.test.ts` — extended: event modal stays closed while a report is pending and opens once the report is closed; `closeStaleLevelOverlays()` clears a merely-pending report too.
- `scripts/scenario-defs/blast-report-visual.json` — new screenshot beat: ~1s post-fire (collapse visible, no report) and ~3.5s post-fire (report open), using an explicit real-time `wait` rather than a DOM-presence `waitForSelector` (the close button is always present in the DOM; only the overlay's `display` toggles, so a presence-based wait would fire immediately and prove nothing about the delay).
- 13 other scenario-def files: raised the post-blast step `timeout` from 15/20 to 30 wherever it waits on `report-close`, to absorb the added ~3s.

### Verification channels run

- **static** — `npm run typecheck`: clean.
- **logic** — `npm run test`: 302 files / 8767 tests pass.
- **scenario** — `npm run scenarios` (command mode): 127/127 pass; command mode never touches `BlastReportModal`'s DOM, so post-blast state assertions are unaffected by the timing change.
- **visual** — `npm run scenario -- blast-report-visual --mode interaction --screenshots`, screenshots opened and inspected: report renders with correct blast content (Rating, Cleared, Cracked, Fragments, Oversized, Volume, Spent, Ore Value) once open; player click-through to Close via the real button succeeds. The specific "screenshot fragments-only, no report, ~1s post-fire" moment could not be captured in this sandbox — every CDP round trip already costs multiple seconds under this environment's documented GPU-less software rasterization cost (`CLAUDE.md`, #475), so no local screenshot lands inside the 3s window. The withhold-until-deadline behavior this moment was meant to demonstrate is instead proven directly by the logic channel's exact-boundary fake-clock tests (hidden at `DELAY_MS - 1`, opens at exactly `DELAY_MS`). `full-ci` is applied so the CI interaction-mode job (real scenario run) reports on this scenario itself.
- `npm run validate` (typecheck → coverage → integration → build): full chain green, including `test:integration` (526 tests) and `vite build`.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run; none change gameplay, economy, or a player-facing default, so no `decision-review` follow-up issue.

- **What was open:** the issue named `BlastReportModal.ts`'s `resetForNewSite` as the level-transition hook to extend, but no such method exists in this codebase.
  **Chosen:** the real hook is `UIManager.closeStaleLevelOverlays()` (already wired into `main.ts`'s `enteredNewLevel` branch since #504).
  **Why:** narrowest source — the actual code, not the issue's paraphrase.
  **If reversed:** n/a, naming correction only.

- **What was open:** whether a second blast fired inside the delay window extends the original deadline or starts a fresh one.
  **Chosen:** replace the pending report and start a full fresh `BLAST_REPORT_DELAY_MS` window from the second blast's own arrival time.
  **Why:** matches `FragmentAnimator.begin()`'s existing convention of replacing collapse state wholesale on a new blast rather than extending the previous one — each blast's own report gets the same clear-view guarantee the first one did.
  **If reversed:** change the arm branch in `BlastReportModal.update()` to `Math.max(this.pendingDeadlineMs ?? 0, this.now() + BLAST_REPORT_DELAY_MS)`.

- **What was open:** whether `reset()` should also null `lastShownReport`.
  **Chosen:** no — only clears `pendingReport`/`pendingDeadlineMs` and hides.
  **Why:** every real call site swaps `ctx.state` to a brand-new object before the next `update()` call, so the case this would guard against can't occur through any real path.
  **If reversed:** add `this.lastShownReport = null;` to `reset()`.

- **What was open:** which of the issue's listed scenario files actually needed a timeout bump.
  **Chosen:** 14 files, derived by parsing each file's actual `step.timeout` against the interaction harness's real defaults, not the issue's suggested list verbatim (e.g. `blast-detonation-sequence-ui.json` never fires a blast — left untouched).
  **Why:** source #1 (actual harness code) over a restated guess.
  **If reversed:** re-run the same audit if scenario files change shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

READY TO MERGE