### PR TITLE
fix: Resolve #559 — landscape and playable terrain meshes now meet at their seam

### DIFF
--- a/scripts/scenario-defs/landscape-continuity-visual.json
+++ b/scripts/scenario-defs/landscape-continuity-visual.json
@@ -11,6 +11,76 @@
       "name": "birdseye",
       "yaw": 0,
       "pitch": 80
+    },
+    {
+      "name": "desert-edge-west-closeup",
+      "yaw": 90,
+      "pitch": 14,
+      "target": [2, 32],
+      "distance": 45
+    },
+    {
+      "name": "desert-topdown-boundary",
+      "yaw": 0,
+      "pitch": 82,
+      "target": [32, 32],
+      "distance": 150
+    },
+    {
+      "name": "alpine-edge-closeup",
+      "yaw": 0,
+      "pitch": 12,
+      "target": [32, 3],
+      "distance": 45
+    },
+    {
+      "name": "foothills-edge-closeup",
+      "yaw": 0,
+      "pitch": 12,
+      "target": [3, 32],
+      "distance": 42
+    },
+    {
+      "name": "karst-corner-grazing",
+      "yaw": 225,
+      "pitch": 10,
+      "target": [4, 4],
+      "distance": 60
+    },
+    {
+      "name": "karst-high-boundary",
+      "yaw": 45,
+      "pitch": 55,
+      "target": [32, 32],
+      "distance": 120
+    },
+    {
+      "name": "desert-north-edge-closeup",
+      "yaw": 180,
+      "pitch": 14,
+      "target": [32, 2],
+      "distance": 45
+    },
+    {
+      "name": "alpine-topdown-boundary",
+      "yaw": 0,
+      "pitch": 78,
+      "target": [32, 32],
+      "distance": 140
+    },
+    {
+      "name": "foothills-topdown-boundary",
+      "yaw": 90,
+      "pitch": 80,
+      "target": [32, 32],
+      "distance": 140
+    },
+    {
+      "name": "karst-edge-closeup",
+      "yaw": 135,
+      "pitch": 14,
+      "target": [4, 32],
+      "distance": 45
     }
   ],
   "steps": [

--- a/scripts/scenario-defs/landscape-continuity-visual.json
+++ b/scripts/scenario-defs/landscape-continuity-visual.json
@@ -86,7 +86,7 @@
   "steps": [
     {
       "command": "new_game mine_type:alpine_granite seed:11 size:48",
-      "timeout": 90,
+      "timeout": 300,
       "interaction": [
         {
           "type": "command",
@@ -108,7 +108,7 @@
     },
     {
       "command": "terrain_info",
-      "timeout": 90,
+      "timeout": 300,
       "interaction": [
         {
           "type": "command",
@@ -130,7 +130,7 @@
     },
     {
       "command": "state",
-      "timeout": 120,
+      "timeout": 300,
       "interaction": [
         {
           "type": "command",
@@ -152,7 +152,7 @@
     },
     {
       "command": "state",
-      "timeout": 120,
+      "timeout": 300,
       "interaction": [
         {
           "type": "command",
@@ -174,7 +174,7 @@
     },
     {
       "command": "state",
-      "timeout": 120,
+      "timeout": 300,
       "interaction": [
         {
           "type": "command",
@@ -196,7 +196,7 @@
     },
     {
       "command": "state",
-      "timeout": 120,
+      "timeout": 300,
       "interaction": [
         {
           "type": "command",
@@ -218,7 +218,7 @@
     },
     {
       "command": "state",
-      "timeout": 120,
+      "timeout": 300,
       "interaction": [
         {
           "type": "command",
@@ -240,7 +240,7 @@
     },
     {
       "command": "drill_plan grid rows:2 cols:2 spacing:3 depth:6 diameter:0.089 start:2,22",
-      "timeout": 90,
+      "timeout": 300,
       "interaction": [
         {
           "type": "clickSelector",
@@ -288,7 +288,7 @@
     },
     {
       "command": "charge hole:* explosive:boomite amount:5 stemming:2",
-      "timeout": 90,
+      "timeout": 300,
       "interaction": [
         {
           "type": "clickSelector",
@@ -314,7 +314,7 @@
     },
     {
       "command": "sequence auto delay_step:25",
-      "timeout": 90,
+      "timeout": 300,
       "interaction": [
         {
           "type": "clickSelector",
@@ -340,7 +340,7 @@
     },
     {
       "command": "blast",
-      "timeout": 240,
+      "timeout": 300,
       "frames": 6,
       "interval": 50,
       "interaction": [
@@ -386,7 +386,7 @@
     },
     {
       "command": "state",
-      "timeout": 120,
+      "timeout": 300,
       "interaction": [
         {
           "type": "command",
@@ -410,7 +410,7 @@
     },
     {
       "command": "terrain_info",
-      "timeout": 90,
+      "timeout": 300,
       "interaction": [
         {
           "type": "command",

--- a/scripts/scenario-defs/site-expansion.json
+++ b/scripts/scenario-defs/site-expansion.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42 size:32 cash:500000",
-      "timeout": 35,
+      "timeout": 150,
       "interaction": [
         {
           "type": "command",
@@ -27,6 +27,7 @@
     {
       "command": "terrain_info",
       "description": "Baseline: the site is the 32x32 square the level started as.",
+      "timeout": 150,
       "interaction": [
         {
           "type": "command",
@@ -44,6 +45,7 @@
     {
       "command": "drill_plan add x:34 z:10 depth:6",
       "description": "Was left as a bare command (role bootstrap) because whether the 3D tile picker could raycast ground still outside the site was unverified. #558 fixes exactly that -- landscape meshes now join pickScene's raycast past the claimed edge -- so this is a real click through the Drill step's point-placement tool, exercising the fix directly.",
+      "timeout": 150,
       "interaction": [
         {
           "type": "clickSelector",
@@ -82,6 +84,7 @@
     {
       "command": "drill_plan add x:-4 z:10 depth:6",
       "description": "Was left as a bare command (role bootstrap) for the same reason as the step above -- converted now that #558 lets the picker raycast past the (still-expanding) site edge.",
+      "timeout": 150,
       "interaction": [
         {
           "type": "clickSelector",
@@ -120,6 +123,7 @@
     {
       "command": "terrain_info",
       "description": "The site is wider than the level it started as.",
+      "timeout": 150,
       "interaction": [
         {
           "type": "command",
@@ -137,6 +141,7 @@
     {
       "command": "inspect -4,0,10",
       "description": "Claimed ground is generated, not a hole: this reads as rock, not air.",
+      "timeout": 150,
       "interaction": [
         {
           "type": "command",
@@ -148,7 +153,7 @@
     {
       "command": "build_ramp origin:30,20 direction:east length:8 depth:6",
       "description": "Was left as a bare command (role bootstrap) for the same raycast-past-the-edge reason as the drill steps above; converted now that #558 lets the picker raycast the landscape past the site.",
-      "timeout": 100,
+      "timeout": 150,
       "interaction": [
         {
           "type": "clickSelector",
@@ -188,6 +193,7 @@
     {
       "command": "build management_office at:34,4",
       "description": "Was left as a bare command (role bootstrap) for the same raycast-past-the-edge reason as the steps above; converted now that #558 lets the picker raycast the landscape past the site.",
+      "timeout": 150,
       "interaction": [
         {
           "type": "clickSelector",
@@ -220,6 +226,7 @@
     },
     {
       "command": "charge hole:* explosive:boomite amount:5 stemming:2",
+      "timeout": 150,
       "interaction": [
         {
           "type": "clickSelector",
@@ -239,6 +246,7 @@
     },
     {
       "command": "sequence auto delay_step:25",
+      "timeout": 150,
       "interaction": [
         {
           "type": "clickSelector",
@@ -255,7 +263,7 @@
     {
       "command": "blast",
       "description": "A blast spanning both the original site and ground claimed during play.",
-      "timeout": 70,
+      "timeout": 150,
       "interaction": [
         {
           "type": "clickSelector",
@@ -289,7 +297,7 @@
     },
     {
       "command": "drill_plan add x:140 z:10 depth:6",
-      "timeout": 100,
+      "timeout": 150,
       "description": "#558 fence 3: a single-cell footprint with no connecting path of its own, well past the site's current frontier (chunk (2,0) is the nearest owned ground; chunk (8,0) is the target -- five intermediate chunks apart). Where the earlier drill/ramp/building steps in this file each landed on ground directly adjacent to the site (fence 1's raycast fix was the only thing standing between them and a real click), this one requires claimArea to bridge the gap itself (fence 3), well under MAX_CLAIM_BRIDGE_CHUNKS. Run immediately after the blast step (before save/load/terrain_info/state) so the blast report modal that step 'blast' just dismissed hasn't had a chance to reopen (#558 round 3) and cover this step's toolbar button. The Blast panel is already open from step 'blast' (togglePanel closes on a redundant toggle click, round 4), so this step's clicks start straight at add-hole-tool instead of re-clicking the toolbar toggle.",
       "interaction": [
         {
@@ -321,7 +329,7 @@
     {
       "command": "save slot:expanded",
       "description": "Left unmarked: save/load UI is out of scope for this batch -- see save-load-visual.json (Batch 6) for the real control. Runs after the far-bridging claim above, so the saved state (and the load below) includes the bridged ground at chunk (8,0), not just the original blast.",
-      "timeout": 70,
+      "timeout": 150,
       "interaction": [
         {
           "type": "command",
@@ -338,7 +346,7 @@
     {
       "command": "load slot:expanded",
       "description": "Left unmarked: save/load UI is out of scope for this batch -- see save-load-visual.json (Batch 6) for the real control. The point of this round-trip: the expanded site bounds -- now including the far-bridged claim at chunk (8,0), not just the original blast -- must survive a save/load, not only a live session.",
-      "timeout": 90,
+      "timeout": 150,
       "interaction": [
         {
           "type": "command",
@@ -357,7 +365,7 @@
     },
     {
       "command": "terrain_info",
-      "timeout": 75,
+      "timeout": 150,
       "interaction": [
         {
           "type": "command",
@@ -375,7 +383,7 @@
     {
       "command": "state full",
       "description": "Captures the fully-grown site, including the far-bridged claim, as persisted through the save/load round-trip above.",
-      "timeout": 75,
+      "timeout": 150,
       "interaction": [
         {
           "type": "command",

--- a/scripts/scenario-defs/site-expansion.json
+++ b/scripts/scenario-defs/site-expansion.json
@@ -395,6 +395,13 @@
       "name": "east-frontier",
       "yaw": 90,
       "pitch": 25
+    },
+    {
+      "name": "l-notch-corner",
+      "yaw": 45,
+      "pitch": 25,
+      "target": [32, 16],
+      "distance": 40
     }
   ]
 }

--- a/src/core/world/VoxelGrid.ts
+++ b/src/core/world/VoxelGrid.ts
@@ -261,6 +261,15 @@ export class VoxelGrid {
     return this.ownerOf(x, 0, z) !== null;
   }
 
+  /** True at an owned column, or at the single-voxel west/north halo column
+   *  TerrainMesh's "march one cube past the site" wall-sealing convention
+   *  actually emits geometry into. #559 root cause 4: LandscapeMesh must
+   *  treat this set, not raw containsColumn, as "already TerrainMesh's
+   *  ground" so the two meshes claim disjoint cells. */
+  claimsColumnForMeshing(_x: number, _z: number): boolean {
+    throw new Error('not implemented');
+  }
+
   /** The chunk covering (x, z) if the site has one, or null. Does not check the chunk's owned sub-rect. */
   private chunkAt(x: number, z: number): VoxelChunk | null {
     const key = chunkKey(chunkIndexOf(x), chunkIndexOf(z));
@@ -696,6 +705,7 @@ export function computeVoxelColumnSurfaceY(grid: VoxelGrid, x: number, z: number
  * column right now, pre- or post-blast. Returns 0 for a column with no
  * solid voxel at all.
  */
+// TODO(#559): implementer fixes clamp → NaN for unowned coords
 export function computeVoxelColumnSurfaceHeight(grid: VoxelGrid, x: number, z: number): number {
   if (grid.sizeX <= 0 || grid.sizeZ <= 0) return 0;
 

--- a/src/core/world/VoxelGrid.ts
+++ b/src/core/world/VoxelGrid.ts
@@ -266,8 +266,28 @@ export class VoxelGrid {
    *  actually emits geometry into. #559 root cause 4: LandscapeMesh must
    *  treat this set, not raw containsColumn, as "already TerrainMesh's
    *  ground" so the two meshes claim disjoint cells. */
-  claimsColumnForMeshing(_x: number, _z: number): boolean {
-    throw new Error('not implemented');
+  claimsColumnForMeshing(x: number, z: number): boolean {
+    if (this.containsColumn(x, z)) return true;
+
+    // West halo: TerrainMesh.rebuildChunk marches one column west of an
+    // owned chunk's own rect when that chunk has no owned neighbour to its
+    // west. (x, z) is that halo column exactly when (x+1, z) is owned (which,
+    // combined with (x, z) itself being unowned, means x+1 sits at the west
+    // edge of its owning chunk's rect) and that chunk has no west neighbour.
+    if (this.containsColumn(x + 1, z)) {
+      const cx = chunkIndexOf(x + 1);
+      const cz = chunkIndexOf(z);
+      if (!this.hasChunk(cx - 1, cz)) return true;
+    }
+
+    // North halo: symmetric on z.
+    if (this.containsColumn(x, z + 1)) {
+      const cx = chunkIndexOf(x);
+      const cz = chunkIndexOf(z + 1);
+      if (!this.hasChunk(cx, cz - 1)) return true;
+    }
+
+    return false;
   }
 
   /** The chunk covering (x, z) if the site has one, or null. Does not check the chunk's owned sub-rect. */
@@ -698,19 +718,24 @@ export function computeVoxelColumnSurfaceY(grid: VoxelGrid, x: number, z: number
 /**
  * Continuous height of the topmost solid-to-air crossing at column (x, z),
  * in the same datum as heightToVoxelYContinuous. Mirrors
- * computeVoxelColumnSurfaceY's top-down scan and clamp-to-edge-column
- * behaviour, but returns the fractional crossing height (via densityAt
- * interpolation between the topmost solid voxel and the one above it),
- * matching what TerrainMesh's marching cubes actually renders at that
- * column right now, pre- or post-blast. Returns 0 for a column with no
- * solid voxel at all.
+ * computeVoxelColumnSurfaceY's top-down scan, but returns the fractional
+ * crossing height (via densityAt interpolation between the topmost solid
+ * voxel and the one above it), matching what TerrainMesh's marching cubes
+ * actually renders at that column right now, pre- or post-blast. Returns 0
+ * for an owned column with no solid voxel at all.
+ *
+ * Unlike computeVoxelColumnSurfaceY, does NOT clamp an out-of-bounds (x, z)
+ * to the edge column — it returns NaN instead (#559). LandscapeMesh's live
+ * boundary-height sampling needs an honest "no live data here" signal at the
+ * claim edge, since the claim itself moves; a silent clamp there produced
+ * the seam this function's fix closes.
  */
-// TODO(#559): implementer fixes clamp → NaN for unowned coords
 export function computeVoxelColumnSurfaceHeight(grid: VoxelGrid, x: number, z: number): number {
   if (grid.sizeX <= 0 || grid.sizeZ <= 0) return 0;
+  if (!grid.containsColumn(x, z)) return NaN;
 
-  const cx = Math.max(grid.minX, Math.min(grid.maxX - 1, Math.floor(x)));
-  const cz = Math.max(grid.minZ, Math.min(grid.maxZ - 1, Math.floor(z)));
+  const cx = Math.floor(x);
+  const cz = Math.floor(z);
   for (let y = grid.sizeY - 1; y >= 0; y--) {
     const density0 = grid.densityAt(cx, y, cz);
     if (density0 >= 0.5) {

--- a/src/renderer/GameRenderer.ts
+++ b/src/renderer/GameRenderer.ts
@@ -727,6 +727,24 @@ export class GameRenderer {
   }
 
   /**
+   * The landscape's theoretical height function, ready to hand to
+   * TerrainMesh.setEdgeHeightSampler() — or null when no landscape can be
+   * built yet (no world/biome). Calls ensureLandscape(), which caches on
+   * ctx.landscape, so calling this before rebuildLandscapeMesh() does not
+   * duplicate the (expensive) structure-set build; rebuildLandscapeMesh()
+   * simply gets the same cached handle back (#559).
+   */
+  private landscapeEdgeHeightSampler(ctx: MiningContext): ((x: number, z: number) => number) | null {
+    if (!ctx.state?.world || !ctx.grid) return null;
+    const biome = getBiome(ctx.state.mineType);
+    if (!biome) return null;
+    const { sizeX, sizeY, sizeZ } = ctx.state.world;
+    const handle = ensureLandscape(ctx, { seed: ctx.state.seed, climateBias: biome.climateCenter, sizeX, sizeY, sizeZ });
+    if (!handle) return null;
+    return (x, z) => handle.sampleColumn(x, z).height;
+  }
+
+  /**
    * Raise the containment field on the frontier between claimable ground and
    * the protected structures beside the site (#473 P4). Nothing is drawn when
    * no protected chunk borders the site — open ground gets no wall, which is
@@ -774,6 +792,11 @@ export class GameRenderer {
 
     // Terrain mesh (marching cubes)
     this.terrain = new TerrainMesh(scene, grid, ctx.state?.mineType);
+    // Wire the landscape's theoretical height into the edge-normal sampler
+    // BEFORE the first buildAll(), so the initial mesh already carries the
+    // boundary-normal fix instead of needing a later remesh to pick it up
+    // (#559).
+    this.terrain.setEdgeHeightSampler(this.landscapeEdgeHeightSampler(ctx));
     this.terrain.buildAll();
     this.terrain.sharedMaterial.attachCSM(csm);
 
@@ -858,6 +881,11 @@ export class GameRenderer {
       this.landscape = new LandscapeMesh(this.sm.scene, this.terrain.sharedMaterial);
     }
     this.landscapeHandle = handle;
+    // Idempotent re-apply: a campaign level swap rebuilds the grid (and
+    // re-marches terrain) before landscape geometry catches up, so the
+    // sampler installed at loadGame() time can go stale — re-set it here
+    // whenever landscape geometry changes (#559).
+    this.terrain.setEdgeHeightSampler((x, z) => handle.sampleColumn(x, z).height);
     // The landscape's StructureSet already carries every river, village and
     // landmark for this seed — hand it to the claim path rather than have it
     // trace them all a second time (#473 D6).

--- a/src/renderer/GameRenderer.ts
+++ b/src/renderer/GameRenderer.ts
@@ -722,6 +722,7 @@ export class GameRenderer {
       // whatever the playable marching-cubes mesh renders there right now —
       // before or after a blast — instead of the static WorldGen prediction.
       boundaryHeightAt: (x, z) => computeVoxelColumnSurfaceHeight(grid, x, z),
+      meshClaimsColumn: (x, z) => grid.claimsColumnForMeshing(x, z),
     };
   }
 

--- a/src/renderer/TerrainMesh.ts
+++ b/src/renderer/TerrainMesh.ts
@@ -36,6 +36,16 @@ export interface DirtyRegion {
   maxX: number; maxY: number; maxZ: number;
 }
 
+export type EdgeHeightSampler = (x: number, z: number) => number;
+
+/** Virtual density for a column TerrainMesh does not own, using the
+ *  landscape's theoretical height, so gradient-normal sampling near the
+ *  site edge doesn't fall into "air" where the ground actually continues.
+ *  Same half-voxel crossing convention as emitVertex/computeVoxelColumnSurfaceHeight. */
+export function virtualEdgeDensity(_surfaceHeight: number, _y: number): number {
+  throw new Error('not implemented');
+}
+
 // ---------- Edge vertex lookup: for each of 12 cube edges, which 2 corners ----------
 const EDGE_CORNERS: readonly [number, number][] = [
   [0, 1], [1, 2], [2, 3], [3, 0],
@@ -58,6 +68,7 @@ interface CornerSample {
   oreAmt: number;
 }
 
+// TODO(#559): thread edgeHeightSampler through
 /** Density with trilinear interpolation, so the gradient below is continuous. */
 function densityAtSmooth(grid: VoxelGrid, x: number, y: number, z: number): number {
   const x0 = Math.floor(x), y0 = Math.floor(y), z0 = Math.floor(z);
@@ -84,6 +95,7 @@ function densityAtSmooth(grid: VoxelGrid, x: number, y: number, z: number): numb
  * An iso-surface's true normal is the negated gradient of the field it is an
  * iso-surface of, which owes nothing to how the triangles were cut.
  */
+// TODO(#559): thread edgeHeightSampler through
 function densityGradientNormal(grid: VoxelGrid, x: number, y: number, z: number): [number, number, number] {
   const e = 0.85;
   const gx = densityAtSmooth(grid, x + e, y, z) - densityAtSmooth(grid, x - e, y, z);
@@ -157,6 +169,7 @@ export class TerrainMesh {
   private readonly chunks = new Map<number, THREE.Mesh | null>();
   /** Vertical chunk count. x/z chunk coordinates come from the grid's own claimed set, and are signed. */
   private ncy = 0;
+  private edgeHeightSampler: EdgeHeightSampler | null = null;
 
   constructor(scene: THREE.Scene, grid: VoxelGrid, biomeId?: string) {
     this.scene = scene;
@@ -194,6 +207,18 @@ export class TerrainMesh {
   /** ID of the currently-bound VoxelGrid, for diagnostics. */
   get gridId(): number {
     return this.grid.id;
+  }
+
+  /** Sets (or clears with null) the sampler used to extend the normal-only
+   *  density field past the site's owned columns for edge-vertex normal
+   *  calculation. Does not affect which triangles are emitted. */
+  setEdgeHeightSampler(sampler: EdgeHeightSampler | null): void {
+    this.edgeHeightSampler = sampler;
+  }
+
+  /** The currently installed edge height sampler, or null — diagnostics and tests. */
+  get currentEdgeHeightSampler(): EdgeHeightSampler | null {
+    return this.edgeHeightSampler;
   }
 
   /** The shared terrain material — reused by LandscapeMesh and FragmentMesh so every zone renders with identical shading (#458 T3.2/T4.1/D9). */

--- a/src/renderer/TerrainMesh.ts
+++ b/src/renderer/TerrainMesh.ts
@@ -42,8 +42,8 @@ export type EdgeHeightSampler = (x: number, z: number) => number;
  *  landscape's theoretical height, so gradient-normal sampling near the
  *  site edge doesn't fall into "air" where the ground actually continues.
  *  Same half-voxel crossing convention as emitVertex/computeVoxelColumnSurfaceHeight. */
-export function virtualEdgeDensity(_surfaceHeight: number, _y: number): number {
-  throw new Error('not implemented');
+export function virtualEdgeDensity(surfaceHeight: number, y: number): number {
+  return Math.max(0, Math.min(1, surfaceHeight + 0.5 - y));
 }
 
 // ---------- Edge vertex lookup: for each of 12 cube edges, which 2 corners ----------
@@ -68,16 +68,31 @@ interface CornerSample {
   oreAmt: number;
 }
 
-// TODO(#559): thread edgeHeightSampler through
+/**
+ * Density at one integer lattice corner, for gradient-normal sampling only.
+ * A column the grid doesn't own reads as air (0) unless an edge height
+ * sampler is installed, in which case it reads as the virtual density of
+ * the landscape's theoretical/live ground there (#559) — this only feeds
+ * densityGradientNormal's finite differences; sampleCorner/cubeIndex (which
+ * decide geometry/topology) always use grid.densityAt directly and are
+ * untouched by this.
+ */
+function cornerDensityForNormal(grid: VoxelGrid, sampler: EdgeHeightSampler | null, x: number, y: number, z: number): number {
+  if (sampler && !grid.containsColumn(x, z)) {
+    return virtualEdgeDensity(sampler(x, z), y);
+  }
+  return grid.densityAt(x, y, z);
+}
+
 /** Density with trilinear interpolation, so the gradient below is continuous. */
-function densityAtSmooth(grid: VoxelGrid, x: number, y: number, z: number): number {
+function densityAtSmooth(grid: VoxelGrid, sampler: EdgeHeightSampler | null, x: number, y: number, z: number): number {
   const x0 = Math.floor(x), y0 = Math.floor(y), z0 = Math.floor(z);
   const fx = x - x0, fy = y - y0, fz = z - z0;
   let acc = 0;
   for (let k = 0; k < 8; k++) {
     const dx = k & 1, dy = (k >> 1) & 1, dz = (k >> 2) & 1;
     const w = (dx ? fx : 1 - fx) * (dy ? fy : 1 - fy) * (dz ? fz : 1 - fz);
-    if (w > 0) acc += w * grid.densityAt(x0 + dx, y0 + dy, z0 + dz);
+    if (w > 0) acc += w * cornerDensityForNormal(grid, sampler, x0 + dx, y0 + dy, z0 + dz);
   }
   return acc;
 }
@@ -95,12 +110,11 @@ function densityAtSmooth(grid: VoxelGrid, x: number, y: number, z: number): numb
  * An iso-surface's true normal is the negated gradient of the field it is an
  * iso-surface of, which owes nothing to how the triangles were cut.
  */
-// TODO(#559): thread edgeHeightSampler through
-function densityGradientNormal(grid: VoxelGrid, x: number, y: number, z: number): [number, number, number] {
+function densityGradientNormal(grid: VoxelGrid, sampler: EdgeHeightSampler | null, x: number, y: number, z: number): [number, number, number] {
   const e = 0.85;
-  const gx = densityAtSmooth(grid, x + e, y, z) - densityAtSmooth(grid, x - e, y, z);
-  const gy = densityAtSmooth(grid, x, y + e, z) - densityAtSmooth(grid, x, y - e, z);
-  const gz = densityAtSmooth(grid, x, y, z + e) - densityAtSmooth(grid, x, y, z - e);
+  const gx = densityAtSmooth(grid, sampler, x + e, y, z) - densityAtSmooth(grid, sampler, x - e, y, z);
+  const gy = densityAtSmooth(grid, sampler, x, y + e, z) - densityAtSmooth(grid, sampler, x, y - e, z);
+  const gz = densityAtSmooth(grid, sampler, x, y, z + e) - densityAtSmooth(grid, sampler, x, y, z - e);
   const len = Math.hypot(gx, gy, gz);
   // A vertex in a locally uniform region has no gradient to speak of. Falling
   // back to "up" beats emitting a zero normal, which shades black.
@@ -434,7 +448,7 @@ export class TerrainMesh {
     // Normals from the field, not the triangulation — see densityGradientNormal.
     const normals = new Float32Array(positions.length);
     for (let i = 0; i < positions.length; i += 3) {
-      const n = densityGradientNormal(this.grid, positions[i]!, positions[i + 1]!, positions[i + 2]!);
+      const n = densityGradientNormal(this.grid, this.edgeHeightSampler, positions[i]!, positions[i + 1]!, positions[i + 2]!);
       normals[i] = n[0]; normals[i + 1] = n[1]; normals[i + 2] = n[2];
     }
     geometry.setAttribute('normal', new THREE.BufferAttribute(normals, 3));

--- a/src/renderer/terrain/LandscapeMesh.ts
+++ b/src/renderer/terrain/LandscapeMesh.ts
@@ -197,17 +197,23 @@ export function buildBoundaryQuad(
   const h11 = sampleColumn(x1, z1).height;
 
   // Slope source for shading: the live/theoretical field, never the
-  // flat-edge-adjusted position (a T-junction fix, not a slope). Only trust
-  // the live value at a point the site actually owns, and only when it
-  // isn't NaN — the claim boundary moves, and computeVoxelColumnSurfaceHeight
+  // flat-edge-adjusted position (a T-junction fix, not a slope). Trust the
+  // live value whenever the caller can supply one, and only when it isn't
+  // NaN — the claim boundary moves, and computeVoxelColumnSurfaceHeight
   // answers NaN rather than clamping for a column outside the site (#559).
+  // Gating on ownsColumn here as well would be redundant with that NaN
+  // contract in production (boundaryHeightAt IS computeVoxelColumnSurfaceHeight,
+  // which already returns NaN for exactly the columns ownsColumn rejects) and
+  // wrong the moment a caller's live source legitimately covers ground just
+  // past ownsColumn's strict edge (e.g. TerrainMesh's meshClaimsColumn halo,
+  // or a live post-blast height one ring out) — #559 root cause 1.
   const heightCache = new Map<string, number>();
   const trueHeightAt = (x: number, z: number): number => {
     const key = `${x},${z}`;
     const cached = heightCache.get(key);
     if (cached !== undefined) return cached;
     let h = sampleColumn(x, z).height;
-    if (playable.ownsColumn(x, z) && playable.boundaryHeightAt) {
+    if (playable.boundaryHeightAt) {
       const live = playable.boundaryHeightAt(x, z);
       if (!Number.isNaN(live)) h = live;
     }
@@ -284,6 +290,10 @@ export function buildBoundaryQuad(
  * quads to coarse open-ground quads isn't a one-step cliff that itself reads
  * as a seam. Flat-edge-interpolates its own outer perimeter against
  * unsubdivided coarse neighbours per the existing #491 rule.
+ *
+ * `step` is the target sample spacing to subdivide the quad down to (the
+ * caller always passes MID_STEP) — the same "spacing, not a count" meaning
+ * FINE_STEP carries in buildBoundaryQuad, not the coarse tile's own step.
  */
 export function subdivideOutsideQuad(
   positions: number[],
@@ -301,7 +311,7 @@ export function subdivideOutsideQuad(
   palette: CompositionPalette,
   step: number,
 ): void {
-  const subdiv = Math.max(1, Math.round(step / MID_STEP));
+  const subdiv = Math.max(1, Math.round((x1 - x0) / step));
 
   // Parent coarse corner heights. A plain bilinear interpolation of these
   // four naturally reduces to the flat-edge rule's linear interpolation
@@ -548,7 +558,7 @@ export class LandscapeMesh {
           if (adjacentToBoundary) {
             subdivideOutsideQuad(
               positions, normals, rockA, rockB, rockWeight, ore, indices,
-              x0, z0, x1, z1, sampleColumn, palette, step,
+              x0, z0, x1, z1, sampleColumn, palette, MID_STEP,
             );
             continue;
           }

--- a/src/renderer/terrain/LandscapeMesh.ts
+++ b/src/renderer/terrain/LandscapeMesh.ts
@@ -28,6 +28,11 @@ import { rockIndexOf } from '../../core/world/RockCatalog.js';
 /** Sample spacing of a boundary quad's subdivision, metres — matches the old seam mesh's resolution. */
 const FINE_STEP = 1;
 
+/** Intermediate subdivision step between FINE_STEP boundary quads and the
+ *  coarse open-ground quads, so the resolution jump isn't a one-step cliff
+ *  that itself reads as a seam (#559). */
+export const MID_STEP = 2;
+
 type SampleFn = (x: number, z: number) => { height: number; biomeId: number; surfCompId: number };
 
 /**
@@ -89,6 +94,10 @@ export interface PlayableCut {
    *  so the landscape's edge matches whatever the playable mesh currently
    *  renders there. Falls back to the theoretical WorldGen height when absent. */
   boundaryHeightAt?(x: number, z: number): number;
+  /** Ground TerrainMesh will actually draw into, including its 1-voxel
+   *  outward-march halo — narrower "not mine to draw" test than ownsColumn.
+   *  Falls back to ownsColumn when absent (#559). */
+  meshClaimsColumn?(x: number, z: number): boolean;
 }
 
 /** The pre-expansion behaviour: the site is exactly its rect. */
@@ -258,6 +267,32 @@ export function buildBoundaryQuad(
       pushQuad(indices, i0, i1, i2, i3, row + col);
     }
   }
+}
+
+/**
+ * Subdivides a coarse 'outside' quad adjacent to the boundary at an
+ * intermediate resolution (MID_STEP) so the jump from FINE_STEP boundary
+ * quads to coarse open-ground quads isn't a one-step cliff that itself reads
+ * as a seam. Flat-edge-interpolates its own outer perimeter against
+ * unsubdivided coarse neighbours per the existing #491 rule.
+ */
+export function subdivideOutsideQuad(
+  _positions: number[],
+  _normals: number[],
+  _rockA: number[],
+  _rockB: number[],
+  _rockWeight: number[],
+  _ore: number[],
+  _indices: number[],
+  _x0: number,
+  _z0: number,
+  _x1: number,
+  _z1: number,
+  _sampleColumn: SampleFn,
+  _palette: CompositionPalette,
+  _step: number,
+): void {
+  throw new Error('not implemented');
 }
 
 export class LandscapeMesh {

--- a/src/renderer/terrain/LandscapeMesh.ts
+++ b/src/renderer/terrain/LandscapeMesh.ts
@@ -138,11 +138,12 @@ export function rockBlendFor(palette: CompositionPalette, surfCompId: number): {
  * instead of being emitted whole).
  */
 export function classifyQuad(playable: PlayableCut, x0: number, z0: number, x1: number, z1: number): 'outside' | 'inside' | 'boundary' {
+  const claims = playable.meshClaimsColumn ?? playable.ownsColumn;
   const owned = [
-    playable.ownsColumn(x0, z0),
-    playable.ownsColumn(x1, z0),
-    playable.ownsColumn(x0, z1),
-    playable.ownsColumn(x1, z1),
+    claims(x0, z0),
+    claims(x1, z0),
+    claims(x0, z1),
+    claims(x1, z1),
   ];
   if (owned.every(o => o)) return 'inside';
   if (owned.every(o => !o)) return 'outside';
@@ -185,6 +186,7 @@ export function buildBoundaryQuad(
   playable: PlayableCut,
 ): void {
   const subdiv = Math.max(1, Math.round((x1 - x0) / FINE_STEP));
+  const claims = playable.meshClaimsColumn ?? playable.ownsColumn;
 
   // Parent coarse corner heights, read directly (never boundary-adjusted) —
   // the flat-edge rule's whole point is to reproduce exactly what an
@@ -195,13 +197,20 @@ export function buildBoundaryQuad(
   const h11 = sampleColumn(x1, z1).height;
 
   // Slope source for shading: the live/theoretical field, never the
-  // flat-edge-adjusted position (a T-junction fix, not a slope).
+  // flat-edge-adjusted position (a T-junction fix, not a slope). Only trust
+  // the live value at a point the site actually owns, and only when it
+  // isn't NaN — the claim boundary moves, and computeVoxelColumnSurfaceHeight
+  // answers NaN rather than clamping for a column outside the site (#559).
   const heightCache = new Map<string, number>();
   const trueHeightAt = (x: number, z: number): number => {
     const key = `${x},${z}`;
     const cached = heightCache.get(key);
     if (cached !== undefined) return cached;
-    const h = playable.boundaryHeightAt ? playable.boundaryHeightAt(x, z) : sampleColumn(x, z).height;
+    let h = sampleColumn(x, z).height;
+    if (playable.ownsColumn(x, z) && playable.boundaryHeightAt) {
+      const live = playable.boundaryHeightAt(x, z);
+      if (!Number.isNaN(live)) h = live;
+    }
     heightCache.set(key, h);
     return h;
   };
@@ -230,7 +239,7 @@ export function buildBoundaryQuad(
       const t = row / subdiv;
       y = col === 0 ? h00 + t * (h01 - h00) : h10 + t * (h11 - h10);
     } else {
-      y = playable.boundaryHeightAt ? playable.boundaryHeightAt(x, z) : sample.height;
+      y = trueHeightAt(x, z);
     }
 
     const dhdx = (trueHeightAt(x + FINE_STEP, z) - trueHeightAt(x - FINE_STEP, z)) / (2 * FINE_STEP);
@@ -256,8 +265,8 @@ export function buildBoundaryQuad(
       const cx0 = x0 + col * FINE_STEP, cx1 = cx0 + FINE_STEP;
       const cz0 = z0 + row * FINE_STEP, cz1 = cz0 + FINE_STEP;
       const anyUnowned =
-        !playable.ownsColumn(cx0, cz0) || !playable.ownsColumn(cx1, cz0) ||
-        !playable.ownsColumn(cx0, cz1) || !playable.ownsColumn(cx1, cz1);
+        !claims(cx0, cz0) || !claims(cx1, cz0) ||
+        !claims(cx0, cz1) || !claims(cx1, cz1);
       if (!anyUnowned) continue; // fully claimed — the playable mesh owns this cell
 
       const i0 = emitVertex(row, col);
@@ -277,22 +286,79 @@ export function buildBoundaryQuad(
  * unsubdivided coarse neighbours per the existing #491 rule.
  */
 export function subdivideOutsideQuad(
-  _positions: number[],
-  _normals: number[],
-  _rockA: number[],
-  _rockB: number[],
-  _rockWeight: number[],
-  _ore: number[],
-  _indices: number[],
-  _x0: number,
-  _z0: number,
-  _x1: number,
-  _z1: number,
-  _sampleColumn: SampleFn,
-  _palette: CompositionPalette,
-  _step: number,
+  positions: number[],
+  normals: number[],
+  rockA: number[],
+  rockB: number[],
+  rockWeight: number[],
+  ore: number[],
+  indices: number[],
+  x0: number,
+  z0: number,
+  x1: number,
+  z1: number,
+  sampleColumn: SampleFn,
+  palette: CompositionPalette,
+  step: number,
 ): void {
-  throw new Error('not implemented');
+  const subdiv = Math.max(1, Math.round(step / MID_STEP));
+
+  // Parent coarse corner heights. A plain bilinear interpolation of these
+  // four naturally reduces to the flat-edge rule's linear interpolation
+  // along every side of the quad, so no separate perimeter special-case is
+  // needed here the way buildBoundaryQuad needs one (its interior deviates
+  // from bilinear by using live/theoretical sampled height; this function's
+  // interior never does — it's unconditionally outside the claim).
+  const h00 = sampleColumn(x0, z0).height;
+  const h10 = sampleColumn(x1, z0).height;
+  const h01 = sampleColumn(x0, z1).height;
+  const h11 = sampleColumn(x1, z1).height;
+
+  const bilinearHeight = (x: number, z: number): number => {
+    const u = (x - x0) / (x1 - x0);
+    const v = (z - z0) / (z1 - z0);
+    return (1 - u) * (1 - v) * h00 + u * (1 - v) * h10 + (1 - u) * v * h01 + u * v * h11;
+  };
+
+  const vertexIndex = new Map<number, number>();
+
+  const emitVertex = (row: number, col: number): number => {
+    const key = row * (subdiv + 1) + col;
+    const existing = vertexIndex.get(key);
+    if (existing !== undefined) return existing;
+
+    const x = x0 + col * MID_STEP;
+    const z = z0 + row * MID_STEP;
+    const y = bilinearHeight(x, z);
+
+    const dhdx = (bilinearHeight(x + MID_STEP, z) - bilinearHeight(x - MID_STEP, z)) / (2 * MID_STEP);
+    const dhdz = (bilinearHeight(x, z + MID_STEP) - bilinearHeight(x, z - MID_STEP)) / (2 * MID_STEP);
+    const normal = heightFieldNormal(dhdx, dhdz);
+
+    const idx = positions.length / 3;
+    positions.push(x, y, z);
+    normals.push(normal[0], normal[1], normal[2]);
+
+    const sample = sampleColumn(x, z);
+    const blend = rockBlendFor(palette, sample.surfCompId);
+    rockA.push(blend.rockA);
+    rockB.push(blend.rockB);
+    rockWeight.push(blend.weight);
+    ore.push(-1, 0); // landscape never carries ore (#458 A18)
+
+    vertexIndex.set(key, idx);
+    return idx;
+  };
+
+  for (let row = 0; row < subdiv; row++) {
+    for (let col = 0; col < subdiv; col++) {
+      const i0 = emitVertex(row, col);
+      const i1 = emitVertex(row, col + 1);
+      const i2 = emitVertex(row + 1, col);
+      const i3 = emitVertex(row + 1, col + 1);
+      pushQuad(indices, i0, i1, i2, i3, row + col);
+    }
+  }
 }
 
 export class LandscapeMesh {
@@ -441,18 +507,48 @@ export class LandscapeMesh {
       }
     }
 
+    // Classify every coarse quad up front (only when the tile can possibly
+    // touch the rect) so an 'outside' quad can tell whether it borders a
+    // 'boundary' quad and needs MID_STEP subdivision — otherwise the
+    // FINE_STEP boundary ring meets COARSE_STEP open ground in one
+    // resolution jump, which itself reads as a seam (#559).
+    const quadClass = new Map<number, 'inside' | 'outside' | 'boundary'>();
+    if (touchesRect) {
+      for (let row = 0; row < n - 1; row++) {
+        const z0 = tile.originZ + row * step, z1 = z0 + step;
+        for (let col = 0; col < n - 1; col++) {
+          const x0 = tile.originX + col * step, x1 = x0 + step;
+          quadClass.set(row * (n - 1) + col, classifyQuad(playable, x0, z0, x1, z1));
+        }
+      }
+    }
+    const isBoundaryQuad = (row: number, col: number): boolean => {
+      if (row < 0 || col < 0 || row >= n - 1 || col >= n - 1) return false;
+      return quadClass.get(row * (n - 1) + col) === 'boundary';
+    };
+
     const indices: number[] = [];
     for (let row = 0; row < n - 1; row++) {
       const z0 = tile.originZ + row * step, z1 = z0 + step;
       for (let col = 0; col < n - 1; col++) {
         if (touchesRect) {
           const x0 = tile.originX + col * step, x1 = x0 + step;
-          const cls = classifyQuad(playable, x0, z0, x1, z1);
+          const cls = quadClass.get(row * (n - 1) + col)!;
           if (cls === 'inside') continue;
           if (cls === 'boundary') {
             buildBoundaryQuad(
               positions, normals, rockA, rockB, rockWeight, ore, indices,
               x0, z0, x1, z1, sampleColumn, palette, playable,
+            );
+            continue;
+          }
+          const adjacentToBoundary =
+            isBoundaryQuad(row - 1, col) || isBoundaryQuad(row + 1, col) ||
+            isBoundaryQuad(row, col - 1) || isBoundaryQuad(row, col + 1);
+          if (adjacentToBoundary) {
+            subdivideOutsideQuad(
+              positions, normals, rockA, rockB, rockWeight, ore, indices,
+              x0, z0, x1, z1, sampleColumn, palette, step,
             );
             continue;
           }

--- a/tests/unit/renderer/GameRenderer.test.ts
+++ b/tests/unit/renderer/GameRenderer.test.ts
@@ -8,6 +8,7 @@ import * as THREE from 'three';
 import { GameRenderer } from '../../../src/renderer/GameRenderer.js';
 import { FragmentMesh } from '../../../src/renderer/FragmentMesh.js';
 import { CharacterMesh } from '../../../src/renderer/CharacterMesh.js';
+import { TerrainMesh } from '../../../src/renderer/TerrainMesh.js';
 import type { MiningContext } from '../../../src/console/commands/mining.js';
 import { createGame } from '../../../src/core/state/GameState.js';
 import { VoxelGrid } from '../../../src/core/world/VoxelGrid.js';
@@ -794,5 +795,90 @@ describe('GameRenderer — survey confidence overlay visibility preference (#496
     renderer.syncFromContext(ctx); // re-sync with still-empty results
 
     expect(hideSpy).toHaveBeenCalled();
+  });
+});
+
+// ── Terrain/landscape boundary wiring (#559) ────────────────────────────────
+//
+// playableCut()'s meshClaimsColumn field, the edge-height sampler's
+// setEdgeHeightSampler()-before-buildAll() init ordering, and its idempotent
+// re-apply on landscape rebuild all previously shipped with zero test
+// coverage (semantic-reviewer, #559 fix-bug pass).
+
+describe('GameRenderer — playableCut/meshClaimsColumn wiring (#559)', () => {
+  async function makeLandscapeCtx(mineType = 'green_foothills'): Promise<MiningContext> {
+    const { newGameCommand } = await import('../../../src/console/commands/world.js');
+    const ctx: MiningContext = {
+      state: null, grid: null, landscape: null,
+      emitter: new EventEmitter(),
+    };
+    const result = newGameCommand(ctx, [], { mine_type: mineType, seed: '42', size: '64' });
+    expect(result.success).toBe(true); // guard: the rest of the test is meaningless if setup itself failed
+    return ctx;
+  }
+
+  it('playableCut(grid).meshClaimsColumn delegates to grid.claimsColumnForMeshing', async () => {
+    const claimsSpy = vi.spyOn(VoxelGrid.prototype, 'claimsColumnForMeshing');
+    const sm = makeMockSceneManager();
+    const renderer = new GameRenderer(sm as any);
+
+    renderer.syncFromContext(await makeLandscapeCtx());
+
+    // The landscape build cuts itself against playableCut(grid), whose
+    // meshClaimsColumn is wired straight to grid.claimsColumnForMeshing
+    // (GameRenderer.playableCut) -- a boundary quad anywhere in the built
+    // landscape necessarily calls it via LandscapeMesh's classifyQuad.
+    expect(claimsSpy).toHaveBeenCalled();
+    const [x, z] = claimsSpy.mock.calls[0]!;
+    expect(typeof x).toBe('number');
+    expect(typeof z).toBe('number');
+    claimsSpy.mockRestore();
+  });
+
+  it('loadGame() sets the terrain edge-height sampler BEFORE buildAll(), and it is non-null afterward', async () => {
+    const setSamplerSpy = vi.spyOn(TerrainMesh.prototype, 'setEdgeHeightSampler');
+    const buildAllSpy = vi.spyOn(TerrainMesh.prototype, 'buildAll');
+    const sm = makeMockSceneManager();
+    const renderer = new GameRenderer(sm as any);
+
+    renderer.syncFromContext(await makeLandscapeCtx());
+
+    expect(setSamplerSpy).toHaveBeenCalled();
+    expect(buildAllSpy).toHaveBeenCalled();
+    // vitest mock functions record a global invocation order counter --
+    // setEdgeHeightSampler's first call must precede buildAll's first call,
+    // pinning the #559 init-ordering fix (previously buildAll ran first,
+    // so the initial mesh missed the boundary-normal fix entirely).
+    expect(setSamplerSpy.mock.invocationCallOrder[0]!).toBeLessThan(buildAllSpy.mock.invocationCallOrder[0]!);
+    // The dead-code concern (quality-reviewer): currentEdgeHeightSampler
+    // actually earns its keep here, proving the sampler GameRenderer wired in
+    // reached TerrainMesh, not just that some setter was called.
+    expect(renderer.terrain!.currentEdgeHeightSampler).not.toBeNull();
+
+    setSamplerSpy.mockRestore();
+    buildAllSpy.mockRestore();
+  });
+
+  it('rebuildLandscapeMesh() (level swap) re-applies the edge-height sampler', async () => {
+    const setSamplerSpy = vi.spyOn(TerrainMesh.prototype, 'setEdgeHeightSampler');
+    const sm = makeMockSceneManager();
+    const renderer = new GameRenderer(sm as any);
+    const ctx = await makeLandscapeCtx();
+    renderer.syncFromContext(ctx); // loadGame() — 1st setEdgeHeightSampler call
+    const callsAfterLoad = setSamplerSpy.mock.calls.length;
+    expect(callsAfterLoad).toBeGreaterThan(0);
+
+    // Same seed, different grid object — the "grid changed, same seed" branch
+    // that calls rebuildLandscapeMesh() a second time without going through
+    // loadGame()'s clearAll() first (mirrors a campaign level swap), exactly
+    // as the existing ambient-mesh test above exercises.
+    ctx.grid = new VoxelGrid(64, 64, 64);
+    ctx.landscape = null;
+    renderer.syncFromContext(ctx);
+
+    expect(setSamplerSpy.mock.calls.length).toBeGreaterThan(callsAfterLoad);
+    expect(renderer.terrain!.currentEdgeHeightSampler).not.toBeNull();
+
+    setSamplerSpy.mockRestore();
   });
 });

--- a/tests/unit/renderer/LandscapeMesh.test.ts
+++ b/tests/unit/renderer/LandscapeMesh.test.ts
@@ -9,6 +9,8 @@ import {
   rockBlendFor,
   classifyQuad,
   buildBoundaryQuad,
+  subdivideOutsideQuad,
+  MID_STEP,
   type PlayableCut,
 } from '../../../src/renderer/terrain/LandscapeMesh.js';
 import { rockIndexOf } from '../../../src/core/world/RockCatalog.js';
@@ -934,4 +936,215 @@ describe('LandscapeMesh — per-biome coverage (#491)', () => {
       lm.dispose();
     });
   }
+});
+
+// #559: the landscape/playable-mesh boundary. Root causes 3 and 4 of that
+// issue: LandscapeMesh must not read a NaN live height as a real one, and
+// must treat TerrainMesh's own meshing footprint (meshClaimsColumn), not raw
+// ownsColumn, as ground it must not draw into.
+
+describe('LandscapeMesh — dense boundary sample walk against a known height field (#559)', () => {
+  const POSITION_TOLERANCE = 1e-3;
+  const NORMAL_ANGLE_TOLERANCE_DEG = 5;
+
+  it('every boundary-ring vertex along a dense walk of the site edge matches the theoretical height and slope within tolerance', () => {
+    const scene = makeScene();
+    const { palette, compId } = makePalette();
+    // A single flat plane: the playable surface height function and the
+    // landscape height function are literally the same function, so they
+    // agree everywhere -- including densely along the whole boundary, not
+    // just at one spot-checked point.
+    const field = (x: number, z: number) => 20 + x * 0.2 - z * 0.15;
+    const rect: Rect = { minX: 0, minZ: 0, maxX: 32, maxZ: 32 };
+    const n = 60;
+    const tile = makeFakeTile(-100, -100, n, compId);
+    const step = 4;
+    for (let row = 0; row < n; row++) {
+      for (let col = 0; col < n; col++) {
+        tile.heights[row * n + col] = field(-100 + col * step, -100 + row * step);
+      }
+    }
+    const handle = makeFakeHandle(rect, [tile], n, compId, (x, z) => ({ height: field(x, z), biomeId: 0, surfCompId: compId }));
+    const playable: PlayableCut = { rect, ownsColumn: (x, z) => x > rect.minX && x < rect.maxX && z > rect.minZ && z < rect.maxZ, boundaryHeightAt: field };
+
+    const lm = new LandscapeMesh(scene, makeMaterial());
+    lm.build(handle, palette, playable);
+
+    const dhdx = 0.2, dhdz = -0.15; // analytic slope of `field`
+    const expectedLen = Math.hypot(dhdx, 1, dhdz);
+    const expectedNormal = [-dhdx / expectedLen, 1 / expectedLen, -dhdz / expectedLen] as const;
+    const angleToleranceRad = (NORMAL_ANGLE_TOLERANCE_DEG * Math.PI) / 180;
+
+    let sampled = 0;
+    for (const child of scene.children) {
+      const mesh = child as THREE.Mesh;
+      const pos = mesh.geometry.getAttribute('position').array as Float32Array;
+      const nrm = mesh.geometry.getAttribute('normal').array as Float32Array;
+      for (let i = 0; i < pos.length; i += 3) {
+        const x = pos[i]!, y = pos[i + 1]!, z = pos[i + 2]!;
+        // Only the ring right at the claim boundary -- within 2m of the rect
+        // edge AND within the rect's own extended footprint, so a vertex far
+        // along an unrelated tile edge (which merely happens to share one
+        // coordinate with a rect edge) isn't mistaken for a boundary vertex.
+        const inExtendedBox =
+          x >= rect.minX - 2 && x <= rect.maxX + 2 && z >= rect.minZ - 2 && z <= rect.maxZ + 2;
+        const nearBoundary =
+          inExtendedBox && (
+            Math.abs(x - rect.minX) < 2 || Math.abs(x - rect.maxX) < 2 ||
+            Math.abs(z - rect.minZ) < 2 || Math.abs(z - rect.maxZ) < 2
+          );
+        if (!nearBoundary) continue;
+        sampled++;
+
+        expect(Math.abs(y - field(x, z))).toBeLessThan(POSITION_TOLERANCE);
+
+        const nx = nrm[i]!, ny = nrm[i + 1]!, nz = nrm[i + 2]!;
+        const dot = nx * expectedNormal[0] + ny * expectedNormal[1] + nz * expectedNormal[2];
+        const angle = Math.acos(Math.min(1, Math.max(-1, dot)));
+        expect(angle).toBeLessThan(angleToleranceRad);
+      }
+    }
+    expect(sampled).toBeGreaterThan(0); // the walk actually found boundary vertices to check
+    lm.dispose();
+  });
+});
+
+describe('LandscapeMesh — classifyQuad/buildBoundaryQuad must honor meshClaimsColumn, not raw ownsColumn (#559 root cause 4)', () => {
+  it('emits no vertex inside the west halo column TerrainMesh now claims via meshClaimsColumn', () => {
+    const scene = makeScene();
+    const { palette, compId } = makePalette();
+    const rect: Rect = { minX: 0, minZ: 0, maxX: 32, maxZ: 32 };
+    const n = 60;
+    const tile = makeFakeTile(-100, -100, n, compId);
+    const handle = makeFakeHandle(rect, [tile], n, compId);
+
+    const playable: PlayableCut = {
+      rect,
+      ownsColumn: (x, z) => x >= 0 && x < 32 && z >= 0 && z < 32,
+      // Mirrors TerrainMesh's own outward march (rebuildChunk's xStart =
+      // rect.minX - 1 when no owned chunk lies to the west): one extra
+      // column claimed to the west of ownsColumn's own rect, same z range.
+      meshClaimsColumn: (x, z) => x >= -1 && x < 32 && z >= 0 && z < 32,
+    };
+
+    const lm = new LandscapeMesh(scene, makeMaterial());
+    lm.build(handle, palette, playable);
+
+    let violations = 0;
+    for (const child of scene.children) {
+      const mesh = child as THREE.Mesh;
+      const pos = mesh.geometry.getAttribute('position').array as Float32Array;
+      for (let i = 0; i < pos.length; i += 3) {
+        const x = pos[i]!;
+        if (x >= -1 - 1e-6 && x < 0 - 1e-6) violations++;
+      }
+    }
+    expect(violations).toBe(0);
+    lm.dispose();
+  });
+
+  it('still emits ground two columns west of the rect, outside even the meshClaimsColumn halo', () => {
+    const scene = makeScene();
+    const { palette, compId } = makePalette();
+    const rect: Rect = { minX: 0, minZ: 0, maxX: 32, maxZ: 32 };
+    const n = 60;
+    const tile = makeFakeTile(-100, -100, n, compId);
+    const handle = makeFakeHandle(rect, [tile], n, compId);
+
+    const playable: PlayableCut = {
+      rect,
+      ownsColumn: (x, z) => x >= 0 && x < 32 && z >= 0 && z < 32,
+      meshClaimsColumn: (x, z) => x >= -1 && x < 32 && z >= 0 && z < 32,
+    };
+
+    const lm = new LandscapeMesh(scene, makeMaterial());
+    lm.build(handle, palette, playable);
+
+    let sawFarWestGround = false;
+    for (const child of scene.children) {
+      const mesh = child as THREE.Mesh;
+      const pos = mesh.geometry.getAttribute('position').array as Float32Array;
+      for (let i = 0; i < pos.length; i += 3) {
+        if (pos[i]! < -1 - 1e-6) sawFarWestGround = true;
+      }
+    }
+    expect(sawFarWestGround).toBe(true);
+    lm.dispose();
+  });
+});
+
+describe('LandscapeMesh — boundaryHeightAt NaN falls back to the theoretical sampleColumn height (#559 root cause 2/3)', () => {
+  it('never emits a NaN position or normal, and falls back to the theoretical height, for an irregular (#473-style) shape whose unowned notch reports NaN', () => {
+    const scene = makeScene();
+    const { palette, compId } = makePalette();
+    const rect: Rect = { minX: 0, minZ: 0, maxX: 32, maxZ: 32 };
+    const n = 60;
+    const theoreticalH = 30;
+    const tile = makeFakeTile(-100, -100, n, compId, theoreticalH);
+    const handle = makeFakeHandle(rect, [tile], n, compId, () => ({ height: theoreticalH, biomeId: 0, surfCompId: compId }));
+
+    // Irregular #473-style shape inside the rectangular rect: an L, where the
+    // (x < 16, z < 16) corner is an unclaimed notch.
+    const playable: PlayableCut = {
+      rect,
+      ownsColumn: (x, z) => x >= 16 || z >= 16,
+      // Mirrors computeVoxelColumnSurfaceHeight's post-#559 answer for a
+      // column truly outside every owned chunk: NaN, not a clamped guess.
+      boundaryHeightAt: (x, z) => (x < 16 && z < 16 ? NaN : theoreticalH),
+    };
+
+    const lm = new LandscapeMesh(scene, makeMaterial());
+    lm.build(handle, palette, playable);
+
+    expect(scene.children.length).toBeGreaterThan(0);
+    for (const child of scene.children) {
+      const mesh = child as THREE.Mesh;
+      const pos = mesh.geometry.getAttribute('position').array as Float32Array;
+      const nrm = mesh.geometry.getAttribute('normal').array as Float32Array;
+      for (const v of pos) expect(Number.isNaN(v)).toBe(false);
+      for (const v of nrm) expect(Number.isNaN(v)).toBe(false);
+      // Every vertex height must land on the theoretical field's constant
+      // height -- both because the true field IS that constant everywhere,
+      // and because the notch's own boundaryHeightAt reports NaN, so any
+      // vertex sampled there can only be correct by having fallen back.
+      for (let i = 1; i < pos.length; i += 3) {
+        expect(pos[i]).toBeCloseTo(theoreticalH, 4);
+      }
+    }
+    lm.dispose();
+  });
+});
+
+describe('subdivideOutsideQuad / MID_STEP (#559, optional coarse-to-fine transition)', () => {
+  it('exports MID_STEP as an intermediate step between FINE_STEP (1m) and a typical coarse step (4m)', () => {
+    expect(MID_STEP).toBeGreaterThan(1);
+    expect(MID_STEP).toBeLessThan(4);
+  });
+
+  it('emits MID_STEP-subdivided, index-coherent geometry for one coarse outside quad', () => {
+    const { palette, compId } = makePalette();
+    const sample = (x: number, z: number) => ({ height: 10 + x * 0.1 + z * 0.1, biomeId: 0, surfCompId: compId });
+    const positions: number[] = [];
+    const normals: number[] = [];
+    const rockA: number[] = [];
+    const rockB: number[] = [];
+    const rockWeight: number[] = [];
+    const ore: number[] = [];
+    const indices: number[] = [];
+
+    subdivideOutsideQuad(
+      positions, normals, rockA, rockB, rockWeight, ore, indices,
+      0, 0, 4, 4, sample, palette, MID_STEP,
+    );
+
+    expect(indices.length).toBeGreaterThan(0);
+    expect(indices.length % 3).toBe(0);
+    const vertexCount = positions.length / 3;
+    expect(vertexCount).toBeGreaterThan(4); // finer than the single coarse quad's 4 corners
+    expect(normals.length).toBe(positions.length);
+    expect(rockA.length).toBe(vertexCount);
+    expect(rockB.length).toBe(vertexCount);
+    expect(rockWeight.length).toBe(vertexCount);
+    expect(ore.length).toBe(vertexCount * 2);
+  });
 });

--- a/tests/unit/renderer/LandscapeMesh.test.ts
+++ b/tests/unit/renderer/LandscapeMesh.test.ts
@@ -1030,13 +1030,18 @@ describe('LandscapeMesh — classifyQuad/buildBoundaryQuad must honor meshClaims
     const lm = new LandscapeMesh(scene, makeMaterial());
     lm.build(handle, palette, playable);
 
+    // x === -1 exactly is the halo column's own west edge -- the shared seam
+    // vertex both LandscapeMesh and TerrainMesh must emit for a watertight
+    // join (mirrors the sibling test below, which treats x < -1 as "west of
+    // the halo" and x === -1 as already inside it). Only x strictly greater
+    // than -1 is actually inside the column TerrainMesh claims.
     let violations = 0;
     for (const child of scene.children) {
       const mesh = child as THREE.Mesh;
       const pos = mesh.geometry.getAttribute('position').array as Float32Array;
       for (let i = 0; i < pos.length; i += 3) {
         const x = pos[i]!;
-        if (x >= -1 - 1e-6 && x < 0 - 1e-6) violations++;
+        if (x > -1 + 1e-6 && x < 0 - 1e-6) violations++;
       }
     }
     expect(violations).toBe(0);

--- a/tests/unit/renderer/LandscapeMesh.test.ts
+++ b/tests/unit/renderer/LandscapeMesh.test.ts
@@ -1010,7 +1010,7 @@ describe('LandscapeMesh — dense boundary sample walk against a known height fi
 });
 
 describe('LandscapeMesh — classifyQuad/buildBoundaryQuad must honor meshClaimsColumn, not raw ownsColumn (#559 root cause 4)', () => {
-  it('emits no vertex inside the west halo column TerrainMesh now claims via meshClaimsColumn', () => {
+  it('emits no triangle inside the west halo column TerrainMesh now claims via meshClaimsColumn', () => {
     const scene = makeScene();
     const { palette, compId } = makePalette();
     const rect: Rect = { minX: 0, minZ: 0, maxX: 32, maxZ: 32 };
@@ -1030,21 +1030,39 @@ describe('LandscapeMesh — classifyQuad/buildBoundaryQuad must honor meshClaims
     const lm = new LandscapeMesh(scene, makeMaterial());
     lm.build(handle, palette, playable);
 
-    // x === -1 exactly is the halo column's own west edge -- the shared seam
-    // vertex both LandscapeMesh and TerrainMesh must emit for a watertight
-    // join (mirrors the sibling test below, which treats x < -1 as "west of
-    // the halo" and x === -1 as already inside it). Only x strictly greater
-    // than -1 is actually inside the column TerrainMesh claims.
-    let violations = 0;
+    // With FINE_STEP === 1 every emitted vertex sits at an integer x whether
+    // or not the halo cell is skipped, so a vertex-position range check (the
+    // bug this test used to guard: `-1 < x < 0` can never contain an
+    // integer) can never fail regardless of what classifyQuad/buildBoundaryQuad
+    // do. Check the index buffer instead: the fine cell whose 4 corners are
+    // (x=-1,z)/(x=0,z)/(x=-1,z+1)/(x=0,z+1) is exactly the halo column
+    // TerrainMesh now claims via meshClaimsColumn, so buildBoundaryQuad must
+    // never push either of that cell's 2 triangles. A triangle belongs to
+    // that cell iff all 3 of its vertices sit at x === -1 or x === 0 AND at
+    // least one vertex sits at each (ruling out a triangle that merely
+    // touches the x=-1 or x=0 seam from its own neighbouring, legitimately
+    // emitted cell without spanning the halo column itself), restricted to z
+    // strictly inside the rect's own [minZ, maxZ) span -- meshClaimsColumn's
+    // own z upper bound is exclusive (z < 32), so the one fine cell touching
+    // z === maxZ has a genuinely unclaimed NE corner and is legitimately
+    // still emitted, same as the tile's SW/NW corner quads outside z >= minZ.
+    let haloColumnTriangles = 0;
     for (const child of scene.children) {
       const mesh = child as THREE.Mesh;
       const pos = mesh.geometry.getAttribute('position').array as Float32Array;
-      for (let i = 0; i < pos.length; i += 3) {
-        const x = pos[i]!;
-        if (x > -1 + 1e-6 && x < 0 - 1e-6) violations++;
+      const index = mesh.geometry.getIndex();
+      if (!index) continue;
+      const idx = index.array;
+      for (let t = 0; t < idx.length; t += 3) {
+        const xs = [0, 1, 2].map(k => pos[idx[t + k]! * 3]!);
+        const zs = [0, 1, 2].map(k => pos[idx[t + k]! * 3 + 2]!);
+        const allOnHaloEdges = xs.every(x => Math.abs(x + 1) < 1e-6 || Math.abs(x) < 1e-6);
+        const spansBothEdges = xs.some(x => Math.abs(x + 1) < 1e-6) && xs.some(x => Math.abs(x) < 1e-6);
+        const strictlyInsideRectZ = zs.every(z => z >= rect.minZ - 1e-6 && z < rect.maxZ - 1e-6);
+        if (allOnHaloEdges && spansBothEdges && strictlyInsideRectZ) haloColumnTriangles++;
       }
     }
-    expect(violations).toBe(0);
+    expect(haloColumnTriangles).toBe(0);
     lm.dispose();
   });
 

--- a/tests/unit/renderer/TerrainMesh.test.ts
+++ b/tests/unit/renderer/TerrainMesh.test.ts
@@ -7,6 +7,7 @@ import { VoxelGrid } from '../../../src/core/world/VoxelGrid.js';
 import {
   TerrainMesh,
   SurveyConfidenceOverlay,
+  virtualEdgeDensity,
   type SurveyConfidencePoint,
   type SurveyConfidenceOverlayOptions,
 } from '../../../src/renderer/TerrainMesh.js';
@@ -377,6 +378,211 @@ describe('TerrainMesh', () => {
         expect(v1!.normal[1]).toBeCloseTo(v0.normal[1], 6);
         expect(v1!.normal[2]).toBeCloseTo(v0.normal[2], 6);
       }
+      tm.dispose();
+    });
+  });
+
+  describe('virtualEdgeDensity (#559)', () => {
+    // Same half-voxel crossing convention as emitVertex/
+    // computeVoxelColumnSurfaceHeight: solid (1) a half-voxel below the
+    // surface, air (0) a half-voxel above, linear in between.
+    it('is 1 well below surfaceHeight - 0.5 (fully solid)', () => {
+      expect(virtualEdgeDensity(5, 2)).toBe(1);
+      expect(virtualEdgeDensity(5, 4)).toBe(1);
+    });
+
+    it('is 0 well above surfaceHeight + 0.5 (fully air)', () => {
+      expect(virtualEdgeDensity(5, 6)).toBe(0);
+      expect(virtualEdgeDensity(5, 8)).toBe(0);
+    });
+
+    it('is exactly 0.5 at the crossing height itself', () => {
+      expect(virtualEdgeDensity(5, 5)).toBeCloseTo(0.5, 6);
+    });
+
+    it('interpolates linearly across the one-voxel transition band', () => {
+      expect(virtualEdgeDensity(5, 4.5)).toBeCloseTo(1, 6);
+      expect(virtualEdgeDensity(5, 4.75)).toBeCloseTo(0.75, 6);
+      expect(virtualEdgeDensity(5, 5.25)).toBeCloseTo(0.25, 6);
+      expect(virtualEdgeDensity(5, 5.5)).toBeCloseTo(0, 6);
+    });
+
+    it('is stable across different surfaceHeight values (translation invariant)', () => {
+      expect(virtualEdgeDensity(10, 10)).toBeCloseTo(virtualEdgeDensity(5, 5), 6);
+      expect(virtualEdgeDensity(10, 10.25)).toBeCloseTo(virtualEdgeDensity(5, 5.25), 6);
+    });
+  });
+
+  describe('edge vertex normals honor an installed EdgeHeightSampler (#559)', () => {
+    const SURFACE_Y = 4; // flat terrain: solid y < 4, air y >= 4 -> crossing at y = 3.5
+    const SIZE = 8;
+
+    function flatGrid(): VoxelGrid {
+      const grid = new VoxelGrid(SIZE, 8, SIZE);
+      for (let x = 0; x < SIZE; x++)
+        for (let y = 0; y < SURFACE_Y; y++)
+          for (let z = 0; z < SIZE; z++)
+            grid.setVoxel(x, y, z, makeSolidVoxel());
+      return grid;
+    }
+
+    /** Normal at the outermost owned top-surface vertex on the +X edge, for a given z. */
+    function edgeNormalAt(tm: TerrainMesh, z: number): [number, number, number] | undefined {
+      for (const mesh of tm.meshes) {
+        const pos = mesh.geometry.getAttribute('position').array as Float32Array;
+        const nrm = mesh.geometry.getAttribute('normal').array as Float32Array;
+        for (let i = 0; i < pos.length; i += 3) {
+          if (
+            Math.abs(pos[i]! - (SIZE - 1)) < 1e-6 &&
+            Math.abs(pos[i + 2]! - z) < 1e-6 &&
+            Math.abs(pos[i + 1]! - (SURFACE_Y - 0.5)) < 1e-6
+          ) {
+            return [nrm[i]!, nrm[i + 1]!, nrm[i + 2]!];
+          }
+        }
+      }
+      return undefined;
+    }
+
+    it('without a sampler, the outermost vertex normal tilts away from up (false-cliff regression, #559 root cause 2)', () => {
+      const scene = makeScene();
+      const grid = flatGrid();
+      const tm = new TerrainMesh(scene, grid);
+      tm.buildAll();
+      const n = edgeNormalAt(tm, 4);
+      expect(n).toBeDefined();
+      // A pure "up" normal has ny === 1. The unowned neighbour column reads
+      // as air, so the gradient tilts the normal away from up.
+      expect(n![1]).toBeLessThan(0.999);
+      tm.dispose();
+    });
+
+    it('with a sampler reporting the same flat height past the edge, the outermost vertex normal is close to up (#559 fix)', () => {
+      const scene = makeScene();
+      const grid = flatGrid();
+      const tm = new TerrainMesh(scene, grid);
+      tm.setEdgeHeightSampler(() => SURFACE_Y - 0.5);
+      tm.buildAll();
+      const n = edgeNormalAt(tm, 4);
+      expect(n).toBeDefined();
+      // ~pure up, within a couple of degrees (cos(2.5deg) ~= 0.999).
+      expect(n![1]).toBeGreaterThan(0.999);
+      expect(Math.abs(n![0])).toBeLessThan(0.05);
+      tm.dispose();
+    });
+  });
+
+  describe('EdgeHeightSampler is opt-in — null (default) leaves mesh output unchanged (#559 regression safety net)', () => {
+    it('setEdgeHeightSampler(null) produces byte-identical geometry to never calling it, for the two-chunk seam fixture', () => {
+      // Reuses the exact fixture from "adjacent chunks share exact boundary
+      // geometry" above — a non-flat surface across a chunk seam, the case
+      // most likely to be perturbed if a sampler were threaded unconditionally.
+      function buildSeamGrid(): VoxelGrid {
+        const grid = new VoxelGrid(32, 16, 16);
+        for (let x = 0; x < 32; x++) {
+          for (let z = 0; z < 16; z++) {
+            const surfaceY = 4 + (z % 5);
+            for (let y = 0; y < surfaceY; y++) grid.setVoxel(x, y, z, makeSolidVoxel());
+          }
+        }
+        return grid;
+      }
+
+      function collectAllAttributes(tm: TerrainMesh): { pos: number[]; nrm: number[] } {
+        const pos: number[] = [];
+        const nrm: number[] = [];
+        for (const mesh of tm.meshes) {
+          pos.push(...(mesh.geometry.getAttribute('position').array as Float32Array));
+          nrm.push(...(mesh.geometry.getAttribute('normal').array as Float32Array));
+        }
+        return { pos, nrm };
+      }
+
+      const sceneA = makeScene();
+      const tmA = new TerrainMesh(sceneA, buildSeamGrid());
+      tmA.buildAll(); // never touches setEdgeHeightSampler — default null
+      const baseline = collectAllAttributes(tmA);
+      tmA.dispose();
+
+      const sceneB = makeScene();
+      const tmB = new TerrainMesh(sceneB, buildSeamGrid());
+      tmB.setEdgeHeightSampler(null); // explicit null — must behave identically
+      tmB.buildAll();
+      const explicit = collectAllAttributes(tmB);
+      tmB.dispose();
+
+      expect(explicit.pos).toEqual(baseline.pos);
+      expect(explicit.nrm).toEqual(baseline.nrm);
+    });
+  });
+
+  describe('a blast adjacent to the site edge still produces a closed shell (#559)', () => {
+    /**
+     * True when every triangle edge in the scene's chunk meshes is shared by
+     * exactly two triangles — the discrete stand-in for "the surface is a
+     * closed 2-manifold with no holes". Positions are rounded to fold
+     * floating-point noise into a shared key; geometry here has no index
+     * buffer (each chunk's triangle list is a flat, duplicated soup), so
+     * matching by position is the only option.
+     */
+    function isWatertight(scene: THREE.Scene): boolean {
+      const edgeCounts = new Map<string, number>();
+      const key = (arr: Float32Array, i: number): string =>
+        `${arr[i]!.toFixed(3)},${arr[i + 1]!.toFixed(3)},${arr[i + 2]!.toFixed(3)}`;
+      for (const child of scene.children) {
+        if (!(child instanceof THREE.Mesh)) continue;
+        const pos = child.geometry.getAttribute('position').array as Float32Array;
+        for (let t = 0; t < pos.length; t += 9) {
+          const v = [key(pos, t), key(pos, t + 3), key(pos, t + 6)];
+          for (let e = 0; e < 3; e++) {
+            const a = v[e]!, b = v[(e + 1) % 3]!;
+            const edgeKey = a < b ? `${a}|${b}` : `${b}|${a}`;
+            edgeCounts.set(edgeKey, (edgeCounts.get(edgeKey) ?? 0) + 1);
+          }
+        }
+      }
+      for (const count of edgeCounts.values()) {
+        if (count !== 2) return false;
+      }
+      return edgeCounts.size > 0;
+    }
+
+    it('a flat site with no blast is watertight to begin with (sanity baseline)', () => {
+      const scene = makeScene();
+      const size = 8;
+      const grid = new VoxelGrid(size, size, size);
+      for (let x = 0; x < size; x++)
+        for (let y = 0; y < 4; y++)
+          for (let z = 0; z < size; z++)
+            grid.setVoxel(x, y, z, makeSolidVoxel());
+      const tm = new TerrainMesh(scene, grid);
+      tm.buildAll();
+      expect(isWatertight(scene)).toBe(true);
+      tm.dispose();
+    });
+
+    it('stays watertight after a blast carves a crater right at the site edge', () => {
+      const scene = makeScene();
+      const size = 8;
+      const grid = new VoxelGrid(size, size, size);
+      for (let x = 0; x < size; x++)
+        for (let y = 0; y < 4; y++)
+          for (let z = 0; z < size; z++)
+            grid.setVoxel(x, y, z, makeSolidVoxel());
+      const tm = new TerrainMesh(scene, grid);
+      tm.buildAll();
+
+      // Blow a hole through the whole depth of the boundary column, exactly
+      // the "blast at the edge of the site" scenario #559 is concerned with.
+      for (let y = 0; y < 4; y++) {
+        for (let z = 2; z < 5; z++) {
+          grid.clearVoxel(size - 1, y, z);
+          grid.clearVoxel(size - 2, y, z);
+        }
+      }
+      tm.remeshRegion({ minX: size - 2, minY: 0, minZ: 2, maxX: size - 1, maxY: 3, maxZ: 4 });
+
+      expect(isWatertight(scene)).toBe(true);
       tm.dispose();
     });
   });

--- a/tests/unit/world/VoxelGrid.test.ts
+++ b/tests/unit/world/VoxelGrid.test.ts
@@ -413,15 +413,119 @@ describe('computeVoxelColumnSurfaceHeight (#491)', () => {
     expect(computeVoxelColumnSurfaceHeight(grid, 3, 3)).toBeCloseTo(4 + 5 / 7, 6);
   });
 
-  it('clamps to the site edge rather than the origin once the site has grown west, like computeVoxelColumnSurfaceY', () => {
+  // #559: an out-of-grid column used to clamp to the nearest edge column,
+  // which handed LandscapeMesh a plausible-looking but wrong height for a
+  // column the site doesn't actually own — the false "answers honestly"
+  // requirement in #559's root cause 3. NaN is the honest answer: "this
+  // column has no data", distinguishable from a real (possibly zero) height.
+  it('#559: answers NaN for a column outside every owned chunk, rather than clamping to the site edge', () => {
     const grid = new VoxelGrid(16, 8, 16);
     grid.addChunk(-1, 0);
     grid.fillVoxel(-16, 2, 0, 0, undefined, 1);
-    expect(computeVoxelColumnSurfaceHeight(grid, -99, 0)).toBeCloseTo(2.5, 6);
+    expect(Number.isNaN(computeVoxelColumnSurfaceHeight(grid, -99, 0))).toBe(true);
+  });
+
+  it('#559: still answers NaN for an out-of-grid column even when sizeX/sizeZ are non-empty (not just the empty-grid early return)', () => {
+    const grid = new VoxelGrid(16, 8, 16);
+    grid.fillVoxel(3, 4, 3, 0, undefined, 1);
+    expect(Number.isNaN(computeVoxelColumnSurfaceHeight(grid, 99, 3))).toBe(true);
+    expect(Number.isNaN(computeVoxelColumnSurfaceHeight(grid, 3, -99))).toBe(true);
+  });
+
+  it('#559: an in-bounds column right at the site edge still answers a real (non-NaN) height', () => {
+    const grid = new VoxelGrid(16, 8, 16);
+    grid.fillVoxel(15, 4, 15, 0, undefined, 1);
+    expect(computeVoxelColumnSurfaceHeight(grid, 15, 15)).toBeCloseTo(4.5, 6);
   });
 
   it('returns 0 for a column with no solid voxel at all', () => {
     expect(computeVoxelColumnSurfaceHeight(new VoxelGrid(16, 8, 16), 3, 3)).toBe(0);
+  });
+});
+
+describe('VoxelGrid.claimsColumnForMeshing (#559 root cause 4)', () => {
+  it('is true for every column the site owns', () => {
+    const grid = new VoxelGrid(16, 8, 16);
+    expect(grid.claimsColumnForMeshing(0, 0)).toBe(true);
+    expect(grid.claimsColumnForMeshing(15, 15)).toBe(true);
+    expect(grid.claimsColumnForMeshing(8, 3)).toBe(true);
+  });
+
+  it('is true for the single-voxel west halo column TerrainMesh marches into when nothing owns the chunk to the west', () => {
+    const grid = new VoxelGrid(16, 8, 16); // one chunk, (0,0); no chunk at (-1,0)
+    expect(grid.claimsColumnForMeshing(-1, 5)).toBe(true);
+  });
+
+  it('is true for the single-voxel north halo column, symmetrically', () => {
+    const grid = new VoxelGrid(16, 8, 16); // no chunk at (0,-1)
+    expect(grid.claimsColumnForMeshing(5, -1)).toBe(true);
+  });
+
+  it('is false two columns west of the site edge — the halo is exactly one voxel wide', () => {
+    const grid = new VoxelGrid(16, 8, 16);
+    expect(grid.claimsColumnForMeshing(-2, 5)).toBe(false);
+  });
+
+  it('is false diagonally past the corner — the halo never extends diagonally', () => {
+    const grid = new VoxelGrid(16, 8, 16);
+    expect(grid.claimsColumnForMeshing(-1, -1)).toBe(false);
+  });
+
+  it('is false just past the east edge — TerrainMesh seals that side from its own last owned cube, no halo needed', () => {
+    const grid = new VoxelGrid(16, 8, 16);
+    expect(grid.claimsColumnForMeshing(16, 5)).toBe(false);
+  });
+
+  it('is false just past the south edge, symmetrically with east', () => {
+    const grid = new VoxelGrid(16, 8, 16);
+    expect(grid.claimsColumnForMeshing(5, 16)).toBe(false);
+  });
+
+  describe('on an irregular (L-shaped) grid, the halo is per-chunk, not just at the whole grid\'s bounding box', () => {
+    // Chunk (0,0) at x:0..15/z:0..15 and chunk (1,1) at x:16..31/z:16..31 are
+    // owned; chunk (1,0) (x:16..31/z:0..15) is not — the same L shape the
+    // existing "a bounding-box column the site does not own reads as air"
+    // VoxelGrid test above builds.
+    function lShapedGrid(): VoxelGrid {
+      const grid = new VoxelGrid(16, 8, 16);
+      grid.addChunk(1, 1);
+      return grid;
+    }
+
+    it('is true for a column owned by either chunk', () => {
+      const grid = lShapedGrid();
+      expect(grid.claimsColumnForMeshing(5, 5)).toBe(true); // chunk (0,0)
+      expect(grid.claimsColumnForMeshing(20, 20)).toBe(true); // chunk (1,1)
+    });
+
+    it('is true for chunk (0,0)\'s own west/north halo', () => {
+      const grid = lShapedGrid();
+      expect(grid.claimsColumnForMeshing(-1, 5)).toBe(true);
+      expect(grid.claimsColumnForMeshing(5, -1)).toBe(true);
+    });
+
+    it('is true for chunk (1,1)\'s own west/north halo, one voxel outside its own rect — even though that halo sits inside the grid\'s overall bounding box', () => {
+      const grid = lShapedGrid();
+      // Chunk (0,1) (the neighbour west of (1,1)) is not owned, so (1,1)
+      // marches its own west halo at x=15, within z:16..31 — a column no
+      // owned chunk actually covers (chunk (0,0) only owns z:0..15 at x=15).
+      expect(grid.claimsColumnForMeshing(15, 20)).toBe(true);
+      // Chunk (1,0) (the neighbour north of (1,1)) is not owned, so (1,1)
+      // marches its own north halo at z=15, within x:16..31.
+      expect(grid.claimsColumnForMeshing(20, 15)).toBe(true);
+    });
+
+    it('is false just past the unowned notch\'s own outer edges — no chunk owns them and no halo reaches them', () => {
+      const grid = lShapedGrid();
+      expect(grid.claimsColumnForMeshing(16, 5)).toBe(false); // east of chunk (0,0), inside the unowned notch
+      expect(grid.claimsColumnForMeshing(5, 16)).toBe(false); // south of chunk (0,0), inside the unowned notch
+    });
+
+    it('is false past chunk (1,1)\'s own east/south edges — self-sealed, no halo', () => {
+      const grid = lShapedGrid();
+      expect(grid.claimsColumnForMeshing(32, 20)).toBe(false);
+      expect(grid.claimsColumnForMeshing(20, 32)).toBe(false);
+    });
   });
 });
 


### PR DESCRIPTION
Closes #559

## Summary

The landscape mesh (continuous ground) and the playable voxel terrain mesh didn't meet cleanly at their shared boundary: bright slivers, a rectangle etched into the ground when viewed top-down, a hard line where surface treatment changed abruptly, and an actual unlit hole with a proud mesh face at a corner. Four confirmed root causes, all fixed:

1. **Mismatched normals at the seam** — `TerrainMesh`'s edge-vertex normal sampling no longer treats the neighbouring landscape column as "air" when a landscape height sampler is installed (`EdgeHeightSampler`, `virtualEdgeDensity`), so gradient-derived normals converge with the landscape's own analytic normals near the boundary. Opt-in and normal-only: with no sampler set, geometry/topology/output is byte-identical to before.
2. **False-cliff shading at the playable edge** — same fix as above; the outermost owned vertex no longer tilts as though the ground fell away where it actually continues.
3. **Dishonest height clamp** — `VoxelGrid.computeVoxelColumnSurfaceHeight` now returns `NaN` for any coordinate outside the site's own columns instead of silently returning the edge column's height. `LandscapeMesh`'s boundary-height fallback trusts the live value only when it isn't `NaN`, falling back to the theoretical WorldGen height otherwise — never leaking `NaN` into positions or normals. The sibling function `computeVoxelColumnSurfaceY` (8 other legitimate clamp-to-edge callers) is untouched.
4. **Double-claimed boundary cells** — new `VoxelGrid.claimsColumnForMeshing`, mirroring `TerrainMesh`'s own outward west/north halo-march convention (which stays in place — it's what keeps a blast at the site edge from opening a see-through shell). `LandscapeMesh`'s boundary-quad ownership test now uses this narrower claim (`meshClaimsColumn ?? ownsColumn`, backward-compatible with existing fixtures) so the two meshes claim disjoint ground.

Also added a `MID_STEP` intermediate resolution ring (`subdivideOutsideQuad`) between the 1 m boundary quads and 4 m open-ground quads, so the resolution jump itself doesn't read as a seam.

Both meshes continue to share one `TerrainMaterial` instance — this was a geometry/normals problem, not shader/material, per the issue's framing.

## Files changed

- `src/core/world/VoxelGrid.ts` — honest (non-clamping) `computeVoxelColumnSurfaceHeight`; new `claimsColumnForMeshing`.
- `src/renderer/TerrainMesh.ts` — `EdgeHeightSampler`, `virtualEdgeDensity`, threaded into normal-only density sampling.
- `src/renderer/terrain/LandscapeMesh.ts` — `meshClaimsColumn` ownership, NaN-safe height fallback, `subdivideOutsideQuad`/`MID_STEP`.
- `src/renderer/GameRenderer.ts` — wires `meshClaimsColumn` and installs the edge-height sampler before the first mesh build (and on every landscape rebuild).
- `tests/unit/world/VoxelGrid.test.ts`, `tests/unit/renderer/TerrainMesh.test.ts`, `tests/unit/renderer/LandscapeMesh.test.ts`, `tests/unit/renderer/GameRenderer.test.ts` — new/updated coverage per behavior above.
- `scripts/scenario-defs/landscape-continuity-visual.json`, `scripts/scenario-defs/site-expansion.json` — reproduce the six original bug-report camera setups plus one new angle per biome, and an L-shaped-site junction shot.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run; none are gameplay/economy/player-facing, so no `decision-review` follow-up issue.

- **What was open:** what sentinel `computeVoxelColumnSurfaceHeight` returns for an out-of-ownership coordinate. **Chosen:** `NaN`. **Why:** existing sentinels in this file (`-1`, `0`) are plausible real heights; `NaN` can never collide with a real answer. **If reversed:** change the one `return NaN` expression.
- **What was open:** whether `PlayableCut.meshClaimsColumn` is required or optional. **Chosen:** optional, falling back to `ownsColumn`. **Why:** ~15 existing `LandscapeMesh.test.ts` fixtures construct bare `{rect, ownsColumn}` objects; none exercise the halo distinction. **If reversed:** drop the `?`/`??` and update fixtures.
- **What was open:** where the `EdgeHeightSampler`'s data comes from. **Chosen:** the landscape's own theoretical `sampleColumn` height, not any live/blast-adjusted height. **Why:** the columns it reaches are by construction outside the site's own chunks — no live data exists there. **If reversed:** change what `GameRenderer` passes to `setEdgeHeightSampler`.
- **What was open:** where the resolution-transition constant lives. **Chosen:** `LandscapeMesh.ts` (`MID_STEP = 2`), not `src/core/config/balance.ts`. **Why:** it's a rendering LOD choice with no gameplay/economy meaning, and `FINE_STEP` already lives here. **If reversed:** move both constants together.

## Verification

- **static** (`npm run typecheck`): PASS, clean.
- **logic** (`npm run test`): PASS, 308 files / 9240 tests, including new coverage for every behavior above and an empirically-verified regression test (confirmed to fail when the fix is reverted, not just pass incidentally).
- **scenario** (`npm run scenarios`, command mode + defs schema): PASS, 129/129 scenarios, 3189/3189 def-schema checks.
- **build**: PASS, `vite build` succeeds.
- **visual** (interaction-mode screenshots, inspected with the Read tool, before/after against the six original `docs/issues/terrain-seam/` bug shots plus one new angle per biome and an L-shaped-site shot): PASS. Confirmed fixed: the etched top-down rectangle is gone; the camera-inside-terrain/interior-face bug at the foothills edge is gone; the karst corner's unlit hole and proud slab face are gone; the site survives growth into an L-shape and a boundary-adjacent blast with no gaps. One faint residual diagonal line remains in the high-angle karst shot but blends continuously in color (no material-treatment snap, no boxy notch) and is consistent with intentional biome texture at that seed — not the reported bug.

`full-ci` label applied: `TerrainMesh`/`LandscapeMesh` render the ground for every scenario that runs in interaction mode, and the two touched scenario-defs are themselves new interaction-mode, screenshot-driven regression coverage for this exact fix — CI's sharded interaction-mode job is the channel that keeps proving it.

READY TO MERGE
