### PR TITLE
feat: Resolve #547 — ordered actions keep their ghost through claim, walk, and work

### DIFF
--- a/.claude/skills/gameplay-employee-skills/SKILL.md
+++ b/.claude/skills/gameplay-employee-skills/SKILL.md
@@ -66,6 +66,8 @@ ticksRequired = baseDuration / (proficiency_multiplier * wellbeing_multiplier * 
 export interface PendingAction {
   id: number;
   type: ActionType;
+  status: 'queued' | 'assigned' | 'in_progress';
+  holderId: number | null;  // employee id once claimed, else null
   requiredSkill: SkillQualification;
   requiredVehicleRole: VehicleRole | null;  // null = on-foot task
   targetX: number;
@@ -85,13 +87,17 @@ export type ActionType =
   | 'haul_debris';
 ```
 
+A `PendingAction` has a lifecycle, not a single claimed/unclaimed bit: `queued` (unclaimed, `holderId: null`) → `assigned` (claimed, employee en route) → `in_progress` (employee working it) → removed from `state.pendingActions` only on completion. `claimPendingAction` (`src/core/engine/TaskDispatch.ts`) transitions `status`/`holderId` in place; `completePendingAction` is the only function that removes the action from the pool.
+
 **Claim logic (each tick):**
-1. For each unclaimed `PendingAction`, scan idle employees for matching `requiredSkill`
+1. For each `PendingAction` with `status: 'queued'`, scan idle employees for matching `requiredSkill`
 2. If `requiredVehicleRole` non-null, also verify a qualified vehicle+driver is available
 3. If NO employee with the skill exists on roster at all → emit `UnqualifiedTaskError` immediately
 4. If qualified employees exist but all temporarily busy → wait silently (no error)
+5. On claim: `status` moves to `assigned` (then `in_progress` once work starts), `holderId` set to the claiming employee — the action and its ghost stay in place, nothing is deleted
+6. Any count of "unclaimed work" (e.g. `OperationsPanel`) filters `status === 'queued'`, never plain presence in `state.pendingActions`
 
-**Ghost rendering:** For every `PendingAction`, renderer creates blue fresnel-effect translucent mesh with pulsing animation. Ghost removed on claim.
+**Ghost rendering:** For every `PendingAction`, renderer creates blue fresnel-effect translucent mesh with pulsing animation, tracked via `GhostPreview.claimed`. Claiming sets `claimed: true` — the ghost stays blue but renders dimmer and pulses slower (`src/renderer/GhostMesh.ts`) to distinguish claimed from unclaimed work without removing it. The ghost is removed only when the action completes.
 
 **Task progress rendering:** For every employee whose `computeEmployeeActivity` reads `kind: 'working'`, `TaskProgressBar` (`src/renderer/TaskProgressBar.ts`) billboards a fill bar above the character, parented under its `CharacterMesh.getGroup(id)` transform so it tracks position without per-frame copying. Fill fraction comes from `taskProgressFraction`, shared with the Crew panel's own progress line so the two never disagree. Removed when the task ends.
 

--- a/.github/skills/gameplay-employee-skills/SKILL.md
+++ b/.github/skills/gameplay-employee-skills/SKILL.md
@@ -66,6 +66,8 @@ ticksRequired = baseDuration / (proficiency_multiplier * wellbeing_multiplier * 
 export interface PendingAction {
   id: number;
   type: ActionType;
+  status: 'queued' | 'assigned' | 'in_progress';
+  holderId: number | null;  // employee id once claimed, else null
   requiredSkill: SkillQualification;
   requiredVehicleRole: VehicleRole | null;  // null = on-foot task
   targetX: number;
@@ -85,13 +87,17 @@ export type ActionType =
   | 'haul_debris';
 ```
 
+A `PendingAction` has a lifecycle, not a single claimed/unclaimed bit: `queued` (unclaimed, `holderId: null`) → `assigned` (claimed, employee en route) → `in_progress` (employee working it) → removed from `state.pendingActions` only on completion. `claimPendingAction` (`src/core/engine/TaskDispatch.ts`) transitions `status`/`holderId` in place; `completePendingAction` is the only function that removes the action from the pool.
+
 **Claim logic (each tick):**
-1. For each unclaimed `PendingAction`, scan idle employees for matching `requiredSkill`
+1. For each `PendingAction` with `status: 'queued'`, scan idle employees for matching `requiredSkill`
 2. If `requiredVehicleRole` non-null, also verify a qualified vehicle+driver is available
 3. If NO employee with the skill exists on roster at all → emit `UnqualifiedTaskError` immediately
 4. If qualified employees exist but all temporarily busy → wait silently (no error)
+5. On claim: `status` moves to `assigned` (then `in_progress` once work starts), `holderId` set to the claiming employee — the action and its ghost stay in place, nothing is deleted
+6. Any count of "unclaimed work" (e.g. `OperationsPanel`) filters `status === 'queued'`, never plain presence in `state.pendingActions`
 
-**Ghost rendering:** For every `PendingAction`, renderer creates blue fresnel-effect translucent mesh with pulsing animation. Ghost removed on claim.
+**Ghost rendering:** For every `PendingAction`, renderer creates blue fresnel-effect translucent mesh with pulsing animation, tracked via `GhostPreview.claimed`. Claiming sets `claimed: true` — the ghost stays blue but renders dimmer and pulses slower (`src/renderer/GhostMesh.ts`) to distinguish claimed from unclaimed work without removing it. The ghost is removed only when the action completes.
 
 **Task progress rendering:** For every employee whose `computeEmployeeActivity` reads `kind: 'working'`, `TaskProgressBar` (`src/renderer/TaskProgressBar.ts`) billboards a fill bar above the character, parented under its `CharacterMesh.getGroup(id)` transform so it tracks position without per-frame copying. Fill fraction comes from `taskProgressFraction`, shared with the Crew panel's own progress line so the two never disagree. Removed when the task ends.
 

--- a/.opencode/skills/gameplay-employee-skills/SKILL.md
+++ b/.opencode/skills/gameplay-employee-skills/SKILL.md
@@ -66,6 +66,8 @@ ticksRequired = baseDuration / (proficiency_multiplier * wellbeing_multiplier * 
 export interface PendingAction {
   id: number;
   type: ActionType;
+  status: 'queued' | 'assigned' | 'in_progress';
+  holderId: number | null;  // employee id once claimed, else null
   requiredSkill: SkillQualification;
   requiredVehicleRole: VehicleRole | null;  // null = on-foot task
   targetX: number;
@@ -85,13 +87,17 @@ export type ActionType =
   | 'haul_debris';
 ```
 
+A `PendingAction` has a lifecycle, not a single claimed/unclaimed bit: `queued` (unclaimed, `holderId: null`) → `assigned` (claimed, employee en route) → `in_progress` (employee working it) → removed from `state.pendingActions` only on completion. `claimPendingAction` (`src/core/engine/TaskDispatch.ts`) transitions `status`/`holderId` in place; `completePendingAction` is the only function that removes the action from the pool.
+
 **Claim logic (each tick):**
-1. For each unclaimed `PendingAction`, scan idle employees for matching `requiredSkill`
+1. For each `PendingAction` with `status: 'queued'`, scan idle employees for matching `requiredSkill`
 2. If `requiredVehicleRole` non-null, also verify a qualified vehicle+driver is available
 3. If NO employee with the skill exists on roster at all → emit `UnqualifiedTaskError` immediately
 4. If qualified employees exist but all temporarily busy → wait silently (no error)
+5. On claim: `status` moves to `assigned` (then `in_progress` once work starts), `holderId` set to the claiming employee — the action and its ghost stay in place, nothing is deleted
+6. Any count of "unclaimed work" (e.g. `OperationsPanel`) filters `status === 'queued'`, never plain presence in `state.pendingActions`
 
-**Ghost rendering:** For every `PendingAction`, renderer creates blue fresnel-effect translucent mesh with pulsing animation. Ghost removed on claim.
+**Ghost rendering:** For every `PendingAction`, renderer creates blue fresnel-effect translucent mesh with pulsing animation, tracked via `GhostPreview.claimed`. Claiming sets `claimed: true` — the ghost stays blue but renders dimmer and pulses slower (`src/renderer/GhostMesh.ts`) to distinguish claimed from unclaimed work without removing it. The ghost is removed only when the action completes.
 
 **Task progress rendering:** For every employee whose `computeEmployeeActivity` reads `kind: 'working'`, `TaskProgressBar` (`src/renderer/TaskProgressBar.ts`) billboards a fill bar above the character, parented under its `CharacterMesh.getGroup(id)` transform so it tracks position without per-frame copying. Fill fraction comes from `taskProgressFraction`, shared with the Crew panel's own progress line so the two never disagree. Removed when the task ends.
 

--- a/scripts/scenario-defs/employee-skill-progression-visual.json
+++ b/scripts/scenario-defs/employee-skill-progression-visual.json
@@ -136,7 +136,7 @@
     },
     {
       "command": "tick 1",
-      "description": "tickEmployees claims the dispatch: employee A becomes busy and taskTicksRemaining is seeded from BASE_TASK_DURATION_TICKS scaled by proficiency/need/living-quarters multipliers.",
+      "description": "tickEmployees claims the dispatch: employee A becomes busy and taskTicksRemaining is seeded from BASE_TASK_DURATION_TICKS scaled by proficiency/need/living-quarters multipliers. Since #547, claiming transitions the PendingAction's status in place instead of deleting it, so it still counts until the task completes.",
       "interaction": [
         {
           "type": "command",
@@ -147,7 +147,7 @@
       "expect": {
         "equals": {
           "cash": 47700,
-          "pendingActionCount": 0
+          "pendingActionCount": 1
         }
       }
     },
@@ -163,9 +163,9 @@
       "expect": {
         "equals": {
           "cash": 47700,
-          "pendingActionCount": 1
+          "pendingActionCount": 2
         },
-        "note": "the second dispatch's ghost preview -- employee A is still busy with the first task and employee B can't claim it (wrong skill), so this stays queued through the next several checkpoints"
+        "note": "the second dispatch's ghost preview -- employee A is still busy with the first task and employee B can't claim it (wrong skill), so this stays queued through the next several checkpoints. Count is 2 (not 1) since #547: the first dispatch's claimed-but-in-progress PendingAction still counts alongside this new unclaimed one."
       },
       "role": "bootstrap"
     },
@@ -195,7 +195,7 @@
           "cash"
         ],
         "equals": {
-          "pendingActionCount": 1
+          "pendingActionCount": 2
         }
       }
     },
@@ -224,9 +224,9 @@
           "cash"
         ],
         "equals": {
-          "pendingActionCount": 0
+          "pendingActionCount": 1
         },
-        "note": "the second dispatch's ghost preview disappears here -- employee A finished the first task and auto-claimed it"
+        "note": "the second dispatch's ghost preview disappears here -- employee A finished the first task and auto-claimed it. Count is 1 (not 0) since #547: the second dispatch's PendingAction is now claimed-but-in-progress, still counted until it completes too."
       }
     },
     {

--- a/scripts/scenario-defs/needs-collapse-visual.json
+++ b/scripts/scenario-defs/needs-collapse-visual.json
@@ -81,6 +81,22 @@
       "role": "bootstrap"
     },
     {
+      "command": "employee dispatch 1 x:10 z:10",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "employee dispatch 1 x:10 z:10"
+        }
+      ],
+      "description": "Added for #547. Queued now, second in line behind the first dispatch, this claims the instant the first completes -- ahead of any auto-inserted rest, which only gets queued once fatigue crosses its warning threshold near the end of the first task and so always lands later in pendingActions. Before #547, a null-skill dispatch never seeded pendingTaskDuration, so the single original dispatch here never completed and Walt stayed 'busy' (and undisturbable by his own proactive rest) forever -- which is what let fatigue drain straight through to collapse under the old calibration. #547 fixed that leak, so a lone dispatch now genuinely completes and frees Walt to be routed to rest before he ever reaches the collapse floor (see needs-proactive-queue-visual's equivalent note). This second dispatch keeps him continuously working across the handoff, restoring the file's own premise (\"no rest can be claimed\") instead of the accidental one the old bug provided.",
+      "expect": {
+        "equals": {
+          "collapsedCount": 0
+        }
+      },
+      "role": "bootstrap"
+    },
+    {
       "command": "needs",
       "interaction": [
         {

--- a/scripts/scenario-defs/needs-proactive-queue-visual.json
+++ b/scripts/scenario-defs/needs-proactive-queue-visual.json
@@ -75,9 +75,9 @@
           "minFatigue"
         ],
         "equals": {
-          "pendingActionCount": 2
+          "pendingActionCount": 1
         },
-        "note": "#547: employee 1's `dispatch` carries no skill:, so it never seeds taskTicksRemaining and never completes through the normal task-duration path -- once tickEmployees claims it (this batch's first tick), its record now stays in pendingActions forever (nothing calls completePendingAction for it), a permanent +1 on top of whatever this batch's own warning-threshold rest contributes. Before #547 the claim spliced it out immediately, so this was 1 (the warning-rest alone); it is 2 for the rest of this file from here on."
+        "note": "Recalibrated for #547: the dispatch (no `skill:` param) used to never seed pendingTaskDuration and so never completed, permanently inflating this count. #547 fixed the leak (tickEmployees now seeds pendingTaskDuration for every non-rest action regardless of requiredSkill), so the dispatch genuinely completes within this batch and only the warning-threshold rest remains pending."
       }
     },
     {
@@ -146,9 +146,9 @@
         ],
         "equals": {
           "buildingCount": 1,
-          "pendingActionCount": 2
+          "pendingActionCount": 1
         },
-        "note": "#547: still the tick-40 checkpoint's warning-rest + the permanently-stuck original dispatch (see that step's note) -- nothing ticks between there and here."
+        "note": "Recalibrated for #547 (see the tick-40 checkpoint's note for root cause): still just the tick-40 checkpoint's warning-rest -- nothing ticks between there and here."
       }
     },
     {
@@ -172,13 +172,15 @@
       "role": "setup",
       "expect": {
         "decreased": [
-          "cash",
+          "cash"
+        ],
+        "increased": [
           "minFatigue"
         ],
         "equals": {
-          "pendingActionCount": 1
+          "pendingActionCount": 0
         },
-        "note": "minFatigue is now near the collapse threshold (~5); the warning-threshold rest has been claimed and completed. #547: pendingActionCount no longer reaches 0 here -- the original null-skill dispatch (see the tick-40 checkpoint's note) never completes and its record now stays in pendingActions permanently, so this floor is 1 instead of 0 for the rest of this file."
+        "note": "Recalibrated for #547: a null-skill dispatch (no `skill:` param, this scenario's own `employee dispatch 1 x:10 z:10`) used to never seed pendingTaskDuration, so it never completed and left the employee 'busy' forever -- that leak is what let fatigue decline uninterrupted toward collapse under the old calibration. #547 fixed the leak (tickEmployees now seeds pendingTaskDuration for every non-rest action regardless of requiredSkill), so the dispatch genuinely completes (already visible at tick 40 -- 'TASK: Walt Dusty completed task'), fatigue's dip below the warning threshold (21.5 < 25) queues an auto-inserted rest the instant Walt goes idle, and by here it has been claimed, walked to, completed, and the gauge partially recovered -- an increase, not the old trajectory's continued decline toward ~5."
       }
     },
     {
@@ -226,10 +228,10 @@
           "minFatigue"
         ],
         "equals": {
-          "pendingActionCount": 2,
-          "collapsedCount": 1
+          "pendingActionCount": 1,
+          "collapsedCount": 0
         },
-        "note": "minFatigue hits the collapse floor mid-batch (5.0 -> 1.4) and tickCollapse fires before autoInsertNeedTasks ever gets a chance at its own, earlier warning-threshold insertion (25) -- this is a genuine collapse forcing the rest task, not the calm pre-collapse insertion the file's own name implies. pendingActionCount 1->2 is real (the collapse-rest on top of the permanently-stuck original dispatch, #547), it is collapse recovery, not proactive queuing; not fixed here since it is a game-balance question (why the proactive threshold never preempts it), not a command/UI divergence."
+        "note": "Recalibrated for #547 (see the 'tick 80' step's note above for the root cause): with the dispatch-completion leak fixed, Walt now genuinely cycles between finishing work, idling, and being auto-routed to rest well above the collapse floor -- so collapsedCount stays 0 here instead of the old calibration's forced collapse, which only happened because a perpetually-'busy' employee (the pre-#547 bug) could never be idle-claimed for its own proactive rest and so drained straight through it. pendingActionCount 0->1 is a fresh dip below the fatigue warning threshold queuing another auto-inserted rest -- genuine proactive queuing, not collapse recovery. tickCollapse/collapsedCount is exercised directly (and correctly) by needs-collapse-visual instead."
       }
     },
     {
@@ -273,16 +275,14 @@
       "role": "setup",
       "expect": {
         "decreased": [
-          "cash"
-        ],
-        "increased": [
+          "cash",
           "minFatigue"
         ],
         "equals": {
           "pendingActionCount": 1,
           "collapsedCount": 0
         },
-        "note": "the collapse-forced rest queued in the previous step is now active: minFatigue recovers (not decreases) and the task completes, dropping pendingActionCount back to its 1 floor (#547: the permanently-stuck original dispatch, see the tick-40 checkpoint's note -- pre-#547 this floor was 0) and clearing collapsedCount. This batch is interrupted early by an unrelated random event (politics_mining_expo) -- the recovery is already visible in however many ticks actually ran."
+        "note": "Recalibrated for #547 (see the 'tick 80' step's note for root cause): there is no collapse-forced rest to recover from -- the previous step's fresh rest cycle (queued -> claimed -> completed) already finished, and Walt is back to natural fatigue decline while idle. pendingActionCount is 1 again: the decline crosses the warning threshold a second time within this batch, auto-inserting (and, once idle, claiming) another proactive rest -- nowhere near collapse. This batch is interrupted early by an unrelated random event (politics_mining_expo) -- the decline is already visible in however many ticks actually ran."
       }
     },
     {

--- a/scripts/scenario-defs/needs-proactive-queue-visual.json
+++ b/scripts/scenario-defs/needs-proactive-queue-visual.json
@@ -75,8 +75,9 @@
           "minFatigue"
         ],
         "equals": {
-          "pendingActionCount": 1
-        }
+          "pendingActionCount": 2
+        },
+        "note": "#547: employee 1's `dispatch` carries no skill:, so it never seeds taskTicksRemaining and never completes through the normal task-duration path -- once tickEmployees claims it (this batch's first tick), its record now stays in pendingActions forever (nothing calls completePendingAction for it), a permanent +1 on top of whatever this batch's own warning-threshold rest contributes. Before #547 the claim spliced it out immediately, so this was 1 (the warning-rest alone); it is 2 for the rest of this file from here on."
       }
     },
     {
@@ -145,8 +146,9 @@
         ],
         "equals": {
           "buildingCount": 1,
-          "pendingActionCount": 1
-        }
+          "pendingActionCount": 2
+        },
+        "note": "#547: still the tick-40 checkpoint's warning-rest + the permanently-stuck original dispatch (see that step's note) -- nothing ticks between there and here."
       }
     },
     {
@@ -174,9 +176,9 @@
           "minFatigue"
         ],
         "equals": {
-          "pendingActionCount": 0
+          "pendingActionCount": 1
         },
-        "note": "minFatigue is now near the collapse threshold (~5); the earlier dispatch task has been claimed and completed"
+        "note": "minFatigue is now near the collapse threshold (~5); the warning-threshold rest has been claimed and completed. #547: pendingActionCount no longer reaches 0 here -- the original null-skill dispatch (see the tick-40 checkpoint's note) never completes and its record now stays in pendingActions permanently, so this floor is 1 instead of 0 for the rest of this file."
       }
     },
     {
@@ -224,10 +226,10 @@
           "minFatigue"
         ],
         "equals": {
-          "pendingActionCount": 1,
+          "pendingActionCount": 2,
           "collapsedCount": 1
         },
-        "note": "minFatigue hits the collapse floor mid-batch (5.0 -> 1.4) and tickCollapse fires before autoInsertNeedTasks ever gets a chance at its own, earlier warning-threshold insertion (25) -- this is a genuine collapse forcing the rest task, not the calm pre-collapse insertion the file's own name implies. pendingActionCount 0->1 is real, but it is collapse recovery, not proactive queuing; not fixed here since it is a game-balance question (why the proactive threshold never preempts it), not a command/UI divergence."
+        "note": "minFatigue hits the collapse floor mid-batch (5.0 -> 1.4) and tickCollapse fires before autoInsertNeedTasks ever gets a chance at its own, earlier warning-threshold insertion (25) -- this is a genuine collapse forcing the rest task, not the calm pre-collapse insertion the file's own name implies. pendingActionCount 1->2 is real (the collapse-rest on top of the permanently-stuck original dispatch, #547), it is collapse recovery, not proactive queuing; not fixed here since it is a game-balance question (why the proactive threshold never preempts it), not a command/UI divergence."
       }
     },
     {
@@ -277,10 +279,10 @@
           "minFatigue"
         ],
         "equals": {
-          "pendingActionCount": 0,
+          "pendingActionCount": 1,
           "collapsedCount": 0
         },
-        "note": "the collapse-forced rest queued in the previous step is now active: minFatigue recovers (not decreases) and the task completes, dropping pendingActionCount back to 0 and clearing collapsedCount. This batch is interrupted early by an unrelated random event (politics_mining_expo) -- the recovery is already visible in however many ticks actually ran."
+        "note": "the collapse-forced rest queued in the previous step is now active: minFatigue recovers (not decreases) and the task completes, dropping pendingActionCount back to its 1 floor (#547: the permanently-stuck original dispatch, see the tick-40 checkpoint's note -- pre-#547 this floor was 0) and clearing collapsedCount. This batch is interrupted early by an unrelated random event (politics_mining_expo) -- the recovery is already visible in however many ticks actually ran."
       }
     },
     {

--- a/scripts/scenario-defs/survey-overlay-lifecycle.json
+++ b/scripts/scenario-defs/survey-overlay-lifecycle.json
@@ -191,7 +191,8 @@
           "cash"
         ],
         "equals": {
-          "surveyCount": 0
+          "surveyCount": 0,
+          "pendingActionCount": 1
         }
       }
     },
@@ -230,7 +231,8 @@
           "cash"
         ],
         "equals": {
-          "surveyCount": 0
+          "surveyCount": 0,
+          "pendingActionCount": 2
         },
         "note": "both round-1 surveys queued, neither completed yet"
       }
@@ -246,7 +248,8 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "surveyCount": 0
+          "surveyCount": 0,
+          "pendingActionCount": 2
         },
         "note": "both round-1 surveys queued, neither completed yet"
       }
@@ -262,11 +265,28 @@
       "role": "observe"
     },
     {
-      "command": "tick 40",
+      "command": "tick 2",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 40"
+          "command": "tick 2"
+        }
+      ],
+      "role": "setup",
+      "expect": {
+        "equals": {
+          "surveyCount": 0,
+          "pendingActionCount": 2
+        },
+        "note": "#547: tickEmployees claims both round-1 surveys on the very first of these ticks (both surveyors idle, both qualified), but their records now stay in pendingActions -- only status/holderId flip -- instead of being spliced out at claim time. Both surveyors are still many ticks from arriving at (20,20), so pendingActionCount must stay at 2 (unclaimed 0, not the pre-#547 behaviour where a claim alone dropped this to 0)."
+      }
+    },
+    {
+      "command": "tick 38",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 38"
         }
       ],
       "role": "setup"
@@ -402,7 +422,8 @@
           "cash"
         ],
         "equals": {
-          "surveyCount": 2
+          "surveyCount": 2,
+          "pendingActionCount": 1
         }
       }
     },
@@ -417,9 +438,10 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "surveyCount": 2
+          "surveyCount": 2,
+          "pendingActionCount": 1
         },
-        "note": "round 2's aerial survey queued, not yet completed; round 1's 2 stay put"
+        "note": "round 2's aerial survey queued, not yet completed; round 1's 2 stay put. Both round-1 records were removed exactly on completion (#547), not at claim -- surveyCount:2 and pendingActionCount:1 here (only round 2's fresh queue entry) prove that."
       }
     },
     {

--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -24,6 +24,7 @@ import { getVehicleCostsPerTick } from '../../core/entities/Vehicle.js';
 import { tickNeedGauges, needsMoraleEffect } from '../../core/entities/EmployeeNeeds.js';
 import type { FiredEvent } from '../../core/events/EventSystem.js';
 import { tickCollapse, autoInsertNeedTasks, processShiftCycle, tickEmployees, tickGeneralRestCompletion, tickTaskProgress, tickVehicle, tickVehicleTaskState, tickEmployeeMovement, tickArrivalGate } from '../../core/engine/GameLoop.js';
+import { completePendingAction } from '../../core/engine/TaskDispatch.js';
 import { detectUnqualifiedTask, detectTrafficJam } from '../../core/events/EventEngine.js';
 import { estimateSurveyResult, applySeismicSurveyDamage, type SurveyMethod } from '../../core/mining/SurveyCalc.js';
 import { checkDeadlines, generateContracts } from '../../core/economy/Contract.js';
@@ -217,6 +218,13 @@ export function tickCommand(
       if (!progress) continue;
       if (progress.completed) {
         lines.push(`[tick ${state.tickCount}] TASK: ${emp.name} completed task.`);
+
+        // Skill-required actions (survey, etc.) route through tickTaskProgress
+        // — the completing action's record and ghost are removed here, once
+        // the work has actually finished, not at claim time (#547).
+        if (progress.actionId !== undefined) {
+          completePendingAction(state, progress.actionId);
+        }
 
         // A completed 'survey' task resolves here — after the surveyor has
         // actually walked to and worked the site, not the instant it was

--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -219,9 +219,11 @@ export function tickCommand(
       if (progress.completed) {
         lines.push(`[tick ${state.tickCount}] TASK: ${emp.name} completed task.`);
 
-        // Skill-required actions (survey, etc.) route through tickTaskProgress
-        // — the completing action's record and ghost are removed here, once
-        // the work has actually finished, not at claim time (#547).
+        // Any completed non-rest action — skill-required (survey, etc.) or
+        // not (a null-skill general_work dispatch) — routes through
+        // tickTaskProgress and carries an actionId here; completePendingAction
+        // removes the completing action's record and ghost, once the work has
+        // actually finished, not at claim time (#547).
         if (progress.actionId !== undefined) {
           completePendingAction(state, progress.actionId);
         }

--- a/src/core/engine/ArrivalGate.ts
+++ b/src/core/engine/ArrivalGate.ts
@@ -53,12 +53,15 @@ export function tickArrivalGate(state: GameState, emitter?: EventEmitter): Arriv
     const arrived = emp.destinationX === null && emp.destinationZ === null;
     if (!arrived) continue;
 
+    let workStarted = false;
+
     if (emp.pendingRestDuration !== null) {
       emp.restTicksRemaining = emp.pendingRestDuration;
       emp.restNeedKey = emp.pendingRestNeedKey;
       emp.pendingRestDuration = null;
       emp.pendingRestNeedKey = null;
       result.restStarted.push(emp.id);
+      workStarted = true;
     }
 
     if (emp.pendingTaskDuration !== null) {
@@ -71,6 +74,15 @@ export function tickArrivalGate(state: GameState, emitter?: EventEmitter): Arriv
       // them itself. Clearing them here would make every task's completion
       // handler blind to what it just did (see survey.integration.test.ts).
       result.taskStarted.push(emp.id);
+      workStarted = true;
+    }
+
+    // The employee has physically reached the target and started working —
+    // promote the PendingAction from 'assigned' (claimed, still walking) to
+    // 'in_progress' (#547).
+    if (workStarted && emp.activeActionId !== null) {
+      const action = state.pendingActions.find(a => a.id === emp.activeActionId);
+      if (action) action.status = 'in_progress';
     }
 
     if (emp.pendingDriverVehicleId !== null) {

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -17,6 +17,7 @@ import type { EventEmitter } from '../state/EventEmitter.js';
 import { addExpense } from '../economy/Finance.js';
 import { tickVehicle, tickVehicleTaskState, tickEmployeeMovement, type EmployeeMovementResult } from './EntityMovementTick.js';
 import { tickArrivalGate, type ArrivalGateResult } from './ArrivalGate.js';
+import { completePendingAction } from './TaskDispatch.js';
 
 // ── Config ──
 
@@ -145,20 +146,19 @@ export interface TickEmployeesResult {
 
 /**
  * Match pending actions to idle qualified employees.
- * Mutates state: removes claimed actions from pendingActions and sets activeActionId on employees.
- *
- * TODO(#547): claim must transition status to 'assigned' + stamp holderId
- * instead of splicing the action out of pendingActions; the ghost must gain
- * `claimed: true` instead of being deleted. tickArrivalGate's promotion to
- * 'in_progress', and rest-action bookkeeping (autoInsertNeedTasks,
- * tickCollapse, completeRestTick) that filters the pool by action id, need
- * updating for records that now outlive the claim.
+ * Mutates state: transitions claimed actions' status/holderId in place (and
+ * marks their ghost `claimed`) instead of removing them — the record and its
+ * ghost persist until completePendingAction runs at completion (#547). Sets
+ * activeActionId on the claiming employee. Actions already 'assigned' or
+ * 'in_progress' are skipped entirely — not re-evaluated as claimable, not
+ * counted as still-waiting.
  */
 export function tickEmployees(state: GameState): TickEmployeesResult {
   const result: TickEmployeesResult = { claimed: [], unqualified: [], waiting: [] };
-  const remaining: PendingAction[] = [];
 
   for (const action of state.pendingActions) {
+    if (action.status !== 'queued') continue;
+
     // Base eligibility: alive, not injured, not in training.
     const eligible = state.employees.employees.filter(
       emp => emp.alive && !emp.injured && emp.trainingState === null,
@@ -171,7 +171,6 @@ export function tickEmployees(state: GameState): TickEmployeesResult {
 
     if (allWithSkill.length === 0) {
       result.unqualified.push(action.id);
-      remaining.push(action);
       continue;
     }
 
@@ -182,13 +181,19 @@ export function tickEmployees(state: GameState): TickEmployeesResult {
 
     if (!idleMatch) {
       result.waiting.push(action.id);
-      remaining.push(action);
       continue;
     }
 
     idleMatch.activeActionId = action.id;
     result.claimed.push(action.id);
-    // action is consumed — not pushed to remaining
+
+    // Transition status/holderId in place — the record (and its ghost) stay
+    // visible while the employee walks to the target; only completion removes
+    // them (#547). This is the actual claim path the tick loop uses
+    // (claimPendingAction in TaskDispatch.ts is a separate helper nothing
+    // here calls), so it owns marking the ghost claimed too.
+    action.status = 'assigned';
+    action.holderId = idleMatch.id;
 
     // Send the employee walking toward the action's location — targetX/targetZ
     // is documented on PendingAction as existing for exactly this purpose
@@ -196,12 +201,8 @@ export function tickEmployees(state: GameState): TickEmployeesResult {
     idleMatch.destinationX = action.targetX;
     idleMatch.destinationZ = action.targetZ;
 
-    // This is the actual claim path the tick loop uses (claimPendingAction in
-    // TaskDispatch.ts is a separate helper nothing here calls), so it owns
-    // clearing the ghost preview too — otherwise the blue marker never
-    // disappears once a real employee picks up the work (#406).
-    const ghostIdx = state.ghostPreviews.findIndex(g => g.id === action.id);
-    if (ghostIdx !== -1) state.ghostPreviews.splice(ghostIdx, 1);
+    const ghost = state.ghostPreviews.find(g => g.id === action.id);
+    if (ghost) ghost.claimed = true;
 
     // tickCollapse/tickNeedRestoration self-claim (see above) and, like this
     // branch, only ever *queue* the rest via pendingRestDuration/
@@ -253,7 +254,6 @@ export function tickEmployees(state: GameState): TickEmployeesResult {
     }
   }
 
-  state.pendingActions = remaining;
   return result;
 }
 
@@ -312,12 +312,15 @@ export function tickNeedRestoration(state: GameState): NeedRestorationResult {
       targetEmployeeId: emp.id,
       payload: { buildingId: building.id, needKey, restDuration },
     });
+    // Immediately claimed (unlike autoInsertNeedTasks) — status/holderId
+    // reflect that from creation (#547).
+    restAction.status = 'assigned';
+    restAction.holderId = emp.id;
 
     state.pendingActions.push(restAction);
     emp.activeActionId = restAction.id;
-    // Immediately claimed (unlike autoInsertNeedTasks) — but the rest timer
-    // itself does not start until ArrivalGate.tickArrivalGate confirms the
-    // employee has walked to the building (#437).
+    // The rest timer itself does not start until ArrivalGate.tickArrivalGate
+    // confirms the employee has walked to the building (#437).
     emp.pendingRestDuration = restDuration;
     emp.pendingRestNeedKey = needKey;
     emp.destinationX = approach.x;
@@ -390,9 +393,14 @@ export function tickCollapse(state: GameState, _firedEvents?: FiredEvent[], _emi
     // is claimed immediately. Left in the queue it is claimed the moment the
     // collapse rest ends — a second rest cycle and a second NEED_REST_COSTS
     // charge for one collapse, listed alongside the active one in the roster panel.
-    state.pendingActions = state.pendingActions.filter(
-      a => !(a.type === 'rest' && a.targetEmployeeId === emp.id),
-    );
+    // completePendingAction removes both the record and its ghost — a
+    // superseded action is discarded outright, not completed by an employee,
+    // but the removal shape (record + ghost, together) is the same (#547).
+    for (const superseded of state.pendingActions.filter(
+      a => a.type === 'rest' && a.targetEmployeeId === emp.id,
+    )) {
+      completePendingAction(state, superseded.id);
+    }
 
     const restAction = createRestPendingAction(state, {
       targetX,
@@ -400,10 +408,13 @@ export function tickCollapse(state: GameState, _firedEvents?: FiredEvent[], _emi
       targetEmployeeId: emp.id,
       payload: { buildingId, collapsedNeed: collapsedGauge, needKey: collapsedGauge, restDuration },
     });
+    // Immediately claimed — status/holderId reflect that from creation (#547).
+    restAction.status = 'assigned';
+    restAction.holderId = emp.id;
 
     state.pendingActions.push(restAction);
     emp.activeActionId = restAction.id;
-    // Immediately claimed — but the rest timer itself does not start until
+    // The rest timer itself does not start until
     // ArrivalGate.tickArrivalGate confirms arrival (mirrors tickNeedRestoration, #437).
     // When resting in place (targetX/Z === emp.x/z, the two no-building branches
     // above) the employee is already "arrived" and the gate resolves next tick.
@@ -535,9 +546,10 @@ function createRestPendingAction(
     targetY: 0,
     payload: overrides.payload,
     targetEmployeeId: overrides.targetEmployeeId,
-    // TODO(#547): rest actions self-claim immediately at every call site
-    // below — 'queued'/null here is a type-compliance default overwritten by
-    // the caller once the lifecycle claim path lands, not real logic.
+    // Default is genuinely 'queued'/unheld — autoInsertNeedTasks (the
+    // busy-employee case) leaves it exactly this way. The three self-claiming
+    // callers (tickNeedRestoration, tickCollapse, forceShiftRestIfNeeded)
+    // overwrite status/holderId immediately after construction (#547).
     status: 'queued',
     holderId: null,
   };
@@ -672,10 +684,10 @@ export function tickGeneralRestCompletion(state: GameState): GeneralRestCompleti
 
     const completedActionId = emp.activeActionId;
     completeRestForEmployee(state, emp, needKey);
-    // tickCollapse/tickNeedRestoration leave the rest action in pendingActions
-    // at creation (they self-claim instead of routing through tickEmployees),
-    // so nothing else removes it once the rest completes.
-    state.pendingActions = state.pendingActions.filter(a => a.id !== completedActionId);
+    // tickCollapse/tickNeedRestoration/autoInsertNeedTasks leave the rest
+    // action in pendingActions at creation (self-claimed or claimed later via
+    // tickEmployees), so nothing else removes it once the rest completes.
+    if (completedActionId !== null) completePendingAction(state, completedActionId);
 
     completed.push({ employeeId: emp.id, needKey });
   }
@@ -756,6 +768,8 @@ export interface TaskProgressResult {
   actionType?: ActionType;
   /** Payload of the task that just completed — only present when `completed` is true. */
   actionPayload?: Record<string, unknown>;
+  /** ID of the PendingAction that just completed — only present when `completed` is true (#547). */
+  actionId?: number;
 }
 
 /**
@@ -793,13 +807,17 @@ export function tickTaskProgress(state: GameState, emp: Employee, emitter?: Even
   let completed = false;
   let completedActionType: ActionType | undefined;
   let completedActionPayload: Record<string, unknown> | undefined;
+  let completedActionId: number | undefined;
   if (emp.taskTicksRemaining <= 0) {
     completed = true;
     // pendingActionType/pendingActionPayload were left set by tickEmployees at
     // claim time (#437) specifically so completion handling — e.g. resolving
-    // a completed survey — still knows what work this was.
+    // a completed survey — still knows what work this was. activeActionId is
+    // captured here, before it's nulled below, so the caller can remove the
+    // matching PendingAction/ghost via completePendingAction (#547).
     completedActionType = emp.pendingActionType ?? undefined;
     completedActionPayload = emp.pendingActionPayload ?? undefined;
+    completedActionId = emp.activeActionId ?? undefined;
     emp.activeActionId = null;
     emp.taskTicksRemaining = null;
     delete emp.activeTaskTotalTicks;
@@ -815,6 +833,7 @@ export function tickTaskProgress(state: GameState, emp: Employee, emitter?: Even
     ...(levelUpLevels ? { oldLevel: levelUpLevels.oldLevel, newLevel: levelUpLevels.newLevel } : {}),
     ...(completedActionType !== undefined ? { actionType: completedActionType } : {}),
     ...(completedActionPayload !== undefined ? { actionPayload: completedActionPayload } : {}),
+    ...(completedActionId !== undefined ? { actionId: completedActionId } : {}),
   };
 }
 
@@ -836,7 +855,12 @@ function completeRestTick(
   emp.restTicksRemaining -= 1;
 
   if (emp.restTicksRemaining <= 0) {
+    const completedActionId = emp.activeActionId;
     completeRestForEmployee(state, emp, 'fatigue');
+    // forceShiftRestIfNeeded self-claims this action at creation, so — like
+    // tickGeneralRestCompletion's own rest sources — nothing else removes it
+    // from pendingActions/ghostPreviews once the rest completes (#547).
+    if (completedActionId !== null) completePendingAction(state, completedActionId);
     emp.ticksWorked = 0;
     restCompleted.push(emp.id);
   }
@@ -909,6 +933,9 @@ function forceShiftRestIfNeeded(
     targetEmployeeId: emp.id,
     payload: { needType: 'fatigue', triggeredBy: 'shift_cycle', buildingId },
   });
+  // Immediately claimed — status/holderId reflect that from creation (#547).
+  restAction.status = 'assigned';
+  restAction.holderId = emp.id;
 
   state.pendingActions.push(restAction);
   emp.activeActionId = restAction.id;

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -17,7 +17,7 @@ import type { EventEmitter } from '../state/EventEmitter.js';
 import { addExpense } from '../economy/Finance.js';
 import { tickVehicle, tickVehicleTaskState, tickEmployeeMovement, type EmployeeMovementResult } from './EntityMovementTick.js';
 import { tickArrivalGate, type ArrivalGateResult } from './ArrivalGate.js';
-import { completePendingAction } from './TaskDispatch.js';
+import { completePendingAction, claimPendingAction } from './TaskDispatch.js';
 
 // ── Config ──
 
@@ -187,22 +187,16 @@ export function tickEmployees(state: GameState): TickEmployeesResult {
     idleMatch.activeActionId = action.id;
     result.claimed.push(action.id);
 
-    // Transition status/holderId in place — the record (and its ghost) stay
-    // visible while the employee walks to the target; only completion removes
-    // them (#547). This is the actual claim path the tick loop uses
-    // (claimPendingAction in TaskDispatch.ts is a separate helper nothing
-    // here calls), so it owns marking the ghost claimed too.
-    action.status = 'assigned';
-    action.holderId = idleMatch.id;
+    // Transition status/holderId in place (and marks the ghost claimed) via
+    // the shared claim helper — the record (and its ghost) stay visible while
+    // the employee walks to the target; only completion removes them (#547).
+    claimPendingAction(state, action.id, idleMatch.id);
 
     // Send the employee walking toward the action's location — targetX/targetZ
     // is documented on PendingAction as existing for exactly this purpose
     // ("ghost rendering and employee pathfinding"), previously unused.
     idleMatch.destinationX = action.targetX;
     idleMatch.destinationZ = action.targetZ;
-
-    const ghost = state.ghostPreviews.find(g => g.id === action.id);
-    if (ghost) ghost.claimed = true;
 
     // tickCollapse/tickNeedRestoration self-claim (see above) and, like this
     // branch, only ever *queue* the rest via pendingRestDuration/
@@ -225,9 +219,16 @@ export function tickEmployees(state: GameState): TickEmployeesResult {
       }
     }
 
-    // Non-rest actions requiring a skill queue their task duration here — the
-    // claimed employee is guaranteed (via allWithSkill above) to hold
-    // requiredSkill, so proficiency lookup below always succeeds. The
+    // Non-rest actions queue their task duration here — a skill-required
+    // action's claimed employee is guaranteed (via allWithSkill above) to
+    // hold requiredSkill, so the proficiency lookup below always succeeds.
+    // requiredSkill === null (e.g. a console `employee dispatch` with no
+    // skill: param — src/console/commands/employees.ts) has no qualification
+    // to scale off, so it's treated as Rookie baseline (proficiency level 1,
+    // the existing ×1.00 entry in PROFICIENCY_MULTIPLIERS) rather than being
+    // skipped — skipping it left pendingTaskDuration/taskTicksRemaining never
+    // seeded, so ArrivalGate could never promote the action to in_progress
+    // and it, and its ghost, leaked in state forever (#547 review). The
     // countdown itself (taskTicksRemaining) does not start until
     // ArrivalGate.tickArrivalGate confirms the employee has physically
     // reached targetX/targetZ (#437) — a survey used to resolve the instant
@@ -235,8 +236,10 @@ export function tickEmployees(state: GameState): TickEmployeesResult {
     // pendingActionType/pendingActionPayload stay set through to completion
     // (tickTaskProgress clears them) so completion handling (e.g. survey
     // resolution) still knows what work just finished.
-    if (action.type !== 'rest' && action.requiredSkill !== null) {
-      const qual = idleMatch.qualifications.find(q => q.category === action.requiredSkill);
+    if (action.type !== 'rest') {
+      const qual = action.requiredSkill !== null
+        ? idleMatch.qualifications.find(q => q.category === action.requiredSkill)
+        : undefined;
       const level = qual?.proficiencyLevel ?? 1;
       const needMult = getNeedMultiplier(idleMatch);
       const lqMult = getLivingQuartersWellbeingMultiplier(state.buildings, state.employees.employees.length);
@@ -306,16 +309,14 @@ export function tickNeedRestoration(state: GameState): NeedRestorationResult {
 
     const approach = resolveBuildingApproach(state, building, emp.x, emp.z);
 
+    // Immediately claimed (unlike autoInsertNeedTasks) — status/holderId
+    // reflect that from creation (#547).
     const restAction = createRestPendingAction(state, {
       targetX: approach.x,
       targetZ: approach.z,
       targetEmployeeId: emp.id,
       payload: { buildingId: building.id, needKey, restDuration },
-    });
-    // Immediately claimed (unlike autoInsertNeedTasks) — status/holderId
-    // reflect that from creation (#547).
-    restAction.status = 'assigned';
-    restAction.holderId = emp.id;
+    }, emp.id);
 
     state.pendingActions.push(restAction);
     emp.activeActionId = restAction.id;
@@ -402,15 +403,13 @@ export function tickCollapse(state: GameState, _firedEvents?: FiredEvent[], _emi
       completePendingAction(state, superseded.id);
     }
 
+    // Immediately claimed — status/holderId reflect that from creation (#547).
     const restAction = createRestPendingAction(state, {
       targetX,
       targetZ,
       targetEmployeeId: emp.id,
       payload: { buildingId, collapsedNeed: collapsedGauge, needKey: collapsedGauge, restDuration },
-    });
-    // Immediately claimed — status/holderId reflect that from creation (#547).
-    restAction.status = 'assigned';
-    restAction.holderId = emp.id;
+    }, emp.id);
 
     state.pendingActions.push(restAction);
     emp.activeActionId = restAction.id;
@@ -531,10 +530,18 @@ export function autoInsertNeedTasks(state: GameState, _firedEvents?: FiredEvent[
 /**
  * Create a rest PendingAction with boilerplate fields pre-filled.
  * Generates a new ID from state.nextPendingActionId.
+ *
+ * `claimedByEmployeeId`, when given, constructs the record already-claimed
+ * (status 'assigned', holderId set) — the shape tickNeedRestoration,
+ * tickCollapse, and forceShiftRestIfNeeded all need, since each self-claims
+ * a rest action synchronously at creation rather than leaving it for
+ * tickEmployees to match. Omit it for autoInsertNeedTasks' busy-employee
+ * case, which leaves the action genuinely 'queued'/unheld.
  */
 function createRestPendingAction(
   state: GameState,
   overrides: Pick<PendingAction, 'targetX' | 'targetZ' | 'targetEmployeeId' | 'payload'>,
+  claimedByEmployeeId?: number,
 ): PendingAction {
   return {
     id: state.nextPendingActionId++,
@@ -546,12 +553,8 @@ function createRestPendingAction(
     targetY: 0,
     payload: overrides.payload,
     targetEmployeeId: overrides.targetEmployeeId,
-    // Default is genuinely 'queued'/unheld — autoInsertNeedTasks (the
-    // busy-employee case) leaves it exactly this way. The three self-claiming
-    // callers (tickNeedRestoration, tickCollapse, forceShiftRestIfNeeded)
-    // overwrite status/holderId immediately after construction (#547).
-    status: 'queued',
-    holderId: null,
+    status: claimedByEmployeeId !== undefined ? 'assigned' : 'queued',
+    holderId: claimedByEmployeeId ?? null,
   };
 }
 
@@ -927,15 +930,13 @@ function forceShiftRestIfNeeded(
   // confirms the employee has walked to the bunkhouse (#437).
   emp.pendingRestDuration = SHIFT_SLEEP_DURATION_TICKS;
 
+  // Immediately claimed — status/holderId reflect that from creation (#547).
   const restAction = createRestPendingAction(state, {
     targetX,
     targetZ,
     targetEmployeeId: emp.id,
     payload: { needType: 'fatigue', triggeredBy: 'shift_cycle', buildingId },
-  });
-  // Immediately claimed — status/holderId reflect that from creation (#547).
-  restAction.status = 'assigned';
-  restAction.holderId = emp.id;
+  }, emp.id);
 
   state.pendingActions.push(restAction);
   emp.activeActionId = restAction.id;

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -782,8 +782,10 @@ export interface TaskProgressResult {
  *
  * No-op (returns null) for an employee with no in-progress task
  * (taskTicksRemaining === null) — includes employees currently resting and
- * employees dispatched with no required skill (taskTicksRemaining never seeded
- * for those, see tickEmployees).
+ * any employee not yet promoted out of pendingTaskDuration by ArrivalGate
+ * (still walking to the target). requiredSkill === null no longer excludes
+ * an action from this path — tickEmployees seeds pendingTaskDuration for
+ * every non-rest action regardless of requiredSkill (#547).
  */
 export function tickTaskProgress(state: GameState, emp: Employee, emitter?: EventEmitter): TaskProgressResult | null {
   if (emp.taskTicksRemaining === null) return null;

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -146,6 +146,13 @@ export interface TickEmployeesResult {
 /**
  * Match pending actions to idle qualified employees.
  * Mutates state: removes claimed actions from pendingActions and sets activeActionId on employees.
+ *
+ * TODO(#547): claim must transition status to 'assigned' + stamp holderId
+ * instead of splicing the action out of pendingActions; the ghost must gain
+ * `claimed: true` instead of being deleted. tickArrivalGate's promotion to
+ * 'in_progress', and rest-action bookkeeping (autoInsertNeedTasks,
+ * tickCollapse, completeRestTick) that filters the pool by action id, need
+ * updating for records that now outlive the claim.
  */
 export function tickEmployees(state: GameState): TickEmployeesResult {
   const result: TickEmployeesResult = { claimed: [], unqualified: [], waiting: [] };
@@ -528,6 +535,11 @@ function createRestPendingAction(
     targetY: 0,
     payload: overrides.payload,
     targetEmployeeId: overrides.targetEmployeeId,
+    // TODO(#547): rest actions self-claim immediately at every call site
+    // below — 'queued'/null here is a type-compliance default overwritten by
+    // the caller once the lifecycle claim path lands, not real logic.
+    status: 'queued',
+    holderId: null,
   };
 }
 

--- a/src/core/engine/TaskDispatch.ts
+++ b/src/core/engine/TaskDispatch.ts
@@ -69,33 +69,45 @@ export function dispatchPendingAction(
  * its ghost) remain in `state.pendingActions`/`state.ghostPreviews` — only
  * status/holderId (and the ghost's `claimed` flag) change, so the record
  * stays visible while the employee walks to it (#547).
- * Returns the claimed action, or null if not found.
  *
- * TODO: implement — currently a stub, see #547.
+ * Returns null (a no-op guard against double-claiming) when the action does
+ * not exist, or its status is not 'queued' — an already-assigned/in_progress
+ * action cannot be claimed a second time. Returns the mutated action on
+ * success.
  */
 export function claimPendingAction(
   state: GameState,
   actionId: number,
   employeeId: number,
 ): PendingAction | null {
-  void state;
-  void actionId;
-  void employeeId;
-  return null;
+  const action = state.pendingActions.find(a => a.id === actionId);
+  if (!action || action.status !== 'queued') return null;
+
+  action.status = 'assigned';
+  action.holderId = employeeId;
+
+  const ghost = state.ghostPreviews.find(g => g.id === actionId);
+  if (ghost) ghost.claimed = true;
+
+  return action;
 }
 
 /**
  * Remove a completed action and its ghost preview from state entirely.
- * Returns the completed action, or null if not found.
- *
- * TODO: implement — currently a stub, see #547.
+ * Returns the completed action, or null if no action with that id existed —
+ * a safe no-op, callable more than once for the same id.
  */
 export function completePendingAction(
   state: GameState,
   actionId: number,
 ): PendingAction | null {
-  void state;
-  void actionId;
-  return null;
+  const idx = state.pendingActions.findIndex(a => a.id === actionId);
+  if (idx === -1) return null;
+  const [action] = state.pendingActions.splice(idx, 1);
+
+  const ghostIdx = state.ghostPreviews.findIndex(g => g.id === actionId);
+  if (ghostIdx !== -1) state.ghostPreviews.splice(ghostIdx, 1);
+
+  return action ?? null;
 }
 

--- a/src/core/engine/TaskDispatch.ts
+++ b/src/core/engine/TaskDispatch.ts
@@ -32,7 +32,7 @@ export type DispatchRejectionReason = 'target-not-found' | 'target-unqualified' 
  */
 export function dispatchPendingAction(
   state: GameState,
-  action: PendingAction,
+  action: Omit<PendingAction, 'status' | 'holderId'>,
 ): { success: boolean; error?: string; reason?: DispatchRejectionReason } {
   const targetId = action.targetEmployeeId;
   const isQualified = (emp: { alive: boolean; qualifications: { category: string }[] }): boolean =>
@@ -50,30 +50,52 @@ export function dispatchPendingAction(
   } else if (!state.employees.employees.some(isQualified)) {
     return { success: false, error: 'unqualified', reason: 'roster-unqualified' };
   }
-  state.pendingActions.push(action);
+  // Full record constructed here — every dispatch starts life queued and
+  // unheld (#547); callers no longer supply status/holderId themselves.
+  state.pendingActions.push({ ...action, status: 'queued', holderId: null });
   state.ghostPreviews.push({
     id: action.id,
     type: action.type,
     targetX: action.targetX,
     targetZ: action.targetZ,
     targetY: action.targetY,
+    claimed: false,
   });
   return { success: true };
 }
 
 /**
- * Claim a pending action by id — removes it from both `pendingActions` and
- * `ghostPreviews` and returns the action, or null if not found.
+ * Claim a pending action by id, assigning it to `employeeId`. The action (and
+ * its ghost) remain in `state.pendingActions`/`state.ghostPreviews` — only
+ * status/holderId (and the ghost's `claimed` flag) change, so the record
+ * stays visible while the employee walks to it (#547).
+ * Returns the claimed action, or null if not found.
+ *
+ * TODO: implement — currently a stub, see #547.
  */
 export function claimPendingAction(
   state: GameState,
   actionId: number,
+  employeeId: number,
 ): PendingAction | null {
-  const idx = state.pendingActions.findIndex(a => a.id === actionId);
-  if (idx === -1) return null;
-  const [claimed] = state.pendingActions.splice(idx, 1);
-  const ghostIdx = state.ghostPreviews.findIndex(g => g.id === actionId);
-  if (ghostIdx !== -1) state.ghostPreviews.splice(ghostIdx, 1);
-  return claimed!;
+  void state;
+  void actionId;
+  void employeeId;
+  return null;
+}
+
+/**
+ * Remove a completed action and its ghost preview from state entirely.
+ * Returns the completed action, or null if not found.
+ *
+ * TODO: implement — currently a stub, see #547.
+ */
+export function completePendingAction(
+  state: GameState,
+  actionId: number,
+): PendingAction | null {
+  void state;
+  void actionId;
+  return null;
 }
 

--- a/src/core/mining/SurveyCalc.ts
+++ b/src/core/mining/SurveyCalc.ts
@@ -14,6 +14,7 @@ import {
 } from '../config/balance.js';
 import type { GameState } from '../state/GameState.js';
 import { addExpense } from '../economy/Finance.js';
+import { dispatchPendingAction } from '../engine/TaskDispatch.js';
 
 /** The three supported methods for surveying a mining site. */
 export type SurveyMethod = 'seismic' | 'core_sample' | 'aerial';
@@ -287,7 +288,13 @@ export function runSurvey(state: GameState, params: RunSurveyParams): RunSurveyR
 
   const actionId = state.nextPendingActionId++;
 
-  state.pendingActions.push({
+  // Routed through dispatchPendingAction (#547) rather than a hand-built
+  // literal — it owns constructing the full record (status: 'queued',
+  // holderId: null) and its matching GhostPreview (claimed: false), so this
+  // stays in sync with every other dispatch path. The qualification check it
+  // repeats is redundant with hasSurveyor above but harmless — the roster
+  // cannot have changed synchronously between the two checks.
+  dispatchPendingAction(state, {
     id: actionId,
     type: 'survey',
     requiredSkill: 'geology',
@@ -297,21 +304,6 @@ export function runSurvey(state: GameState, params: RunSurveyParams): RunSurveyR
     targetY: 0,
     payload: { method, centerX, centerZ, durationTicks: SURVEY_DURATION_TICKS[method] },
     targetEmployeeId: null,
-    // TODO(#547): minimal type-compliance defaults — real status transitions
-    // (queued → assigned → in_progress → removed) land with the lifecycle
-    // implementation, not here. This should likely be routed through
-    // dispatchPendingAction instead of a direct literal push.
-    status: 'queued',
-    holderId: null,
-  });
-
-  state.ghostPreviews.push({
-    id: actionId,
-    type: 'survey',
-    targetX: centerX,
-    targetZ: centerZ,
-    targetY: 0,
-    claimed: false,
   });
 
   return { success: true, actionId };

--- a/src/core/mining/SurveyCalc.ts
+++ b/src/core/mining/SurveyCalc.ts
@@ -297,6 +297,12 @@ export function runSurvey(state: GameState, params: RunSurveyParams): RunSurveyR
     targetY: 0,
     payload: { method, centerX, centerZ, durationTicks: SURVEY_DURATION_TICKS[method] },
     targetEmployeeId: null,
+    // TODO(#547): minimal type-compliance defaults — real status transitions
+    // (queued → assigned → in_progress → removed) land with the lifecycle
+    // implementation, not here. This should likely be routed through
+    // dispatchPendingAction instead of a direct literal push.
+    status: 'queued',
+    holderId: null,
   });
 
   state.ghostPreviews.push({
@@ -305,6 +311,7 @@ export function runSurvey(state: GameState, params: RunSurveyParams): RunSurveyR
     targetX: centerX,
     targetZ: centerZ,
     targetY: 0,
+    claimed: false,
   });
 
   return { success: true, actionId };

--- a/src/core/state/GameState.ts
+++ b/src/core/state/GameState.ts
@@ -54,7 +54,7 @@ import type { SitePolicy } from '../entities/SitePolicy.js';
 import { createSitePolicy } from '../entities/SitePolicy.js';
 
 /** Save format version — increment when GameState shape changes. */
-export const SAVE_VERSION = 7;
+export const SAVE_VERSION = 8;
 
 export interface GameConfig {
   seed: number;
@@ -76,6 +76,14 @@ export type ActionType =
   | 'rest'
   | 'general_work';
 
+/**
+ * Lifecycle status of a PendingAction — 'queued' (waiting, unclaimed),
+ * 'assigned' (claimed by an employee still walking to the target), or
+ * 'in_progress' (the employee has arrived and is executing it). The record
+ * (and its ghost) is only removed on completion (#547).
+ */
+export type PendingActionStatus = 'queued' | 'assigned' | 'in_progress';
+
 /** A lightweight renderer preview entry — mirrors a PendingAction for ghost-mesh display. */
 export interface GhostPreview {
   id: number;
@@ -83,6 +91,8 @@ export interface GhostPreview {
   targetX: number;
   targetZ: number;
   targetY: number;
+  /** True once an employee has claimed the underlying action (#547). */
+  claimed: boolean;
 }
 
 /** A pending action waiting for a qualified employee to execute it. */
@@ -100,6 +110,10 @@ export interface PendingAction {
   payload: Record<string, unknown>;
   /** If set, only this employee may claim the action. null = any qualified employee. */
   targetEmployeeId: number | null;
+  /** Lifecycle status — see PendingActionStatus (#547). */
+  status: PendingActionStatus;
+  /** Employee currently holding (assigned to/working) this action, or null while 'queued' (#547). Distinct from targetEmployeeId, which restricts eligibility rather than recording who claimed it. */
+  holderId: number | null;
 }
 
 /**

--- a/src/core/state/SaveLoad.ts
+++ b/src/core/state/SaveLoad.ts
@@ -167,13 +167,13 @@ export function deserialize(json: string): GameState {
     // Map pending-action id -> claiming employee id, from each employee's
     // activeActionId — the only place a pre-#547 save records "this action is
     // already claimed by me".
-    const employeesRaw2 = obj['employees'] as Record<string, unknown> | undefined;
-    const employeeList2 = employeesRaw2
-      ? (employeesRaw2['employees'] as Array<Record<string, unknown>> | undefined)
+    const employeesForActiveActionCleanupRaw = obj['employees'] as Record<string, unknown> | undefined;
+    const employeesForActiveActionCleanup = employeesForActiveActionCleanupRaw
+      ? (employeesForActiveActionCleanupRaw['employees'] as Array<Record<string, unknown>> | undefined)
       : undefined;
     const claimingEmployeeByActionId = new Map<unknown, unknown>();
-    if (Array.isArray(employeeList2)) {
-      for (const e of employeeList2) {
+    if (Array.isArray(employeesForActiveActionCleanup)) {
+      for (const e of employeesForActiveActionCleanup) {
         if (e['activeActionId'] !== null && e['activeActionId'] !== undefined) {
           claimingEmployeeByActionId.set(e['activeActionId'], e['id']);
         }
@@ -211,8 +211,8 @@ export function deserialize(json: string): GameState {
     const migratedIds = new Set(
       Array.isArray(pendingActionsRaw) ? pendingActionsRaw.map(a => a['id']) : [],
     );
-    if (Array.isArray(employeeList2)) {
-      for (const e of employeeList2) {
+    if (Array.isArray(employeesForActiveActionCleanup)) {
+      for (const e of employeesForActiveActionCleanup) {
         if (e['activeActionId'] !== null && e['activeActionId'] !== undefined && !migratedIds.has(e['activeActionId'])) {
           e['activeActionId'] = null;
         }

--- a/src/core/state/SaveLoad.ts
+++ b/src/core/state/SaveLoad.ts
@@ -152,6 +152,47 @@ export function deserialize(json: string): GameState {
     if (typeof tubingRaw['inventory'] !== 'number') tubingRaw['inventory'] = 0;
   }
 
+  // v7 → v8: PendingAction/GhostPreview gained a lifecycle (status/holderId,
+  // claimed) — a pre-v8 save's actions were deleted from pendingActions the
+  // instant they were claimed (the bug #547 fixes), so every entry that
+  // survived to be saved was, by construction, still queued and unheld.
+  if ((obj['version'] as number) < 8) {
+    const pendingActionsRaw = obj['pendingActions'] as Array<Record<string, unknown>> | undefined;
+    if (Array.isArray(pendingActionsRaw)) {
+      for (const action of pendingActionsRaw) {
+        if (action['status'] === undefined) action['status'] = 'queued';
+        if (action['holderId'] === undefined) action['holderId'] = null;
+      }
+    }
+
+    const ghostPreviewsRaw = obj['ghostPreviews'] as Array<Record<string, unknown>> | undefined;
+    if (Array.isArray(ghostPreviewsRaw)) {
+      for (const ghost of ghostPreviewsRaw) {
+        if (ghost['claimed'] === undefined) ghost['claimed'] = false;
+      }
+    }
+
+    // A pre-v8 save's claimed actions were already deleted from
+    // pendingActions by the old bug, so an employee's activeActionId can
+    // reference an id no longer present after migration — clear it rather
+    // than leave tickEmployees' idle check permanently blocked on a
+    // dangling reference.
+    const migratedIds = new Set(
+      Array.isArray(pendingActionsRaw) ? pendingActionsRaw.map(a => a['id']) : [],
+    );
+    const employeesRaw2 = obj['employees'] as Record<string, unknown> | undefined;
+    if (employeesRaw2) {
+      const employeeList2 = employeesRaw2['employees'] as Array<Record<string, unknown>> | undefined;
+      if (Array.isArray(employeeList2)) {
+        for (const e of employeeList2) {
+          if (e['activeActionId'] !== null && e['activeActionId'] !== undefined && !migratedIds.has(e['activeActionId'])) {
+            e['activeActionId'] = null;
+          }
+        }
+      }
+    }
+  }
+
   // v6: navGrid is never part of the JSON (see serialize's replacer) — always
   // null here, regardless of what an older save happened to carry. The
   // loader is responsible for rebuilding a real one.

--- a/src/core/state/SaveLoad.ts
+++ b/src/core/state/SaveLoad.ts
@@ -153,41 +153,68 @@ export function deserialize(json: string): GameState {
   }
 
   // v7 → v8: PendingAction/GhostPreview gained a lifecycle (status/holderId,
-  // claimed) — a pre-v8 save's actions were deleted from pendingActions the
-  // instant they were claimed (the bug #547 fixes), so every entry that
-  // survived to be saved was, by construction, still queued and unheld.
+  // claimed). A pre-v8 save's *dispatched-and-idle-claimed* actions were
+  // deleted from pendingActions the instant they were claimed (the bug #547
+  // fixes) — but rest actions created by tickCollapse/tickNeedRestoration/
+  // forceShiftRestIfNeeded (GameLoop.ts) already self-claimed synchronously
+  // at creation even pre-#547: they push the action to pendingActions AND
+  // set the claiming employee's activeActionId immediately, removing it only
+  // at rest completion. So a save taken mid-rest genuinely has a surviving
+  // pendingActions entry already claimed by a specific employee, not queued.
   if ((obj['version'] as number) < 8) {
     const pendingActionsRaw = obj['pendingActions'] as Array<Record<string, unknown>> | undefined;
+
+    // Map pending-action id -> claiming employee id, from each employee's
+    // activeActionId — the only place a pre-#547 save records "this action is
+    // already claimed by me".
+    const employeesRaw2 = obj['employees'] as Record<string, unknown> | undefined;
+    const employeeList2 = employeesRaw2
+      ? (employeesRaw2['employees'] as Array<Record<string, unknown>> | undefined)
+      : undefined;
+    const claimingEmployeeByActionId = new Map<unknown, unknown>();
+    if (Array.isArray(employeeList2)) {
+      for (const e of employeeList2) {
+        if (e['activeActionId'] !== null && e['activeActionId'] !== undefined) {
+          claimingEmployeeByActionId.set(e['activeActionId'], e['id']);
+        }
+      }
+    }
+
     if (Array.isArray(pendingActionsRaw)) {
       for (const action of pendingActionsRaw) {
-        if (action['status'] === undefined) action['status'] = 'queued';
-        if (action['holderId'] === undefined) action['holderId'] = null;
+        const holderId = claimingEmployeeByActionId.get(action['id']);
+        if (action['status'] === undefined) {
+          action['status'] = holderId !== undefined ? 'assigned' : 'queued';
+        }
+        if (action['holderId'] === undefined) {
+          action['holderId'] = holderId !== undefined ? holderId : null;
+        }
       }
     }
 
     const ghostPreviewsRaw = obj['ghostPreviews'] as Array<Record<string, unknown>> | undefined;
     if (Array.isArray(ghostPreviewsRaw)) {
       for (const ghost of ghostPreviewsRaw) {
-        if (ghost['claimed'] === undefined) ghost['claimed'] = false;
+        if (ghost['claimed'] === undefined) {
+          ghost['claimed'] = claimingEmployeeByActionId.has(ghost['id']);
+        }
       }
     }
 
-    // A pre-v8 save's claimed actions were already deleted from
-    // pendingActions by the old bug, so an employee's activeActionId can
-    // reference an id no longer present after migration — clear it rather
-    // than leave tickEmployees' idle check permanently blocked on a
-    // dangling reference.
+    // A pre-v8 save's dispatched-and-claimed actions (not the self-claimed
+    // rest actions handled above) were already deleted from pendingActions by
+    // the old bug, so an employee's activeActionId can reference an id no
+    // longer present after migration — clear a truly-dangling reference
+    // rather than leave tickEmployees' idle check permanently blocked on it.
+    // An action that matched a claiming employee above is, by construction,
+    // still present, so this only ever clears the genuinely-stale case.
     const migratedIds = new Set(
       Array.isArray(pendingActionsRaw) ? pendingActionsRaw.map(a => a['id']) : [],
     );
-    const employeesRaw2 = obj['employees'] as Record<string, unknown> | undefined;
-    if (employeesRaw2) {
-      const employeeList2 = employeesRaw2['employees'] as Array<Record<string, unknown>> | undefined;
-      if (Array.isArray(employeeList2)) {
-        for (const e of employeeList2) {
-          if (e['activeActionId'] !== null && e['activeActionId'] !== undefined && !migratedIds.has(e['activeActionId'])) {
-            e['activeActionId'] = null;
-          }
+    if (Array.isArray(employeeList2)) {
+      for (const e of employeeList2) {
+        if (e['activeActionId'] !== null && e['activeActionId'] !== undefined && !migratedIds.has(e['activeActionId'])) {
+          e['activeActionId'] = null;
         }
       }
     }

--- a/src/renderer/GhostMesh.ts
+++ b/src/renderer/GhostMesh.ts
@@ -23,6 +23,20 @@ const CLAIMED_OPACITY_MIN = 0.10;        // dimmest pulse value, claimed
 const CLAIMED_OPACITY_MAX = 0.30;        // brightest pulse value, claimed
 const CLAIMED_PULSE_SPEED = 1.1;         // radians / second, claimed
 
+/** Builds a ghost mesh material at the given starting opacity — the unclaimed
+ *  and claimed materials differ only in that value (#547 review). */
+function createGhostMaterial(opacity: number): THREE.MeshPhongMaterial {
+  return new THREE.MeshPhongMaterial({
+    color: GHOST_COLOR,
+    emissive: EMISSIVE_COLOR,
+    emissiveIntensity: 0.5,
+    transparent: true,
+    opacity,
+    depthWrite: false,
+    side: THREE.DoubleSide,
+  });
+}
+
 // ---------- Main class ----------
 
 export class GhostMesh {
@@ -36,24 +50,8 @@ export class GhostMesh {
 
   constructor(scene: THREE.Scene) {
     this.scene = scene;
-    this.material = new THREE.MeshPhongMaterial({
-      color: GHOST_COLOR,
-      emissive: EMISSIVE_COLOR,
-      emissiveIntensity: 0.5,
-      transparent: true,
-      opacity: OPACITY_MIN,
-      depthWrite: false,
-      side: THREE.DoubleSide,
-    });
-    this.claimedMaterial = new THREE.MeshPhongMaterial({
-      color: GHOST_COLOR,
-      emissive: EMISSIVE_COLOR,
-      emissiveIntensity: 0.5,
-      transparent: true,
-      opacity: CLAIMED_OPACITY_MIN,
-      depthWrite: false,
-      side: THREE.DoubleSide,
-    });
+    this.material = createGhostMaterial(OPACITY_MIN);
+    this.claimedMaterial = createGhostMaterial(CLAIMED_OPACITY_MIN);
   }
 
   /**

--- a/src/renderer/GhostMesh.ts
+++ b/src/renderer/GhostMesh.ts
@@ -15,19 +15,23 @@ const OPACITY_MAX     = 0.60;            // brightest pulse value
 const PULSE_SPEED     = 2.2;             // radians / second
 const GHOST_SIZE      = 0.9;             // box half-extent in metres
 
-// TODO(#547): claimed ghosts (an employee is en route/working) must read
-// distinctly from unclaimed ones via `preview.claimed` — dimmer, slower
-// pulse — while staying blue. Left unstubbed here (no new exported surface;
-// constants would trip noUnusedLocals until sync()/update() consume them) —
-// the implementer adds CLAIMED_OPACITY_MIN/MAX/CLAIMED_PULSE_SPEED alongside
-// the material swap that uses them.
+// Claimed ghosts (an employee has claimed the action and is en route/working
+// it, #547) read distinctly from unclaimed ones — dimmer and pulsing slower —
+// while staying the same blue. Roughly half the opacity range and half the
+// pulse speed of the unclaimed constants above.
+const CLAIMED_OPACITY_MIN = 0.10;        // dimmest pulse value, claimed
+const CLAIMED_OPACITY_MAX = 0.30;        // brightest pulse value, claimed
+const CLAIMED_PULSE_SPEED = 1.1;         // radians / second, claimed
 
 // ---------- Main class ----------
 
 export class GhostMesh {
   private readonly scene: THREE.Scene;
   private readonly meshes = new Map<number, THREE.Mesh>();
+  /** Material for unclaimed ghosts — brighter, faster pulse. */
   private readonly material: THREE.MeshPhongMaterial;
+  /** Material for claimed ghosts (#547) — dimmer, slower pulse, still blue. */
+  private readonly claimedMaterial: THREE.MeshPhongMaterial;
   private time = 0;
 
   constructor(scene: THREE.Scene) {
@@ -41,11 +45,22 @@ export class GhostMesh {
       depthWrite: false,
       side: THREE.DoubleSide,
     });
+    this.claimedMaterial = new THREE.MeshPhongMaterial({
+      color: GHOST_COLOR,
+      emissive: EMISSIVE_COLOR,
+      emissiveIntensity: 0.5,
+      transparent: true,
+      opacity: CLAIMED_OPACITY_MIN,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+    });
   }
 
   /**
    * Sync ghost meshes against the current ghost preview list.
-   * Adds meshes for new previews and removes meshes for gone ones.
+   * Adds meshes for new previews and removes meshes for gone ones. A preview
+   * whose `claimed` flag flips in place (same id, existing mesh) updates that
+   * mesh's material rather than recreating it (#547).
    * Call after syncFromContext() whenever ghostPreviews may have changed.
    */
   sync(previews: GhostPreview[]): void {
@@ -60,11 +75,18 @@ export class GhostMesh {
       }
     }
 
-    // Add newly queued ghosts
     for (const preview of previews) {
-      if (this.meshes.has(preview.id)) continue;
+      const targetMaterial = preview.claimed ? this.claimedMaterial : this.material;
+      const existing = this.meshes.get(preview.id);
+      if (existing) {
+        // Update material in place on a claimed/unclaimed transition —
+        // never recreate the mesh for this.
+        if (existing.material !== targetMaterial) existing.material = targetMaterial;
+        continue;
+      }
+
       const geo = new THREE.BoxGeometry(GHOST_SIZE, GHOST_SIZE, GHOST_SIZE);
-      const mesh = new THREE.Mesh(geo, this.material);
+      const mesh = new THREE.Mesh(geo, targetMaterial);
       mesh.position.set(
         preview.targetX,
         preview.targetY + GHOST_SIZE / 2,
@@ -77,12 +99,15 @@ export class GhostMesh {
 
   /**
    * Animate ghost opacity. Call every frame with elapsed seconds.
+   * Claimed and unclaimed ghosts pulse independently (#547).
    */
   update(dt: number): void {
     if (this.meshes.size === 0) return;
     this.time += dt;
     const t = (Math.sin(this.time * PULSE_SPEED) + 1) * 0.5; // 0..1
     this.material.opacity = OPACITY_MIN + t * (OPACITY_MAX - OPACITY_MIN);
+    const tc = (Math.sin(this.time * CLAIMED_PULSE_SPEED) + 1) * 0.5; // 0..1
+    this.claimedMaterial.opacity = CLAIMED_OPACITY_MIN + tc * (CLAIMED_OPACITY_MAX - CLAIMED_OPACITY_MIN);
   }
 
   /** Remove all ghost meshes from the scene. */
@@ -102,5 +127,6 @@ export class GhostMesh {
   dispose(): void {
     this.clearAll();
     this.material.dispose();
+    this.claimedMaterial.dispose();
   }
 }

--- a/src/renderer/GhostMesh.ts
+++ b/src/renderer/GhostMesh.ts
@@ -15,6 +15,13 @@ const OPACITY_MAX     = 0.60;            // brightest pulse value
 const PULSE_SPEED     = 2.2;             // radians / second
 const GHOST_SIZE      = 0.9;             // box half-extent in metres
 
+// TODO(#547): claimed ghosts (an employee is en route/working) must read
+// distinctly from unclaimed ones via `preview.claimed` — dimmer, slower
+// pulse — while staying blue. Left unstubbed here (no new exported surface;
+// constants would trip noUnusedLocals until sync()/update() consume them) —
+// the implementer adds CLAIMED_OPACITY_MIN/MAX/CLAIMED_PULSE_SPEED alongside
+// the material swap that uses them.
+
 // ---------- Main class ----------
 
 export class GhostMesh {

--- a/src/ui/panels/OperationsPanel.ts
+++ b/src/ui/panels/OperationsPanel.ts
@@ -153,7 +153,7 @@ export class OperationsPanel {
       oreReport: state.lastOreReport,
       accidents: state.damage.accidents.length,
       injured: state.employees.employees.filter(e => e.injured && e.alive).map(e => e.id),
-      unclaimed: state.pendingActions.filter(a => a.targetEmployeeId === null).length,
+      unclaimed: state.pendingActions.filter(a => a.status === 'queued').length,
       policy: state.sitePolicy.revision,
     });
     if (signature === this.lastSignature) return;
@@ -201,7 +201,7 @@ export class OperationsPanel {
     // pool action repeating on every eligible idle employee's own row — the
     // new CrewPanel shows only an employee's own claimed activity, so this is
     // now the only place an unclaimed action is visible at all (#39).
-    const unclaimed = state.pendingActions.filter(a => a.targetEmployeeId === null).length;
+    const unclaimed = state.pendingActions.filter(a => a.status === 'queued').length;
 
     const wrap = el('div');
     wrap.style.cssText = 'display:flex;flex-direction:column;gap:6px';

--- a/src/ui/panels/SurveyPanel.ts
+++ b/src/ui/panels/SurveyPanel.ts
@@ -191,6 +191,14 @@ export class SurveyPanel {
     const affordable = state.cash >= cost;
     this.runBtn.disabled = !hasSurveyor || !affordable;
 
+    // Deliberately not filtered by status like OperationsPanel's `unclaimed`
+    // count (status === 'queued') — this is meant to span the whole
+    // queued+assigned+in_progress window, matching this panel's "in
+    // progress" label. Pre-#547, claiming deleted the record immediately, so
+    // this undercounted (a claimed-but-not-yet-complete survey vanished from
+    // the total); now the record persists through completion, so this
+    // correctly reflects everything still underway. Don't "fix" this to
+    // match OperationsPanel's filter.
     const pending = state.pendingActions.filter(a => a.type === 'survey').length;
     const done = state.surveyResults.length;
 

--- a/tests/integration/skills.integration.test.ts
+++ b/tests/integration/skills.integration.test.ts
@@ -465,7 +465,7 @@ describe('Tick-driven task/XP pipeline (dispatch + tick command, issue #406)', (
     expect(masterSeeded).toBeLessThan(rookieSeeded);
   });
 
-  it('dispatch without a skill: param still queues general_work with requiredSkill: null and gets claimed (regression)', () => {
+  it('dispatch without a skill: param still queues general_work with requiredSkill: null, gets claimed and seeded, and reaches completion (regression, #547 review — the widened tickEmployees condition, action.type !== \'rest\' rather than requiredSkill !== null, is what makes this possible)', () => {
     const ctx = makeCtx();
     const empId = hireOne(ctx, 'driller');
 
@@ -476,22 +476,6 @@ describe('Tick-driven task/XP pipeline (dispatch + tick command, issue #406)', (
     expect(action).toBeDefined();
     expect(action!.requiredSkill).toBeNull();
     expect(action!.type).toBe('general_work');
-
-    tickCommand(ctx, ['1'], {});
-    const emp = ctx.state!.employees.employees.find(e => e.id === empId)!;
-    expect(emp.activeActionId).not.toBeNull();
-  });
-
-  it('a null-skill general_work action still gets pendingTaskDuration/taskTicksRemaining seeded and reaches completion (regression, #547 review — the widened tickEmployees condition, action.type !== \'rest\' rather than requiredSkill !== null, is what makes this possible)', () => {
-    const ctx = makeCtx();
-    const empId = hireOne(ctx, 'driller');
-
-    const result = employeeCommand(ctx, ['dispatch', String(empId)], { x: '3', z: '3' });
-    expect(result.success, result.output).toBe(true);
-
-    const action = ctx.state!.pendingActions.find(a => a.targetEmployeeId === empId);
-    expect(action).toBeDefined();
-    expect(action!.requiredSkill).toBeNull();
     const dispatchedActionId = action!.id;
 
     // Claim happens the very next tick — pendingTaskDuration is seeded on the

--- a/tests/integration/skills.integration.test.ts
+++ b/tests/integration/skills.integration.test.ts
@@ -482,6 +482,54 @@ describe('Tick-driven task/XP pipeline (dispatch + tick command, issue #406)', (
     expect(emp.activeActionId).not.toBeNull();
   });
 
+  it('a null-skill general_work action still gets pendingTaskDuration/taskTicksRemaining seeded and reaches completion (regression, #547 review — the widened tickEmployees condition, action.type !== \'rest\' rather than requiredSkill !== null, is what makes this possible)', () => {
+    const ctx = makeCtx();
+    const empId = hireOne(ctx, 'driller');
+
+    const result = employeeCommand(ctx, ['dispatch', String(empId)], { x: '3', z: '3' });
+    expect(result.success, result.output).toBe(true);
+
+    const action = ctx.state!.pendingActions.find(a => a.targetEmployeeId === empId);
+    expect(action).toBeDefined();
+    expect(action!.requiredSkill).toBeNull();
+    const dispatchedActionId = action!.id;
+
+    // Claim happens the very next tick — pendingTaskDuration is seeded on the
+    // claiming employee at claim time (tickEmployees), regardless of
+    // requiredSkill being null. Against the old narrow condition
+    // (requiredSkill !== null), this would stay null forever.
+    tickCommand(ctx, ['1'], {});
+    const empAfterClaim = ctx.state!.employees.employees.find(e => e.id === empId)!;
+    expect(empAfterClaim.activeActionId).not.toBeNull();
+    expect(empAfterClaim.pendingTaskDuration).not.toBeNull();
+
+    // ArrivalGate promotes pendingTaskDuration into taskTicksRemaining once
+    // the employee physically reaches (3,3) (#437).
+    tickUntilTaskSeeded(ctx, empId);
+    const seeded = ctx.state!.employees.employees.find(e => e.id === empId)!.taskTicksRemaining;
+    expect(seeded).not.toBeNull();
+    expect(seeded!).toBeGreaterThan(0);
+
+    // Tick through to completion — capped well beyond the seeded duration so
+    // a genuine regression (task stuck in_progress forever) fails fast rather
+    // than hanging.
+    for (let i = 0; i < seeded! + 5; i++) {
+      tickCommand(ctx, ['1'], {});
+      if (ctx.state!.employees.employees.find(e => e.id === empId)!.taskTicksRemaining === null) break;
+    }
+
+    const empFinal = ctx.state!.employees.employees.find(e => e.id === empId)!;
+    expect(empFinal.taskTicksRemaining).toBeNull();
+    expect(empFinal.activeActionId).toBeNull();
+
+    // The old narrow condition left pendingTaskDuration (and thus
+    // taskTicksRemaining) unseeded for a null-skill action, so it could never
+    // reach in_progress/completion and its record + ghost leaked forever.
+    // With the fix, both are cleaned up on completion (#547).
+    expect(ctx.state!.pendingActions.find(a => a.id === dispatchedActionId)).toBeUndefined();
+    expect(ctx.state!.ghostPreviews.find(g => g.id === dispatchedActionId)).toBeUndefined();
+  });
+
   it('dispatching to a skill nobody on the roster holds is rejected immediately, rather than silently queuing forever', () => {
     // dispatch now routes through dispatchPendingAction (TaskDispatch.ts),
     // which rejects a roster-wide-unqualified dispatch at dispatch time —

--- a/tests/integration/survey.integration.test.ts
+++ b/tests/integration/survey.integration.test.ts
@@ -285,6 +285,78 @@ describe('Survey system', () => {
     expect(ctx.state!.surveyResults[0]!.method).toBe('seismic');
   });
 
+  // ── PendingAction/ghost lifecycle spans the whole claim+walk+work period (#547) ──
+  //
+  // Before #547, tickEmployees deleted the PendingAction (and its ghost) the
+  // instant an employee claimed it — long before the surveyor actually
+  // reached the target. This proves the record and its ghost both survive
+  // multiple ticks of walking (only status/holderId/claimed flip), and are
+  // removed together on the exact tick the survey result lands, not before.
+
+  it('a queued survey record and ghost survive multiple ticks while the surveyor walks, and both vanish exactly on the tick the result lands', () => {
+    const empId = hireEmployeeByRole(ctx, 'surveyor');
+    employeeCommand(ctx, ['assign_skill', String(empId)], { skill: 'geology', level: '3' });
+    const emp = ctx.state!.employees.employees.find(e => e.id === empId)!;
+
+    // Survey far enough from the surveyor's spawn that several ticks of
+    // travel are needed before arrival.
+    surveyCommand(ctx as any, ['seismic'], { x: '2', z: '2' });
+
+    const dispatched = ctx.state!.pendingActions.find(a => a.type === 'survey');
+    expect(dispatched).toBeDefined();
+    expect(dispatched!.status).toBe('queued');
+    expect(dispatched!.holderId).toBeNull();
+    const actionId = dispatched!.id;
+
+    let ghost = ctx.state!.ghostPreviews.find(g => g.id === actionId);
+    expect(ghost).toBeDefined();
+    expect(ghost!.claimed).toBe(false);
+
+    // First tick: tickEmployees claims the action — still walking, nowhere
+    // near the target yet.
+    tickCommand(ctx, ['1'], {});
+
+    const claimed = ctx.state!.pendingActions.find(a => a.id === actionId);
+    expect(claimed).toBeDefined(); // record survives the claim — this is the whole point of #547
+    expect(['assigned', 'in_progress']).toContain(claimed!.status);
+    expect(claimed!.holderId).toBe(empId);
+
+    ghost = ctx.state!.ghostPreviews.find(g => g.id === actionId);
+    expect(ghost).toBeDefined();
+    expect(ghost!.claimed).toBe(true);
+
+    const travelTicks = Math.ceil(Math.hypot(emp.x - 2, emp.z - 2) / AGENT_WALK_SPEED);
+
+    // Walk through the remaining travel ticks (short of full arrival+work) —
+    // both the record and its ghost must stay present the entire time, and no
+    // survey result may land early.
+    for (let i = 0; i < Math.max(1, travelTicks - 1); i++) {
+      tickCommand(ctx, ['1'], {});
+      expect(ctx.state!.pendingActions.find(a => a.id === actionId)).toBeDefined();
+      expect(ctx.state!.ghostPreviews.find(g => g.id === actionId)).toBeDefined();
+      expect(ctx.state!.surveyResults).toHaveLength(0);
+    }
+
+    // Remaining ticks cover arrival + the full survey duration with slack.
+    // The result lands on exactly one tick — the same tick both the record
+    // and its ghost disappear, never one tick apart.
+    let removedOnTick = -1;
+    for (let i = 0; i < SURVEY_DURATION_TICKS.seismic + 10; i++) {
+      tickCommand(ctx, ['1'], {});
+      const stillPending = ctx.state!.pendingActions.find(a => a.id === actionId) !== undefined;
+      const stillGhosted = ctx.state!.ghostPreviews.find(g => g.id === actionId) !== undefined;
+      if (!stillPending || !stillGhosted) {
+        expect(stillPending).toBe(false);
+        expect(stillGhosted).toBe(false);
+        removedOnTick = i;
+        break;
+      }
+    }
+
+    expect(removedOnTick).toBeGreaterThanOrEqual(0);
+    expect(ctx.state!.surveyResults).toHaveLength(1);
+  });
+
   it('surveyCommand rejects and queues nothing when no qualified surveyor is available', () => {
     // No employee hired — runSurvey requires a qualified surveyor at queue time.
     const result = surveyCommand(ctx as any, ['core_sample'], { x: '16', z: '16' });

--- a/tests/unit/engine/GameLoop.test.ts
+++ b/tests/unit/engine/GameLoop.test.ts
@@ -435,7 +435,10 @@ describe('tickEmployees — claim logic (Task 3.6)', () => {
     const claimedAction = state.pendingActions.find(a => a.status === 'assigned');
     const queuedAction = state.pendingActions.find(a => a.status === 'queued');
     expect(claimedAction).toBeDefined();
-    expect(claimedAction!.holderId).toBe((employee as any).activeActionId);
+    // holderId is the claiming employee's id; activeActionId is the claimed
+    // action's id — distinct values, not equal to each other (#547).
+    expect(claimedAction!.holderId).toBe(employee.id);
+    expect((employee as any).activeActionId).toBe(claimedAction!.id);
     expect(queuedAction).toBeDefined();
     expect(queuedAction!.holderId).toBeNull();
   });

--- a/tests/unit/engine/GameLoop.test.ts
+++ b/tests/unit/engine/GameLoop.test.ts
@@ -197,7 +197,12 @@ describe('GameLoop', () => {
 describe('tickEmployees — claim logic (Task 3.6)', () => {
   const SEED = 42;
 
-  /** Build a minimal PendingAction for tests. */
+  /**
+   * Build a minimal PendingAction for tests. Defaults to 'queued'/unheld
+   * (#547) — the shape tickEmployees requires to even consider claiming it;
+   * override status/holderId explicitly for tests that need a different
+   * lifecycle state.
+   */
   function makePendingAction(
     overrides: Partial<PendingAction> & { id: number; requiredSkill: PendingAction['requiredSkill'] },
   ): PendingAction {

--- a/tests/unit/engine/GameLoop.test.ts
+++ b/tests/unit/engine/GameLoop.test.ts
@@ -214,9 +214,6 @@ describe('tickEmployees — claim logic (Task 3.6)', () => {
       targetY: 0,
       payload: {},
       targetEmployeeId: null,
-      // Every freshly-dispatched action starts life queued/unheld (#547) —
-      // callers below override status/holderId to model an already-claimed
-      // record.
       status: 'queued',
       holderId: null,
       ...overrides,

--- a/tests/unit/engine/GameLoop.test.ts
+++ b/tests/unit/engine/GameLoop.test.ts
@@ -209,6 +209,11 @@ describe('tickEmployees — claim logic (Task 3.6)', () => {
       targetY: 0,
       payload: {},
       targetEmployeeId: null,
+      // Every freshly-dispatched action starts life queued/unheld (#547) —
+      // callers below override status/holderId to model an already-claimed
+      // record.
+      status: 'queued',
+      holderId: null,
       ...overrides,
     };
   }
@@ -225,17 +230,22 @@ describe('tickEmployees — claim logic (Task 3.6)', () => {
 
     tickEmployees(state);
 
-    // Action should have been claimed — removed from pendingActions
-    expect(state.pendingActions).toHaveLength(0);
+    // Action should have been claimed — the record STAYS in pendingActions,
+    // only its status/holderId change (#547); it is no longer spliced out at
+    // claim time.
+    expect(state.pendingActions).toHaveLength(1);
+    expect(state.pendingActions[0]!.status).toBe('assigned');
+    expect(state.pendingActions[0]!.holderId).toBe(employee.id);
     // Employee should hold the action's id
     expect((employee as any).activeActionId).toBe(action.id);
   });
 
-  it('removes the matching GhostPreview when the action is claimed (issue #406)', () => {
+  it('flips the matching GhostPreview to claimed:true when the action is claimed, without removing it (#547, regression for #406)', () => {
     // tickEmployees is the tick loop's real claim path — claimPendingAction in
     // TaskDispatch.ts is a separate helper nothing in the loop calls — so it
-    // must own clearing ghostPreviews itself, or the blue marker never
-    // disappears once an employee actually picks up the work.
+    // must own updating ghostPreviews itself. Before #547 this deleted the
+    // ghost outright; now the ghost survives the claim (dimmer/slower — see
+    // GhostMesh.ts) and only disappears when the action itself completes.
     const state = createGame({ seed: SEED });
     const rng = new Random(SEED);
 
@@ -244,24 +254,28 @@ describe('tickEmployees — claim logic (Task 3.6)', () => {
 
     const action = makePendingAction({ id: 3, requiredSkill: 'blasting', targetX: 5, targetZ: 6 });
     state.pendingActions.push(action);
-    state.ghostPreviews.push({ id: 3, type: action.type, targetX: 5, targetZ: 6, targetY: 0 });
+    state.ghostPreviews.push({ id: 3, type: action.type, targetX: 5, targetZ: 6, targetY: 0, claimed: false });
 
     tickEmployees(state);
 
-    expect(state.ghostPreviews.find(g => g.id === 3)).toBeUndefined();
+    const ghost = state.ghostPreviews.find(g => g.id === 3);
+    expect(ghost).toBeDefined();
+    expect(ghost!.claimed).toBe(true);
   });
 
-  it('leaves an unclaimed action\'s GhostPreview untouched (issue #406)', () => {
+  it('leaves an unclaimed action\'s GhostPreview untouched, still claimed:false (issue #406)', () => {
     const state = createGame({ seed: SEED });
     // No employees hired — action stays pending and unclaimed.
 
     const action = makePendingAction({ id: 4, requiredSkill: 'geology', targetX: 1, targetZ: 2 });
     state.pendingActions.push(action);
-    state.ghostPreviews.push({ id: 4, type: action.type, targetX: 1, targetZ: 2, targetY: 0 });
+    state.ghostPreviews.push({ id: 4, type: action.type, targetX: 1, targetZ: 2, targetY: 0, claimed: false });
 
     tickEmployees(state);
 
-    expect(state.ghostPreviews.find(g => g.id === 4)).toBeDefined();
+    const ghost = state.ghostPreviews.find(g => g.id === 4);
+    expect(ghost).toBeDefined();
+    expect(ghost!.claimed).toBe(false);
   });
 
   it('returns claimed action ID in result.claimed', () => {
@@ -382,8 +396,13 @@ describe('tickEmployees — claim logic (Task 3.6)', () => {
 
     tickEmployees(state);
 
-    // Both actions must have been claimed
-    expect(state.pendingActions).toHaveLength(0);
+    // Both actions must have been claimed — and, per #547, both records
+    // still live in pendingActions (only status/holderId changed).
+    expect(state.pendingActions).toHaveLength(2);
+    for (const a of state.pendingActions) {
+      expect(a.status).toBe('assigned');
+      expect(a.holderId).not.toBeNull();
+    }
     // Each employee holds one of the action IDs
     const assignedIds = [
       (emp1 as any).activeActionId,
@@ -408,9 +427,68 @@ describe('tickEmployees — claim logic (Task 3.6)', () => {
 
     tickEmployees(state);
 
-    // Only one action can be assigned to the single employee per tick
-    expect(state.pendingActions).toHaveLength(1);
+    // Only one action can be assigned to the single employee per tick — but
+    // per #547 the other stays queued and unheld rather than being spliced
+    // away, so BOTH records remain in pendingActions.
+    expect(state.pendingActions).toHaveLength(2);
     expect((employee as any).activeActionId).not.toBeNull();
+    const claimedAction = state.pendingActions.find(a => a.status === 'assigned');
+    const queuedAction = state.pendingActions.find(a => a.status === 'queued');
+    expect(claimedAction).toBeDefined();
+    expect(claimedAction!.holderId).toBe((employee as any).activeActionId);
+    expect(queuedAction).toBeDefined();
+    expect(queuedAction!.holderId).toBeNull();
+  });
+
+  // ── #547: an already-assigned/in_progress action is not re-claimed ─────────
+
+  it('skips an action already "assigned" to another employee — not re-claimed, not counted in claimed/waiting/unqualified', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee: holder } = hireEmployee(state.employees, 'blaster', rng);
+    assignSkill(state.employees, holder.id, 'blasting', 1);
+    const { employee: idle } = hireEmployee(state.employees, 'blaster', rng);
+    assignSkill(state.employees, idle.id, 'blasting', 1);
+
+    const action = makePendingAction({ id: 30, requiredSkill: 'blasting', status: 'assigned', holderId: holder.id });
+    state.pendingActions.push(action);
+    holder.activeActionId = 30; // mirrors what claiming it would have set
+
+    const result = tickEmployees(state);
+
+    // The idle, equally-qualified employee must not be diverted onto an
+    // action someone else already holds.
+    expect(idle.activeActionId).toBeNull();
+    expect(result.claimed).not.toContain(30);
+    expect(result.waiting).not.toContain(30);
+    expect(result.unqualified).not.toContain(30);
+    // The record is untouched — still held by the original claimant.
+    const stored = state.pendingActions.find(a => a.id === 30)!;
+    expect(stored.status).toBe('assigned');
+    expect(stored.holderId).toBe(holder.id);
+  });
+
+  it('skips an "in_progress" action the same way', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+
+    const { employee: holder } = hireEmployee(state.employees, 'blaster', rng);
+    assignSkill(state.employees, holder.id, 'blasting', 1);
+    const { employee: idle } = hireEmployee(state.employees, 'blaster', rng);
+    assignSkill(state.employees, idle.id, 'blasting', 1);
+
+    const action = makePendingAction({ id: 31, requiredSkill: 'blasting', status: 'in_progress', holderId: holder.id });
+    state.pendingActions.push(action);
+    holder.activeActionId = 31;
+
+    const result = tickEmployees(state);
+
+    expect(idle.activeActionId).toBeNull();
+    expect(result.claimed).not.toContain(31);
+    const stored = state.pendingActions.find(a => a.id === 31)!;
+    expect(stored.status).toBe('in_progress');
+    expect(stored.holderId).toBe(holder.id);
   });
 });
 
@@ -441,6 +519,8 @@ describe('tickEmployees — task duration seeding on claim (Ch.3 skill progressi
       requiredVehicleRole: null,
       targetX: 0, targetZ: 0, targetY: 0,
       payload: {},
+      status: 'queued',
+      holderId: null,
       ...overrides,
     };
   }
@@ -515,6 +595,7 @@ describe('tickEmployees — task duration seeding on claim (Ch.3 skill progressi
       targetX: 0, targetZ: 0, targetY: 0,
       payload: { needKey: 'hunger', restDuration: 5 },
       targetEmployeeId: employee.id,
+      status: 'queued', holderId: null,
     });
     tickEmployees(state);
     resolveArrival(state);
@@ -537,6 +618,7 @@ describe('tickTaskProgress — per-tick countdown, incremental XP, and completio
     state.pendingActions.push({
       id: actionId, type: 'general_work', requiredSkill: 'blasting', requiredVehicleRole: null,
       targetX: 0, targetZ: 0, targetY: 0, payload: {}, targetEmployeeId: employeeId,
+      status: 'queued', holderId: null,
     });
     tickEmployees(state);
     resolveArrival(state);
@@ -614,6 +696,7 @@ describe('tickTaskProgress — per-tick countdown, incremental XP, and completio
     state.pendingActions.push({
       id: 2, type: 'general_work', requiredSkill: 'blasting', requiredVehicleRole: null,
       targetX: 1, targetZ: 1, targetY: 0, payload: {}, targetEmployeeId: null,
+      status: 'queued', holderId: null,
     });
     const result = tickEmployees(state);
 
@@ -783,6 +866,8 @@ describe('tickNeedRestoration (Task 3.11)', () => {
       targetY: 0,
       payload: {},
       targetEmployeeId: null,
+      status: 'queued',
+      holderId: null,
     };
     state.pendingActions.push(workAction);
 
@@ -1420,6 +1505,7 @@ describe('autoInsertNeedTasks (7.7)', () => {
       targetY: 0,
       payload: {},
       targetEmployeeId: employee.id,
+      status: 'queued', holderId: null,
     });
 
     placeBuilding(state.buildings, 'living_quarters', 5, 5, 100, 100);
@@ -1609,6 +1695,7 @@ describe('autoInsertNeedTasks (7.7)', () => {
       targetY: 0,
       payload: {},
       targetEmployeeId: empB.id,
+      status: 'queued', holderId: null,
     });
 
     placeBuilding(state.buildings, 'living_quarters', 5, 5, 100, 100);
@@ -1673,6 +1760,7 @@ describe('autoInsertNeedTasks (7.7)', () => {
       targetY: 0,
       payload: {},
       targetEmployeeId: employee.id,
+      status: 'queued', holderId: null,
     });
 
     placeBuilding(state.buildings, 'living_quarters', 5, 5, 100, 100);
@@ -1709,6 +1797,7 @@ describe('autoInsertNeedTasks (7.7)', () => {
       targetY: 0,
       payload: {},
       targetEmployeeId: employee.id,
+      status: 'queued', holderId: null,
     });
 
     placeBuilding(state.buildings, 'living_quarters', 5, 5, 100, 100);
@@ -2308,6 +2397,8 @@ describe('tickGeneralRestCompletion', () => {
       targetY: 0,
       payload: { needKey: 'hunger' },
       targetEmployeeId: employee.id,
+      status: 'in_progress',
+      holderId: employee.id,
     });
 
     placeBuilding(state.buildings, 'living_quarters', 0, 0, 100, 100, 1);
@@ -2398,5 +2489,44 @@ describe('tickGeneralRestCompletion', () => {
     expect(result.completed).toEqual([{ employeeId: employee.id, needKey: 'hunger' }]);
     expect(employee.restTicksRemaining).toBeNull();
     expect(employee.activeActionId).toBeNull();
+  });
+
+  // ── Test 5: record + ghost both vanish on completion (#547) ────────────────
+  // A rest action's own pendingActions record now outlives its claim just like
+  // any other action, so completion must clean up both the record and any
+  // ghost preview sharing its id — the same completePendingAction contract
+  // TaskDispatch.ts exposes for the dispatch/claim path.
+  it('removes both the pendingActions record and any ghost preview sharing the completed rest action\'s id', () => {
+    const state = createGame({ seed: SEED });
+    state.cash = 1000;
+    const rng = new Random(SEED);
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    employee.hunger = 10;
+    employee.restTicksRemaining = 1;
+    const actionId = state.nextPendingActionId++;
+    employee.activeActionId = actionId;
+    employee.restNeedKey = 'hunger';
+    state.pendingActions.push({
+      id: actionId,
+      type: 'rest',
+      requiredSkill: null,
+      requiredVehicleRole: null,
+      targetX: 5,
+      targetZ: 5,
+      targetY: 0,
+      payload: { needKey: 'hunger' },
+      targetEmployeeId: employee.id,
+      status: 'in_progress',
+      holderId: employee.id,
+    });
+    state.ghostPreviews.push({ id: actionId, type: 'rest', targetX: 5, targetZ: 5, targetY: 0, claimed: true });
+
+    placeBuilding(state.buildings, 'living_quarters', 0, 0, 100, 100, 1);
+
+    tickGeneralRestCompletion(state);
+
+    expect(state.pendingActions.find(a => a.id === actionId)).toBeUndefined();
+    expect(state.ghostPreviews.find(g => g.id === actionId)).toBeUndefined();
   });
 });

--- a/tests/unit/engine/TaskDispatch.test.ts
+++ b/tests/unit/engine/TaskDispatch.test.ts
@@ -24,7 +24,7 @@ import {
 } from '../../../src/core/entities/Employee.js';
 import type { SkillCategory } from '../../../src/core/entities/Employee.js';
 // ── New module (CH1.4 — does not exist yet; ALL tests fail at import) ─────────
-import { dispatchPendingAction } from '../../../src/core/engine/TaskDispatch.js';
+import { dispatchPendingAction, claimPendingAction, completePendingAction } from '../../../src/core/engine/TaskDispatch.js';
 import type { PendingAction } from '../../../src/core/state/GameState.js';
 
 // ── Deterministic fixture helpers ────────────────────────────────────────────
@@ -375,4 +375,178 @@ describe('dispatchPendingAction — all SkillCategory values are routable', () =
       expect(result.error).toBe('unqualified');
     });
   }
+});
+
+// ── Section 5: PendingAction lifecycle (#547) ────────────────────────────────
+//   Claiming no longer deletes the record the instant an employee picks it up
+//   — the action (and its ghost) stay visible through the walk and the work
+//   itself, only disappearing on genuine completion.
+
+describe('dispatchPendingAction — pushes lifecycle-ready records (#547)', () => {
+  let state: GameState;
+
+  beforeEach(() => {
+    state = makeGame();
+  });
+
+  it('the pushed PendingAction starts life status:"queued", holderId:null', () => {
+    addQualifiedEmployee(state, 'blasting', SEED);
+    const action = makePendingAction({ id: 1, requiredSkill: 'blasting' });
+    dispatchPendingAction(state, action);
+
+    const stored: PendingAction = (state as any).pendingActions[0];
+    expect(stored.status).toBe('queued');
+    expect(stored.holderId).toBeNull();
+  });
+
+  it('the mirrored GhostPreview starts life claimed:false', () => {
+    addQualifiedEmployee(state, 'blasting', SEED);
+    const action = makePendingAction({ id: 2, requiredSkill: 'blasting', targetX: 4, targetZ: 7 });
+    dispatchPendingAction(state, action);
+
+    const ghost = (state as any).ghostPreviews.find((g: { id: number }) => g.id === 2);
+    expect(ghost).toBeDefined();
+    expect(ghost.claimed).toBe(false);
+  });
+});
+
+describe('claimPendingAction (#547)', () => {
+  let state: GameState;
+
+  beforeEach(() => {
+    state = makeGame();
+  });
+
+  it('transitions a queued action to "assigned" and stamps holderId, without removing it from pendingActions', () => {
+    addQualifiedEmployee(state, 'blasting', SEED);
+    const action = makePendingAction({ id: 10, requiredSkill: 'blasting' });
+    dispatchPendingAction(state, action);
+
+    const claimed = claimPendingAction(state, 10, 999);
+
+    expect(claimed).not.toBeNull();
+    expect(claimed!.status).toBe('assigned');
+    expect(claimed!.holderId).toBe(999);
+    // Still in the array — not spliced out (#547 is exactly about this).
+    const pending: PendingAction[] = (state as any).pendingActions;
+    expect(pending).toHaveLength(1);
+    expect(pending[0]!.status).toBe('assigned');
+    expect(pending[0]!.holderId).toBe(999);
+  });
+
+  it('flips the matching GhostPreview to claimed:true without removing it', () => {
+    addQualifiedEmployee(state, 'blasting', SEED);
+    const action = makePendingAction({ id: 11, requiredSkill: 'blasting' });
+    dispatchPendingAction(state, action);
+
+    claimPendingAction(state, 11, 5);
+
+    const ghosts: Array<{ id: number; claimed: boolean }> = (state as any).ghostPreviews;
+    expect(ghosts).toHaveLength(1);
+    expect(ghosts[0]!.id).toBe(11);
+    expect(ghosts[0]!.claimed).toBe(true);
+  });
+
+  it('returns null for an id with no matching pendingAction', () => {
+    const result = claimPendingAction(state, 9999, 1);
+    expect(result).toBeNull();
+  });
+
+  it('a second claim on an already-"assigned" action returns null and leaves the original holder intact', () => {
+    addQualifiedEmployee(state, 'blasting', SEED);
+    const action = makePendingAction({ id: 12, requiredSkill: 'blasting' });
+    dispatchPendingAction(state, action);
+
+    const first = claimPendingAction(state, 12, 1);
+    expect(first).not.toBeNull();
+    expect(first!.holderId).toBe(1);
+
+    const second = claimPendingAction(state, 12, 2);
+
+    expect(second).toBeNull();
+    const stored = (state as any).pendingActions.find((a: PendingAction) => a.id === 12);
+    expect(stored.holderId).toBe(1);
+    expect(stored.status).toBe('assigned');
+    // The ghost still reads as claimed by the original holder's claim, not the rejected second one.
+    const ghost = (state as any).ghostPreviews.find((g: { id: number }) => g.id === 12);
+    expect(ghost.claimed).toBe(true);
+  });
+
+  it('a second claim on an "in_progress" action also returns null and leaves the holder intact', () => {
+    addQualifiedEmployee(state, 'blasting', SEED);
+    const action = makePendingAction({ id: 13, requiredSkill: 'blasting' });
+    dispatchPendingAction(state, action);
+    claimPendingAction(state, 13, 1);
+    // Simulate ArrivalGate's later 'assigned' -> 'in_progress' promotion.
+    const stored = (state as any).pendingActions.find((a: PendingAction) => a.id === 13);
+    stored.status = 'in_progress';
+
+    const second = claimPendingAction(state, 13, 2);
+
+    expect(second).toBeNull();
+    expect(stored.holderId).toBe(1);
+    expect(stored.status).toBe('in_progress');
+  });
+});
+
+describe('completePendingAction (#547)', () => {
+  let state: GameState;
+
+  beforeEach(() => {
+    state = makeGame();
+  });
+
+  it('removes the completed action from pendingActions and returns it', () => {
+    addQualifiedEmployee(state, 'blasting', SEED);
+    const action = makePendingAction({ id: 20, requiredSkill: 'blasting' });
+    dispatchPendingAction(state, action);
+    claimPendingAction(state, 20, 1);
+
+    const removed = completePendingAction(state, 20);
+
+    expect(removed).not.toBeNull();
+    expect(removed!.id).toBe(20);
+    const pending: PendingAction[] = (state as any).pendingActions;
+    expect(pending.find(a => a.id === 20)).toBeUndefined();
+  });
+
+  it('removes the matching GhostPreview from ghostPreviews', () => {
+    addQualifiedEmployee(state, 'blasting', SEED);
+    const action = makePendingAction({ id: 21, requiredSkill: 'blasting' });
+    dispatchPendingAction(state, action);
+
+    completePendingAction(state, 21);
+
+    const ghosts: Array<{ id: number }> = (state as any).ghostPreviews;
+    expect(ghosts.find(g => g.id === 21)).toBeUndefined();
+  });
+
+  it('leaves unrelated actions and ghosts untouched', () => {
+    addQualifiedEmployee(state, 'blasting', SEED);
+    dispatchPendingAction(state, makePendingAction({ id: 22, requiredSkill: 'blasting' }));
+    dispatchPendingAction(state, makePendingAction({ id: 23, requiredSkill: 'blasting' }));
+
+    completePendingAction(state, 22);
+
+    const pending: PendingAction[] = (state as any).pendingActions;
+    const ghosts: Array<{ id: number }> = (state as any).ghostPreviews;
+    expect(pending.find(a => a.id === 23)).toBeDefined();
+    expect(ghosts.find(g => g.id === 23)).toBeDefined();
+  });
+
+  it('is a safe no-op returning null for an unknown action id', () => {
+    addQualifiedEmployee(state, 'blasting', SEED);
+    dispatchPendingAction(state, makePendingAction({ id: 24, requiredSkill: 'blasting' }));
+
+    const result = completePendingAction(state, 999999);
+
+    expect(result).toBeNull();
+    const pending: PendingAction[] = (state as any).pendingActions;
+    expect(pending).toHaveLength(1);
+  });
+
+  it('is a safe no-op returning null on an empty pendingActions array', () => {
+    const result = completePendingAction(state, 1);
+    expect(result).toBeNull();
+  });
 });

--- a/tests/unit/renderer/GhostMesh.test.ts
+++ b/tests/unit/renderer/GhostMesh.test.ts
@@ -12,6 +12,8 @@ function makePreview(id: number, overrides: Partial<GhostPreview> = {}): GhostPr
     targetX: id * 3,
     targetY: 0,
     targetZ: id * 3,
+    // Unclaimed by default (#547) — callers override to model a claimed ghost.
+    claimed: false,
     ...overrides,
   };
 }
@@ -111,5 +113,115 @@ describe('GhostMesh', () => {
     gm.dispose();
     expect(gm.count).toBe(0);
     expect(scene.children.length).toBe(0);
+  });
+
+  // ── #547: claimed vs unclaimed previews must read distinctly ────────────────
+  // An employee still walking to a claimed action should not look identical to
+  // an untouched, unclaimed one — dimmer + slower pulse, both stay blue.
+
+  describe('claimed vs unclaimed rendering (#547)', () => {
+    it('a claimed preview animates with a lower peak opacity than an unclaimed one', () => {
+      const scene = new THREE.Scene();
+      const gm = new GhostMesh(scene);
+      gm.sync([makePreview(1, { claimed: false }), makePreview(2, { claimed: true })]);
+
+      // Identify each mesh by its (unique, preview-id-derived) x position —
+      // GhostMesh exposes no id->mesh lookup, only the synced scene graph.
+      const unclaimedMesh = scene.children.find(c => (c as THREE.Mesh).position.x === 3) as THREE.Mesh;
+      const claimedMesh = scene.children.find(c => (c as THREE.Mesh).position.x === 6) as THREE.Mesh;
+      expect(unclaimedMesh).toBeDefined();
+      expect(claimedMesh).toBeDefined();
+
+      let unclaimedMax = -Infinity;
+      let claimedMax = -Infinity;
+      for (let i = 0; i < 180; i++) {
+        gm.update(1 / 60);
+        unclaimedMax = Math.max(unclaimedMax, (unclaimedMesh.material as THREE.MeshPhongMaterial).opacity);
+        claimedMax = Math.max(claimedMax, (claimedMesh.material as THREE.MeshPhongMaterial).opacity);
+      }
+
+      expect(claimedMax).toBeLessThan(unclaimedMax);
+      gm.dispose();
+    });
+
+    it('a claimed preview pulses slower than an unclaimed one (smaller opacity swing on the very first tick, both starting from their own minimum)', () => {
+      const scene = new THREE.Scene();
+      const gm = new GhostMesh(scene);
+      gm.sync([makePreview(1, { claimed: false }), makePreview(2, { claimed: true })]);
+
+      const unclaimedMesh = scene.children.find(c => (c as THREE.Mesh).position.x === 3) as THREE.Mesh;
+      const claimedMesh = scene.children.find(c => (c as THREE.Mesh).position.x === 6) as THREE.Mesh;
+
+      const unclaimedStart = (unclaimedMesh.material as THREE.MeshPhongMaterial).opacity;
+      const claimedStart = (claimedMesh.material as THREE.MeshPhongMaterial).opacity;
+
+      gm.update(0.05);
+
+      const unclaimedDelta = Math.abs((unclaimedMesh.material as THREE.MeshPhongMaterial).opacity - unclaimedStart);
+      const claimedDelta = Math.abs((claimedMesh.material as THREE.MeshPhongMaterial).opacity - claimedStart);
+
+      expect(claimedDelta).toBeLessThan(unclaimedDelta);
+      gm.dispose();
+    });
+
+    it('both a claimed and unclaimed preview stay blue (blue channel dominant)', () => {
+      const scene = new THREE.Scene();
+      const gm = new GhostMesh(scene);
+      gm.sync([makePreview(1, { claimed: false }), makePreview(2, { claimed: true })]);
+
+      for (const mesh of scene.children as THREE.Mesh[]) {
+        const mat = mesh.material as THREE.MeshPhongMaterial;
+        expect(mat.transparent).toBe(true);
+        expect(mat.color.b).toBeGreaterThan(mat.color.r);
+      }
+      gm.dispose();
+    });
+
+    it('flipping claimed in place on the same id updates the existing mesh rather than recreating it, and its opacity ceiling drops into the claimed (dimmer) range', () => {
+      const scene = new THREE.Scene();
+      const gm = new GhostMesh(scene);
+      // A permanently-unclaimed control preview (id 9) syncs alongside the one
+      // whose claimed flag flips, so this test has a same-run baseline to
+      // compare against rather than a hardcoded opacity constant.
+      gm.sync([makePreview(1, { claimed: false }), makePreview(9, { claimed: false })]);
+
+      expect(scene.children).toHaveLength(2);
+      const meshBefore = scene.children.find(c => (c as THREE.Mesh).position.x === 3) as THREE.Mesh;
+
+      gm.sync([makePreview(1, { claimed: true }), makePreview(9, { claimed: false })]);
+
+      expect(scene.children).toHaveLength(2);
+      const meshAfter = scene.children.find(c => (c as THREE.Mesh).position.x === 3) as THREE.Mesh;
+      const controlMesh = scene.children.find(c => (c as THREE.Mesh).position.x === 27) as THREE.Mesh;
+      // Same mesh instance — not removed/re-added — proving the material was
+      // swapped/updated in place rather than the whole ghost being recreated.
+      expect(meshAfter).toBe(meshBefore);
+
+      let maxAfter = -Infinity;
+      let controlMax = -Infinity;
+      for (let i = 0; i < 180; i++) {
+        gm.update(1 / 60);
+        maxAfter = Math.max(maxAfter, (meshAfter.material as THREE.MeshPhongMaterial).opacity);
+        controlMax = Math.max(controlMax, (controlMesh.material as THREE.MeshPhongMaterial).opacity);
+      }
+      // The flipped mesh's ceiling must now sit below the still-unclaimed
+      // control's ceiling — proving the in-place update actually changed its
+      // rendering, not merely its `claimed` bookkeeping field.
+      expect(maxAfter).toBeLessThan(controlMax);
+      gm.dispose();
+    });
+
+    it('removing a claimed preview from the sync input removes its mesh, same as an unclaimed one', () => {
+      const scene = new THREE.Scene();
+      const gm = new GhostMesh(scene);
+      gm.sync([makePreview(1, { claimed: true })]);
+      expect(gm.count).toBe(1);
+
+      gm.sync([]);
+
+      expect(gm.count).toBe(0);
+      expect(scene.children.length).toBe(0);
+      gm.dispose();
+    });
   });
 });

--- a/tests/unit/state/GameState.test.ts
+++ b/tests/unit/state/GameState.test.ts
@@ -204,7 +204,10 @@ describe('dispatchPendingAction — ghost preview side-effect (task 3.8)', () =>
   });
 });
 
-// ── 3.8.3 — claimPendingAction removes action and ghost, returns action ───────
+// ── 3.8.3 — claimPendingAction transitions action + ghost, returns action ─────
+//   (#547 — claiming no longer deletes the record; it moves to
+//   status:'assigned'/holderId set, and the ghost flips claimed:true. Both
+//   stay in their arrays until completePendingAction removes them.)
 
 describe('claimPendingAction (task 3.8)', () => {
   let state: GameState;
@@ -216,27 +219,42 @@ describe('claimPendingAction (task 3.8)', () => {
     dispatchPendingAction(state, makeAction({ id: 99, targetX: 1, targetZ: 2, targetY: 0 }));
   });
 
-  it('removes the action from pendingActions', () => {
-    claimPendingAction(state, 99);
+  it('does not remove the action from pendingActions', () => {
+    claimPendingAction(state, 99, 1);
 
-    expect(state.pendingActions).toHaveLength(0);
+    expect(state.pendingActions).toHaveLength(1);
   });
 
-  it('removes the corresponding ghost from ghostPreviews', () => {
-    claimPendingAction(state, 99);
+  it('does not remove the corresponding ghost from ghostPreviews', () => {
+    claimPendingAction(state, 99, 1);
 
-    expect(state.ghostPreviews).toHaveLength(0);
+    expect(state.ghostPreviews).toHaveLength(1);
+  });
+
+  it('transitions the action status to "assigned" and stamps holderId', () => {
+    claimPendingAction(state, 99, 1);
+
+    const stored = state.pendingActions.find(a => a.id === 99);
+    expect(stored!.status).toBe('assigned');
+    expect(stored!.holderId).toBe(1);
+  });
+
+  it('flips the matching ghost claimed field to true', () => {
+    claimPendingAction(state, 99, 1);
+
+    const ghost = state.ghostPreviews.find(g => g.id === 99);
+    expect(ghost!.claimed).toBe(true);
   });
 
   it('returns the claimed PendingAction object', () => {
-    const claimed = claimPendingAction(state, 99);
+    const claimed = claimPendingAction(state, 99, 1);
 
     expect(claimed).not.toBeNull();
     expect(claimed!.id).toBe(99);
   });
 
   it('returned action retains all original fields', () => {
-    const claimed = claimPendingAction(state, 99);
+    const claimed = claimPendingAction(state, 99, 1);
 
     expect(claimed!.targetX).toBe(1);
     expect(claimed!.targetZ).toBe(2);
@@ -244,48 +262,52 @@ describe('claimPendingAction (task 3.8)', () => {
   });
 
   it('returns null when actionId does not exist in pendingActions', () => {
-    const result = claimPendingAction(state, 9999);
+    const result = claimPendingAction(state, 9999, 1);
 
     expect(result).toBeNull();
   });
 
   it('does not modify pendingActions when actionId is not found', () => {
-    claimPendingAction(state, 9999);
+    claimPendingAction(state, 9999, 1);
 
     expect(state.pendingActions).toHaveLength(1);
   });
 
   it('does not modify ghostPreviews when actionId is not found', () => {
-    claimPendingAction(state, 9999);
+    claimPendingAction(state, 9999, 1);
 
     expect(state.ghostPreviews).toHaveLength(1);
   });
 
-  it('claiming one action out of many removes only that action from pendingActions', () => {
+  it('claiming one action out of many transitions only that action, leaving the others queued', () => {
     // Add two more actions (id 100 and 101) on top of the id-99 from beforeEach
     dispatchPendingAction(state, makeAction({ id: 100 }));
     dispatchPendingAction(state, makeAction({ id: 101 }));
 
-    claimPendingAction(state, 100);
+    claimPendingAction(state, 100, 1);
 
     const pending: PendingAction[] = state.pendingActions;
-    expect(pending).toHaveLength(2);
-    expect(pending.map(a => a.id)).not.toContain(100);
-    expect(pending.map(a => a.id)).toContain(99);
-    expect(pending.map(a => a.id)).toContain(101);
+    expect(pending).toHaveLength(3);
+    const claimedEntry = pending.find(a => a.id === 100);
+    expect(claimedEntry!.status).toBe('assigned');
+    expect(claimedEntry!.holderId).toBe(1);
+    const untouched99 = pending.find(a => a.id === 99);
+    const untouched101 = pending.find(a => a.id === 101);
+    expect(untouched99!.status).toBe('queued');
+    expect(untouched101!.status).toBe('queued');
   });
 
-  it('claiming one action out of many removes only that ghost from ghostPreviews', () => {
+  it('claiming one action out of many flips only that ghost, leaving the others unclaimed', () => {
     dispatchPendingAction(state, makeAction({ id: 100 }));
     dispatchPendingAction(state, makeAction({ id: 101 }));
 
-    claimPendingAction(state, 100);
+    claimPendingAction(state, 100, 1);
 
     const ghosts: GhostPreview[] = state.ghostPreviews;
-    expect(ghosts).toHaveLength(2);
-    expect(ghosts.map(g => g.id)).not.toContain(100);
-    expect(ghosts.map(g => g.id)).toContain(99);
-    expect(ghosts.map(g => g.id)).toContain(101);
+    expect(ghosts).toHaveLength(3);
+    expect(ghosts.find(g => g.id === 100)!.claimed).toBe(true);
+    expect(ghosts.find(g => g.id === 99)!.claimed).toBe(false);
+    expect(ghosts.find(g => g.id === 101)!.claimed).toBe(false);
   });
 });
 // =============================================================================

--- a/tests/unit/state/SaveLoad.test.ts
+++ b/tests/unit/state/SaveLoad.test.ts
@@ -167,10 +167,11 @@ describe('deserialize — v7→v8 migration for PendingAction lifecycle (#547)',
 
     const restoredEmployee = restored.employees.employees.find(e => e.id === employee.id)!;
     expect(restoredEmployee.activeActionId).toBe(5);
-    // The surviving record itself still migrates its own status to 'queued' —
-    // migration does not try to infer 'assigned' from the employee side.
-    expect(restored.pendingActions[0]!.status).toBe('queued');
-    expect(restored.pendingActions[0]!.holderId).toBeNull();
+    // The surviving record's own status/holderId were stripped to simulate a
+    // pre-#547 save; migration re-derives them from the employee's
+    // activeActionId, so the action comes back 'assigned' to that employee.
+    expect(restored.pendingActions[0]!.status).toBe('assigned');
+    expect(restored.pendingActions[0]!.holderId).toBe(employee.id);
   });
 
   it('a v8+ save (already carrying status/holderId) is left untouched by the migration', () => {

--- a/tests/unit/state/SaveLoad.test.ts
+++ b/tests/unit/state/SaveLoad.test.ts
@@ -4,6 +4,8 @@ import * as path from 'path';
 import { createGame } from '../../../src/core/state/GameState.js';
 import { serialize, deserialize } from '../../../src/core/state/SaveLoad.js';
 import { FilePersistence } from '../../../src/persistence/FilePersistence.js';
+import { Random } from '../../../src/core/math/Random.js';
+import { hireEmployee } from '../../../src/core/entities/Employee.js';
 
 const TEST_SAVE_DIR = path.join(process.cwd(), 'tmp-test-saves');
 
@@ -60,6 +62,130 @@ describe('deserialize — v4→v5 migration for collectedOre (task 5.18)', () =>
     });
     const restored = deserialize(v4save);
     expect(restored.collectedOre).toEqual({});
+  });
+});
+
+// ── v7→v8 migration for PendingAction lifecycle (#547) ──────────────────────
+// SAVE_VERSION bumped 7→8 when PendingAction gained status/holderId. A save
+// written before that has pendingActions entries with neither field — they
+// must load as status:'queued', holderId:null (the pre-#547 semantics: an
+// entry in the array always meant "still waiting to be claimed"). An
+// employee whose activeActionId pointed at an action that isn't present after
+// migration must have that reference cleared to null rather than dangling.
+
+describe('deserialize — v7→v8 migration for PendingAction lifecycle (#547)', () => {
+  it('a pre-v8 pendingActions entry with no status field loads as status:"queued", holderId:null', () => {
+    const state = createGame({ seed: 42 });
+    state.pendingActions.push({
+      id: 1, type: 'survey', requiredSkill: null, requiredVehicleRole: null,
+      targetX: 3, targetZ: 4, targetY: 0, payload: {}, targetEmployeeId: null,
+      status: 'queued', holderId: null,
+    });
+    const json = serialize(state);
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    parsed['version'] = 7;
+    // Simulate a genuine pre-#547 save: no status/holderId field at all.
+    const pending = parsed['pendingActions'] as Array<Record<string, unknown>>;
+    delete pending[0]!['status'];
+    delete pending[0]!['holderId'];
+
+    const restored = deserialize(JSON.stringify(parsed));
+
+    expect(restored.pendingActions).toHaveLength(1);
+    expect(restored.pendingActions[0]!.status).toBe('queued');
+    expect(restored.pendingActions[0]!.holderId).toBeNull();
+  });
+
+  it('multiple pre-v8 entries all migrate to queued/null independently', () => {
+    const state = createGame({ seed: 42 });
+    state.pendingActions.push(
+      {
+        id: 1, type: 'survey', requiredSkill: null, requiredVehicleRole: null,
+        targetX: 0, targetZ: 0, targetY: 0, payload: {}, targetEmployeeId: null,
+        status: 'queued', holderId: null,
+      },
+      {
+        id: 2, type: 'rest', requiredSkill: null, requiredVehicleRole: null,
+        targetX: 1, targetZ: 1, targetY: 0, payload: {}, targetEmployeeId: null,
+        status: 'queued', holderId: null,
+      },
+    );
+    const json = serialize(state);
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    parsed['version'] = 7;
+    const pending = parsed['pendingActions'] as Array<Record<string, unknown>>;
+    for (const p of pending) {
+      delete p['status'];
+      delete p['holderId'];
+    }
+
+    const restored = deserialize(JSON.stringify(parsed));
+
+    expect(restored.pendingActions).toHaveLength(2);
+    for (const p of restored.pendingActions) {
+      expect(p.status).toBe('queued');
+      expect(p.holderId).toBeNull();
+    }
+  });
+
+  it('an employee whose activeActionId refers to an action absent from the migrated list has activeActionId cleared to null', () => {
+    const state = createGame({ seed: 42 });
+    const rng = new Random(42);
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    // Points at an action id that never made it into this save at all.
+    employee.activeActionId = 999;
+
+    const json = serialize(state);
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    parsed['version'] = 7;
+
+    const restored = deserialize(JSON.stringify(parsed));
+
+    const restoredEmployee = restored.employees.employees.find(e => e.id === employee.id)!;
+    expect(restoredEmployee.activeActionId).toBeNull();
+  });
+
+  it('leaves activeActionId untouched when it refers to a pendingAction that survives migration', () => {
+    const state = createGame({ seed: 42 });
+    const rng = new Random(42);
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    state.pendingActions.push({
+      id: 5, type: 'survey', requiredSkill: null, requiredVehicleRole: null,
+      targetX: 0, targetZ: 0, targetY: 0, payload: {}, targetEmployeeId: employee.id,
+      status: 'assigned', holderId: employee.id,
+    });
+    employee.activeActionId = 5;
+
+    const json = serialize(state);
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    parsed['version'] = 7;
+    const pending = parsed['pendingActions'] as Array<Record<string, unknown>>;
+    delete pending[0]!['status'];
+    delete pending[0]!['holderId'];
+
+    const restored = deserialize(JSON.stringify(parsed));
+
+    const restoredEmployee = restored.employees.employees.find(e => e.id === employee.id)!;
+    expect(restoredEmployee.activeActionId).toBe(5);
+    // The surviving record itself still migrates its own status to 'queued' —
+    // migration does not try to infer 'assigned' from the employee side.
+    expect(restored.pendingActions[0]!.status).toBe('queued');
+    expect(restored.pendingActions[0]!.holderId).toBeNull();
+  });
+
+  it('a v8+ save (already carrying status/holderId) is left untouched by the migration', () => {
+    const state = createGame({ seed: 42 });
+    state.pendingActions.push({
+      id: 1, type: 'survey', requiredSkill: null, requiredVehicleRole: null,
+      targetX: 0, targetZ: 0, targetY: 0, payload: {}, targetEmployeeId: null,
+      status: 'in_progress', holderId: 3,
+    });
+    const json = serialize(state);
+
+    const restored = deserialize(json);
+
+    expect(restored.pendingActions[0]!.status).toBe('in_progress');
+    expect(restored.pendingActions[0]!.holderId).toBe(3);
   });
 });
 

--- a/tests/unit/ui/panels/OperationsPanel.test.ts
+++ b/tests/unit/ui/panels/OperationsPanel.test.ts
@@ -55,9 +55,9 @@ describe('OperationsPanel', () => {
     const { panel } = makePanel();
     const state = makeState();
     state.pendingActions = [
-      { id: 1, type: 'general_work', requiredSkill: null, requiredVehicleRole: null, targetX: 0, targetZ: 0, targetY: 0, payload: {}, targetEmployeeId: null },
-      { id: 2, type: 'survey', requiredSkill: 'geology', requiredVehicleRole: null, targetX: 0, targetZ: 0, targetY: 0, payload: {}, targetEmployeeId: null },
-      { id: 3, type: 'haul_debris', requiredSkill: null, requiredVehicleRole: 'debris_hauler', targetX: 0, targetZ: 0, targetY: 0, payload: {}, targetEmployeeId: 7 },
+      { id: 1, type: 'general_work', requiredSkill: null, requiredVehicleRole: null, targetX: 0, targetZ: 0, targetY: 0, payload: {}, targetEmployeeId: null, status: 'queued', holderId: null },
+      { id: 2, type: 'survey', requiredSkill: 'geology', requiredVehicleRole: null, targetX: 0, targetZ: 0, targetY: 0, payload: {}, targetEmployeeId: null, status: 'queued', holderId: null },
+      { id: 3, type: 'haul_debris', requiredSkill: null, requiredVehicleRole: 'debris_hauler', targetX: 0, targetZ: 0, targetY: 0, payload: {}, targetEmployeeId: 7, status: 'assigned', holderId: 7 },
     ];
     panel.update(state);
     const text = panel.root.textContent ?? '';

--- a/tests/unit/ui/panels/OperationsPanel.test.ts
+++ b/tests/unit/ui/panels/OperationsPanel.test.ts
@@ -57,6 +57,7 @@ describe('OperationsPanel', () => {
     state.pendingActions = [
       { id: 1, type: 'general_work', requiredSkill: null, requiredVehicleRole: null, targetX: 0, targetZ: 0, targetY: 0, payload: {}, targetEmployeeId: null, status: 'queued', holderId: null },
       { id: 2, type: 'survey', requiredSkill: 'geology', requiredVehicleRole: null, targetX: 0, targetZ: 0, targetY: 0, payload: {}, targetEmployeeId: null, status: 'queued', holderId: null },
+      // Already claimed by employee 7 (#547) — reserved/assigned work is not "unclaimed", so this one is excluded from the count below.
       { id: 3, type: 'haul_debris', requiredSkill: null, requiredVehicleRole: 'debris_hauler', targetX: 0, targetZ: 0, targetY: 0, payload: {}, targetEmployeeId: 7, status: 'assigned', holderId: 7 },
     ];
     panel.update(state);

--- a/tests/unit/ui/tutorialGuide.test.ts
+++ b/tests/unit/ui/tutorialGuide.test.ts
@@ -434,4 +434,51 @@ describe('decideClock', () => {
     });
     expect(arrived.hold).toBe(true);
   });
+
+  // -- #547: a claimed PendingAction now stays in state.pendingActions through
+  // the whole walk+work period instead of being deleted the instant it's
+  // claimed (only its status/holderId change). isWorkInProgress/workSignature
+  // only ever looked at *presence* (array length, and each entry's `id`) —
+  // never at `status`/`holderId` — so a longer-lived record must not change
+  // the tutorial's one-survey-outstanding clock-hold decision. This was
+  // already true before #547 too: an employee mid-claim already reports
+  // hasOutstandingWork via activeActionId/destinationX regardless of whether
+  // the pendingActions array still carries a matching entry — this test
+  // proves the decision (and the fingerprint driving the grace window) does
+  // not change across the record's lifecycle, not that new behavior exists.
+  it('#547: a pendingAction\'s lifecycle status (queued/assigned/in_progress) does not change the clock-hold decision or its progress signature', () => {
+    const statuses: Array<'queued' | 'assigned' | 'in_progress'> = ['queued', 'assigned', 'in_progress'];
+    const signatures: string[] = [];
+
+    for (const status of statuses) {
+      const s = state();
+      s.tickCount = DEFAULT_TICK_BUDGET + 5;
+      s.pendingActions = [{
+        id: 1, type: 'survey', requiredSkill: null, requiredVehicleRole: null,
+        targetX: 0, targetZ: 0, targetY: 0, payload: {}, targetEmployeeId: null,
+        status, holderId: status === 'queued' ? null : 7,
+      } as unknown as GameState['pendingActions'][number]];
+
+      const decision = decideClock(s, 0, DEFAULT_TICK_BUDGET, true);
+      // Still work in progress regardless of status — the clock must not hold.
+      expect(decision.hold).toBe(false);
+      signatures.push(decision.progressSignature!);
+    }
+
+    // workSignature fingerprints pendingActions by id only, never status/
+    // holderId — the fingerprint (and therefore the grace-window bookkeeping
+    // built on it) is identical across the record's whole lifecycle.
+    expect(new Set(signatures).size).toBe(1);
+  });
+
+  it('#547: an already-claimed (assigned) action still holds the clock once budget and grace both run out, exactly like the old queued-only representation did', () => {
+    const s = state();
+    s.tickCount = DEFAULT_TICK_BUDGET + WORK_GRACE_TICKS;
+    s.pendingActions = [{
+      id: 1, type: 'survey', requiredSkill: null, requiredVehicleRole: null,
+      targetX: 0, targetZ: 0, targetY: 0, payload: {}, targetEmployeeId: null,
+      status: 'assigned', holderId: 7,
+    } as unknown as GameState['pendingActions'][number]];
+    expect(decideClock(s, 0, DEFAULT_TICK_BUDGET, true).hold).toBe(true);
+  });
 });


### PR DESCRIPTION
Closes #547

## Summary

An ordered action (`PendingAction`) now carries a lifecycle instead of being deleted from `state.pendingActions` the instant an employee claims it:

- `status: 'queued' | 'assigned' | 'in_progress'` plus `holderId: number | null` on `PendingAction`; `claimed: boolean` on `GhostPreview`.
- Dispatch creates a `queued` record + an unclaimed (`claimed: false`) ghost.
- Claiming (`claimPendingAction` in `src/core/engine/TaskDispatch.ts`, called by `tickEmployees`) transitions `status`→`'assigned'`, stamps `holderId`, and flips the ghost's `claimed` to `true` — the record and ghost are never removed at this point. A second claim attempt on an already-assigned/in-progress action fails.
- Arrival (`tickArrivalGate`) promotes `'assigned'` → `'in_progress'`.
- Completion (`completePendingAction`, called from the rest-completion path and from `src/console/commands/events.ts`'s tick-completion branch) removes the record and its ghost — the only point either disappears.
- Ghost rendering (`src/renderer/GhostMesh.ts`) distinguishes claimed from unclaimed via dimmer opacity + slower pulse, both staying blue.
- Consumers audited: `OperationsPanel`'s unclaimed-work count now filters `status === 'queued'`; `SurveyPanel`'s in-progress count is deliberately left unfiltered (now correctly spans the whole queued→assigned→in_progress window instead of undercounting); `tutorialGuide`'s clock-hold logic verified unchanged; `SaveLoad.ts` gained a v7→v8 migration that infers `status`/`holderId` for actions still referenced by an employee's `activeActionId` at save time, defaulting everything else to `queued`.
- Along the way, fixed a real (previously masked) bug: a `general_work` action dispatched with no required skill never got its work-duration seeded, so it could never complete — pre-#547 this was invisible because claiming deleted the record immediately; post-#547 it would have leaked a record + a permanently pulsing ghost forever. Now seeded at a Rookie (proficiency level 1) baseline.

9 test files updated/added: `tests/unit/engine/TaskDispatch.test.ts`, `tests/unit/engine/GameLoop.test.ts`, `tests/unit/renderer/GhostMesh.test.ts`, `tests/unit/ui/tutorialGuide.test.ts`, `tests/unit/state/SaveLoad.test.ts`, `tests/unit/state/GameState.test.ts`, `tests/unit/ui/panels/OperationsPanel.test.ts`, `tests/integration/survey.integration.test.ts`, `tests/integration/skills.integration.test.ts`; plus 3 scenario-defs recalibrated for the new (correct) `pendingActionCount` semantics and the null-skill leak fix's timing effect on need/collapse scenarios: `scripts/scenario-defs/survey-overlay-lifecycle.json`, `scripts/scenario-defs/employee-skill-progression-visual.json`, `scripts/scenario-defs/needs-proactive-queue-visual.json`, `scripts/scenario-defs/needs-collapse-visual.json`.

8958 tests — all passing. 127/127 scenarios passing. Typecheck clean. Production build succeeds.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** exact `PendingActionStatus` string values.
  **Chosen:** `'queued' | 'assigned' | 'in_progress'` (snake_case for the multi-word value).
  **Why:** matches every other phase/state string union already in `src/core/` (`haulingPhase`'s `'to_fragment'`/`'to_depot'`, `ActionType`'s `'drill_hole'`/`'charge_hole'`).
  **If reversed:** the `PendingActionStatus` type alias in `GameState.ts`; three literals to change.

- **What was open:** field name for "the employee currently holding this action."
  **Chosen:** `holderId: number | null`, kept separate from the pre-existing `targetEmployeeId` (eligibility restriction, set at dispatch, independent of who currently holds it).
  **Why:** conflating the two would make "can only ever go to employee 5" indistinguishable from "employee 5 is currently doing this" — already independent concepts in the pre-existing code.
  **If reversed:** rename `holderId` in `GameState.ts` and its ~4 write sites.

- **What was open:** exact claimed-ghost visual treatment ("dimmer, slower pulse, or similar").
  **Chosen:** halved opacity range and pulse speed relative to the unclaimed constants (`CLAIMED_OPACITY_MIN/MAX`, `CLAIMED_PULSE_SPEED` in `src/renderer/GhostMesh.ts`).
  **Why:** smallest change that reads as unambiguously different in a screenshot without introducing a second color (issue requires staying blue in both states). Verified via pixel-level analysis in the visual channel: unclaimed frames average blue-channel ≈176–183, claimed ≈158–166, non-overlapping.
  **If reversed:** the four `CLAIMED_*` constants at the top of `GhostMesh.ts`.

- **What was open:** whether player-ordered vs. system-inserted rest actions should get a ghost.
  **Chosen:** no — rest actions still never push a `GhostPreview` (unchanged from before).
  **Why:** the design intent frames the ghost as marking what the *player* ordered; a rest is system-inserted, and pre-existing code already treated it this way. Out of this issue's scope.
  **If reversed:** add a `ghostPreviews.push(...)` in `createRestPendingAction` (`GameLoop.ts`).

- **What was open:** what happens to a `PendingAction` whose holder is fired or dies mid-task.
  **Chosen:** out of scope for this PR — the record stays `assigned`/`in_progress` with a `holderId` pointing at a gone employee.
  **Why:** the issue's own text defers this explicitly ("or cancelled — see the follow-up issue"), and that follow-up (#548, cancellation) is the natural owner of a "release a held action" mechanic.
  **If reversed:** #548 adds a release-on-fire/release-on-death call from the relevant employee-removal call sites.

- **What was open:** the baseline task duration for a `general_work` action dispatched with no required skill (root cause of the leak fix above).
  **Chosen:** proficiency level 1 (Rookie, `PROFICIENCY_MULTIPLIERS[1] = 1.00`), via the same `computeTaskDuration` formula already used for skill-required actions.
  **Why:** no existing "unskilled labor" constant to reuse; level 1 is already this codebase's own fallback for "no qualification to look up."
  **If reversed:** change the `level` fallback in `tickEmployees`'s widened `if (action.type !== 'rest')` duration-seeding block in `GameLoop.ts`.

## Verification

- static: `npm run typecheck` — clean.
- logic: `npm run test` — 8958/8958 passing; `npm run test:integration` — 534/534 passing.
- scenario: `npm run scenarios` — 127/127 passing (command mode), including the three recalibrated need/collapse/skill-progression scenarios and the modified `survey-overlay-lifecycle.json`.
- visual: `npm run scenario -- --scenario survey-overlay-lifecycle --mode interaction --screenshots` — PASS. Screenshots inspected: unclaimed ghost appears immediately on dispatch, transitions to a visibly dimmer/slower claimed treatment once claimed, persists through the whole walk+work window, disappears exactly when the survey result lands. Operations panel's "Unclaimed Work" count confirmed 1→0 across the claim via a throwaway probe scenario. `npm run a11y` — PASS.
- build: `npx vite build` — succeeds.

## full-ci

Applying `full-ci` — `scripts/scenario-defs/survey-overlay-lifecycle.json` is a `role: 'player'` interaction-mode scenario that drives the exact renderer change this PR makes (claimed vs. unclaimed ghost material), so CI's interaction-mode job is the strongest evidence for that path.

READY TO MERGE