### PR TITLE
fix: linked-PR checks accept only deliverable PRs, never mentions

### DIFF
--- a/.github/actions/agentic-assign/action.yml
+++ b/.github/actions/agentic-assign/action.yml
@@ -102,11 +102,43 @@ runs:
             return [...deps];
           };
 
-          const hasLinkedPr = async (number) => {
-            const { data: events } = await github.rest.issues.listEventsForTimeline({
-              owner, repo, issue_number: number, per_page: 100
+          // A PR counts only when its head is the pipeline's own branch for
+          // the issue, or GitHub records it as closing the issue. A timeline
+          // cross-reference counts for nothing: any PR that merely writes "#N"
+          // anywhere in its body raises one, which here would kill the chain
+          // (closed_without_pr guard) or defer every future assignment behind
+          // a mention (single flight). Same predicate inlined in
+          // agentic-run-state and agentic-watchdog.yml — no shared file,
+          // because the watchdog runs without a checkout to read one from.
+          const deliverablePr = async (number) => {
+            const { data: headPrs } = await github.rest.pulls.list({
+              owner, repo, state: 'all',
+              head: `${owner}:pipeline/feature-${number}`, per_page: 20
             });
-            return events.some((e) => e.event === 'cross-referenced' && e.source?.issue?.pull_request);
+            const fromPipeline = headPrs.find((pr) => pr.state === 'open' || pr.merged_at);
+            if (fromPipeline) {
+              return {
+                number: fromPipeline.number,
+                how: `from pipeline/feature-${number}, ${fromPipeline.merged_at ? 'merged' : 'open'}`
+              };
+            }
+            const linked = await github.graphql(
+              `query($owner: String!, $repo: String!, $number: Int!) {
+                 repository(owner: $owner, name: $repo) {
+                   issue(number: $number) {
+                     closedByPullRequestsReferences(first: 10, includeClosedPrs: false) {
+                       nodes { number merged }
+                     }
+                   }
+                 }
+               }`,
+              { owner, repo, number }
+            );
+            const closer = linked?.repository?.issue?.closedByPullRequestsReferences?.nodes?.[0];
+            if (closer) {
+              return { number: closer.number, how: `closing reference, ${closer.merged ? 'merged' : 'open'}` };
+            }
+            return null;
           };
 
           // --- Guard: only chain when the finished issue produced no PR ---
@@ -122,8 +154,12 @@ runs:
               core.info(`Issue #${completed} still open — a PR is expected to carry the chain.`);
               return;
             }
-            if (await hasLinkedPr(completed)) {
-              core.info(`Issue #${completed} has a linked PR — the merge event carries the chain.`);
+            const completedPr = await deliverablePr(completed);
+            if (completedPr) {
+              core.info(
+                `Issue #${completed} has pull request #${completedPr.number} (${completedPr.how}) — ` +
+                'the merge event carries the chain.'
+              );
               return;
             }
             core.info(`Issue #${completed} closed without a PR — chaining directly.`);
@@ -148,9 +184,10 @@ runs:
           for (const busy of inProgress) {
             if (busy.number === completed) continue;
 
-            if (await hasLinkedPr(busy.number)) {
+            const busyPr = await deliverablePr(busy.number);
+            if (busyPr) {
               core.info(
-                `Issue #${busy.number} is in progress with a linked PR — deferring. ` +
+                `Issue #${busy.number} is in progress with pull request #${busyPr.number} (${busyPr.how}) — deferring. ` +
                 'Merging that PR re-enters this step.'
               );
             } else {

--- a/.github/actions/agentic-rescue/action.yml
+++ b/.github/actions/agentic-rescue/action.yml
@@ -201,9 +201,10 @@ runs:
         fi
 
         # Draft, and deliberately without `READY TO MERGE`: this PR is
-        # unreviewed and unvalidated by definition. `Closes #N` is what
-        # cross-references the issue, which is how the watchdog and the
-        # single-flight check see that the work exists.
+        # unreviewed and unvalidated by definition. `Closes #N` records the PR
+        # as closing the issue — and the head branch is `pipeline/feature-<N>`
+        # — so the watchdog and the single-flight check, which accept exactly
+        # those two links and ignore mere mentions, see that the work exists.
         cat > /tmp/agentic-rescue-body.md <<EOF
         Closes #${ISSUE}
 

--- a/.github/actions/agentic-run-state/action.yml
+++ b/.github/actions/agentic-run-state/action.yml
@@ -129,15 +129,54 @@ runs:
           }
 
           // A linked PR is the deliverable. Its own CI and review carry it from
-          // here, however long that takes, so the run is done either way.
-          const { data: events } = await github.rest.issues.listEventsForTimeline({
-            owner, repo, issue_number: number, per_page: 100
-          });
-          const linked = events.find(
-            (e) => e.event === 'cross-referenced' && e.source?.issue?.pull_request
-          );
-          if (linked) {
-            settle(true, false, `Issue #${number} has a linked pull request — the run produced its deliverable.`);
+          // here, however long that takes, so the run is done either way. But
+          // "linked" must mean a PR from this run's own branch, or one GitHub
+          // records as closing the issue — never a timeline cross-reference.
+          // Any PR that merely writes "#N" anywhere in its body raises one of
+          // those: docs PR #561's passing mention of #547 read as run #133's
+          // deliverable and disarmed its retry with five hours of budget left.
+          // The same predicate is inlined in agentic-watchdog.yml and
+          // agentic-assign — no shared file, because the watchdog runs without
+          // a checkout to read one from. The verdict names the PR it matched,
+          // so a false positive is visible in the job log instead of silent.
+          const deliverablePr = async (issueNumber) => {
+            const { data: headPrs } = await github.rest.pulls.list({
+              owner, repo, state: 'all',
+              head: `${owner}:pipeline/feature-${issueNumber}`, per_page: 20
+            });
+            const fromPipeline = headPrs.find((pr) => pr.state === 'open' || pr.merged_at);
+            if (fromPipeline) {
+              return {
+                number: fromPipeline.number,
+                how: `from pipeline/feature-${issueNumber}, ${fromPipeline.merged_at ? 'merged' : 'open'}`
+              };
+            }
+            // Closing references cover the manual-completion path: a human PR
+            // from any branch whose body says `Closes #N`. `includeClosedPrs:
+            // false` keeps open and merged PRs and drops closed-unmerged ones,
+            // matching agentic-rescue's `state != "CLOSED"` reading.
+            const linked = await github.graphql(
+              `query($owner: String!, $repo: String!, $number: Int!) {
+                 repository(owner: $owner, name: $repo) {
+                   issue(number: $number) {
+                     closedByPullRequestsReferences(first: 10, includeClosedPrs: false) {
+                       nodes { number merged }
+                     }
+                   }
+                 }
+               }`,
+              { owner, repo, number: issueNumber }
+            );
+            const closer = linked?.repository?.issue?.closedByPullRequestsReferences?.nodes?.[0];
+            if (closer) {
+              return { number: closer.number, how: `closing reference, ${closer.merged ? 'merged' : 'open'}` };
+            }
+            return null;
+          };
+
+          const pr = await deliverablePr(number);
+          if (pr) {
+            settle(true, false, `Issue #${number} has pull request #${pr.number} (${pr.how}) — the run produced its deliverable.`);
             return;
           }
 

--- a/.github/workflows/agentic-watchdog.yml
+++ b/.github/workflows/agentic-watchdog.yml
@@ -58,20 +58,61 @@ jobs:
               return;
             }
 
+            // A PR counts only when its head is the pipeline's own branch for
+            // the issue, or GitHub records it as closing the issue. A timeline
+            // cross-reference counts for nothing: any PR that merely writes
+            // "#N" anywhere in its body raises one, and this sweep is the
+            // last-resort net — a stray mention must not make a dead run's
+            // issue immortally `in-progress`. Same predicate inlined in
+            // agentic-run-state and agentic-assign (no shared file — this
+            // workflow runs without a checkout to read one from).
+            const deliverablePr = async (issueNumber) => {
+              const { data: headPrs } = await github.rest.pulls.list({
+                owner, repo, state: 'all',
+                head: `${owner}:pipeline/feature-${issueNumber}`, per_page: 20
+              });
+              const fromPipeline = headPrs.find((pr) => pr.state === 'open' || pr.merged_at);
+              if (fromPipeline) {
+                return {
+                  number: fromPipeline.number,
+                  how: `from pipeline/feature-${issueNumber}, ${fromPipeline.merged_at ? 'merged' : 'open'}`
+                };
+              }
+              const linked = await github.graphql(
+                `query($owner: String!, $repo: String!, $number: Int!) {
+                   repository(owner: $owner, name: $repo) {
+                     issue(number: $number) {
+                       closedByPullRequestsReferences(first: 10, includeClosedPrs: false) {
+                         nodes { number merged }
+                       }
+                     }
+                   }
+                 }`,
+                { owner, repo, number: issueNumber }
+              );
+              const closer = linked?.repository?.issue?.closedByPullRequestsReferences?.nodes?.[0];
+              if (closer) {
+                return { number: closer.number, how: `closing reference, ${closer.merged ? 'merged' : 'open'}` };
+              }
+              return null;
+            };
+
             let swept = 0;
             for (const issue of inProgress) {
               const n = issue.number;
 
+              // A deliverable PR means the run produced something; it is the
+              // PR's CI and review that carry it from here, however long that
+              // takes.
+              const pr = await deliverablePr(n);
+              if (pr) {
+                core.info(`#${n}: pull request #${pr.number} (${pr.how}) carries it, leaving alone.`);
+                continue;
+              }
+
               const { data: events } = await github.rest.issues.listEventsForTimeline({
                 owner, repo, issue_number: n, per_page: 100
               });
-
-              // A linked PR means the run produced something; it is the PR's
-              // CI and review that carry it from here, however long that takes.
-              if (events.some((e) => e.event === 'cross-referenced' && e.source?.issue?.pull_request)) {
-                core.info(`#${n}: has a linked PR, leaving alone.`);
-                continue;
-              }
 
               const labelledAt = events
                 .filter((e) => e.event === 'labeled' && e.label?.name === 'in-progress')

--- a/.github/workflows/auto-assign-next.yml
+++ b/.github/workflows/auto-assign-next.yml
@@ -61,7 +61,14 @@ jobs:
             const repo = context.repo.repo;
             const prBody = context.payload.pull_request.body || '';
 
-            const closesMatch = prBody.match(/(?:Closes?|Resolves|Fixes)\s+#(\d+)/i);
+            // Anchored to a line of its own: `Closes #N` on its own line is the
+            // pipeline's PR-body convention (agentic-assign writes it into every
+            // assignment, agentic-rescue writes it into every rescue body). An
+            // unanchored match let any prose mention — "also fixes #X
+            // partially", a quoted issue body — close the wrong issue, label it
+            // `done`, and feed the wrong number to agentic-assign, while the
+            // right issue kept holding the queue.
+            const closesMatch = prBody.match(/^\s*(?:Closes?|Resolves|Fixes)\s+#(\d+)\s*$/im);
             if (!closesMatch) {
               core.info('No explicit close directive found in PR body. Skipping issue close.');
               core.setOutput('issue', '');


### PR DESCRIPTION
## Why

Investigation of rescue PR #566 (issue #547, run [#133](https://github.com/Nico2398/BlastSimulator2026/actions/runs/31487715945)) found two stacked failures:

1. The session died mid-validation: its feature-branch `npx vitest run` was auto-backgrounded by the harness and the turn ended "waiting to be notified" — a notification that never arrives in a one-shot runner.
2. The retry built precisely for that case never fired. `agentic-run-state` treated **any** timeline cross-reference from a PR as "the run produced its deliverable" — and docs PR #561's passing mention of `#547` (in its full-ci label list) satisfied it. Verdict: *"Issue #547 has a linked pull request"*, terminal, no retry, with ~5 hours of job budget left.

The same mention-foolable predicate existed in `agentic-watchdog.yml` (a stray "#N" makes a dead run's issue immortally `in-progress` — never swept, never notified) and in `agentic-assign` (chain death via the `closed_without_pr` guard; permanent single-flight deferral).

## What changed

- **`agentic-run-state`, `agentic-watchdog.yml`, `agentic-assign`** — the linked-PR predicate now accepts exactly two links, neither of which prose can raise:
  - a non-closed (open or merged) PR whose head is `pipeline/feature-<N>` — the same key `agentic-rescue` already trusts;
  - a PR GitHub records as closing the issue (`closedByPullRequestsReferences`, open and merged only), covering manual completion from arbitrary branches.

  Verdict/log lines now name the matched PR number, so a future false positive is visible instead of silent. The predicate is inlined at each site rather than shared from a file because the watchdog deliberately runs without a checkout. The unpaginated `listEventsForTimeline` reads are gone with it.
- **`auto-assign-next.yml`** — the close directive must now be `Closes #N` on a line of its own (the pipeline's PR-body convention, written by both `agentic-assign` and `agentic-rescue`). Previously the first `fixes #X` anywhere in prose closed that issue, labelled it `done`, and fed the wrong number to the assignment chain.
- **`agentic-rescue`** — comment updated to describe the two links the checks now accept (was: "cross-references").

## Verification

- All five YAML files parse; every embedded `github-script` block passes `node --check`.
- Anchored regex tested against pipeline, rescue, CRLF, prose-trap, quoted and mention-only bodies (7/7).
- Both predicate arms tested against live repo data: issue #547 matches PR #566 by head branch **and** by closing reference; issue #549 — cross-referenced by PR #561 exactly like #547 was — now matches nothing, where the old check matched (false positive reproduced live before the fix).
- `npm run validate:context` passes. The four game-code channels are untouched by this diff (`.github/` only).

## Residual, out of scope

- The primary failure (a turn ended on a backgrounded command) is a session-discipline issue; with this fix the retry gate now actually catches it. A context-file warning at the `[test-runner]` steps naming the auto-background trap is a possible follow-up.
- A leftover open/merged PR from a *previous* run of the same issue number still reads as that issue's deliverable — pre-existing behaviour, shared with `agentic-rescue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McMB9ezTyEpYm3nyE2mcng

---
_Generated by [Claude Code](https://claude.ai/code/session_01McMB9ezTyEpYm3nyE2mcng)_