### PR TITLE
feat: Resolve #546 — task-progress indicator above working employees

### DIFF
--- a/.claude/skills/gameplay-employee-skills/SKILL.md
+++ b/.claude/skills/gameplay-employee-skills/SKILL.md
@@ -3,8 +3,9 @@ name: gameplay-employee-skills
 description: >
   Employee skills and task queue system for BlastSimulator2026: skill categories,
   proficiency levels (1-5), XP gain, task duration formula, pending-action pool,
-  and ghost preview rendering. Use when implementing or modifying
-  employee qualifications, task dispatch, action queuing, or proficiency mechanics.
+  ghost preview rendering, and in-scene task progress bars. Use when implementing
+  or modifying employee qualifications, task dispatch, action queuing, or
+  proficiency mechanics.
 ---
 
 ## Design Philosophy
@@ -13,6 +14,7 @@ Employees not interchangeable tokens. Each has skill qualifications with profici
 
 - **Every physical action is queued, not instant.** Commands → global pending-action pool → free qualified employee auto-claims.
 - **Pending actions show 3D ghost.** Semi-transparent blue fresnel-effect mesh at target position — distinguishes pending from completed.
+- **Working actions show a progress bar.** Billboarded fill above the employee, tracking `taskProgressFraction` (`src/core/entities/EmployeeActivity.ts`) from empty to full over the task's duration — distinguishes "busy" from "idle" once the ghost's action is claimed.
 - **No qualified employee = immediate error** (not silent queue). Fired when zero employees have required skill.
 - **Some tasks require vehicle.** Hauling + drilling require employee to board vehicle of appropriate role.
 
@@ -90,6 +92,8 @@ export type ActionType =
 4. If qualified employees exist but all temporarily busy → wait silently (no error)
 
 **Ghost rendering:** For every `PendingAction`, renderer creates blue fresnel-effect translucent mesh with pulsing animation. Ghost removed on claim.
+
+**Task progress rendering:** For every employee whose `computeEmployeeActivity` reads `kind: 'working'`, `TaskProgressBar` (`src/renderer/TaskProgressBar.ts`) billboards a fill bar above the character, parented under its `CharacterMesh.getGroup(id)` transform so it tracks position without per-frame copying. Fill fraction comes from `taskProgressFraction`, shared with the Crew panel's own progress line so the two never disagree. Removed when the task ends.
 
 ## Salary Calculation
 

--- a/.github/skills/gameplay-employee-skills/SKILL.md
+++ b/.github/skills/gameplay-employee-skills/SKILL.md
@@ -3,8 +3,9 @@ name: gameplay-employee-skills
 description: >
   Employee skills and task queue system for BlastSimulator2026: skill categories,
   proficiency levels (1-5), XP gain, task duration formula, pending-action pool,
-  and ghost preview rendering. Use when implementing or modifying
-  employee qualifications, task dispatch, action queuing, or proficiency mechanics.
+  ghost preview rendering, and in-scene task progress bars. Use when implementing
+  or modifying employee qualifications, task dispatch, action queuing, or
+  proficiency mechanics.
 ---
 
 ## Design Philosophy
@@ -13,6 +14,7 @@ Employees not interchangeable tokens. Each has skill qualifications with profici
 
 - **Every physical action is queued, not instant.** Commands → global pending-action pool → free qualified employee auto-claims.
 - **Pending actions show 3D ghost.** Semi-transparent blue fresnel-effect mesh at target position — distinguishes pending from completed.
+- **Working actions show a progress bar.** Billboarded fill above the employee, tracking `taskProgressFraction` (`src/core/entities/EmployeeActivity.ts`) from empty to full over the task's duration — distinguishes "busy" from "idle" once the ghost's action is claimed.
 - **No qualified employee = immediate error** (not silent queue). Fired when zero employees have required skill.
 - **Some tasks require vehicle.** Hauling + drilling require employee to board vehicle of appropriate role.
 
@@ -90,6 +92,8 @@ export type ActionType =
 4. If qualified employees exist but all temporarily busy → wait silently (no error)
 
 **Ghost rendering:** For every `PendingAction`, renderer creates blue fresnel-effect translucent mesh with pulsing animation. Ghost removed on claim.
+
+**Task progress rendering:** For every employee whose `computeEmployeeActivity` reads `kind: 'working'`, `TaskProgressBar` (`src/renderer/TaskProgressBar.ts`) billboards a fill bar above the character, parented under its `CharacterMesh.getGroup(id)` transform so it tracks position without per-frame copying. Fill fraction comes from `taskProgressFraction`, shared with the Crew panel's own progress line so the two never disagree. Removed when the task ends.
 
 ## Salary Calculation
 

--- a/.opencode/skills/gameplay-employee-skills/SKILL.md
+++ b/.opencode/skills/gameplay-employee-skills/SKILL.md
@@ -3,8 +3,9 @@ name: gameplay-employee-skills
 description: >
   Employee skills and task queue system for BlastSimulator2026: skill categories,
   proficiency levels (1-5), XP gain, task duration formula, pending-action pool,
-  and ghost preview rendering. Use when implementing or modifying
-  employee qualifications, task dispatch, action queuing, or proficiency mechanics.
+  ghost preview rendering, and in-scene task progress bars. Use when implementing
+  or modifying employee qualifications, task dispatch, action queuing, or
+  proficiency mechanics.
 ---
 
 ## Design Philosophy
@@ -13,6 +14,7 @@ Employees not interchangeable tokens. Each has skill qualifications with profici
 
 - **Every physical action is queued, not instant.** Commands → global pending-action pool → free qualified employee auto-claims.
 - **Pending actions show 3D ghost.** Semi-transparent blue fresnel-effect mesh at target position — distinguishes pending from completed.
+- **Working actions show a progress bar.** Billboarded fill above the employee, tracking `taskProgressFraction` (`src/core/entities/EmployeeActivity.ts`) from empty to full over the task's duration — distinguishes "busy" from "idle" once the ghost's action is claimed.
 - **No qualified employee = immediate error** (not silent queue). Fired when zero employees have required skill.
 - **Some tasks require vehicle.** Hauling + drilling require employee to board vehicle of appropriate role.
 
@@ -90,6 +92,8 @@ export type ActionType =
 4. If qualified employees exist but all temporarily busy → wait silently (no error)
 
 **Ghost rendering:** For every `PendingAction`, renderer creates blue fresnel-effect translucent mesh with pulsing animation. Ghost removed on claim.
+
+**Task progress rendering:** For every employee whose `computeEmployeeActivity` reads `kind: 'working'`, `TaskProgressBar` (`src/renderer/TaskProgressBar.ts`) billboards a fill bar above the character, parented under its `CharacterMesh.getGroup(id)` transform so it tracks position without per-frame copying. Fill fraction comes from `taskProgressFraction`, shared with the Crew panel's own progress line so the two never disagree. Removed when the task ends.
 
 ## Salary Calculation
 

--- a/scripts/scenario-defs/survey-execution.json
+++ b/scripts/scenario-defs/survey-execution.json
@@ -163,6 +163,9 @@
         {
           "type": "command",
           "command": "tick 23"
+        },
+        {
+          "type": "screenshot"
         }
       ],
       "role": "setup"
@@ -243,6 +246,9 @@
         {
           "type": "command",
           "command": "survey show"
+        },
+        {
+          "type": "screenshot"
         }
       ],
       "role": "observe",

--- a/src/core/entities/EmployeeActivity.ts
+++ b/src/core/entities/EmployeeActivity.ts
@@ -57,3 +57,15 @@ export function computeEmployeeActivity(employee: Employee, vehicles: readonly V
 
   return IDLE;
 }
+
+/**
+ * Fraction of the current task's total duration completed, clamped to
+ * [0, 1]. Null when `activity` isn't an active timed task — the same
+ * 'working' + totalTicks > 0 guard the Crew panel's progress line and the
+ * floating task-progress bar both need before they have anything to show.
+ */
+export function taskProgressFraction(activity: EmployeeActivity): number | null {
+  if (activity.kind !== 'working' || activity.totalTicks === null || activity.totalTicks <= 0) return null;
+  const ticksRemaining = activity.ticksRemaining ?? 0;
+  return Math.min(1, Math.max(0, (activity.totalTicks - ticksRemaining) / activity.totalTicks));
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -641,6 +641,7 @@ window.__debugGridInfo = () => {
     lastGridId: gameRenderer.lastGridId,
     terrainGridId: gameRenderer.terrain?.gridId ?? null,
     ghostCount: gameRenderer.ghostCount,
+    taskProgressBarCount: gameRenderer.taskProgressBarCount,
     ghostPreviewsInState: ctx.state?.ghostPreviews.length ?? -1,
     surveyOverlayVisible: gameRenderer.surveyOverlayVisible,
   };

--- a/src/renderer/CharacterMesh.ts
+++ b/src/renderer/CharacterMesh.ts
@@ -184,6 +184,12 @@ export class CharacterMesh {
     return this.characters.get(id)?.group.position.clone() ?? null;
   }
 
+  /** An employee's root Group, or null if it isn't rendered — anchor for billboarded overlays (#546). */
+  getGroup(_id: number): THREE.Group | null {
+    // TODO: implement
+    return null;
+  }
+
   dispose(): void {
     this.clearAll();
   }

--- a/src/renderer/CharacterMesh.ts
+++ b/src/renderer/CharacterMesh.ts
@@ -185,9 +185,8 @@ export class CharacterMesh {
   }
 
   /** An employee's root Group, or null if it isn't rendered — anchor for billboarded overlays (#546). */
-  getGroup(_id: number): THREE.Group | null {
-    // TODO: implement
-    return null;
+  getGroup(id: number): THREE.Group | null {
+    return this.characters.get(id)?.group ?? null;
   }
 
   dispose(): void {

--- a/src/renderer/GameRenderer.ts
+++ b/src/renderer/GameRenderer.ts
@@ -209,6 +209,15 @@ export class GameRenderer {
       this.ghosts.sync(previews);
     }
 
+    // Task progress bars — reflect the current working/idle state each sync (#546)
+    if (this.taskProgress && this.characters) {
+      this.taskProgress.sync(
+        ctx.state.employees.employees,
+        ctx.state.vehicles.vehicles,
+        id => this.characters!.getGroup(id),
+      );
+    }
+
     // Blink employees still inside an active safety zone during clearing
     if (this.characters) {
       const zone = ctx.state.zone.activeZone;
@@ -317,6 +326,8 @@ export class GameRenderer {
     if (this.characters && this.lastState) {
       this.characters.update(this.lastState.employees.employees, dt);
     }
+
+    this.taskProgress?.update(dt);
 
     if (this.vehicles && this.lastState) {
       this.vehicles.update(this.lastState.vehicles.vehicles, dt);
@@ -776,6 +787,9 @@ export class GameRenderer {
       this.characters.addEmployee(e, surfaceY);
     }
 
+    // Task progress bars — billboarded above working employees (#546)
+    this.taskProgress = new TaskProgressBar(scene, this.sm.camera);
+
     // Weather sky
     this.skybox = new SkyboxWeather(scene, sunLight, ambient, fill);
 
@@ -927,6 +941,7 @@ export class GameRenderer {
     this.landscape?.dispose();
     this.blastOverlay?.dispose();
     this.ghosts?.dispose();
+    this.taskProgress?.dispose();
 
     this.terrain = null;
     this.landscapeHandle = null;
@@ -949,6 +964,7 @@ export class GameRenderer {
     this.landscape = null;
     this.blastOverlay = null;
     this.ghosts = null;
+    this.taskProgress = null;
     this.lastGrid = null;
 
     this.renderedBuildingIds.clear();

--- a/src/renderer/GameRenderer.ts
+++ b/src/renderer/GameRenderer.ts
@@ -123,7 +123,7 @@ export class GameRenderer {
     return this.lastGrid?.id ?? null;
   }
 
-  /** Number of task-progress-bar meshes currently rendered — for diagnostics. */
+  /** Number of task-progress bars currently rendered — for diagnostics. */
   get taskProgressBarCount(): number {
     return this.taskProgress?.count ?? 0;
   }

--- a/src/renderer/GameRenderer.ts
+++ b/src/renderer/GameRenderer.ts
@@ -32,6 +32,7 @@ import { LandscapeMesh, type PlayableCut } from './terrain/LandscapeMesh.js';
 import { WorldBorderWall } from './WorldBorderWall.js';
 import { BlastPlanOverlay } from './BlastPlanOverlay.js';
 import { GhostMesh } from './GhostMesh.js';
+import { TaskProgressBar } from './TaskProgressBar.js';
 import { syncEntitySets, buildingCenterSurfaceY } from './EntitySync.js';
 import type { SurveyConfidenceOverlayOptions, SurveyConfidencePoint } from './SurveyConfidenceOverlay.js';
 import { isSurveyStale } from '../core/mining/SurveyCalc.js';
@@ -91,6 +92,7 @@ export class GameRenderer {
   private lastCutBounds = '';
   private blastOverlay: BlastPlanOverlay | null = null;
   private ghosts: GhostMesh | null = null;
+  private taskProgress: TaskProgressBar | null = null;
   private lastGrid: VoxelGrid | null = null;
 
   /** Seed of the currently loaded game — used to detect new_game calls. */
@@ -119,6 +121,11 @@ export class GameRenderer {
   /** ID of the currently-bound VoxelGrid, for diagnostics. Null if no grid is loaded. */
   get lastGridId(): number | null {
     return this.lastGrid?.id ?? null;
+  }
+
+  /** Number of task-progress-bar meshes currently rendered — for diagnostics. */
+  get taskProgressBarCount(): number {
+    return this.taskProgress?.count ?? 0;
   }
 
   /** Number of ghost-preview meshes currently rendered — for diagnostics. */

--- a/src/renderer/TaskProgressBar.ts
+++ b/src/renderer/TaskProgressBar.ts
@@ -20,27 +20,6 @@ const BAR_HEIGHT = 0.08;
 const BAR_Y_OFFSET = 1.35;
 const FILL_Z_OFFSET = 0.001; // keep fill in front of track, avoid z-fighting
 
-// ---------- Shared resources (built once, reused across every bar) ----------
-
-const trackGeometry = new THREE.PlaneGeometry(BAR_WIDTH, BAR_HEIGHT);
-const fillGeometry = new THREE.PlaneGeometry(BAR_WIDTH, BAR_HEIGHT);
-// Pivot at the fill's own left edge so scaling scale.x grows it rightward
-// from a fixed left edge instead of from center.
-fillGeometry.translate(BAR_WIDTH / 2, 0, 0);
-
-const trackMaterial = new THREE.MeshBasicMaterial({
-  color: TRACK_COLOR,
-  transparent: true,
-  opacity: 0.85,
-  depthWrite: false,
-});
-const fillMaterial = new THREE.MeshBasicMaterial({
-  color: FILL_COLOR,
-  transparent: true,
-  opacity: 0.95,
-  depthWrite: false,
-});
-
 interface Bar {
   group: THREE.Group;
   fillMesh: THREE.Mesh;
@@ -53,9 +32,34 @@ export class TaskProgressBar {
   private readonly camera: THREE.Camera;
   private readonly bars = new Map<number, Bar>();
 
+  // ---------- Shared resources (built once per instance, reused across every bar) ----------
+  private readonly trackGeometry: THREE.PlaneGeometry;
+  private readonly fillGeometry: THREE.PlaneGeometry;
+  private readonly trackMaterial: THREE.MeshBasicMaterial;
+  private readonly fillMaterial: THREE.MeshBasicMaterial;
+
   constructor(scene: THREE.Scene, camera: THREE.Camera) {
     this.scene = scene;
     this.camera = camera;
+
+    this.trackGeometry = new THREE.PlaneGeometry(BAR_WIDTH, BAR_HEIGHT);
+    this.fillGeometry = new THREE.PlaneGeometry(BAR_WIDTH, BAR_HEIGHT);
+    // Pivot at the fill's own left edge so scaling scale.x grows it rightward
+    // from a fixed left edge instead of from center.
+    this.fillGeometry.translate(BAR_WIDTH / 2, 0, 0);
+
+    this.trackMaterial = new THREE.MeshBasicMaterial({
+      color: TRACK_COLOR,
+      transparent: true,
+      opacity: 0.85,
+      depthWrite: false,
+    });
+    this.fillMaterial = new THREE.MeshBasicMaterial({
+      color: FILL_COLOR,
+      transparent: true,
+      opacity: 0.95,
+      depthWrite: false,
+    });
   }
 
   /** Number of progress bars currently rendered. */
@@ -128,10 +132,10 @@ export class TaskProgressBar {
 
   dispose(): void {
     this.clearAll();
-    trackGeometry.dispose();
-    fillGeometry.dispose();
-    trackMaterial.dispose();
-    fillMaterial.dispose();
+    this.trackGeometry.dispose();
+    this.fillGeometry.dispose();
+    this.trackMaterial.dispose();
+    this.fillMaterial.dispose();
   }
 
   // ---------- Helpers ----------
@@ -144,10 +148,10 @@ export class TaskProgressBar {
     // whatever parent it already has), so this is only ever a transient home.
     this.scene.add(group);
 
-    const trackMesh = new THREE.Mesh(trackGeometry, trackMaterial);
+    const trackMesh = new THREE.Mesh(this.trackGeometry, this.trackMaterial);
     group.add(trackMesh);
 
-    const fillMesh = new THREE.Mesh(fillGeometry, fillMaterial);
+    const fillMesh = new THREE.Mesh(this.fillGeometry, this.fillMaterial);
     fillMesh.position.set(-BAR_WIDTH / 2, 0, FILL_Z_OFFSET);
     fillMesh.scale.x = 0;
     group.add(fillMesh);

--- a/src/renderer/TaskProgressBar.ts
+++ b/src/renderer/TaskProgressBar.ts
@@ -7,17 +7,60 @@
 import * as THREE from 'three';
 import type { Employee } from '../core/entities/Employee.js';
 import type { Vehicle } from '../core/entities/Vehicle.js';
+import { computeEmployeeActivity } from '../core/entities/EmployeeActivity.js';
+
+// ---------- Config ----------
+
+const TRACK_COLOR = 0x11161c; // --bsx-well
+const FILL_COLOR  = 0x4fc76b; // --bsx-positive
+
+const BAR_WIDTH  = 0.6;  // world units — proportionate to CharacterMesh's ~0.4-wide capsule
+const BAR_HEIGHT = 0.08;
+/** Height above the anchor's local origin — clears the character's hard hat (capsule top ~1.0). */
+const BAR_Y_OFFSET = 1.35;
+const FILL_Z_OFFSET = 0.001; // keep fill in front of track, avoid z-fighting
+
+// ---------- Shared resources (built once, reused across every bar) ----------
+
+const trackGeometry = new THREE.PlaneGeometry(BAR_WIDTH, BAR_HEIGHT);
+const fillGeometry = new THREE.PlaneGeometry(BAR_WIDTH, BAR_HEIGHT);
+// Pivot at the fill's own left edge so scaling scale.x grows it rightward
+// from a fixed left edge instead of from center.
+fillGeometry.translate(BAR_WIDTH / 2, 0, 0);
+
+const trackMaterial = new THREE.MeshBasicMaterial({
+  color: TRACK_COLOR,
+  transparent: true,
+  opacity: 0.85,
+  depthWrite: false,
+});
+const fillMaterial = new THREE.MeshBasicMaterial({
+  color: FILL_COLOR,
+  transparent: true,
+  opacity: 0.95,
+  depthWrite: false,
+});
+
+interface Bar {
+  group: THREE.Group;
+  fillMesh: THREE.Mesh;
+}
 
 // ---------- Main class ----------
 
 export class TaskProgressBar {
-  constructor(_scene: THREE.Scene, _camera: THREE.Camera) {
-    // TODO: implement
+  private readonly scene: THREE.Scene;
+  private readonly camera: THREE.Camera;
+  private readonly bars = new Map<number, Bar>();
+
+  constructor(scene: THREE.Scene, camera: THREE.Camera) {
+    this.scene = scene;
+    this.camera = camera;
   }
 
   /** Number of progress bars currently rendered. */
   get count(): number {
-    return 0;
+    return this.bars.size;
   }
 
   /**
@@ -27,24 +70,95 @@ export class TaskProgressBar {
    * Group to billboard above.
    */
   sync(
-    _employees: Employee[],
-    _vehicles: Vehicle[],
-    _getAnchor: (id: number) => THREE.Group | null,
+    employees: Employee[],
+    vehicles: readonly Vehicle[],
+    getAnchor: (id: number) => THREE.Group | null,
   ): void {
-    // TODO: implement
+    const liveIds = new Set<number>();
+
+    for (const employee of employees) {
+      liveIds.add(employee.id);
+
+      const activity = computeEmployeeActivity(employee, vehicles);
+      const anchor = getAnchor(employee.id);
+      const hasProgress = activity.kind === 'working'
+        && typeof activity.totalTicks === 'number'
+        && activity.totalTicks > 0
+        && anchor !== null;
+
+      if (!hasProgress) {
+        this.removeBar(employee.id);
+        continue;
+      }
+
+      let bar = this.bars.get(employee.id);
+      if (!bar) {
+        bar = this.createBar();
+        this.bars.set(employee.id, bar);
+      }
+      if (bar.group.parent !== anchor) {
+        anchor!.add(bar.group);
+      }
+
+      const totalTicks = activity.totalTicks as number;
+      const ticksRemaining = activity.ticksRemaining ?? 0;
+      const fraction = (totalTicks - ticksRemaining) / totalTicks;
+      bar.fillMesh.scale.x = Math.min(1, Math.max(0, fraction));
+    }
+
+    // Sweep any bar whose employee is no longer in the roster at all (death/removal).
+    for (const id of Array.from(this.bars.keys())) {
+      if (!liveIds.has(id)) this.removeBar(id);
+    }
   }
 
   /** Animate/refresh fill levels and billboard orientation. Call every frame with elapsed seconds. */
   update(_dt: number): void {
-    // TODO: implement
+    for (const { group } of this.bars.values()) {
+      group.quaternion.copy(this.camera.quaternion);
+    }
   }
 
   /** Remove all progress-bar meshes from the scene. */
   clearAll(): void {
-    // TODO: implement
+    for (const id of Array.from(this.bars.keys())) {
+      this.removeBar(id);
+    }
   }
 
   dispose(): void {
-    // TODO: implement
+    this.clearAll();
+    trackGeometry.dispose();
+    fillGeometry.dispose();
+    trackMaterial.dispose();
+    fillMaterial.dispose();
+  }
+
+  // ---------- Helpers ----------
+
+  private createBar(): Bar {
+    const group = new THREE.Group();
+    group.position.set(0, BAR_Y_OFFSET, 0);
+    // Parented into the scene root on creation; sync() immediately reparents
+    // it under the resolved anchor group (THREE.Object3D.add() detaches from
+    // whatever parent it already has), so this is only ever a transient home.
+    this.scene.add(group);
+
+    const trackMesh = new THREE.Mesh(trackGeometry, trackMaterial);
+    group.add(trackMesh);
+
+    const fillMesh = new THREE.Mesh(fillGeometry, fillMaterial);
+    fillMesh.position.set(-BAR_WIDTH / 2, 0, FILL_Z_OFFSET);
+    fillMesh.scale.x = 0;
+    group.add(fillMesh);
+
+    return { group, fillMesh };
+  }
+
+  private removeBar(id: number): void {
+    const bar = this.bars.get(id);
+    if (!bar) return;
+    bar.group.removeFromParent();
+    this.bars.delete(id);
   }
 }

--- a/src/renderer/TaskProgressBar.ts
+++ b/src/renderer/TaskProgressBar.ts
@@ -1,0 +1,50 @@
+// BlastSimulator2026 — Task Progress Bar Renderer (#546)
+// Billboarded fill-bar floating above each currently-working employee,
+// keyed by employee id. Progress is read off computeEmployeeActivity()'s
+// 'working' kind (ticksRemaining / totalTicks) — the same fields the Crew
+// panel's "current task" line uses.
+
+import * as THREE from 'three';
+import type { Employee } from '../core/entities/Employee.js';
+import type { Vehicle } from '../core/entities/Vehicle.js';
+
+// ---------- Main class ----------
+
+export class TaskProgressBar {
+  constructor(_scene: THREE.Scene, _camera: THREE.Camera) {
+    // TODO: implement
+  }
+
+  /** Number of progress bars currently rendered. */
+  get count(): number {
+    return 0;
+  }
+
+  /**
+   * Sync progress-bar meshes against the current employee/vehicle roster.
+   * Adds bars for newly-working employees and removes bars for employees no
+   * longer working. `getAnchor` resolves an employee id to the CharacterMesh
+   * Group to billboard above.
+   */
+  sync(
+    _employees: Employee[],
+    _vehicles: Vehicle[],
+    _getAnchor: (id: number) => THREE.Group | null,
+  ): void {
+    // TODO: implement
+  }
+
+  /** Animate/refresh fill levels and billboard orientation. Call every frame with elapsed seconds. */
+  update(_dt: number): void {
+    // TODO: implement
+  }
+
+  /** Remove all progress-bar meshes from the scene. */
+  clearAll(): void {
+    // TODO: implement
+  }
+
+  dispose(): void {
+    // TODO: implement
+  }
+}

--- a/src/renderer/TaskProgressBar.ts
+++ b/src/renderer/TaskProgressBar.ts
@@ -7,7 +7,7 @@
 import * as THREE from 'three';
 import type { Employee } from '../core/entities/Employee.js';
 import type { Vehicle } from '../core/entities/Vehicle.js';
-import { computeEmployeeActivity } from '../core/entities/EmployeeActivity.js';
+import { computeEmployeeActivity, taskProgressFraction } from '../core/entities/EmployeeActivity.js';
 
 // ---------- Config ----------
 
@@ -74,7 +74,7 @@ export class TaskProgressBar {
    * Group to billboard above.
    */
   sync(
-    employees: Employee[],
+    employees: readonly Employee[],
     vehicles: readonly Vehicle[],
     getAnchor: (id: number) => THREE.Group | null,
   ): void {
@@ -85,12 +85,9 @@ export class TaskProgressBar {
 
       const activity = computeEmployeeActivity(employee, vehicles);
       const anchor = getAnchor(employee.id);
-      const hasProgress = activity.kind === 'working'
-        && typeof activity.totalTicks === 'number'
-        && activity.totalTicks > 0
-        && anchor !== null;
+      const fraction = activity.kind === 'working' ? taskProgressFraction(activity) : null;
 
-      if (!hasProgress) {
+      if (fraction === null || anchor === null) {
         this.removeBar(employee.id);
         continue;
       }
@@ -101,13 +98,10 @@ export class TaskProgressBar {
         this.bars.set(employee.id, bar);
       }
       if (bar.group.parent !== anchor) {
-        anchor!.add(bar.group);
+        anchor.add(bar.group);
       }
 
-      const totalTicks = activity.totalTicks as number;
-      const ticksRemaining = activity.ticksRemaining ?? 0;
-      const fraction = (totalTicks - ticksRemaining) / totalTicks;
-      bar.fillMesh.scale.x = Math.min(1, Math.max(0, fraction));
+      bar.fillMesh.scale.x = fraction;
     }
 
     // Sweep any bar whose employee is no longer in the roster at all (death/removal).

--- a/src/ui/crewDetailSections.ts
+++ b/src/ui/crewDetailSections.ts
@@ -10,7 +10,7 @@ import type { Employee, EmployeeRole, SkillCategory } from '../core/entities/Emp
 import { BASE_SALARIES } from '../core/entities/Employee.js';
 import type { GameState } from '../core/state/GameState.js';
 import type { ActionType } from '../core/state/GameState.js';
-import { computeEmployeeActivity, type EmployeeActivity } from '../core/entities/EmployeeActivity.js';
+import { computeEmployeeActivity, taskProgressFraction, type EmployeeActivity } from '../core/entities/EmployeeActivity.js';
 import { availableTrainingOffers, planTraining, MAX_PROFICIENCY } from '../core/entities/EmployeeTraining.js';
 import { NEED_THRESHOLDS, MORALE_THRESHOLDS, XP_THRESHOLDS, PROFICIENCY_MULTIPLIERS, QUALIFICATION_SALARY_BONUS } from '../core/config/balance.js';
 import { ROLE_COLORS } from '../renderer/CharacterMesh.js';
@@ -142,8 +142,9 @@ export function makeCurrentTaskSection(e: Employee, state: GameState): HTMLEleme
   }
 
   const children: HTMLElement[] = [headRow];
-  if (activity.ticksRemaining !== null && activity.totalTicks !== null && activity.totalTicks > 0) {
-    const pct = Math.round((1 - activity.ticksRemaining / activity.totalTicks) * 100);
+  const fraction = taskProgressFraction(activity);
+  if (fraction !== null) {
+    const pct = Math.round(fraction * 100);
     const track = el('div', { attrs: { style: 'height:4px;border-radius:2px;overflow:hidden;background:#242c36' } });
     track.appendChild(el('div', { attrs: { style: `height:100%;background:var(--bsx-amber);width:${Math.max(0, Math.min(100, pct))}%` } }));
     children.push(track);

--- a/tests/unit/renderer/CharacterMesh.test.ts
+++ b/tests/unit/renderer/CharacterMesh.test.ts
@@ -273,4 +273,54 @@ describe('CharacterMesh', () => {
       cm.dispose();
     });
   });
+
+  describe('getGroup() — billboard anchor for overlays (#546)', () => {
+    it('returns the same Group added to the scene for a rendered employee', () => {
+      const scene = new THREE.Scene();
+      const cm = new CharacterMesh(scene);
+      cm.addEmployee(makeEmployee(1));
+
+      const group = cm.getGroup(1);
+      expect(group).toBe(scene.children[0]);
+      cm.dispose();
+    });
+
+    it('returns null for an id that was never added', () => {
+      const scene = new THREE.Scene();
+      const cm = new CharacterMesh(scene);
+      cm.addEmployee(makeEmployee(1));
+
+      expect(cm.getGroup(999)).toBeNull();
+      cm.dispose();
+    });
+
+    it('an object parented under getGroup(id) tracks the interpolated tween position automatically', () => {
+      const scene = new THREE.Scene();
+      const cm = new CharacterMesh(scene);
+      const emp = makeEmployee(1, { x: 0, z: 0 });
+      cm.addEmployee(emp, 0);
+
+      const group = cm.getGroup(1);
+      expect(group).not.toBeNull();
+      const indicator = new THREE.Object3D();
+      group!.add(indicator);
+
+      emp.x = 10;
+      emp.z = 10;
+      // Partial tween step (dt well under MOVE_TWEEN_DURATION_S), matching
+      // the existing "update() eases across multiple small-dt frames" test.
+      cm.update([emp], 0.05);
+
+      const groupPos = group!.position.clone();
+      const indicatorWorldPos = new THREE.Vector3();
+      indicator.getWorldPosition(indicatorWorldPos);
+
+      // The tween must have actually moved the group off the origin for this
+      // to be a meaningful check (otherwise both sides trivially agree at 0).
+      expect(groupPos.x).toBeGreaterThan(0);
+      expect(indicatorWorldPos.x).toBeCloseTo(groupPos.x);
+      expect(indicatorWorldPos.z).toBeCloseTo(groupPos.z);
+      cm.dispose();
+    });
+  });
 });

--- a/tests/unit/renderer/TaskProgressBar.test.ts
+++ b/tests/unit/renderer/TaskProgressBar.test.ts
@@ -1,0 +1,235 @@
+// TaskProgressBar — unit tests (#546)
+// Billboarded fill-bar floating above each currently-working employee.
+// Fixture shape follows tests/unit/entities/EmployeeActivity.test.ts's
+// makeEmployee/makeVehicle helpers (the same functions computeEmployeeActivity
+// is exercised against), since TaskProgressBar's own state derives from that
+// function's 'working' classification.
+
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { TaskProgressBar } from '../../../src/renderer/TaskProgressBar.js';
+import type { Employee } from '../../../src/core/entities/Employee.js';
+import type { Vehicle } from '../../../src/core/entities/Vehicle.js';
+
+function makeEmployee(overrides: Partial<Employee> = {}): Employee {
+  return {
+    id: 1, name: 'Test Employee', role: 'driller', salary: 1000, morale: 60,
+    unionized: false, injured: false, alive: true,
+    x: 0, z: 0,
+    qualifications: [],
+    trainingState: null,
+    activeActionId: null,
+    hunger: 100, fatigue: 100, breakNeed: 100,
+    collapsing: false,
+    interruptedActionPayload: null,
+    ticksWorked: 0,
+    restTicksRemaining: null,
+    restNeedKey: null,
+    taskTicksRemaining: null,
+    activeTaskSkill: null,
+    destinationX: null,
+    destinationZ: null,
+    moveConsecutiveFailures: 0,
+    isMoveStuck: false,
+    pendingRestDuration: null,
+    pendingRestNeedKey: null,
+    pendingTaskDuration: null,
+    pendingActionType: null,
+    pendingActionPayload: null,
+    pendingDriverVehicleId: null,
+    ...overrides,
+  };
+}
+
+/** Unused directly (sync's vehicles arg is only consulted by computeEmployeeActivity
+ * for the 'driving' state, irrelevant here), kept for signature parity with sync(). */
+const NO_VEHICLES: Vehicle[] = [];
+
+function makeCamera(): THREE.PerspectiveCamera {
+  return new THREE.PerspectiveCamera(55, 16 / 9, 0.5, 4000);
+}
+
+/** Every THREE.Mesh anywhere under `object`, recursively. */
+function collectMeshes(object: THREE.Object3D): THREE.Mesh[] {
+  const out: THREE.Mesh[] = [];
+  object.traverse(child => {
+    if ((child as THREE.Mesh).isMesh) out.push(child as THREE.Mesh);
+  });
+  return out;
+}
+
+/** True if some mesh under `anchor` has scale.x within `tolerance` of `expected`. */
+function anyMeshScaleXCloseTo(anchor: THREE.Object3D, expected: number, tolerance = 0.1): boolean {
+  return collectMeshes(anchor).some(m => Math.abs(m.scale.x - expected) <= tolerance);
+}
+
+describe('TaskProgressBar', () => {
+  it('a working employee produces exactly one indicator', () => {
+    const scene = new THREE.Scene();
+    const bar = new TaskProgressBar(scene, makeCamera());
+    const anchor = new THREE.Group();
+    scene.add(anchor);
+    const emp = makeEmployee({ id: 1, taskTicksRemaining: 10, activeTaskTotalTicks: 20 });
+
+    bar.sync([emp], NO_VEHICLES, id => (id === 1 ? anchor : null));
+
+    expect(bar.count).toBe(1);
+    bar.dispose();
+  });
+
+  describe('fill ratio tracks task completion progress', () => {
+    it('reads ~0 just after the task starts (ticksRemaining ≈ totalTicks)', () => {
+      const scene = new THREE.Scene();
+      const bar = new TaskProgressBar(scene, makeCamera());
+      const anchor = new THREE.Group();
+      scene.add(anchor);
+      const emp = makeEmployee({ id: 1, taskTicksRemaining: 20, activeTaskTotalTicks: 20 });
+
+      bar.sync([emp], NO_VEHICLES, id => (id === 1 ? anchor : null));
+
+      expect(anyMeshScaleXCloseTo(anchor, 0)).toBe(true);
+      bar.dispose();
+    });
+
+    it('reads ~0.5 halfway through the task', () => {
+      const scene = new THREE.Scene();
+      const bar = new TaskProgressBar(scene, makeCamera());
+      const anchor = new THREE.Group();
+      scene.add(anchor);
+      const emp = makeEmployee({ id: 1, taskTicksRemaining: 10, activeTaskTotalTicks: 20 });
+
+      bar.sync([emp], NO_VEHICLES, id => (id === 1 ? anchor : null));
+
+      expect(anyMeshScaleXCloseTo(anchor, 0.5)).toBe(true);
+      bar.dispose();
+    });
+
+    it('reads ~1 just before the task completes', () => {
+      const scene = new THREE.Scene();
+      const bar = new TaskProgressBar(scene, makeCamera());
+      const anchor = new THREE.Group();
+      scene.add(anchor);
+      const emp = makeEmployee({ id: 1, taskTicksRemaining: 1, activeTaskTotalTicks: 20 });
+
+      bar.sync([emp], NO_VEHICLES, id => (id === 1 ? anchor : null));
+
+      expect(anyMeshScaleXCloseTo(anchor, 0.95, 0.15)).toBe(true);
+      bar.dispose();
+    });
+  });
+
+  it('an idle employee produces no indicator', () => {
+    const scene = new THREE.Scene();
+    const bar = new TaskProgressBar(scene, makeCamera());
+    const anchor = new THREE.Group();
+    scene.add(anchor);
+    const emp = makeEmployee({ id: 1 }); // all activity fields default → idle
+
+    bar.sync([emp], NO_VEHICLES, id => (id === 1 ? anchor : null));
+
+    expect(bar.count).toBe(0);
+    expect(anchor.children.length).toBe(0);
+    bar.dispose();
+  });
+
+  it('a walking employee produces no indicator', () => {
+    const scene = new THREE.Scene();
+    const bar = new TaskProgressBar(scene, makeCamera());
+    const anchor = new THREE.Group();
+    scene.add(anchor);
+    const emp = makeEmployee({ id: 1, destinationX: 12, destinationZ: 4, pendingActionType: 'drill_hole' });
+
+    bar.sync([emp], NO_VEHICLES, id => (id === 1 ? anchor : null));
+
+    expect(bar.count).toBe(0);
+    expect(anchor.children.length).toBe(0);
+    bar.dispose();
+  });
+
+  it('a resting employee produces no indicator (rest gets no progress bar, per plan)', () => {
+    const scene = new THREE.Scene();
+    const bar = new TaskProgressBar(scene, makeCamera());
+    const anchor = new THREE.Group();
+    scene.add(anchor);
+    const emp = makeEmployee({ id: 1, restTicksRemaining: 7 });
+
+    bar.sync([emp], NO_VEHICLES, id => (id === 1 ? anchor : null));
+
+    expect(bar.count).toBe(0);
+    expect(anchor.children.length).toBe(0);
+    bar.dispose();
+  });
+
+  it('an old-save employee with taskTicksRemaining but no activeTaskTotalTicks gets no fabricated bar', () => {
+    const scene = new THREE.Scene();
+    const bar = new TaskProgressBar(scene, makeCamera());
+    const anchor = new THREE.Group();
+    scene.add(anchor);
+    // activeTaskTotalTicks intentionally omitted — computeEmployeeActivity
+    // reports totalTicks: null for this shape (old save, pre-#546 field).
+    const emp = makeEmployee({ id: 1, taskTicksRemaining: 8 });
+
+    bar.sync([emp], NO_VEHICLES, id => (id === 1 ? anchor : null));
+
+    expect(bar.count).toBe(0);
+    expect(anchor.children.length).toBe(0);
+    bar.dispose();
+  });
+
+  it('completing the task removes the bar on the next sync', () => {
+    const scene = new THREE.Scene();
+    const bar = new TaskProgressBar(scene, makeCamera());
+    const anchor = new THREE.Group();
+    scene.add(anchor);
+    const working = makeEmployee({ id: 1, taskTicksRemaining: 5, activeTaskTotalTicks: 20 });
+
+    bar.sync([working], NO_VEHICLES, id => (id === 1 ? anchor : null));
+    expect(bar.count).toBe(1);
+    const childrenWhileWorking = anchor.children.length;
+    expect(childrenWhileWorking).toBeGreaterThan(0);
+
+    const idle = makeEmployee({ id: 1 }); // task cleared → idle
+    bar.sync([idle], NO_VEHICLES, id => (id === 1 ? anchor : null));
+
+    expect(bar.count).toBe(0);
+    expect(anchor.children.length).toBe(0);
+    bar.dispose();
+  });
+
+  it('dispose() leaves nothing behind', () => {
+    const scene = new THREE.Scene();
+    const bar = new TaskProgressBar(scene, makeCamera());
+    const anchor = new THREE.Group();
+    scene.add(anchor);
+    const emp = makeEmployee({ id: 1, taskTicksRemaining: 5, activeTaskTotalTicks: 20 });
+
+    bar.sync([emp], NO_VEHICLES, id => (id === 1 ? anchor : null));
+    expect(bar.count).toBeGreaterThan(0);
+
+    bar.dispose();
+
+    expect(bar.count).toBe(0);
+    expect(anchor.children.length).toBe(0);
+  });
+
+  it('clearAll() removes every bar without disposing the whole instance', () => {
+    const scene = new THREE.Scene();
+    const bar = new TaskProgressBar(scene, makeCamera());
+    const anchorA = new THREE.Group();
+    const anchorB = new THREE.Group();
+    scene.add(anchorA, anchorB);
+    const empA = makeEmployee({ id: 1, taskTicksRemaining: 5, activeTaskTotalTicks: 20 });
+    const empB = makeEmployee({ id: 2, taskTicksRemaining: 5, activeTaskTotalTicks: 20 });
+    const getAnchor = (id: number): THREE.Group | null => (id === 1 ? anchorA : id === 2 ? anchorB : null);
+
+    bar.sync([empA, empB], NO_VEHICLES, getAnchor);
+    expect(bar.count).toBe(2);
+
+    bar.clearAll();
+
+    expect(bar.count).toBe(0);
+    expect(anchorA.children.length).toBe(0);
+    expect(anchorB.children.length).toBe(0);
+    bar.dispose();
+  });
+});

--- a/tests/unit/renderer/TaskProgressBar.test.ts
+++ b/tests/unit/renderer/TaskProgressBar.test.ts
@@ -58,9 +58,18 @@ function collectMeshes(object: THREE.Object3D): THREE.Mesh[] {
   return out;
 }
 
-/** True if some mesh under `anchor` has scale.x within `tolerance` of `expected`. */
-function anyMeshScaleXCloseTo(anchor: THREE.Object3D, expected: number, tolerance = 0.1): boolean {
-  return collectMeshes(anchor).some(m => Math.abs(m.scale.x - expected) <= tolerance);
+/**
+ * The bar's fill mesh under `anchor` — distinguished from the track mesh by
+ * FILL_Z_OFFSET (the only mesh TaskProgressBar ever offsets on Z, to sit in
+ * front of the track and avoid z-fighting). The track mesh's scale.x is
+ * never touched — it stays at THREE's default of 1 — so keying off Z instead
+ * of "any mesh" ensures this actually checks the fill level, not a
+ * coincidental default.
+ */
+function findFillMesh(anchor: THREE.Object3D): THREE.Mesh {
+  const fill = collectMeshes(anchor).find(m => m.position.z !== 0);
+  if (!fill) throw new Error('no fill mesh found under anchor');
+  return fill;
 }
 
 describe('TaskProgressBar', () => {
@@ -87,7 +96,7 @@ describe('TaskProgressBar', () => {
 
       bar.sync([emp], NO_VEHICLES, id => (id === 1 ? anchor : null));
 
-      expect(anyMeshScaleXCloseTo(anchor, 0)).toBe(true);
+      expect(findFillMesh(anchor).scale.x).toBeCloseTo(0, 5);
       bar.dispose();
     });
 
@@ -100,11 +109,11 @@ describe('TaskProgressBar', () => {
 
       bar.sync([emp], NO_VEHICLES, id => (id === 1 ? anchor : null));
 
-      expect(anyMeshScaleXCloseTo(anchor, 0.5)).toBe(true);
+      expect(findFillMesh(anchor).scale.x).toBeCloseTo(0.5, 5);
       bar.dispose();
     });
 
-    it('reads ~1 just before the task completes', () => {
+    it('reads ~0.95 just before the task completes', () => {
       const scene = new THREE.Scene();
       const bar = new TaskProgressBar(scene, makeCamera());
       const anchor = new THREE.Group();
@@ -113,7 +122,7 @@ describe('TaskProgressBar', () => {
 
       bar.sync([emp], NO_VEHICLES, id => (id === 1 ? anchor : null));
 
-      expect(anyMeshScaleXCloseTo(anchor, 0.95, 0.15)).toBe(true);
+      expect(findFillMesh(anchor).scale.x).toBeCloseTo(0.95, 5);
       bar.dispose();
     });
   });
@@ -210,6 +219,28 @@ describe('TaskProgressBar', () => {
 
     expect(bar.count).toBe(0);
     expect(anchor.children.length).toBe(0);
+  });
+
+  it('update() billboards the bar group to face the camera', () => {
+    const scene = new THREE.Scene();
+    const camera = makeCamera();
+    camera.quaternion.setFromEuler(new THREE.Euler(0.4, 1.1, 0.2));
+    const bar = new TaskProgressBar(scene, camera);
+    const anchor = new THREE.Group();
+    scene.add(anchor);
+    const emp = makeEmployee({ id: 1, taskTicksRemaining: 10, activeTaskTotalTicks: 20 });
+
+    bar.sync([emp], NO_VEHICLES, id => (id === 1 ? anchor : null));
+    const [group] = anchor.children;
+    // Sanity: freshly-created bar starts at THREE's default identity rotation,
+    // distinct from the camera's — otherwise the assertion below would pass
+    // even if update() never ran.
+    expect(group.quaternion.equals(camera.quaternion)).toBe(false);
+
+    bar.update(0.016);
+
+    expect(group.quaternion.equals(camera.quaternion)).toBe(true);
+    bar.dispose();
   });
 
   it('clearAll() removes every bar without disposing the whole instance', () => {


### PR DESCRIPTION
Closes #546

## Summary

Employees executing a task now carry a small billboarded progress bar floating above them in the 3D scene, filling from empty to full as `ticksRemaining`/`totalTicks` (from `computeEmployeeActivity`) counts down, and disappearing the instant the task completes. Idle and walking employees show nothing; resting employees show nothing (see Decisions taken). Bar geometry/material is instance-scoped and shared across every bar an instance owns — no per-frame allocation, no per-character material — and is disposed cleanly on level reload/employee removal.

New: `src/renderer/TaskProgressBar.ts`. Modified: `src/renderer/CharacterMesh.ts` (`getGroup(id)` accessor so the bar parents under the character's tween group and tracks it automatically, no per-frame lag), `src/renderer/GameRenderer.ts` (lifecycle wiring + `taskProgressBarCount` diagnostic), `src/main.ts` (`window.__debugGridInfo`), `src/core/entities/EmployeeActivity.ts` (new pure `taskProgressFraction` helper, shared with `src/ui/crewDetailSections.ts`'s existing Crew-panel percent display — same computation, one source of truth now).

Tests: `tests/unit/renderer/TaskProgressBar.test.ts` (new, 12 cases), `tests/unit/renderer/CharacterMesh.test.ts` (+3 cases for `getGroup`/tween-tracking), `scripts/scenario-defs/survey-execution.json` (+2 screenshot beats, seismic round).

## Design iteration

Iterated visually across zoom/pitch/multi-worker screenshots (see verification below). Track/fill are two shared `PlaneGeometry`+`MeshBasicMaterial` pairs per `TaskProgressBar` instance, billboarded via `quaternion.copy(camera.quaternion)` each frame (no allocation). Fill grows rightward from a fixed left edge (geometry pre-translated to its own edge, scaled via `scale.x`). Positioned above the character's hard hat; legible at close/medium zoom and low/high pitch without obscuring the character silhouette; confirmed non-clashing with 3 simultaneous workers on screen.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** whether resting gets a distinct indicator or none.
  **Chosen:** none — resting employees carry no bar at all.
  **Why:** `computeEmployeeActivity`'s `resting` branch always returns `totalTicks: null` (no paired duration field exists on `Employee` for rest) — a ratio bar needs a denominator, and fabricating one for rest is the same violation the old-save "no `activeTaskTotalTicks`" case exists to forbid for the working case.
  **If reversed:** needs a new rest-duration field first; not a constant flip.

- **What was open:** exact bar colours.
  **Chosen:** track `0x11161c` (`// --bsx-well`), fill `0x4fc76b` (`// --bsx-positive`), both named constants in `TaskProgressBar.ts` with the value documented against the CSS custom property it mirrors, matching `EntityHighlight.ts`'s existing convention (the only "design token" pattern the renderer has — `src/ui/tokens.ts`'s `--bsx-*` are DOM-only, nothing in `src/renderer/` reads them at runtime).
  **If reversed:** change `TRACK_COLOR`/`FILL_COLOR`; no call site moves.

- **What was open:** how many of the three survey methods get the new screenshot beats.
  **Chosen:** seismic round only.
  **Why:** interaction-mode cost is real (documented in `CLAUDE.md`); one pair of beats proves the rendering behaviour, tripling it proves the same code path three times for ~3x harness cost.
  **If reversed:** copy the two `{"type": "screenshot"}` insertions into the `core_sample`/`aerial` rounds.

- **What was open:** where the diagnostic count is exposed.
  **Chosen:** `GameRenderer.taskProgressBarCount` getter, wired into `window.__debugGridInfo` next to `ghostCount`.
  **Why:** literal reading of the issue's "a count for diagnostics the way `ghostCount` already does" — that getter's only consumer is that exact bridge.

## Verification

- **static** (`npm run typecheck`): PASS.
- **logic** (`npm run test`): PASS — 8782/8782, no regression.
- **scenario** (`npm run scenarios`, command mode): PASS — 127/127, including modified `survey-execution` (43 steps; screenshot-only actions are no-ops in command mode as expected).
- **build**: PASS — production bundle succeeds.
- **visual** (`npm run scenario -- --scenario survey-execution --mode interaction --screenshots`, plus ad hoc camera-targeted screenshots): PASS. Inspected via Read tool across close/medium/far zoom and low/high pitch: bar absent while walking, appears and visibly fills (0% -> ~40% -> ~90% -> 100%) while `kind: 'working'`, vanishes exactly on completion. Re-confirmed after the critical lifecycle fix and refactor below with a targeted tick-by-tick capture (ticks 33/36/40/41) via `__debugGridInfo().taskProgressBarCount` + camera-focus bridging, since the scenario's default camera doesn't naturally frame the survey site. Bright-terrain legibility confirmed; no naturally dark/shadowed pit area existed in this scenario (no blasting occurred), so shadow-contrast is untested — flagged, not failed.
- 5 parallel code reviewers ran (security/quality/i18n/duplication/semantic). One critical finding (module-level shared geometry/material disposed on every level reload, breaking bars after the first `new_game`/campaign transition) — fixed by scoping those resources to the instance, matching `GhostMesh`'s existing pattern. Remaining warnings (readonly consistency, doc-comment wording, `taskProgressFraction` duplication with the Crew panel, a vacuous test tolerance, missing `update()` billboard test coverage) addressed in the refactor commit; full suite re-verified after each fix with no regression.

## full-ci label

Applied — the modified `survey-execution.json` interaction-mode scenario drives an employee through `kind: 'working'` continuously in a live browser, exercising `TaskProgressBar.sync()` end to end; this is the change the label's "an interaction-mode scenario drives the change" test names.

READY TO MERGE
