### PR TITLE
Migrate all scenario files off absolute cash checkpoints to changedBy

### DIFF
--- a/scripts/scenario-defs/action-queue-dispatch.json
+++ b/scripts/scenario-defs/action-queue-dispatch.json
@@ -47,8 +47,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1200
+        },
         "equals": {
-          "cash": 48800,
           "employeeCount": 1
         }
       }
@@ -68,8 +70,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1200
+        },
         "equals": {
-          "cash": 47600,
           "employeeCount": 2
         }
       }
@@ -181,11 +185,10 @@
       ],
       "role": "player",
       "expect": {
-        "decreased": [
-          "cash"
-        ],
+        "changedBy": {
+          "cash": -800
+        },
         "equals": {
-          "cash": 45200,
           "pendingActionCount": 3,
           "surveyCount": 0
         },

--- a/scripts/scenario-defs/building-destruction-visual.json
+++ b/scripts/scenario-defs/building-destruction-visual.json
@@ -162,8 +162,10 @@
       "role": "player",
       "description": "#553: built directly on top of hole H1's now-drilled cell — placeBuilding only checks bounds/other-building occupancy, not NavGrid cell type, so a landed drill_hole cell is a legal building site.",
       "expect": {
+        "changedBy": {
+          "cash": -20000
+        },
         "equals": {
-          "cash": 15454,
           "buildingCount": 1
         }
       }
@@ -194,8 +196,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -15000
+        },
         "equals": {
-          "cash": 454,
           "buildingCount": 2
         }
       }

--- a/scripts/scenario-defs/building-lifecycle.json
+++ b/scripts/scenario-defs/building-lifecycle.json
@@ -49,8 +49,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 42000,
           "buildingCount": 1
+        },
+        "changedBy": {
+          "cash": -8000
         }
       }
     },

--- a/scripts/scenario-defs/building-living-visual.json
+++ b/scripts/scenario-defs/building-living-visual.json
@@ -51,8 +51,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 175000,
           "buildingCount": 1
+        },
+        "changedBy": {
+          "cash": -25000
         }
       }
     },
@@ -83,8 +85,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 165000,
           "buildingCount": 2
+        },
+        "changedBy": {
+          "cash": -10000
         }
       }
     },
@@ -107,8 +111,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 160000
+        "changedBy": {
+          "cash": -5000
         }
       }
     },

--- a/scripts/scenario-defs/building-menu-visual.json
+++ b/scripts/scenario-defs/building-menu-visual.json
@@ -71,8 +71,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -10000
+        },
         "equals": {
-          "cash": 90000,
           "buildingCount": 1
         }
       }
@@ -103,8 +105,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -8000
+        },
         "equals": {
-          "cash": 82000,
           "buildingCount": 2
         }
       }
@@ -135,8 +139,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -12000
+        },
         "equals": {
-          "cash": 70000,
           "buildingCount": 3
         }
       }
@@ -167,8 +173,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -20000
+        },
         "equals": {
-          "cash": 50000,
           "buildingCount": 4
         }
       }
@@ -204,8 +212,10 @@
       "role": "player",
       "description": "Was an unmarked command step that reached cash -$15,000: the Build panel disables a buy button on `cash < def.constructionCost` (BuildMenu.ts) so no click could place this, while the console `build` command overdrew happily. The console now refuses an unaffordable build too, and with the level funded at $100,000 there is $35,000 in hand against a $15,000 warehouse — the button is enabled and this is a genuine player click. The awaitUsable ahead of it is the affordability assertion: an underfunded run fails here instead of quietly overdrawing.",
       "expect": {
+        "changedBy": {
+          "cash": -15000
+        },
         "equals": {
-          "cash": 35000,
           "buildingCount": 5
         }
       }
@@ -241,8 +251,10 @@
       "role": "player",
       "description": "The second former overdraw step, converted the same way: $35,000 in hand against an $18,000 depot, so the catalog row is enabled and the click lands. Cash stays positive through the whole build-out, which is the point of funding the scenario instead of letting the console overdraw.",
       "expect": {
+        "changedBy": {
+          "cash": -18000
+        },
         "equals": {
-          "cash": 17000,
           "buildingCount": 6
         }
       }

--- a/scripts/scenario-defs/building-placement-visual.json
+++ b/scripts/scenario-defs/building-placement-visual.json
@@ -51,8 +51,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -10000
+        },
         "equals": {
-          "cash": 140000,
           "buildingCount": 1
         }
       }
@@ -94,8 +96,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -15000
+        },
         "equals": {
-          "cash": 125000,
           "buildingCount": 2
         }
       }
@@ -137,8 +141,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -12000
+        },
         "equals": {
-          "cash": 113000,
           "buildingCount": 3
         }
       }
@@ -180,8 +186,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -8000
+        },
         "equals": {
-          "cash": 105000,
           "buildingCount": 4
         }
       }
@@ -224,8 +232,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -8000
+        },
         "equals": {
-          "cash": 97000,
           "buildingCount": 5
         },
         "increased": ["worldSizeX"]

--- a/scripts/scenario-defs/building-ramp-visual.json
+++ b/scripts/scenario-defs/building-ramp-visual.json
@@ -67,8 +67,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 49000
+        "changedBy": {
+          "cash": -1000
         }
       }
     },
@@ -109,8 +109,8 @@
       "role": "player",
       "description": "Ramp depth defaults to 8m and only moves via the strip's -/+ stepper (#bs-param-strip .bsx-stepper-btn, the only field this tool shows) -- two decrements land on the scenario's depth:6.",
       "expect": {
-        "equals": {
-          "cash": 48200
+        "changedBy": {
+          "cash": -800
         }
       }
     },

--- a/scripts/scenario-defs/building-research-progression-visual.json
+++ b/scripts/scenario-defs/building-research-progression-visual.json
@@ -50,8 +50,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -25000
+        },
         "equals": {
-          "cash": 205000,
           "buildingCount": 1
         }
       }
@@ -77,8 +79,10 @@
         }
       ],
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 205000,
           "buildingCount": 1
         },
         "blocked": "#bs-build-panel [data-build-type=\"research_center\"] .bs-build-buy-btn",
@@ -116,8 +120,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 200000
+        "changedBy": {
+          "cash": -5000
         }
       }
     },
@@ -141,8 +145,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 200000,
           "buildingCount": 1
         },
         "note": "rejected: tier 2 research is only queued, not yet completed"

--- a/scripts/scenario-defs/building-research-visual.json
+++ b/scripts/scenario-defs/building-research-visual.json
@@ -49,8 +49,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -25000
+        },
         "equals": {
-          "cash": 205000,
           "buildingCount": 1
         }
       }
@@ -66,8 +68,10 @@
         }
       ],
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 205000,
           "buildingCount": 1
         },
         "blocked": "#bs-build-panel [data-build-type=\"research_center\"] .bs-build-buy-btn",
@@ -94,8 +98,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 200000
+        "changedBy": {
+          "cash": -5000
         }
       }
     },
@@ -119,8 +123,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 200000,
           "buildingCount": 1
         },
         "note": "rejected: tier 2 research is only queued, not yet completed"

--- a/scripts/scenario-defs/building-tier-system-visual.json
+++ b/scripts/scenario-defs/building-tier-system-visual.json
@@ -55,8 +55,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -25000
+        },
         "equals": {
-          "cash": 175000,
           "buildingCount": 1
         }
       }
@@ -93,8 +95,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -10000
+        },
         "equals": {
-          "cash": 165000,
           "buildingCount": 2
         }
       }
@@ -118,8 +122,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 160000
+        "changedBy": {
+          "cash": -5000
         }
       }
     },

--- a/scripts/scenario-defs/building-training-visual.json
+++ b/scripts/scenario-defs/building-training-visual.json
@@ -49,8 +49,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -12000
+        },
         "equals": {
-          "cash": 48000,
           "buildingCount": 1
         }
       }
@@ -81,8 +83,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -15000
+        },
         "equals": {
-          "cash": 33000,
           "buildingCount": 2
         }
       }
@@ -113,8 +117,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -8000
+        },
         "equals": {
-          "cash": 25000,
           "buildingCount": 3
         }
       }
@@ -145,8 +151,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -12000
+        },
         "equals": {
-          "cash": 13000,
           "buildingCount": 4
         }
       }
@@ -179,8 +187,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1000
+        },
         "equals": {
-          "cash": 12000,
           "employeeCount": 1
         }
       }
@@ -199,8 +209,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1500
+        },
         "equals": {
-          "cash": 10500,
           "employeeCount": 2
         }
       }
@@ -233,8 +245,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -2500
+        },
         "equals": {
-          "cash": 8000,
           "trainingCount": 1
         }
       }

--- a/scripts/scenario-defs/building-vehicle-depot-visual.json
+++ b/scripts/scenario-defs/building-vehicle-depot-visual.json
@@ -49,8 +49,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -18000
+        },
         "equals": {
-          "cash": 32000,
           "buildingCount": 1
         }
       }
@@ -66,8 +68,10 @@
       ],
       "description": "role: guard (issue #515): selecting tier 2 in the catalog row's own tier dropdown is a real interaction; the Buy button is then genuinely disabled — `refreshCatalogButtons`'s `locked` check (BuildMenu.ts) is true since tier 2 is not researched — so `expect.blocked` proves the same rejection command mode shows.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 32000,
           "buildingCount": 1
         },
         "blocked": "#bs-build-panel [data-build-type=\"vehicle_depot\"] .bs-build-buy-btn",
@@ -86,8 +90,10 @@
       ],
       "description": "role: guard (issue #515) — same reasoning as the tier:2 attempt above, for tier 3.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 32000,
           "buildingCount": 1
         },
         "blocked": "#bs-build-panel [data-build-type=\"vehicle_depot\"] .bs-build-buy-btn",

--- a/scripts/scenario-defs/building-warehouse-visual.json
+++ b/scripts/scenario-defs/building-warehouse-visual.json
@@ -49,8 +49,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -20000
+        },
         "equals": {
-          "cash": 30000,
           "buildingCount": 1
         }
       }
@@ -81,8 +83,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -15000
+        },
         "equals": {
-          "cash": 15000,
           "buildingCount": 2
         }
       }
@@ -98,8 +102,10 @@
       ],
       "description": "role: guard (issue #515): selecting tier 2 in the catalog row's own tier dropdown is a real interaction; the Buy button is then genuinely disabled — `refreshCatalogButtons`'s `locked` check (BuildMenu.ts) is true since tier 2 is not researched.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 15000,
           "buildingCount": 2
         },
         "blocked": "#bs-build-panel [data-build-type=\"explosive_warehouse\"] .bs-build-buy-btn",
@@ -118,8 +124,10 @@
       ],
       "description": "role: guard (issue #515) — same reasoning as the explosive_warehouse tier:2 attempt above.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 15000,
           "buildingCount": 2
         },
         "blocked": "#bs-build-panel [data-build-type=\"freight_warehouse\"] .bs-build-buy-btn",

--- a/scripts/scenario-defs/collapse-recovery.json
+++ b/scripts/scenario-defs/collapse-recovery.json
@@ -59,10 +59,12 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1000
+        },
         "equals": {
           "employeeCount": 1,
-          "collapsedCount": 0,
-          "cash": 49000
+          "collapsedCount": 0
         },
         "note": "HIRING_COSTS.driller = 1000 (balance.ts)"
       }
@@ -98,9 +100,11 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -10000
+        },
         "equals": {
-          "buildingCount": 1,
-          "cash": 39000
+          "buildingCount": 1
         },
         "note": "living_quarters T1 constructionCost = 10000 (balance.ts)"
       }

--- a/scripts/scenario-defs/contract-negotiation.json
+++ b/scripts/scenario-defs/contract-negotiation.json
@@ -56,8 +56,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 50000
+        "changedBy": {
+          "cash": 0
         },
         "note": "negotiating costs nothing and moves no count -- the only real effect is on the contract's own terms, which no state field exposes. Confirmed via direct trace (seed:42, dusty_hollow): this first attempt genuinely FAILS (deadline worsened by 11%)."
       }
@@ -73,8 +73,8 @@
       ],
       "role": "setup",
       "expect": {
-        "equals": {
-          "cash": 50000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -89,8 +89,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 50000
+        "changedBy": {
+          "cash": 0
         },
         "note": "confirmed via direct trace: this second attempt genuinely SUCCEEDS (deadline improved by 8%) -- opposite of round 1, proving the file's own claim (\"observe both improved and worsened pricing outcomes\") for real rather than asserting it never happened."
       }
@@ -110,8 +110,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 50000,
           "activeContractCount": 1
+        },
+        "changedBy": {
+          "cash": 0
         }
       },
       "description": "#513/#581: the accept click is scoped to `[data-contract-id=\"1\"]`, the contract this step's `command` names. Unscoped, `.bs-contract-accept` always resolves to whichever offered card is first in the DOM, so command mode accepted contract #1 literally while interaction mode accepted whatever led the list -- two channels driving different contracts while both reported pass, because nothing asserted here can tell them apart (`activeContractCount` counts accepts, not identities). `level1-win-efficient` is what that costs once a `[data-contract-id]`-scoped assertion is added on top: its guard failed with its control absent from the DOM entirely, red on `main`, cause pointing nowhere near the accept step. ContractsPanel sets `data-contract-id` on offered cards (`makeOfferedCard`), so scoping removes the DOM-order coupling rather than baking around it."
@@ -127,8 +129,10 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": 50000,
           "activeContractCount": 1
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -143,8 +147,10 @@
       "description": "role: guard (issue #515): both the amount input and DELIVER button are genuinely disabled here \u2014 `amountInput.disabled = maxDeliverable <= 0` and `deliverBtn.disabled = maxDeliverable <= 0` (ContractsPanel.ts) \u2014 this file's scope is negotiation and accept/decline, not the full haul-to-storage pipeline, so nothing is ever in storage. A real click cannot land on either control, so this proves the same refusal `expect.blocked` already asserted (now scoped to `[data-contract-id=\"1\"]`, issue #513) rather than performing one.",
       "expect": {
         "equals": {
-          "cash": 50000,
           "activeContractCount": 1
+        },
+        "changedBy": {
+          "cash": 0
         },
         "usable": "#bs-contract-panel [data-action=\"goto-ops\"]",
         "blocked": "#bs-contract-panel [data-contract-id=\"1\"] .bs-contract-deliver",
@@ -173,8 +179,10 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 50000,
           "activeContractCount": 1
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     }

--- a/scripts/scenario-defs/contract-panel-visual.json
+++ b/scripts/scenario-defs/contract-panel-visual.json
@@ -55,9 +55,11 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "activeContractCount": 1,
-          "cash": 50000
+          "activeContractCount": 1
         },
         "note": "real click on the Contracts panel's first available row -- contract #1 (Supply dirtite) is genuinely first in both the console list and the panel, matching `contract accept 1`'s explicit id; no Finding #55-class mismatch here"
       },
@@ -83,8 +85,8 @@
       ],
       "role": "setup",
       "expect": {
-        "equals": {
-          "cash": 50000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -108,8 +110,8 @@
       ],
       "role": "setup",
       "expect": {
-        "equals": {
-          "cash": 50000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -147,9 +149,11 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "activeContractCount": 2,
-          "cash": 50000
+          "activeContractCount": 2
         },
         "note": "2nd real click on the same unqualified .bs-contract-accept selector -- with contract #1 already moved to active, the panel's first available row is now #2 (Dispose of rubble), matching `contract accept 2`'s explicit id; verified via a real interaction-mode run rather than assumed from panel-ordering logic"
       },
@@ -175,8 +179,8 @@
       ],
       "role": "setup",
       "expect": {
-        "equals": {
-          "cash": 50000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -200,9 +204,11 @@
       ],
       "description": "role: guard (issue #515): both the amount input and DELIVER button are genuinely disabled here \u2014 `amountInput.disabled = maxDeliverable <= 0` and `deliverBtn.disabled = maxDeliverable <= 0` (ContractsPanel.ts) \u2014 because this scenario never mines or hauls, so nothing is ever in storage (0.0 kg available). A real click cannot land on either control, so this proves the same refusal `expect.blocked` already asserted (now scoped to `[data-contract-id=\"2\"]`, issue #513) rather than performing one.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "activeContractCount": 2,
-          "cash": 50000
+          "activeContractCount": 2
         },
         "usable": "#bs-contract-panel [data-action=\"goto-ops\"]",
         "blocked": "#bs-contract-panel [data-contract-id=\"2\"] .bs-contract-deliver",
@@ -230,8 +236,8 @@
       ],
       "role": "observe",
       "expect": {
-        "equals": {
-          "cash": 50000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -245,8 +251,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 50000,
           "activeContractCount": 2
         }
       }

--- a/scripts/scenario-defs/core-loop-visual.json
+++ b/scripts/scenario-defs/core-loop-visual.json
@@ -66,8 +66,10 @@
         }
       ],
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 198800,
           "proficiencyTotal": 3
         }
       },
@@ -123,8 +125,10 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 195800,
           "surveyCount": 0
         },
         "note": "confirmed via direct trace: cash stays flat here -- with only 1 employee and no buildings/vehicles yet, payroll doesn't cycle within just 5 ticks"

--- a/scripts/scenario-defs/crew-fleet-panels-visual.json
+++ b/scripts/scenario-defs/crew-fleet-panels-visual.json
@@ -53,8 +53,8 @@
       ],
       "expect": {
         "increased": ["employeeCount"],
-        "equals": {
-          "cash": 49000
+        "changedBy": {
+          "cash": -1000
         },
         "note": "HIRING_COSTS.driller is 1000 (balance.ts)"
       }
@@ -75,8 +75,8 @@
       ],
       "expect": {
         "increased": ["employeeCount"],
-        "equals": {
-          "cash": 48200
+        "changedBy": {
+          "cash": -800
         },
         "note": "HIRING_COSTS.driver is 800 (balance.ts)"
       }
@@ -101,8 +101,8 @@
       ],
       "expect": {
         "increased": ["vehicleCount"],
-        "equals": {
-          "cash": 23200
+        "changedBy": {
+          "cash": -25000
         },
         "note": "tier-1 debris_hauler costs 25000 (confirmed against the real state dump, VEHICLE_BASE_STATS pricing is computed, not a flat constant)"
       }

--- a/scripts/scenario-defs/economy-full-loop.json
+++ b/scripts/scenario-defs/economy-full-loop.json
@@ -66,8 +66,10 @@
       ],
       "description": "Left unmarked: hiring already grants the Rookie starting qualification (ROLE_STARTING_QUALIFICATION in Employee.ts); this only raises the level for the scenario's needs -- the player-facing path is `employee train`.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 248800,
           "proficiencyTotal": 5
         }
       },
@@ -182,8 +184,10 @@
       ],
       "description": "Left unmarked: hiring already grants the Rookie starting qualification (ROLE_STARTING_QUALIFICATION in Employee.ts); this only raises the level for the scenario's needs -- the player-facing path is `employee train`.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 243700,
           "proficiencyTotal": 10
         }
       },
@@ -227,8 +231,10 @@
       "description": "Grants the driller (employee #2) the licence to drive the drill_rig just purchased -- the real path is training at a driving_center (see employee-training.json's own conversion of that exact flow); left as a test-only bootstrap since this file's focus is the economy loop, not re-proving vehicle licensing.",
       "role": "bootstrap",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 208700,
           "proficiencyTotal": 11
         }
       }
@@ -482,8 +488,10 @@
       ],
       "description": "Left unmarked: hiring already grants the Rookie starting qualification (ROLE_STARTING_QUALIFICATION in Employee.ts); this only raises the level for the scenario's needs -- the player-facing path is `employee train`.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 196794,
           "proficiencyTotal": 16
         }
       },
@@ -567,8 +575,10 @@
       "description": "Unlike the driving.truck bootstrap above, this one grants a licence from nothing: employee #4 was hired as a driver (ROLE_STARTING_QUALIFICATION driving.truck only), and driving.excavator (the rock_fragmenter's licence) belongs to no hiring role at all -- the real path is training at a driving_center (see employee-training.json's own conversion of that exact flow, and rock-fragmenter-breaking.json's identical bootstrap). Left as a test-only bootstrap since this file's focus is the hauling/contract loop, not re-proving excavator licensing.",
       "role": "bootstrap",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 180994,
           "proficiencyTotal": 22
         }
       }
@@ -614,8 +624,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 148994
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -672,8 +682,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 123924
+        "changedBy": {
+          "cash": 0
         }
       }
     },

--- a/scripts/scenario-defs/employee-skill-progression-visual.json
+++ b/scripts/scenario-defs/employee-skill-progression-visual.json
@@ -82,8 +82,10 @@
         }
       ],
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 47700,
           "proficiencyTotal": 2
         },
         "note": "already level 1 from hiring's Rookie starting qualification -- this call is a same-level no-op, not the first level-up"
@@ -100,8 +102,10 @@
       ],
       "description": "Left unmarked: hiring already grants the Rookie starting qualification (ROLE_STARTING_QUALIFICATION in Employee.ts); this only raises the level for the scenario's needs -- the player-facing path is `employee train`.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 47700,
           "proficiencyTotal": 2
         }
       },
@@ -127,8 +131,10 @@
         }
       ],
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 47700,
           "pendingActionCount": 1
         }
       },
@@ -145,8 +151,10 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 47700,
           "pendingActionCount": 1
         }
       }
@@ -161,8 +169,10 @@
         }
       ],
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 47700,
           "pendingActionCount": 2
         },
         "note": "the second dispatch's ghost preview -- employee A is still busy with the first task and employee B can't claim it (wrong skill), so this stays queued through the next several checkpoints. Count is 2 (not 1) since #547: the first dispatch's claimed-but-in-progress PendingAction still counts alongside this new unclaimed one."

--- a/scripts/scenario-defs/employee-skills-visual.json
+++ b/scripts/scenario-defs/employee-skills-visual.json
@@ -35,7 +35,9 @@
       ],
       "role": "player",
       "expect": {
-        "decreased": ["cash"],
+        "decreased": [
+          "cash"
+        ],
         "equals": {
           "employeeCount": 1,
           "qualificationCount": 1,
@@ -57,7 +59,9 @@
       ],
       "role": "player",
       "expect": {
-        "decreased": ["cash"],
+        "decreased": [
+          "cash"
+        ],
         "equals": {
           "employeeCount": 2,
           "qualificationCount": 2,
@@ -79,7 +83,9 @@
       ],
       "role": "player",
       "expect": {
-        "decreased": ["cash"],
+        "decreased": [
+          "cash"
+        ],
         "equals": {
           "employeeCount": 3,
           "qualificationCount": 3,
@@ -101,7 +107,9 @@
       ],
       "role": "player",
       "expect": {
-        "decreased": ["cash"],
+        "decreased": [
+          "cash"
+        ],
         "equals": {
           "employeeCount": 4,
           "qualificationCount": 4,
@@ -123,7 +131,9 @@
       ],
       "role": "player",
       "expect": {
-        "decreased": ["cash"],
+        "decreased": [
+          "cash"
+        ],
         "equals": {
           "employeeCount": 5,
           "qualificationCount": 5,
@@ -133,7 +143,7 @@
     },
     {
       "command": "employee hire role:driller",
-      "description": "Employee #6 — hired but never given an assign_skill call. Only carries its role's default 'blasting' qualification, exercising the minimal-qualifications display (contrast with #1, which gets two more assigned below). Toggled bottom-up (6 -> 1) so the panel's own scrollIntoView leaves it resting on #1's card once every row is expanded — #1 is the one that later gains a second qualification, and every screenshot from here on needs it in frame, not wherever the last click of a top-down pass happened to land. A screenshot right after each individual click — before the next click's own scrollIntoView moves the panel again — is what gets #2-#5's cards in frame too; the step's single closing screenshot only ever shows one scroll position.",
+      "description": "Employee #6 \u2014 hired but never given an assign_skill call. Only carries its role's default 'blasting' qualification, exercising the minimal-qualifications display (contrast with #1, which gets two more assigned below). Toggled bottom-up (6 -> 1) so the panel's own scrollIntoView leaves it resting on #1's card once every row is expanded \u2014 #1 is the one that later gains a second qualification, and every screenshot from here on needs it in frame, not wherever the last click of a top-down pass happened to land. A screenshot right after each individual click \u2014 before the next click's own scrollIntoView moves the panel again \u2014 is what gets #2-#5's cards in frame too; the step's single closing screenshot only ever shows one scroll position.",
       "interaction": [
         {
           "type": "waitForSelector",
@@ -146,7 +156,9 @@
       ],
       "role": "player",
       "expect": {
-        "decreased": ["cash"],
+        "decreased": [
+          "cash"
+        ],
         "equals": {
           "employeeCount": 6,
           "qualificationCount": 6,
@@ -164,8 +176,10 @@
       ],
       "description": "Left unmarked: hiring already grants the Rookie starting qualification (ROLE_STARTING_QUALIFICATION in Employee.ts); this only raises the level for the scenario's needs -- the player-facing path is `employee train`.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 42500,
           "qualificationCount": 7,
           "proficiencyTotal": 9
         },
@@ -183,8 +197,10 @@
       ],
       "description": "Left unmarked: hiring already grants the Rookie starting qualification (ROLE_STARTING_QUALIFICATION in Employee.ts); this only raises the level for the scenario's needs -- the player-facing path is `employee train`.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 42500,
           "qualificationCount": 8,
           "proficiencyTotal": 11
         },
@@ -202,8 +218,10 @@
       ],
       "description": "Left unmarked: hiring already grants the Rookie starting qualification (ROLE_STARTING_QUALIFICATION in Employee.ts); this only raises the level for the scenario's needs -- the player-facing path is `employee train`.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 42500,
           "qualificationCount": 8,
           "proficiencyTotal": 14
         },
@@ -221,8 +239,10 @@
       ],
       "description": "Left unmarked: hiring already grants the Rookie starting qualification (ROLE_STARTING_QUALIFICATION in Employee.ts); this only raises the level for the scenario's needs -- the player-facing path is `employee train`.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 42500,
           "qualificationCount": 8,
           "proficiencyTotal": 14
         },
@@ -240,8 +260,10 @@
       ],
       "description": "Left unmarked: hiring already grants the Rookie starting qualification (ROLE_STARTING_QUALIFICATION in Employee.ts); this only raises the level for the scenario's needs -- the player-facing path is `employee train`.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 42500,
           "qualificationCount": 8,
           "proficiencyTotal": 18
         },
@@ -259,8 +281,10 @@
       ],
       "description": "Left unmarked: hiring already grants the Rookie starting qualification (ROLE_STARTING_QUALIFICATION in Employee.ts); this only raises the level for the scenario's needs -- the player-facing path is `employee train`.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 42500,
           "qualificationCount": 8,
           "proficiencyTotal": 19
         },
@@ -288,8 +312,10 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 42500,
           "qualificationCount": 8,
           "proficiencyTotal": 19
         }
@@ -315,8 +341,10 @@
         }
       ],
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 42500,
           "pendingActionCount": 1
         }
       },
@@ -423,8 +451,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 42500,
           "pendingActionCount": 6
         }
       }

--- a/scripts/scenario-defs/event-dialog-visual.json
+++ b/scripts/scenario-defs/event-dialog-visual.json
@@ -73,8 +73,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 42000
+        "changedBy": {
+          "cash": -8000
         },
         "increased": [
           "wellBeing"
@@ -92,8 +92,8 @@
       ],
       "role": "setup",
       "expect": {
-        "equals": {
-          "cash": 42000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -143,8 +143,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 42000
+        "changedBy": {
+          "cash": 0
         },
         "decreased": [
           "wellBeing",
@@ -189,8 +189,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 37000
+        "changedBy": {
+          "cash": -5000
         },
         "increased": [
           "safety"
@@ -234,8 +234,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": -163000
+        "changedBy": {
+          "cash": -200000
         },
         "increased": [
           "safety"
@@ -279,8 +279,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": -203000
+        "changedBy": {
+          "cash": -40000
         },
         "increased": [
           "ecology"
@@ -324,8 +324,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": -223000
+        "changedBy": {
+          "cash": -20000
         },
         "increased": [
           "ecology",
@@ -344,8 +344,8 @@
       ],
       "role": "setup",
       "expect": {
-        "equals": {
-          "cash": -223000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -379,8 +379,8 @@
       ],
       "role": "setup",
       "expect": {
-        "equals": {
-          "cash": -223000
+        "changedBy": {
+          "cash": 0
         }
       }
     },

--- a/scripts/scenario-defs/hauling-gate.json
+++ b/scripts/scenario-defs/hauling-gate.json
@@ -269,8 +269,8 @@
       ],
       "description": "Left unmarked: hiring already grants the Rookie starting qualification (ROLE_STARTING_QUALIFICATION in Employee.ts); this only raises the level for the scenario's needs -- the player-facing path is `employee train`. #553: employee 6, not 1 -- staffed:true's roster occupies ids 1-5.",
       "expect": {
-        "equals": {
-          "cash": 79268
+        "changedBy": {
+          "cash": 0
         },
         "note": "the driver already holds driving.truck at level 1 from ROLE_STARTING_QUALIFICATION -- this call is a same-level no-op"
       },
@@ -300,8 +300,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 79268
+        "changedBy": {
+          "cash": 0
         }
       }
     },

--- a/scripts/scenario-defs/i18n-display-visual.json
+++ b/scripts/scenario-defs/i18n-display-visual.json
@@ -107,8 +107,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 50000,
           "wellBeing": 50,
           "safety": 50,
           "ecology": 50,

--- a/scripts/scenario-defs/insufficient-funds-guards-visual.json
+++ b/scripts/scenario-defs/insufficient-funds-guards-visual.json
@@ -36,7 +36,8 @@
         { "type": "wait", "durationMs": 500 }
       ],
       "expect": {
-        "equals": { "cash": 192000, "buildingCount": 1 }
+        "changedBy": { "cash": -8000 },
+        "equals": { "buildingCount": 1 }
       }
     },
     {
@@ -49,7 +50,8 @@
         { "type": "clickSelector", "selector": "#bs-employee-panel [data-role=\"driller\"]" }
       ],
       "expect": {
-        "equals": { "cash": 191000, "employeeCount": 1 }
+        "changedBy": { "cash": -1000 },
+        "equals": { "employeeCount": 1 }
       }
     },
     {
@@ -59,7 +61,7 @@
         { "type": "command", "command": "corrupt target:witness" }
       ],
       "expect": {
-        "equals": { "cash": 181000 }
+        "changedBy": { "cash": -10000 }
       },
       "role": "bootstrap"
     },
@@ -70,7 +72,7 @@
         { "type": "command", "command": "corrupt target:witness" }
       ],
       "expect": {
-        "equals": { "cash": 171000 }
+        "changedBy": { "cash": -10000 }
       },
       "role": "bootstrap"
     },
@@ -81,7 +83,7 @@
         { "type": "command", "command": "corrupt target:witness" }
       ],
       "expect": {
-        "equals": { "cash": 161000 }
+        "changedBy": { "cash": -10000 }
       },
       "role": "bootstrap"
     },

--- a/scripts/scenario-defs/level1-lose-arrest.json
+++ b/scripts/scenario-defs/level1-lose-arrest.json
@@ -28,8 +28,8 @@
       ],
       "role": "setup",
       "expect": {
-        "equals": {
-          "cash": 80000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -43,8 +43,8 @@
       ],
       "description": "role: bootstrap (issue #515): the cost:X override is a scenario-only convenience to hit an exact cash delta -- ShadyPanel's real \"Make the Call\" button always bribes at the fixed TARGET_COSTS rate (Corruption.ts), which does not match the scripted amount here, so no real click can reproduce this exact state change. ShadyPanel now DOES scope its buttons (data-target/data-action, issue #513) -- the earlier \"no stable selector\" reasoning was stale.",
       "expect": {
-        "equals": {
-          "cash": 75000
+        "changedBy": {
+          "cash": -5000
         },
         "note": "the bribe's own success/scandal roll (attemptCorruption, corruptCommand -- events.ts) is RNG-driven and not asserted here, but the cost deduction (state.cash -= result.cost) happens unconditionally regardless of that roll, so cash is safe to assert exactly."
       },
@@ -60,8 +60,8 @@
       ],
       "description": "role: bootstrap (issue #515): the cost:X override is a scenario-only convenience to hit an exact cash delta -- ShadyPanel's real \"Make the Call\" button always bribes at the fixed TARGET_COSTS rate (Corruption.ts), which does not match the scripted amount here, so no real click can reproduce this exact state change. ShadyPanel now DOES scope its buttons (data-target/data-action, issue #513) -- the earlier \"no stable selector\" reasoning was stale.",
       "expect": {
-        "equals": {
-          "cash": 70000
+        "changedBy": {
+          "cash": -5000
         }
       },
       "role": "bootstrap"
@@ -76,8 +76,8 @@
       ],
       "description": "role: bootstrap (issue #515): the cost:X override is a scenario-only convenience to hit an exact cash delta -- ShadyPanel's real \"Make the Call\" button always bribes at the fixed TARGET_COSTS rate (Corruption.ts), which does not match the scripted amount here, so no real click can reproduce this exact state change. ShadyPanel now DOES scope its buttons (data-target/data-action, issue #513) -- the earlier \"no stable selector\" reasoning was stale.",
       "expect": {
-        "equals": {
-          "cash": 65000
+        "changedBy": {
+          "cash": -5000
         }
       },
       "role": "bootstrap"
@@ -92,8 +92,8 @@
       ],
       "description": "role: bootstrap (issue #515): the cost:X override is a scenario-only convenience to hit an exact cash delta -- ShadyPanel's real \"Make the Call\" button always bribes at the fixed TARGET_COSTS rate (Corruption.ts), which does not match the scripted amount here, so no real click can reproduce this exact state change. ShadyPanel now DOES scope its buttons (data-target/data-action, issue #513) -- the earlier \"no stable selector\" reasoning was stale.",
       "expect": {
-        "equals": {
-          "cash": 60000
+        "changedBy": {
+          "cash": -5000
         }
       },
       "role": "bootstrap"
@@ -108,8 +108,8 @@
       ],
       "description": "role: bootstrap (issue #515): the cost:X override is a scenario-only convenience to hit an exact cash delta -- ShadyPanel's real \"Make the Call\" button always bribes at the fixed TARGET_COSTS rate (Corruption.ts), which does not match the scripted amount here, so no real click can reproduce this exact state change. ShadyPanel now DOES scope its buttons (data-target/data-action, issue #513) -- the earlier \"no stable selector\" reasoning was stale.",
       "expect": {
-        "equals": {
-          "cash": 55000
+        "changedBy": {
+          "cash": -5000
         }
       },
       "role": "bootstrap"
@@ -124,8 +124,8 @@
       ],
       "description": "role: bootstrap (issue #515): the cost:X override is a scenario-only convenience to hit an exact cash delta -- ShadyPanel's real \"Make the Call\" button always bribes at the fixed TARGET_COSTS rate (Corruption.ts), which does not match the scripted amount here, so no real click can reproduce this exact state change. ShadyPanel now DOES scope its buttons (data-target/data-action, issue #513) -- the earlier \"no stable selector\" reasoning was stale.",
       "expect": {
-        "equals": {
-          "cash": 45000
+        "changedBy": {
+          "cash": -10000
         }
       },
       "role": "bootstrap"
@@ -140,8 +140,8 @@
       ],
       "description": "role: bootstrap (issue #515): the cost:X override is a scenario-only convenience to hit an exact cash delta -- ShadyPanel's real \"Make the Call\" button always bribes at the fixed TARGET_COSTS rate (Corruption.ts), which does not match the scripted amount here, so no real click can reproduce this exact state change. ShadyPanel now DOES scope its buttons (data-target/data-action, issue #513) -- the earlier \"no stable selector\" reasoning was stale.",
       "expect": {
-        "equals": {
-          "cash": 35000
+        "changedBy": {
+          "cash": -10000
         }
       },
       "role": "bootstrap"
@@ -156,8 +156,8 @@
       ],
       "description": "role: bootstrap (issue #515): the cost:X override is a scenario-only convenience to hit an exact cash delta -- ShadyPanel's real \"Make the Call\" button always bribes at the fixed TARGET_COSTS rate (Corruption.ts), which does not match the scripted amount here, so no real click can reproduce this exact state change. ShadyPanel now DOES scope its buttons (data-target/data-action, issue #513) -- the earlier \"no stable selector\" reasoning was stale.",
       "expect": {
-        "equals": {
-          "cash": 25000
+        "changedBy": {
+          "cash": -10000
         },
         "note": "the eighth and last opening bribe: $55,000 of bribes against the level's $80,000, leaving $25,000 -- enough for both hires below to be real clicks on enabled buttons. `corrupt` itself still has no funds guard (only employee hire / vehicle buy / build got one), so this scenario no longer relies on that: it stays solvent by being funded, not by overdrawing."
       },
@@ -173,8 +173,8 @@
       ],
       "description": "role: bootstrap (issue #515): bare `corrupt` is a read-only status query (corruption level/success rate/mafia-unlocked/attempts) with no dedicated UI readout of its own -- ShadyPanel shows the influence level but not attempts/success-rate as text a selector could assert against. No mutating effect, so bootstrap is a safe fit despite that role's doc leading with \"mutating command\".",
       "expect": {
-        "equals": {
-          "cash": 25000
+        "changedBy": {
+          "cash": 0
         },
         "note": "bare `corrupt` is a read-only status query (corruption level/success rate/mafia-unlocked/attempts) -- no cost, cash unchanged."
       },
@@ -218,8 +218,10 @@
       ],
       "description": "Was an unmarked command step that overdrew to -$6,000: cash had already gone negative on the bribes, so the Crew panel's hire button was disabled (CrewPanel.ts: `hireBtn.disabled = state.cash < HIRING_COSTS[role]`) while the console hired anyway. The console now refuses an unaffordable hire, and with the level funded at $80,000 there is real money in hand, so this is a genuine player click: open the Crew panel and click the driller row's Hire button. awaitUsable is the affordability assertion -- an underfunded run fails here instead of quietly overdrawing.",
       "expect": {
+        "changedBy": {
+          "cash": -1000
+        },
         "equals": {
-          "cash": 24000,
           "employeeCount": 1
         }
       },
@@ -239,8 +241,10 @@
       ],
       "description": "The blaster hire, same conversion, reusing the Crew panel already open from the driller hire (re-clicking the toolbar entry would close it). $1,500 against a positive balance, so the row is enabled.",
       "expect": {
+        "changedBy": {
+          "cash": -1500
+        },
         "equals": {
-          "cash": 22500,
           "employeeCount": 2
         }
       },
@@ -264,8 +268,8 @@
       ],
       "description": "role: player (issue #515): a real click on ShadyPanel's smuggling toggle ([data-action=\"mafia-smuggle\"]) -- unlike the corrupt bribes above, this command takes no cost override so the real button reproduces the exact same state change. ShadyPanel now DOES scope its buttons (data-target/data-action, issue #513) -- the earlier \"no stable selector\" reasoning was stale.",
       "expect": {
-        "equals": {
-          "cash": 22500
+        "changedBy": {
+          "cash": 0
         },
         "note": "toggling smuggling ON is free and instant -- the $8000/tick income (SMUGGLE_BASE_INCOME, MafiaActions.ts) only starts accruing once ticking resumes, checked on the next tick step. This single toggle is the whole reason the level ends in a win before arrest ever triggers -- see the file's own top-level description."
       },
@@ -281,8 +285,10 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": 78700
+        },
         "equals": {
-          "cash": 101200,
           "tickCount": 10,
           "levelEnded": false
         },
@@ -338,8 +344,10 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": 78700
+        },
         "equals": {
-          "cash": 258600,
           "tickCount": 30
         }
       }
@@ -384,8 +392,8 @@
       ],
       "description": "role: bootstrap (issue #515): the cost:X override is a scenario-only convenience to hit an exact cash delta -- ShadyPanel's real \"Make the Call\" button always bribes at the fixed TARGET_COSTS rate (Corruption.ts), which does not match the scripted amount here, so no real click can reproduce this exact state change. ShadyPanel now DOES scope its buttons (data-target/data-action, issue #513) -- the earlier \"no stable selector\" reasoning was stale.",
       "expect": {
-        "equals": {
-          "cash": 253600
+        "changedBy": {
+          "cash": -5000
         }
       },
       "role": "bootstrap"
@@ -400,8 +408,8 @@
       ],
       "description": "role: bootstrap (issue #515): the cost:X override is a scenario-only convenience to hit an exact cash delta -- ShadyPanel's real \"Make the Call\" button always bribes at the fixed TARGET_COSTS rate (Corruption.ts), which does not match the scripted amount here, so no real click can reproduce this exact state change. ShadyPanel now DOES scope its buttons (data-target/data-action, issue #513) -- the earlier \"no stable selector\" reasoning was stale.",
       "expect": {
-        "equals": {
-          "cash": 248600
+        "changedBy": {
+          "cash": -5000
         }
       },
       "role": "bootstrap"
@@ -416,8 +424,10 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": 78700
+        },
         "equals": {
-          "cash": 327300,
           "tickCount": 40
         }
       }
@@ -442,8 +452,10 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": 78700
+        },
         "equals": {
-          "cash": 406000,
           "tickCount": 50,
           "arrested": true
         },
@@ -470,8 +482,10 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": 78700
+        },
         "equals": {
-          "cash": 484700,
           "tickCount": 60
         }
       }
@@ -496,8 +510,10 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": 78700
+        },
         "equals": {
-          "cash": 563400,
           "tickCount": 70
         }
       }
@@ -562,8 +578,10 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 563400,
           "tickCount": 70,
           "arrested": true,
           "levelEnded": true,

--- a/scripts/scenario-defs/level1-lose-bankruptcy.json
+++ b/scripts/scenario-defs/level1-lose-bankruptcy.json
@@ -28,8 +28,8 @@
       ],
       "role": "setup",
       "expect": {
-        "equals": {
-          "cash": 147500
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -53,8 +53,10 @@
       ],
       "description": "Left unmarked: not a real building type (commandOutput: \"Unknown subcommand or building type\") -- there is no catalog row to click, this step is a genuine no-op in both modes. Same class as Finding #5 (needs-cycle's `build canteen`). Per #526: \"office\" maps to the real management_office building; kept as a documented phantom-string no-op here to avoid re-tuning this file's hard-asserted cash totals for a real construction cost — see gameplay-employee-needs for the corrected mapping.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 147500,
           "buildingCount": 0
         }
       },
@@ -70,8 +72,10 @@
       ],
       "description": "Left unmarked: not a real building type (commandOutput: \"Unknown subcommand or building type\") -- there is no catalog row to click, this step is a genuine no-op in both modes. Same class as Finding #5 (needs-cycle's `build canteen`). Per #526: \"office\" maps to the real management_office building; kept as a documented phantom-string no-op here to avoid re-tuning this file's hard-asserted cash totals for a real construction cost — see gameplay-employee-needs for the corrected mapping.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 147500,
           "buildingCount": 0
         }
       },
@@ -87,8 +91,10 @@
       ],
       "description": "Left unmarked: not a real building type (commandOutput: \"Unknown subcommand or building type\") -- there is no catalog row to click, this step is a genuine no-op in both modes. Same class as Finding #5 (needs-cycle's `build canteen`). Per #526: \"medical_bay\" maps to the real living_quarters building; kept as a documented phantom-string no-op here to avoid re-tuning this file's hard-asserted cash totals for a real construction cost — see gameplay-employee-needs for the corrected mapping.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 147500,
           "buildingCount": 0
         }
       },
@@ -104,8 +110,10 @@
       ],
       "description": "Left unmarked: not a real building type (commandOutput: \"Unknown subcommand or building type\") -- there is no catalog row to click, this step is a genuine no-op in both modes. Same class as Finding #5 (needs-cycle's `build canteen`). Per #526: \"canteen\" maps to the real living_quarters building; kept as a documented phantom-string no-op here to avoid re-tuning this file's hard-asserted cash totals for a real construction cost — see gameplay-employee-needs for the corrected mapping.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 147500,
           "buildingCount": 0
         }
       },
@@ -121,8 +129,10 @@
       ],
       "description": "Left unmarked: not a real building type (commandOutput: \"Unknown subcommand or building type\") -- there is no catalog row to click, this step is a genuine no-op in both modes. Same class as Finding #5 (needs-cycle's `build canteen`). Per #526: \"storage_depot\" maps to the real freight_warehouse building; kept as a documented phantom-string no-op here to avoid re-tuning this file's hard-asserted cash totals for a real construction cost — see gameplay-employee-needs for the corrected mapping.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 147500,
           "buildingCount": 0
         }
       },
@@ -138,8 +148,10 @@
       ],
       "description": "Left unmarked: not a real building type (commandOutput: \"Unknown subcommand or building type\") -- there is no catalog row to click, this step is a genuine no-op in both modes. Same class as Finding #5 (needs-cycle's `build canteen`). Per #526: \"break_room\" maps to the real living_quarters building; kept as a documented phantom-string no-op here to avoid re-tuning this file's hard-asserted cash totals for a real construction cost — see gameplay-employee-needs for the corrected mapping.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 147500,
           "buildingCount": 0
         },
         "note": "confirmed via direct trace: all six declared building types are invalid, none of them ever exist -- this file's own \"overspend on buildings\" half of its premise never actually happens, only vehicles and employees genuinely drive the overspend below."
@@ -174,8 +186,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -50000
+        },
         "equals": {
-          "cash": 97500,
           "vehicleCount": 1
         }
       }
@@ -194,8 +208,10 @@
       ],
       "description": "Was an unmarked command step that overdrew: the Fleet panel disables a dealership row on `cash < def.purchaseCost` (setTierButtonAffordable, FleetPanel.ts), so no click could buy this while the console bought it anyway. The console now refuses an unaffordable purchase and the level is funded for the full fleet, so this is a real click on the debris_hauler tier-1 row ($25,000) in the panel already open from the rock_digger buy. awaitUsable is the affordability assertion.",
       "expect": {
+        "changedBy": {
+          "cash": -25000
+        },
         "equals": {
-          "cash": 72500,
           "vehicleCount": 2
         }
       },
@@ -215,8 +231,10 @@
       ],
       "description": "Was an unmarked command step that overdrew: the Fleet panel disables a dealership row on `cash < def.purchaseCost` (setTierButtonAffordable, FleetPanel.ts), so no click could buy this while the console bought it anyway. The console now refuses an unaffordable purchase and the level is funded for the full fleet, so this is a real click on the drill_rig tier-1 row ($35,000) in the panel already open from the rock_digger buy. awaitUsable is the affordability assertion.",
       "expect": {
+        "changedBy": {
+          "cash": -35000
+        },
         "equals": {
-          "cash": 37500,
           "vehicleCount": 3
         }
       },
@@ -236,8 +254,10 @@
       ],
       "description": "Was an unmarked command step that overdrew: the Fleet panel disables a dealership row on `cash < def.purchaseCost` (setTierButtonAffordable, FleetPanel.ts), so no click could buy this while the console bought it anyway. The console now refuses an unaffordable purchase and the level is funded for the full fleet, so this is a real click on the building_destroyer tier-1 row ($30,000) in the panel already open from the rock_digger buy. awaitUsable is the affordability assertion.",
       "expect": {
+        "changedBy": {
+          "cash": -30000
+        },
         "equals": {
-          "cash": 7500,
           "vehicleCount": 4
         }
       },
@@ -271,8 +291,10 @@
       ],
       "description": "Was an unmarked command step that overdrew: CrewPanel.ts disables a hire button on `state.cash < HIRING_COSTS[role]`, so no click could make this hire while the console made it anyway. With the level funded the button is enabled and this is a real click on the driller row ($1,000). Opens the Crew panel first; the five hires below reuse it.",
       "expect": {
+        "changedBy": {
+          "cash": -1000
+        },
         "equals": {
-          "cash": 6500,
           "employeeCount": 1
         }
       },
@@ -292,8 +314,10 @@
       ],
       "description": "Was an unmarked command step that overdrew: CrewPanel.ts disables a hire button on `state.cash < HIRING_COSTS[role]`, so no click could make this hire while the console made it anyway. With the level funded the button is enabled and this is a real click on the driller row ($1,000).",
       "expect": {
+        "changedBy": {
+          "cash": -1000
+        },
         "equals": {
-          "cash": 5500,
           "employeeCount": 2
         }
       },
@@ -313,8 +337,10 @@
       ],
       "description": "Was an unmarked command step that overdrew: CrewPanel.ts disables a hire button on `state.cash < HIRING_COSTS[role]`, so no click could make this hire while the console made it anyway. With the level funded the button is enabled and this is a real click on the blaster row ($1,500).",
       "expect": {
+        "changedBy": {
+          "cash": -1500
+        },
         "equals": {
-          "cash": 4000,
           "employeeCount": 3
         }
       },
@@ -334,8 +360,10 @@
       ],
       "description": "Was an unmarked command step that overdrew: CrewPanel.ts disables a hire button on `state.cash < HIRING_COSTS[role]`, so no click could make this hire while the console made it anyway. With the level funded the button is enabled and this is a real click on the driver row ($800).",
       "expect": {
+        "changedBy": {
+          "cash": -800
+        },
         "equals": {
-          "cash": 3200,
           "employeeCount": 4
         }
       },
@@ -355,8 +383,10 @@
       ],
       "description": "Was an unmarked command step that overdrew: CrewPanel.ts disables a hire button on `state.cash < HIRING_COSTS[role]`, so no click could make this hire while the console made it anyway. With the level funded the button is enabled and this is a real click on the surveyor row ($1,200).",
       "expect": {
+        "changedBy": {
+          "cash": -1200
+        },
         "equals": {
-          "cash": 2000,
           "employeeCount": 5
         }
       },
@@ -376,8 +406,10 @@
       ],
       "description": "Was an unmarked command step that overdrew: CrewPanel.ts disables a hire button on `state.cash < HIRING_COSTS[role]`, so no click could make this hire while the console made it anyway. With the level funded the button is enabled and this is a real click on the manager row ($2,000).",
       "expect": {
+        "changedBy": {
+          "cash": -2000
+        },
         "equals": {
-          "cash": 0,
           "employeeCount": 6
         }
       },
@@ -403,8 +435,10 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": -4160
+        },
         "equals": {
-          "cash": -4160,
           "tickCount": 10,
           "bankrupt": false
         }
@@ -430,8 +464,10 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": -4160
+        },
         "equals": {
-          "cash": -8320,
           "tickCount": 20
         }
       }
@@ -456,8 +492,10 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": -4160
+        },
         "equals": {
-          "cash": -12480,
           "tickCount": 30
         }
       }
@@ -492,8 +530,10 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": -4240
+        },
         "equals": {
-          "cash": -16720,
           "tickCount": 45
         }
       }
@@ -518,8 +558,10 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": -8240
+        },
         "equals": {
-          "cash": -24960,
           "tickCount": 60
         }
       }
@@ -544,8 +586,10 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": -4240
+        },
         "equals": {
-          "cash": -29200,
           "tickCount": 75
         }
       }
@@ -580,8 +624,10 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": -8240
+        },
         "equals": {
-          "cash": -37440,
           "tickCount": 90
         }
       }
@@ -636,8 +682,10 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": -8240
+        },
         "equals": {
-          "cash": -49920,
           "tickCount": 120,
           "bankrupt": true
         }

--- a/scripts/scenario-defs/level1-lose-ecology.json
+++ b/scripts/scenario-defs/level1-lose-ecology.json
@@ -214,8 +214,8 @@
       ],
       "role": "setup",
       "expect": {
-        "equals": {
-          "cash": 5042800
+        "changedBy": {
+          "cash": 0
         }
       }
     },

--- a/scripts/scenario-defs/level1-lose-revolt.json
+++ b/scripts/scenario-defs/level1-lose-revolt.json
@@ -37,8 +37,8 @@
       "description": "#553: crews the free rig so it's actually usable -- and, confirmed via direct trace, this is the single decision that dooms this file. Vehicle #1's shortest path from its (0,2) spawn to the first drill_plan's origin (5,5) steps onto (2,2), permanently occupied by the staffed debris_hauler (vehicle #2, no driver, never moves). EntityMovementTick.ts's occupancy check has no stuck-detection or replanning fallback for a blocked-but-pathable route (only a failed pathfind trips isMoveStuck), so vehicle #1 waits at (1,2) forever -- a 500-tick sandbox probe showed zero movement. Employee #1 is therefore permanently 'moving', never idle, draining its own needs gauges with nothing on this level to replenish them -- the first domino in this file's real conclusion (see top-level description).",
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 550000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -52,8 +52,8 @@
       ],
       "role": "setup",
       "expect": {
-        "equals": {
-          "cash": 550000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -76,8 +76,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 549000,
           "employeeCount": 6
+        },
+        "changedBy": {
+          "cash": -1000
         }
       }
     },
@@ -96,8 +98,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 548000,
           "employeeCount": 7
+        },
+        "changedBy": {
+          "cash": -1000
         }
       }
     },
@@ -116,8 +120,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 547000,
           "employeeCount": 8
+        },
+        "changedBy": {
+          "cash": -1000
         }
       }
     },
@@ -136,8 +142,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 545500,
           "employeeCount": 9
+        },
+        "changedBy": {
+          "cash": -1500
         }
       }
     },
@@ -156,8 +164,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 544700,
           "employeeCount": 10
+        },
+        "changedBy": {
+          "cash": -800
         }
       }
     },
@@ -176,8 +186,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 543500,
           "employeeCount": 11
+        },
+        "changedBy": {
+          "cash": -1200
         }
       }
     },
@@ -226,8 +238,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 542500,
           "employeeCount": 12
+        },
+        "changedBy": {
+          "cash": -1000
         }
       }
     },
@@ -242,8 +256,8 @@
       "description": "#553: the drill_rig licence employee #12 needs before any drill_hole action can be assigned to them -- hiring only grants the role's own starting qualification. Left unmarked (role: bootstrap): the player-facing path is `employee train` at a driving_center, not exercised by this file.",
       "role": "bootstrap",
       "expect": {
-        "equals": {
-          "cash": 542500
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -267,8 +281,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 507500,
           "vehicleCount": 5
+        },
+        "changedBy": {
+          "cash": -35000
         }
       }
     },
@@ -287,8 +303,8 @@
       "description": "#553: employee #12 (licensed above) takes the new rig (vehicle #5).",
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 507500
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -331,8 +347,10 @@
       "expect": {
         "equals": {
           "orderedHoleCount": 25,
-          "holeCount": 0,
-          "cash": 507500
+          "holeCount": 0
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },

--- a/scripts/scenario-defs/level1-playthrough-revolt.json
+++ b/scripts/scenario-defs/level1-playthrough-revolt.json
@@ -37,8 +37,8 @@
       "description": "#553: staffed:true does NOT auto-assign a driver -- the free drill_rig (vehicle #1) is still a mesh nobody can drive until employee #1, the only qualified driller on the roster at this point, boards it. The assign row's <select> defaults to its only eligible option (employee #1 is the sole driving.drill_rig holder here), so the plain assign click resolves to them without needing to pick an option.",
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 50000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -52,8 +52,8 @@
       ],
       "role": "setup",
       "expect": {
-        "equals": {
-          "cash": 50000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -67,8 +67,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 50000,
           "ecology": 50,
           "safety": 50,
           "wellBeing": 50,
@@ -86,8 +88,8 @@
       ],
       "role": "observe",
       "expect": {
-        "equals": {
-          "cash": 50000
+        "changedBy": {
+          "cash": 0
         }
       }
     },

--- a/scripts/scenario-defs/level1-playthrough-win.json
+++ b/scripts/scenario-defs/level1-playthrough-win.json
@@ -10,7 +10,7 @@
           "command": "campaign start level:dusty_hollow staffed:true"
         }
       ],
-      "description": "#553: staffed:true hires and equips, for free, before any assertion: employee #1 driller (blasting lvl1, driving.drill_rig lvl1), #2 blaster (blasting lvl1), #3/#4/#5 drivers (driving.truck/driving.excavator/driving.excavator lvl1), vehicle #1 drill_rig, #2 debris_hauler, #3 rock_digger, #4 rock_fragmenter (all tier 1, all unmanned). Free -- cash is unaffected, still $50,000, matching dusty_hollow's own default.",
+      "description": "#553: staffed:true hires and equips, for free, before any assertion: employee #1 driller (blasting lvl1, driving.drill_rig lvl1), #2 blaster (blasting lvl1), #3/#4/#5 drivers (driving.truck/driving.excavator/driving.excavator lvl1), vehicle #1 drill_rig, #2 debris_hauler, #3 rock_digger, #4 rock_fragmenter (all tier 1, all unmanned). Free -- cash is unaffected, still $50,000, matching dusty_hollow's own default. Left as `equals` (issue #596): this is the file's first step, so there is no prior-step \"before\" cash for `changedBy` to diff against -- the evaluator reads it as 0, not the pre-game state.",
       "expect": {
         "equals": {
           "cash": 50000
@@ -27,8 +27,8 @@
         }
       ],
       "expect": {
-        "equals": {
-          "cash": 50000
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "setup"
@@ -43,11 +43,13 @@
       ],
       "expect": {
         "equals": {
-          "cash": 50000,
           "ecology": 50,
           "safety": 50,
           "wellBeing": 50,
           "nuisance": 50
+        },
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "observe"
@@ -61,8 +63,8 @@
         }
       ],
       "expect": {
-        "equals": {
-          "cash": 50000
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "observe"
@@ -105,8 +107,8 @@
       "description": "New finding (see file description): the free debris_hauler (#2) is the first of three parked vehicles standing directly in drill_rig #1's only cheap route east -- confirmed directly by sandbox trace, the rig sits welded to (1,2) for 300+ ticks otherwise, for any target requiring eastward travel. Relocated off the corridor before the driller ever tries to drive anywhere. `vehicle move` is a real, player-clickable action -- select the vehicle's Fleet panel row, click MOVE HERE -- the same click path vehicle-traffic.json already exercises for this exact command. Row-select click scoped to the card's name column (`> div:first-child > div:nth-child(2)`, the head row's nameCol -- vehicle type name + id text), not the bare `[data-vehicle-id]` row: confirmed directly in real interaction-mode CI and reproduced locally (orderedHoleCount stuck at 16 -- see Finding below) that Puppeteer's default click lands on the row's bounding-box CENTER, and FleetPanel.ts's row-click handler bails out (`target.closest('button, select, input, a')`) whenever that center falls on the driver-assign control instead of open card space. debris_hauler's extra load-gauge row (makeLoadGauge, FleetPanel.ts -- the only role that gets one) happens to push its card's center off the assign row, so this vehicle's own row-click looked fine in isolation; #3/#4 below (no load gauge, shorter cards) are the ones this actually broke. `.bs-fleet-hp`/`.bs-fleet-status` were tried first and rejected -- FleetPanel.ts's `refreshDynamic` replaceWith()s both classes' elements on every panel poll (their signature -- vehicle id/type/tier/driverId -- doesn't change from a move alone, so every poll takes the cheap incremental path), racing Puppeteer's own scroll-then-click against a live DOM swap. `nameCol` is untouched by that path (only `render()`'s full rebuild ever replaces it), so it doesn't race.",
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 50000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -144,8 +146,8 @@
       "description": "The second blocker in line -- clearing #2 alone only reveals rock_digger (#3) welded to the next cell over, confirmed directly. Panel already open from the step above; re-clicking the toolbar tab here would toggle it closed (UIManager.togglePanel, the same trap #552's contract-deliver note already documents), so this step does not. Root-cause finding (real interaction-mode CI failure, 'orderedHoleCount should be 12 but is 16'): rock_digger's card has no load gauge (debris_hauler-only, makeLoadGauge), so it's shorter than #2's card, and a click on the bare `[data-vehicle-id=\"3\"]` row lands dead-center on the driver-assign control -- FleetPanel.ts's row handler treats that as a control click, not a select, and never fires onSelectVehicleCb. Confirmed directly: `#bs-selection-bar .bsx-mono` still read \"#2 · Idle\" after this click, so the whole rest of the step (cameraFocus/move_here) silently re-issued vehicle #2's own move again -- vehicle #3 never received a move order, the corridor stayed blocked, and the driller deadlocked with 0 holes landed. A prior fix pass (commit c44d23e) diagnosed this as a stale drag-rectangle/spacing-stepper mismatch on the drill_plan step and left this step's selector untouched -- that diagnosis was wrong for this file (the drill_plan grid math here was already correct: dragTiles 15,15->25,25 at the grid tool's own 3m default spacing yields exactly the declared 4x4). Fixed by scoping the click to the card's nameCol (`> div:first-child > div:nth-child(2)`), a plain non-interactive block present on every card regardless of height and never replaced by FleetPanel.ts's incremental refresh path (unlike `.bs-fleet-hp`/`.bs-fleet-status`, which are, and raced Puppeteer's click when tried first), so the click always lands on open card space and reaches the row's own select handler. Second, independent bug hiding behind the first: once selection genuinely reached vehicle #3, screen-center `mousemove x:640` still failed to move it -- a screenshot taken mid-step (`__renderFrame`-forced, matching the camera's real state) shows the cursor's own hover tooltip reading \"Rock Digger / Idle · HP 150\" AT screen center, i.e. `cameraFocus(4.5,6.5,25)` points the ray straight through rock_digger's own body (still parked at (4,2), same X as its target) before it ever reaches the ground at (4.5,6.5) -- `scenePicking.aim.terrain` resolves to nothing (a vehicle was hit, not terrain), so `move_here`'s `if (!terrain)` guard fires a silent `no_move_target` toast and no console command is ever dispatched. Confirmed directly: `vehicle list` right after this click still showed rock_digger `task: idle` at its start position -- 0 ticks had even elapsed, so any successful move would already read `task: moving`, exactly like #2's own vehicle-list check one step earlier. Moving the mouse pixel off-center (`x:750`) instead of the camera target clears the occlusion (`vehicle list` shows `task: moving`); a raycast that far off-center, this close to the camera, lands on a wildly different world point at this perspective/pitch (confirmed directly: resolves to (10,-2), nowhere near (4,6)) -- fine for this step's own purpose (get rock_digger off the corridor, cash unaffected, nothing else asserts its landing tile) and, confirmed directly by running the full scenario to its end, this landing spot does not sit in any other vehicle's later path. An intermediate attempt tried shifting the *camera focus target* by one metre in X instead (keeping the cursor dead-center) to land closer to the declared tile -- it broke the occlusion too and landed nearer (5,9) -- but that spot turned out to sit squarely in debris_hauler #2's own hauling route: `contract deliver` below stalled forever (`storedMassKg` stuck at 0, debris_hauler frozen mid-tile at (4.12,8.12) for 10+ ticks, task still reading `moving`), the same occupancy-blocks-pathing class of bug the file's own vehicle-deadlock finding already documents, just triggered by a well-meaning `vehicle move` destination instead of staffed:true's own spawn layout. Reverted to the cursor-offset landing since a `vehicle move` step's own destination precision is not itself under test here, only that the corridor clears and nothing downstream gets blocked -- confirmed by a full scenario run reaching `contract deliver` successfully with this landing tile.",
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 50000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -183,8 +185,8 @@
       "description": "The third and last blocker (rock_fragmenter). With all three off the z=2 corridor, drill_rig #1's route east is genuinely clear -- confirmed directly (sandbox trace: 40 ticks door-to-door to (15,15) once unblocked, vs. never before). Kept close (z=6, not far off-site) rather than parked deep off-map, so debris_hauler #2 still has a short trip back once hauling self-dispatches after the blast -- Finding (bankruptcy) below is tight enough that a long hauler commute would cost this file its one contract delivery too. Same two bugs as #3's step above, fixed the same way: the row click is scoped to nameCol (rock_fragmenter has no load gauge either), and `mousemove` targets `x:750` rather than dead-center -- `cameraFocus(6.5,6.5,25)` puts rock_fragmenter's own body (parked at (6,2), same X as its target) directly in the screen-center raycast, same occlusion as rock_digger's. Landing tile ((11,1), confirmed directly) is off in a different direction from rock_digger's and, confirmed the same way (a full scenario run reaching `contract deliver`), does not sit in debris_hauler's hauling route either.",
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 50000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -203,8 +205,8 @@
       "description": "#553: staffed:true's free driller (employee #1, already licensed blasting lvl1 + driving.drill_rig lvl1) boards the free drill_rig (vehicle #1). Without a driver the rig is a mesh and no drill_hole action ever starts.",
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 50000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -540,8 +542,8 @@
       "description": "#552/#553: staffed:true's free debris_hauler (vehicle #2) is reused here rather than buying a second one by hand -- the file's own hauling volume (one 260kg rubble delivery this cycle, matching Finding #48's fragment-matching constraint below) never needs a second hauler, and this file's budget cannot spare the $25,000 a manual purchase would cost on top of everything else -- see the file description's bankruptcy finding for just how tight that budget already is. Employee #10 (hired driver, licensed driving.truck lvl5 above) boards it. Re-opens the vehicles panel first (UIManager.togglePanel, same pattern as level2-playthrough-win's fix): the panel had switched to employees then build (the surveyor/driller/blaster/driver hires and the freight_warehouse placement above), so #bs-vehicle-panel's own [data-vehicle-id=\"2\"] row was off-screen (display:none, zero size) at this point -- not a stale selector, the panel itself just wasn't the active one. togglePanel only closes an ALREADY-active panel, so this click safely switches to vehicles rather than toggling it shut. New finding, real interaction-mode CI: `.bs-vehicle-assign-btn` (`makeAssignRow`, fleetDetailSections.ts) reads a `<select>` next to it, not a fixed target -- clicking Assign without first choosing an option in that select just assigns whoever the browser's default selection lands on (its first eligible option), which for this vehicle is one of staffed:true's own free drivers (a lower employee id than the hired #10), not employee #10 named in the command. Confirmed directly: `vehicle list` after this step showed debris_hauler's `driver` as employee #3, not #10, and hauling still happened (#552 self-dispatch doesn't care WHICH qualified driver boards) but not the one this step names. Fixed with a `set` action on the row's own `select` (scoped by `[data-vehicle-id=\"2\"]`, matching the file's other dropdown-driven steps) before the Assign click, mirroring the Charge step's own real-control convention (issue #515) rather than relying on whatever the dropdown defaulted to.",
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 26000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -555,12 +557,14 @@
       ],
       "expect": {
         "equals": {
-          "cash": 26000,
           "tickCount": 0,
           "holeCount": 0,
           "deathCount": 0,
           "employeeCount": 13,
           "vehicleCount": 4
+        },
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "observe"

--- a/scripts/scenario-defs/level1-win-conservative.json
+++ b/scripts/scenario-defs/level1-win-conservative.json
@@ -310,8 +310,10 @@
       ],
       "description": "role: player (issue #515): the Charge step's amount/stemming steppers and product-card explosive selector are real controls \u2014 this reaches the declared explosive/amount/stemming via clicks instead of Charge All using whatever the panel's fields already showed. Sandbox-measured: charging pop_rock at this amount costs nothing here (cash unchanged before/after in both this file's pre-#553 version and a direct #553 trace) -- unlike tutorial-playthrough's boomite charge, whatever pricing this leaves at $0 for this explosive/amount combination, not an authoring oversight.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 10620,
           "tickCount": 50,
           "deathCount": 0,
           "employeeCount": 1,
@@ -346,8 +348,10 @@
       "role": "player",
       "description": "Sequence's delay-step stepper carries data-field=\"delay-step\" (Sequence.ts) for unambiguous click targeting. 1 increment click: 25ms default -> 30 (DELAY_STEP_INCREMENT=5ms, Sequence.ts). dstepMs is a plain instance field with no reset path (Finding #75/level1-lose-revolt.json) -- this file's later delay_step:25 occurrence below relies on it moving back down.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 10620,
           "tickCount": 50,
           "deathCount": 0,
           "employeeCount": 1,
@@ -388,8 +392,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 10620,
           "tickCount": 50,
           "deathCount": 1,
           "employeeCount": 1,
@@ -411,8 +417,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 10620,
           "tickCount": 50,
           "deathCount": 1,
           "employeeCount": 1,
@@ -430,8 +438,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 10620,
           "tickCount": 50,
           "deathCount": 1,
           "employeeCount": 1,
@@ -1153,8 +1163,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": -19317,
           "tickCount": 140,
           "deathCount": 1,
           "employeeCount": 1,
@@ -1622,8 +1634,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": -23453,
           "tickCount": 220,
           "deathCount": 1,
           "employeeCount": 1,
@@ -1646,8 +1660,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": -23453,
           "tickCount": 220,
           "deathCount": 1,
           "employeeCount": 1,

--- a/scripts/scenario-defs/level1-win-efficient.json
+++ b/scripts/scenario-defs/level1-win-efficient.json
@@ -34,12 +34,14 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": 3000000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
           "activeContractCount": 0,
           "surveyCount": 0
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -54,7 +56,6 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 3000000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
@@ -64,6 +65,9 @@
           "safety": 50,
           "ecology": 50,
           "nuisance": 50
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -78,12 +82,14 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 3000000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
           "activeContractCount": 0,
           "surveyCount": 0
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -106,12 +112,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 2998800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 0
+        },
+        "changedBy": {
+          "cash": -1200
         }
       }
     },
@@ -127,12 +135,14 @@
       "role": "bootstrap",
       "expect": {
         "equals": {
-          "cash": 2998800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 0
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -147,12 +157,14 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 2998800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 0
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -167,12 +179,14 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 2998800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 0
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -211,12 +225,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 2998000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 0
+        },
+        "changedBy": {
+          "cash": -800
         }
       }
     },
@@ -251,12 +267,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 2995000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 0
+        },
+        "changedBy": {
+          "cash": -3000
         }
       }
     },
@@ -271,12 +289,14 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 2995000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 0
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -291,12 +311,14 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 2995000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 0
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -311,13 +333,15 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": 2994180,
           "tickCount": 10,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 0
-        }
+        },
+        "decreased": [
+          "cash"
+        ]
       }
     },
     {
@@ -331,12 +355,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 2994180,
           "tickCount": 10,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 0
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -351,13 +377,15 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": 2993360,
           "tickCount": 20,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 0
-        }
+        },
+        "decreased": [
+          "cash"
+        ]
       }
     },
     {
@@ -371,12 +399,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 2993360,
           "tickCount": 20,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 0
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -391,13 +421,15 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": 2992540,
           "tickCount": 30,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 0
-        }
+        },
+        "decreased": [
+          "cash"
+        ]
       }
     },
     {
@@ -411,12 +443,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 2992540,
           "tickCount": 30,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 0
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -431,13 +465,15 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": 2991720,
           "tickCount": 40,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 0
-        }
+        },
+        "decreased": [
+          "cash"
+        ]
       }
     },
     {
@@ -451,12 +487,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 2991720,
           "tickCount": 40,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 0
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -471,12 +509,14 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 2991720,
           "tickCount": 40,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 0
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -491,12 +531,14 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 2991720,
           "tickCount": 40,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 0
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -511,12 +553,14 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": 2991720,
           "tickCount": 48,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 1
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -531,12 +575,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 2991720,
           "tickCount": 48,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 1
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -551,13 +597,15 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": 2990900,
           "tickCount": 56,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 1
-        }
+        },
+        "decreased": [
+          "cash"
+        ]
       }
     },
     {
@@ -571,12 +619,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 2990900,
           "tickCount": 56,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 1
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -591,13 +641,15 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": 2990080,
           "tickCount": 64,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 1
-        }
+        },
+        "decreased": [
+          "cash"
+        ]
       }
     },
     {
@@ -611,12 +663,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 2990080,
           "tickCount": 64,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 1
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -631,13 +685,15 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": 2989260,
           "tickCount": 72,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 2
-        }
+        },
+        "decreased": [
+          "cash"
+        ]
       }
     },
     {
@@ -651,12 +707,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 2989260,
           "tickCount": 72,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 2
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -672,12 +730,14 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 2989260,
           "tickCount": 72,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 2
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -692,12 +752,14 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 2989260,
           "tickCount": 72,
           "deathCount": 0,
           "employeeCount": 1,
           "activeContractCount": 0,
           "surveyCount": 2
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -721,12 +783,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 2988260,
           "tickCount": 72,
           "deathCount": 0,
           "employeeCount": 2,
           "activeContractCount": 0,
           "surveyCount": 2
+        },
+        "changedBy": {
+          "cash": -1000
         }
       }
     },
@@ -742,12 +806,14 @@
       "role": "bootstrap",
       "expect": {
         "equals": {
-          "cash": 2988260,
           "tickCount": 72,
           "deathCount": 0,
           "employeeCount": 2,
           "activeContractCount": 0,
           "surveyCount": 2
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -767,12 +833,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 2987260,
           "tickCount": 72,
           "deathCount": 0,
           "employeeCount": 3,
           "activeContractCount": 0,
           "surveyCount": 2
+        },
+        "changedBy": {
+          "cash": -1000
         }
       }
     },
@@ -787,12 +855,14 @@
       "role": "bootstrap",
       "expect": {
         "equals": {
-          "cash": 2987260,
           "tickCount": 72,
           "deathCount": 0,
           "employeeCount": 3,
           "activeContractCount": 0,
           "surveyCount": 2
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -812,12 +882,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 2986260,
           "tickCount": 72,
           "deathCount": 0,
           "employeeCount": 4,
           "activeContractCount": 0,
           "surveyCount": 2
+        },
+        "changedBy": {
+          "cash": -1000
         }
       }
     },
@@ -832,12 +904,14 @@
       "role": "bootstrap",
       "expect": {
         "equals": {
-          "cash": 2986260,
           "tickCount": 72,
           "deathCount": 0,
           "employeeCount": 4,
           "activeContractCount": 0,
           "surveyCount": 2
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -861,12 +935,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 2846260,
           "tickCount": 72,
           "deathCount": 0,
           "employeeCount": 4,
           "activeContractCount": 0,
           "surveyCount": 2
+        },
+        "changedBy": {
+          "cash": -140000
         }
       }
     },
@@ -885,12 +961,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 2846260,
           "tickCount": 72,
           "deathCount": 0,
           "employeeCount": 4,
           "activeContractCount": 0,
           "surveyCount": 2
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -910,12 +988,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 2706260,
           "tickCount": 72,
           "deathCount": 0,
           "employeeCount": 4,
           "activeContractCount": 0,
           "surveyCount": 2
+        },
+        "changedBy": {
+          "cash": -140000
         }
       }
     },
@@ -934,12 +1014,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 2706260,
           "tickCount": 72,
           "deathCount": 0,
           "employeeCount": 4,
           "activeContractCount": 0,
           "surveyCount": 2
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -959,12 +1041,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 2566260,
           "tickCount": 72,
           "deathCount": 0,
           "employeeCount": 4,
           "activeContractCount": 0,
           "surveyCount": 2
+        },
+        "changedBy": {
+          "cash": -140000
         }
       }
     },
@@ -983,12 +1067,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 2566260,
           "tickCount": 72,
           "deathCount": 0,
           "employeeCount": 4,
           "activeContractCount": 0,
           "surveyCount": 2
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -1030,7 +1116,6 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 2566260,
           "tickCount": 72,
           "deathCount": 0,
           "employeeCount": 4,
@@ -1040,6 +1125,9 @@
           "holeCount": 0,
           "chargedCount": 0,
           "sequencedCount": 0
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },

--- a/scripts/scenario-defs/level2-playthrough-bankruptcy.json
+++ b/scripts/scenario-defs/level2-playthrough-bankruptcy.json
@@ -35,13 +35,15 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": 185800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       },
       "description": "No `cash:` here on purpose: this command fails (tier-2 level, locked on a fresh campaign), so the run continues on the new_game world above and any override attached here would be discarded with it."
@@ -57,13 +59,15 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": 185800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -78,7 +82,6 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 185800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
@@ -89,6 +92,9 @@
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -103,13 +109,15 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 185800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -124,13 +132,15 @@
       "description": "Left unmarked: not a real building type (commandOutput: \"Unknown subcommand or building type\") -- there is no catalog row to click, this step is a genuine no-op in both modes. Same class as Finding #5 (needs-cycle's `build canteen`). Per #526: \"office\" maps to the real management_office building; kept as a documented phantom-string no-op here to avoid re-tuning this file's hard-asserted cash totals for a real construction cost — see gameplay-employee-needs for the corrected mapping.",
       "expect": {
         "equals": {
-          "cash": 185800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "bootstrap"
@@ -146,13 +156,15 @@
       "description": "Left unmarked: not a real building type (commandOutput: \"Unknown subcommand or building type\") -- there is no catalog row to click, this step is a genuine no-op in both modes. Same class as Finding #5 (needs-cycle's `build canteen`). Per #526: \"storage_depot\" maps to the real freight_warehouse building; kept as a documented phantom-string no-op here to avoid re-tuning this file's hard-asserted cash totals for a real construction cost — see gameplay-employee-needs for the corrected mapping.",
       "expect": {
         "equals": {
-          "cash": 185800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "bootstrap"
@@ -168,13 +180,15 @@
       "description": "Left unmarked: not a real building type (commandOutput: \"Unknown subcommand or building type\") -- there is no catalog row to click, this step is a genuine no-op in both modes. Same class as Finding #5 (needs-cycle's `build canteen`). Per #526: \"medical_bay\" maps to the real living_quarters building; kept as a documented phantom-string no-op here to avoid re-tuning this file's hard-asserted cash totals for a real construction cost — see gameplay-employee-needs for the corrected mapping.",
       "expect": {
         "equals": {
-          "cash": 185800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "bootstrap"
@@ -190,13 +204,15 @@
       "description": "Left unmarked: not a real building type (commandOutput: \"Unknown subcommand or building type\") -- there is no catalog row to click, this step is a genuine no-op in both modes. Same class as Finding #5 (needs-cycle's `build canteen`). Per #526: \"canteen\" maps to the real living_quarters building; kept as a documented phantom-string no-op here to avoid re-tuning this file's hard-asserted cash totals for a real construction cost — see gameplay-employee-needs for the corrected mapping.",
       "expect": {
         "equals": {
-          "cash": 185800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "bootstrap"
@@ -212,13 +228,15 @@
       "description": "Left unmarked: not a real building type (commandOutput: \"Unknown subcommand or building type\") -- there is no catalog row to click, this step is a genuine no-op in both modes. Same class as Finding #5 (needs-cycle's `build canteen`). Per #526: \"break_room\" maps to the real living_quarters building; kept as a documented phantom-string no-op here to avoid re-tuning this file's hard-asserted cash totals for a real construction cost — see gameplay-employee-needs for the corrected mapping.",
       "expect": {
         "equals": {
-          "cash": 185800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "bootstrap"
@@ -234,13 +252,15 @@
       "description": "Left unmarked: not a real building type (commandOutput: \"Unknown subcommand or building type\") -- there is no catalog row to click, this step is a genuine no-op in both modes. Same class as Finding #5 (needs-cycle's `build canteen`). Per #526: \"bunkhouse\" maps to the real living_quarters building; kept as a documented phantom-string no-op here to avoid re-tuning this file's hard-asserted cash totals for a real construction cost — see gameplay-employee-needs for the corrected mapping.",
       "expect": {
         "equals": {
-          "cash": 185800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "bootstrap"
@@ -276,13 +296,15 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 177800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -8000
         }
       }
     },
@@ -297,13 +319,15 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 177800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -318,13 +342,15 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 177800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -347,13 +373,15 @@
       "description": "Was an unmarked command step that overdrew: the Fleet panel disables a dealership row on `cash < def.purchaseCost` (setTierButtonAffordable, FleetPanel.ts), so no click could buy this while the console bought it anyway. The console now refuses an unaffordable purchase and the run is funded for the whole fleet, so this is a real click on the rock_digger tier-1 row ($50,000). awaitUsable is the affordability assertion. Opens the Fleet panel first; the four buys below reuse it.",
       "expect": {
         "equals": {
-          "cash": 127800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -50000
         }
       },
       "role": "player"
@@ -373,13 +401,15 @@
       "description": "Was an unmarked command step that overdrew: the Fleet panel disables a dealership row on `cash < def.purchaseCost` (setTierButtonAffordable, FleetPanel.ts), so no click could buy this while the console bought it anyway. The console now refuses an unaffordable purchase and the run is funded for the whole fleet, so this is a real click on the debris_hauler tier-1 row ($25,000). awaitUsable is the affordability assertion.",
       "expect": {
         "equals": {
-          "cash": 102800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -25000
         }
       },
       "role": "player"
@@ -399,13 +429,15 @@
       "description": "Was an unmarked command step that overdrew: the Fleet panel disables a dealership row on `cash < def.purchaseCost` (setTierButtonAffordable, FleetPanel.ts), so no click could buy this while the console bought it anyway. The console now refuses an unaffordable purchase and the run is funded for the whole fleet, so this is a real click on the drill_rig tier-1 row ($35,000). awaitUsable is the affordability assertion.",
       "expect": {
         "equals": {
-          "cash": 67800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -35000
         }
       },
       "role": "player"
@@ -425,13 +457,15 @@
       "description": "Was an unmarked command step that overdrew: the Fleet panel disables a dealership row on `cash < def.purchaseCost` (setTierButtonAffordable, FleetPanel.ts), so no click could buy this while the console bought it anyway. The console now refuses an unaffordable purchase and the run is funded for the whole fleet, so this is a real click on the building_destroyer tier-1 row ($30,000). awaitUsable is the affordability assertion.",
       "expect": {
         "equals": {
-          "cash": 37800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -30000
         }
       },
       "role": "player"
@@ -451,13 +485,15 @@
       "description": "Was an unmarked command step that overdrew: the Fleet panel disables a dealership row on `cash < def.purchaseCost` (setTierButtonAffordable, FleetPanel.ts), so no click could buy this while the console bought it anyway. The console now refuses an unaffordable purchase and the run is funded for the whole fleet, so this is a real click on the debris_hauler tier-1 row ($25,000). awaitUsable is the affordability assertion.",
       "expect": {
         "equals": {
-          "cash": 12800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -25000
         }
       },
       "role": "player"
@@ -473,13 +509,15 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 12800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -494,13 +532,15 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 12800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 0,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -523,13 +563,15 @@
       "description": "Was an unmarked command step that overdrew: CrewPanel.ts disables a hire button on `state.cash < HIRING_COSTS[role]`, so no click could make this hire while the console made it anyway. With the run funded the button is enabled and this is a real click on the driller row ($1,000). Opens the Crew panel first; the nine hires below reuse it.",
       "expect": {
         "equals": {
-          "cash": 11800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 1,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -1000
         }
       },
       "role": "player"
@@ -549,13 +591,15 @@
       "description": "Was an unmarked command step that overdrew: CrewPanel.ts disables a hire button on `state.cash < HIRING_COSTS[role]`, so no click could make this hire while the console made it anyway. With the run funded the button is enabled and this is a real click on the driller row ($1,000).",
       "expect": {
         "equals": {
-          "cash": 10800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 2,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -1000
         }
       },
       "role": "player"
@@ -575,13 +619,15 @@
       "description": "Was an unmarked command step that overdrew: CrewPanel.ts disables a hire button on `state.cash < HIRING_COSTS[role]`, so no click could make this hire while the console made it anyway. With the run funded the button is enabled and this is a real click on the driller row ($1,000).",
       "expect": {
         "equals": {
-          "cash": 9800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 3,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -1000
         }
       },
       "role": "player"
@@ -601,13 +647,15 @@
       "description": "Was an unmarked command step that overdrew: CrewPanel.ts disables a hire button on `state.cash < HIRING_COSTS[role]`, so no click could make this hire while the console made it anyway. With the run funded the button is enabled and this is a real click on the blaster row ($1,500).",
       "expect": {
         "equals": {
-          "cash": 8300,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 4,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -1500
         }
       },
       "role": "player"
@@ -627,13 +675,15 @@
       "description": "Was an unmarked command step that overdrew: CrewPanel.ts disables a hire button on `state.cash < HIRING_COSTS[role]`, so no click could make this hire while the console made it anyway. With the run funded the button is enabled and this is a real click on the blaster row ($1,500).",
       "expect": {
         "equals": {
-          "cash": 6800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -1500
         }
       },
       "role": "player"
@@ -653,13 +703,15 @@
       "description": "Was an unmarked command step that overdrew: CrewPanel.ts disables a hire button on `state.cash < HIRING_COSTS[role]`, so no click could make this hire while the console made it anyway. With the run funded the button is enabled and this is a real click on the driver row ($800).",
       "expect": {
         "equals": {
-          "cash": 6000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 6,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -800
         }
       },
       "role": "player"
@@ -679,13 +731,15 @@
       "description": "Was an unmarked command step that overdrew: CrewPanel.ts disables a hire button on `state.cash < HIRING_COSTS[role]`, so no click could make this hire while the console made it anyway. With the run funded the button is enabled and this is a real click on the driver row ($800).",
       "expect": {
         "equals": {
-          "cash": 5200,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 7,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -800
         }
       },
       "role": "player"
@@ -705,13 +759,15 @@
       "description": "Was an unmarked command step that overdrew: CrewPanel.ts disables a hire button on `state.cash < HIRING_COSTS[role]`, so no click could make this hire while the console made it anyway. With the run funded the button is enabled and this is a real click on the surveyor row ($1,200).",
       "expect": {
         "equals": {
-          "cash": 4000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 8,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -1200
         }
       },
       "role": "player"
@@ -731,13 +787,15 @@
       "description": "Was an unmarked command step that overdrew: CrewPanel.ts disables a hire button on `state.cash < HIRING_COSTS[role]`, so no click could make this hire while the console made it anyway. With the run funded the button is enabled and this is a real click on the manager row ($2,000).",
       "expect": {
         "equals": {
-          "cash": 2000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 9,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -2000
         }
       },
       "role": "player"
@@ -757,13 +815,15 @@
       "description": "Was an unmarked command step that overdrew: CrewPanel.ts disables a hire button on `state.cash < HIRING_COSTS[role]`, so no click could make this hire while the console made it anyway. With the run funded the button is enabled and this is a real click on the manager row ($2,000).",
       "expect": {
         "equals": {
-          "cash": 0,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -2000
         }
       },
       "role": "player"
@@ -779,13 +839,15 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 0,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -800,13 +862,15 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 0,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -821,13 +885,15 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 0,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -842,13 +908,15 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": -7050,
           "tickCount": 10,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -7050
         }
       }
     },
@@ -862,13 +930,15 @@
       "description": "Resolved through the event dialog's own buttons. Decides whether an event is pending from authoritative game state, not from whether the modal has rendered -- a DOM-only probe silently missed events on a no-GPU runner where a frame costs ~6s, leaving them pending so later ticks halted and the run diverged while still passing command mode.",
       "expect": {
         "equals": {
-          "cash": -7050,
           "tickCount": 10,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "player"
@@ -884,13 +954,15 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": -14100,
           "tickCount": 20,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -7050
         }
       }
     },
@@ -904,13 +976,15 @@
       "description": "Resolved through the event dialog's own buttons. Decides whether an event is pending from authoritative game state, not from whether the modal has rendered -- a DOM-only probe silently missed events on a no-GPU runner where a frame costs ~6s, leaving them pending so later ticks halted and the run diverged while still passing command mode.",
       "expect": {
         "equals": {
-          "cash": -14100,
           "tickCount": 20,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "player"
@@ -926,13 +1000,15 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": -21150,
           "tickCount": 30,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -7050
         }
       }
     },
@@ -946,13 +1022,15 @@
       "description": "Resolved through the event dialog's own buttons. Decides whether an event is pending from authoritative game state, not from whether the modal has rendered -- a DOM-only probe silently missed events on a no-GPU runner where a frame costs ~6s, leaving them pending so later ticks halted and the run diverged while still passing command mode.",
       "expect": {
         "equals": {
-          "cash": -21150,
           "tickCount": 30,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "player"
@@ -968,13 +1046,15 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": -21150,
           "tickCount": 30,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -989,7 +1069,6 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": -21150,
           "tickCount": 30,
           "deathCount": 0,
           "employeeCount": 10,
@@ -1000,6 +1079,9 @@
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -1014,13 +1096,15 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": -28325,
           "tickCount": 45,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -7175
         }
       }
     },
@@ -1034,13 +1118,15 @@
       "description": "Resolved through the event dialog's own buttons. Decides whether an event is pending from authoritative game state, not from whether the modal has rendered -- a DOM-only probe silently missed events on a no-GPU runner where a frame costs ~6s, leaving them pending so later ticks halted and the run diverged while still passing command mode.",
       "expect": {
         "equals": {
-          "cash": -28325,
           "tickCount": 45,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "player"
@@ -1056,13 +1142,15 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": -42300,
           "tickCount": 60,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -13975
         }
       }
     },
@@ -1076,13 +1164,15 @@
       "description": "Resolved through the event dialog's own buttons. Decides whether an event is pending from authoritative game state, not from whether the modal has rendered -- a DOM-only probe silently missed events on a no-GPU runner where a frame costs ~6s, leaving them pending so later ticks halted and the run diverged while still passing command mode.",
       "expect": {
         "equals": {
-          "cash": -42300,
           "tickCount": 60,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "player"
@@ -1098,13 +1188,15 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": -49475,
           "tickCount": 75,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -7175
         }
       }
     },
@@ -1118,13 +1210,15 @@
       "description": "Resolved through the event dialog's own buttons. Decides whether an event is pending from authoritative game state, not from whether the modal has rendered -- a DOM-only probe silently missed events on a no-GPU runner where a frame costs ~6s, leaving them pending so later ticks halted and the run diverged while still passing command mode.",
       "expect": {
         "equals": {
-          "cash": -49475,
           "tickCount": 75,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "player"
@@ -1140,13 +1234,15 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": -49475,
           "tickCount": 75,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -1161,7 +1257,6 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": -49475,
           "tickCount": 75,
           "deathCount": 0,
           "employeeCount": 10,
@@ -1172,6 +1267,9 @@
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -1186,13 +1284,15 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": -63450,
           "tickCount": 90,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -13975
         }
       }
     },
@@ -1206,13 +1306,15 @@
       "description": "Resolved through the event dialog's own buttons. Decides whether an event is pending from authoritative game state, not from whether the modal has rendered -- a DOM-only probe silently missed events on a no-GPU runner where a frame costs ~6s, leaving them pending so later ticks halted and the run diverged while still passing command mode.",
       "expect": {
         "equals": {
-          "cash": -63450,
           "tickCount": 90,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": false,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "player"
@@ -1249,13 +1351,15 @@
       "description": "Resolved through the event dialog's own buttons. Decides whether an event is pending from authoritative game state, not from whether the modal has rendered -- a DOM-only probe silently missed events on a no-GPU runner where a frame costs ~6s, leaving them pending so later ticks halted and the run diverged while still passing command mode.",
       "expect": {
         "equals": {
-          "cash": -70625,
           "tickCount": 105,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": true,
           "levelEnded": true,
           "levelEndReason": "bankruptcy"
+        },
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "player"
@@ -1271,13 +1375,15 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": -84600,
           "tickCount": 120,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": true,
           "levelEnded": true,
           "levelEndReason": "bankruptcy"
+        },
+        "changedBy": {
+          "cash": -13975
         }
       }
     },
@@ -1291,13 +1397,15 @@
       "description": "Resolved through the event dialog's own buttons. Decides whether an event is pending from authoritative game state, not from whether the modal has rendered -- a DOM-only probe silently missed events on a no-GPU runner where a frame costs ~6s, leaving them pending so later ticks halted and the run diverged while still passing command mode.",
       "expect": {
         "equals": {
-          "cash": -84600,
           "tickCount": 120,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": true,
           "levelEnded": true,
           "levelEndReason": "bankruptcy"
+        },
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "player"
@@ -1313,13 +1421,15 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": -84600,
           "tickCount": 120,
           "deathCount": 0,
           "employeeCount": 10,
           "bankrupt": true,
           "levelEnded": true,
           "levelEndReason": "bankruptcy"
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -1334,7 +1444,6 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": -84600,
           "tickCount": 120,
           "deathCount": 0,
           "employeeCount": 10,
@@ -1345,6 +1454,9 @@
           "bankrupt": true,
           "levelEnded": true,
           "levelEndReason": "bankruptcy"
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -1366,7 +1478,9 @@
           "levelEnded": true,
           "levelEndReason": "bankruptcy"
         },
-        "decreased": ["cash"],
+        "decreased": [
+          "cash"
+        ],
         "note": "issues #596/#597: cash relaxed from equals to decreased -- which tick a random event becomes pending (and whether it costs money once resolved) now lands at a different point than before these fixes, so this batch's own cash delta is no longer safe to pin exactly. tickCount was re-measured via a real run (135, up from the pre-fix 130): this particular batch now completes its full 15 ticks without an early halt, unlike the very next `tick 15` below, which still gets interrupted at +10. tickCount stays a hardcoded exact figure -- deterministic for this seed/command sequence in command mode -- not a directional check."
       }
     },
@@ -1409,7 +1523,9 @@
           "levelEnded": true,
           "levelEndReason": "bankruptcy"
         },
-        "decreased": ["cash"],
+        "decreased": [
+          "cash"
+        ],
         "note": "issues #596/#597: cash relaxed to decreased, same event-timing class as the tick-130 checkpoint above. tickCount stays exact."
       }
     },
@@ -1452,7 +1568,9 @@
           "levelEnded": true,
           "levelEndReason": "bankruptcy"
         },
-        "decreased": ["cash"],
+        "decreased": [
+          "cash"
+        ],
         "note": "issues #596/#597: cash relaxed to decreased, same event-timing class as the checkpoints above. tickCount stays exact."
       }
     },
@@ -1541,7 +1659,9 @@
           "levelEnded": true,
           "levelEndReason": "bankruptcy"
         },
-        "decreased": ["cash"],
+        "decreased": [
+          "cash"
+        ],
         "note": "issues #596/#597: cash relaxed to decreased, same event-timing class as the checkpoints above. tickCount stays exact."
       }
     },
@@ -1584,7 +1704,9 @@
           "levelEnded": true,
           "levelEndReason": "bankruptcy"
         },
-        "decreased": ["cash"],
+        "decreased": [
+          "cash"
+        ],
         "note": "issues #596/#597: cash relaxed to decreased, same event-timing class as the checkpoints above. tickCount stays exact."
       }
     },

--- a/scripts/scenario-defs/level2-playthrough-win.json
+++ b/scripts/scenario-defs/level2-playthrough-win.json
@@ -42,13 +42,15 @@
       "description": "#553: crews the free drill_rig (vehicle #1) with the free driller (employee #1) staffed:true just hired -- unmanned, the rig is a mesh no queued drill_hole action can ever start against.",
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
           "activeContractCount": 0,
-          "surveyCount": 0,
-          "cash": 150000
+          "surveyCount": 0
         }
       }
     },
@@ -62,13 +64,15 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
           "activeContractCount": 0,
-          "surveyCount": 0,
-          "cash": 150000
+          "surveyCount": 0
         }
       },
       "description": "No `cash:` here on purpose: this command fails (tier-2 level, locked on a fresh campaign), so the run continues on the new_game world above and any override attached here would be discarded with it."
@@ -83,13 +87,15 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
           "activeContractCount": 0,
-          "surveyCount": 0,
-          "cash": 150000
+          "surveyCount": 0
         }
       }
     },
@@ -103,13 +109,15 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
           "activeContractCount": 0,
           "surveyCount": 0,
-          "cash": 150000,
           "wellBeing": 50,
           "safety": 50,
           "ecology": 50,
@@ -127,13 +135,15 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
           "activeContractCount": 0,
-          "surveyCount": 0,
-          "cash": 150000
+          "surveyCount": 0
         }
       }
     },
@@ -155,13 +165,15 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1200
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 6,
           "activeContractCount": 0,
-          "surveyCount": 0,
-          "cash": 148800
+          "surveyCount": 0
         }
       }
     },
@@ -179,13 +191,15 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1200
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 7,
           "activeContractCount": 0,
-          "surveyCount": 0,
-          "cash": 147600
+          "surveyCount": 0
         }
       }
     },
@@ -203,13 +217,15 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1000
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 8,
           "activeContractCount": 0,
-          "surveyCount": 0,
-          "cash": 146600
+          "surveyCount": 0
         }
       }
     },
@@ -227,13 +243,15 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1000
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 9,
           "activeContractCount": 0,
-          "surveyCount": 0,
-          "cash": 145600
+          "surveyCount": 0
         }
       }
     },
@@ -251,13 +269,15 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1500
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 10,
           "activeContractCount": 0,
-          "surveyCount": 0,
-          "cash": 144100
+          "surveyCount": 0
         }
       }
     },
@@ -275,13 +295,15 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1500
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 11,
           "activeContractCount": 0,
-          "surveyCount": 0,
-          "cash": 142600
+          "surveyCount": 0
         }
       }
     },
@@ -299,13 +321,15 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -800
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 12,
           "activeContractCount": 0,
-          "surveyCount": 0,
-          "cash": 141800
+          "surveyCount": 0
         }
       }
     },
@@ -319,13 +343,15 @@
       ],
       "description": "Left unmarked: hiring already grants the Rookie starting qualification (ROLE_STARTING_QUALIFICATION in Employee.ts); this only raises the level for the scenario's needs -- the player-facing path is `employee train`.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 12,
           "activeContractCount": 0,
-          "surveyCount": 0,
-          "cash": 141800
+          "surveyCount": 0
         }
       },
       "role": "bootstrap"
@@ -340,13 +366,15 @@
       ],
       "description": "Left unmarked: hiring already grants the Rookie starting qualification (ROLE_STARTING_QUALIFICATION in Employee.ts); this only raises the level for the scenario's needs -- the player-facing path is `employee train`.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 12,
           "activeContractCount": 0,
-          "surveyCount": 0,
-          "cash": 141800
+          "surveyCount": 0
         }
       },
       "role": "bootstrap"
@@ -361,13 +389,15 @@
       ],
       "description": "#553: driller #8 (this file's own first hired driller, renumbered from the pre-#553 file's #3 -- staffed's free crew claims #1-5) needs the drill_rig licence before any drill_hole action can be assigned to them -- hiring grants only the role's own starting qualification (blasting), never a driving licence. Left unmarked for the same reason as the other assign_skill steps in this file: the player-facing path is `employee train` at a driving_center. Driller #9 (this file's second hired driller) is deliberately left unlicensed, matching this file's own original design -- it never licensed either driller for driving.drill_rig, and #9 is not needed to crew the second rig bought below.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 12,
           "activeContractCount": 0,
-          "surveyCount": 0,
-          "cash": 141800
+          "surveyCount": 0
         }
       },
       "role": "bootstrap"
@@ -382,13 +412,15 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 12,
           "activeContractCount": 0,
-          "surveyCount": 0,
-          "cash": 141800
+          "surveyCount": 0
         }
       }
     },
@@ -402,13 +434,15 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 12,
           "activeContractCount": 0,
-          "surveyCount": 0,
-          "cash": 141800
+          "surveyCount": 0
         }
       }
     },
@@ -446,13 +480,15 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -3000
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 12,
           "activeContractCount": 0,
-          "surveyCount": 0,
-          "cash": 138800
+          "surveyCount": 0
         }
       }
     },
@@ -486,13 +522,15 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -800
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 12,
           "activeContractCount": 0,
-          "surveyCount": 0,
-          "cash": 138000
+          "surveyCount": 0
         }
       }
     },
@@ -526,13 +564,15 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1500
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 12,
           "activeContractCount": 0,
-          "surveyCount": 0,
-          "cash": 136500
+          "surveyCount": 0
         }
       }
     },
@@ -546,13 +586,15 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 12,
           "activeContractCount": 0,
-          "surveyCount": 0,
-          "cash": 136500
+          "surveyCount": 0
         }
       }
     },
@@ -566,13 +608,15 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 12,
           "activeContractCount": 0,
-          "surveyCount": 0,
-          "cash": 136500
+          "surveyCount": 0
         }
       }
     },

--- a/scripts/scenario-defs/level3-playthrough-ecology.json
+++ b/scripts/scenario-defs/level3-playthrough-ecology.json
@@ -42,12 +42,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 50000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -71,12 +73,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 60000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 10000
         }
       }
     },
@@ -100,12 +104,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 80000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 20000
         }
       }
     },
@@ -129,12 +135,14 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 92800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 12800
         }
       }
     },
@@ -150,12 +158,14 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": 92800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -170,12 +180,14 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": 92800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -190,7 +202,6 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 92800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
@@ -200,6 +211,9 @@
           "nuisance": 50,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -214,12 +228,14 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 92800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -261,7 +277,6 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 92800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
@@ -271,6 +286,9 @@
           "sequencedCount": 0,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -311,13 +329,15 @@
       "expect": {
         "equals": {
           "tickCount": 20,
-          "cash": 87212,
           "holeCount": 1,
           "orderedHoleCount": 19,
           "deathCount": 0,
           "employeeCount": 5,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -357,13 +377,15 @@
       "expect": {
         "equals": {
           "tickCount": 40,
-          "cash": 81612,
           "holeCount": 4,
           "orderedHoleCount": 16,
           "deathCount": 0,
           "employeeCount": 5,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -403,13 +425,15 @@
       "expect": {
         "equals": {
           "tickCount": 60,
-          "cash": 76060,
           "holeCount": 5,
           "orderedHoleCount": 15,
           "deathCount": 0,
           "employeeCount": 5,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -449,13 +473,15 @@
       "expect": {
         "equals": {
           "tickCount": 80,
-          "cash": 70508,
           "holeCount": 8,
           "orderedHoleCount": 12,
           "deathCount": 0,
           "employeeCount": 5,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -495,13 +521,15 @@
       "expect": {
         "equals": {
           "tickCount": 100,
-          "cash": 64882,
           "holeCount": 9,
           "orderedHoleCount": 11,
           "deathCount": 0,
           "employeeCount": 5,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -541,13 +569,15 @@
       "expect": {
         "equals": {
           "tickCount": 120,
-          "cash": 59378,
           "holeCount": 10,
           "orderedHoleCount": 10,
           "deathCount": 0,
           "employeeCount": 5,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -587,13 +617,15 @@
       "expect": {
         "equals": {
           "tickCount": 140,
-          "cash": 53790,
           "holeCount": 12,
           "orderedHoleCount": 8,
           "deathCount": 0,
           "employeeCount": 5,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -633,13 +665,15 @@
       "expect": {
         "equals": {
           "tickCount": 160,
-          "cash": 48066,
           "holeCount": 13,
           "orderedHoleCount": 7,
           "deathCount": 0,
           "employeeCount": 5,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -679,13 +713,15 @@
       "expect": {
         "equals": {
           "tickCount": 180,
-          "cash": 42464,
           "holeCount": 15,
           "orderedHoleCount": 5,
           "deathCount": 0,
           "employeeCount": 5,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -725,13 +761,15 @@
       "expect": {
         "equals": {
           "tickCount": 200,
-          "cash": 36894,
           "holeCount": 16,
           "orderedHoleCount": 4,
           "deathCount": 0,
           "employeeCount": 5,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -771,13 +809,15 @@
       "expect": {
         "equals": {
           "tickCount": 220,
-          "cash": 31360,
           "holeCount": 18,
           "orderedHoleCount": 2,
           "deathCount": 0,
           "employeeCount": 5,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -817,13 +857,15 @@
       "expect": {
         "equals": {
           "tickCount": 240,
-          "cash": 25588,
           "holeCount": 20,
           "orderedHoleCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -863,13 +905,15 @@
       "expect": {
         "equals": {
           "tickCount": 260,
-          "cash": 20088,
           "holeCount": 20,
           "orderedHoleCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -893,7 +937,6 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 19088,
           "tickCount": 260,
           "holeCount": 20,
           "orderedHoleCount": 0,
@@ -901,6 +944,9 @@
           "employeeCount": 6,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -1000
         }
       }
     },
@@ -919,7 +965,6 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 18088,
           "tickCount": 260,
           "holeCount": 20,
           "orderedHoleCount": 0,
@@ -927,6 +972,9 @@
           "employeeCount": 7,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -1000
         }
       }
     },
@@ -945,7 +993,6 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 17088,
           "tickCount": 260,
           "holeCount": 20,
           "orderedHoleCount": 0,
@@ -953,6 +1000,9 @@
           "employeeCount": 8,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -1000
         }
       }
     },
@@ -971,7 +1021,6 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 15588,
           "tickCount": 260,
           "holeCount": 20,
           "orderedHoleCount": 0,
@@ -979,6 +1028,9 @@
           "employeeCount": 9,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -1500
         }
       }
     },
@@ -997,7 +1049,6 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 14088,
           "tickCount": 260,
           "holeCount": 20,
           "orderedHoleCount": 0,
@@ -1005,6 +1056,9 @@
           "employeeCount": 10,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -1500
         }
       }
     },
@@ -1023,7 +1077,6 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 12588,
           "tickCount": 260,
           "holeCount": 20,
           "orderedHoleCount": 0,
@@ -1031,6 +1084,9 @@
           "employeeCount": 11,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -1500
         }
       }
     },
@@ -1049,7 +1105,6 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 11788,
           "tickCount": 260,
           "holeCount": 20,
           "orderedHoleCount": 0,
@@ -1057,6 +1112,9 @@
           "employeeCount": 12,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": -800
         }
       }
     },
@@ -1071,7 +1129,6 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 11788,
           "tickCount": 260,
           "holeCount": 20,
           "orderedHoleCount": 0,
@@ -1079,6 +1136,9 @@
           "employeeCount": 12,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -1093,7 +1153,6 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "cash": 11788,
           "tickCount": 260,
           "holeCount": 20,
           "orderedHoleCount": 0,
@@ -1101,6 +1160,9 @@
           "employeeCount": 12,
           "levelEnded": false,
           "levelEndReason": null
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -1116,7 +1178,6 @@
       "expect": {
         "equals": {
           "tickCount": 265,
-          "cash": 11768,
           "holeCount": 20,
           "orderedHoleCount": 0,
           "deathCount": 0,
@@ -1124,6 +1185,9 @@
           "levelEnded": false,
           "levelEndReason": null
         },
+        "decreased": [
+          "cash"
+        ],
         "note": "#553: payroll for all 12 employees is now live. This tick lands mid-event (5 of the requested 20 ticks -- \"Advanced 5 of 20 requested ticks\") because a real event fires at tick 265; the event choose 0 step right after resolves it before the next tick block can run."
       }
     },

--- a/scripts/scenario-defs/level3-playthrough-win.json
+++ b/scripts/scenario-defs/level3-playthrough-win.json
@@ -41,8 +41,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 220000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
@@ -62,8 +64,10 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 220000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
@@ -83,8 +87,10 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 220000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
@@ -103,8 +109,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 220000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
@@ -127,8 +135,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 220000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 5,
@@ -155,8 +165,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1200
+        },
         "equals": {
-          "cash": 218800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 6,
@@ -180,8 +192,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1200
+        },
         "equals": {
-          "cash": 217600,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 7,
@@ -204,8 +218,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1000
+        },
         "equals": {
-          "cash": 216600,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 8,
@@ -228,8 +244,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1000
+        },
         "equals": {
-          "cash": 215600,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 9,
@@ -252,8 +270,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1000
+        },
         "equals": {
-          "cash": 214600,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 10,
@@ -276,8 +296,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1500
+        },
         "equals": {
-          "cash": 213100,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 11,
@@ -300,8 +322,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1500
+        },
         "equals": {
-          "cash": 211600,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 12,
@@ -324,8 +348,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -800
+        },
         "equals": {
-          "cash": 210800,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 13,
@@ -348,8 +374,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -800
+        },
         "equals": {
-          "cash": 210000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 14,
@@ -372,8 +400,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -2000
+        },
         "equals": {
-          "cash": 208000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 15,
@@ -392,8 +422,10 @@
       ],
       "role": "bootstrap",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 208000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 15,
@@ -413,8 +445,10 @@
       ],
       "role": "bootstrap",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 208000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 15,
@@ -434,8 +468,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 208000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 15,
@@ -454,8 +490,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 208000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 15,
@@ -498,8 +536,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -3000
+        },
         "equals": {
-          "cash": 205000,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 15,
@@ -538,8 +578,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -800
+        },
         "equals": {
-          "cash": 204200,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 15,
@@ -578,8 +620,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1500
+        },
         "equals": {
-          "cash": 202700,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 15,
@@ -598,8 +642,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 202700,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 15,
@@ -618,8 +664,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 202700,
           "tickCount": 0,
           "deathCount": 0,
           "employeeCount": 15,
@@ -638,8 +686,10 @@
       ],
       "role": "setup",
       "expect": {
+        "decreased": [
+          "cash"
+        ],
         "equals": {
-          "cash": 202572,
           "tickCount": 8,
           "deathCount": 0,
           "employeeCount": 15,
@@ -658,8 +708,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 202572,
           "tickCount": 8,
           "deathCount": 0,
           "employeeCount": 15,
@@ -679,8 +731,10 @@
       ],
       "role": "setup",
       "expect": {
+        "decreased": [
+          "cash"
+        ],
         "equals": {
-          "cash": 192594,
           "tickCount": 16,
           "deathCount": 0,
           "employeeCount": 15,
@@ -698,8 +752,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 192594,
           "tickCount": 16,
           "deathCount": 0,
           "employeeCount": 15,
@@ -719,8 +775,10 @@
       ],
       "role": "setup",
       "expect": {
+        "decreased": [
+          "cash"
+        ],
         "equals": {
-          "cash": 182616,
           "tickCount": 24,
           "deathCount": 0,
           "employeeCount": 15,
@@ -738,8 +796,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 182616,
           "tickCount": 24,
           "deathCount": 0,
           "employeeCount": 15,
@@ -759,8 +819,10 @@
       ],
       "role": "setup",
       "expect": {
+        "decreased": [
+          "cash"
+        ],
         "equals": {
-          "cash": 172638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -778,8 +840,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 172638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -799,8 +863,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 172638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -819,8 +885,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 172638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -839,8 +907,10 @@
       ],
       "role": "bootstrap",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 172638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -860,8 +930,10 @@
       ],
       "role": "bootstrap",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 172638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -881,8 +953,10 @@
       ],
       "role": "bootstrap",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 172638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -902,8 +976,10 @@
       ],
       "role": "bootstrap",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 172638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -923,8 +999,10 @@
       ],
       "role": "bootstrap",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 172638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -944,8 +1022,10 @@
       ],
       "role": "bootstrap",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 172638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -965,8 +1045,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 172638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -985,8 +1067,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 172638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -1013,8 +1097,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -50000
+        },
         "equals": {
-          "cash": 122638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -1038,8 +1124,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -25000
+        },
         "equals": {
-          "cash": 97638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -1063,8 +1151,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -35000
+        },
         "equals": {
-          "cash": 62638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -1088,8 +1178,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -30000
+        },
         "equals": {
-          "cash": 32638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -1113,8 +1205,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -25000
+        },
         "equals": {
-          "cash": 7638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -1134,8 +1228,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 7638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -1154,8 +1250,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 7638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -1174,8 +1272,10 @@
       ],
       "role": "bootstrap",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 7638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -1199,8 +1299,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 7638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -1246,8 +1348,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 7638,
           "tickCount": 32,
           "deathCount": 0,
           "employeeCount": 15,
@@ -1560,9 +1664,11 @@
       ],
       "role": "guard",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 410,
-          "cash": -387412,
           "deathCount": 0,
           "employeeCount": 15,
           "activeContractCount": 0,
@@ -1585,9 +1691,11 @@
       ],
       "role": "guard",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 410,
-          "cash": -387412,
           "deathCount": 0,
           "employeeCount": 15,
           "activeContractCount": 0,
@@ -1610,9 +1718,11 @@
       ],
       "role": "guard",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 410,
-          "cash": -387412,
           "deathCount": 11,
           "employeeCount": 15,
           "activeContractCount": 0,
@@ -1635,9 +1745,11 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 410,
-          "cash": -387412,
           "deathCount": 11,
           "employeeCount": 15,
           "activeContractCount": 0,
@@ -1655,9 +1767,11 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 410,
-          "cash": -387412,
           "deathCount": 11,
           "employeeCount": 15,
           "activeContractCount": 0,
@@ -1675,9 +1789,11 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 410,
-          "cash": -387412,
           "deathCount": 11,
           "employeeCount": 15,
           "activeContractCount": 0,
@@ -1700,9 +1816,11 @@
       ],
       "role": "setup",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 410,
-          "cash": -387412,
           "deathCount": 11,
           "employeeCount": 15,
           "activeContractCount": 0,
@@ -1721,9 +1839,11 @@
       ],
       "role": "guard",
       "expect": {
+        "changedBy": {
+          "cash": 10000
+        },
         "equals": {
           "tickCount": 410,
-          "cash": -377412,
           "deathCount": 11,
           "employeeCount": 15,
           "activeContractCount": 0,
@@ -1743,9 +1863,11 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 410,
-          "cash": -377412,
           "deathCount": 11,
           "employeeCount": 15,
           "activeContractCount": 0,
@@ -1763,9 +1885,11 @@
       ],
       "role": "guard",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 410,
-          "cash": -377412,
           "deathCount": 11,
           "employeeCount": 15,
           "activeContractCount": 1,
@@ -1785,9 +1909,11 @@
       ],
       "role": "guard",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 410,
-          "cash": -377412,
           "deathCount": 11,
           "employeeCount": 15,
           "activeContractCount": 1,
@@ -1807,9 +1933,11 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 410,
-          "cash": -377412,
           "deathCount": 11,
           "employeeCount": 15,
           "activeContractCount": 1,
@@ -1827,9 +1955,11 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "tickCount": 410,
-          "cash": -377412,
           "deathCount": 11,
           "employeeCount": 15,
           "activeContractCount": 1,

--- a/scripts/scenario-defs/main-menu-visual.json
+++ b/scripts/scenario-defs/main-menu-visual.json
@@ -89,8 +89,8 @@
       ],
       "role": "setup",
       "expect": {
-        "equals": {
-          "cash": 50000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -114,8 +114,8 @@
       ],
       "role": "setup",
       "expect": {
-        "equals": {
-          "cash": 50000
+        "changedBy": {
+          "cash": 0
         },
         "note": "confirmed via direct trace: cash stays flat with no employees/buildings/vehicles to drain it"
       }

--- a/scripts/scenario-defs/nav-cell-types-visual.json
+++ b/scripts/scenario-defs/nav-cell-types-visual.json
@@ -112,8 +112,8 @@
       "role": "player",
       "expect": {
         "increased": ["buildingCount"],
-        "equals": {
-          "cash": 21544
+        "changedBy": {
+          "cash": -8000
         },
         "note": "management_office tier 1 costs 8000 (BuildingDefs.ts constructionCost) off the $29,544 the site had left after the #553 drilling wait. $29,544, not $29,356: the drill_plan command above now passes diameter:0.089, matching the Drill panel's own DEFAULT_DIAMETER_M (Drill.ts) that the click always used — computeDrillHoleDurationTicks (DrillPlan.ts) scales duration by diameter, so the console text used to drill each hole ~2 ticks slower than the click's real grid (0.15m default vs 0.089m), leaving the drill_rig busy (fuelCostPerTick+maintenanceCostPerTick, balance.ts) for 18 more ticks across all 9 holes and draining $188 more than the real click ever did."
       }
@@ -150,8 +150,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 20544
+        "changedBy": {
+          "cash": -1000
         },
         "note": "confirmed against the real state dump (1000 for this 10-tile ramp), not computed from the pricing formula. 20544 carries forward the +188 diameter fix from the office step above (21544-1000)."
       }

--- a/scripts/scenario-defs/nav-dynamic-updates-visual.json
+++ b/scripts/scenario-defs/nav-dynamic-updates-visual.json
@@ -218,8 +218,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -25000
+        },
         "equals": {
-          "cash": 16318,
           "vehicleCount": 4
         }
       }
@@ -259,8 +261,10 @@
       "description": "Real click path: select hauler #5 in the 3D scene (#553: the just-bought debris_hauler is the fleet's 5th vehicle under staffed:true, not its 1st), rest the cursor on the destination tile, then press the selection bar's MOVE HERE. The old description here claimed no UI drives this command and none should exist -- that is false since the SelectionBar gained `move_here` (G4), and it was only unusable with a mouse until ScenePicking started latching `.aim` separately from the live hover (47f4fef). cameraFocus sits at z=16.5, one tile past the target: at the default orbit the camera ray hits terrain about a tile short of its focus point, so the offset was calibrated in a real browser until the dispatched command read exactly `vehicle move 5 to:15,15`. Never adjust the camera focus offset arithmetically -- re-measure.",
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 16318,
           "vehicleCount": 4
         }
       }

--- a/scripts/scenario-defs/nav-minimap-integration-visual.json
+++ b/scripts/scenario-defs/nav-minimap-integration-visual.json
@@ -112,10 +112,10 @@
       "role": "player",
       "expect": {
         "increased": ["buildingCount"],
-        "equals": {
-          "cash": 21544
+        "changedBy": {
+          "cash": -8000
         },
-        "note": "management_office tier 1 costs 8000 (BuildingDefs.ts constructionCost) off the $29,544 the site had left after the #553 drilling wait. $29,544, not $29,356: the drill_plan command above now passes diameter:0.089, matching the Drill panel's own DEFAULT_DIAMETER_M (Drill.ts) that the click always used — computeDrillHoleDurationTicks (DrillPlan.ts) scales duration by diameter, so the console text used to drill each hole ~2 ticks slower than the click's real grid (0.15m default vs 0.089m), leaving the drill_rig busy (fuelCostPerTick+maintenanceCostPerTick, balance.ts) for 18 more ticks across all 9 holes and draining $188 more than the real click ever did."
+        "note": "management_office tier 1 costs 8000 (BuildingDefs.ts constructionCost). $29,544, not $29,356: the drill_plan command above now passes diameter:0.089, matching the Drill panel's own DEFAULT_DIAMETER_M (Drill.ts) that the click always used — computeDrillHoleDurationTicks (DrillPlan.ts) scales duration by diameter, so the console text used to drill each hole ~2 ticks slower than the click's real grid (0.15m default vs 0.089m), leaving the drill_rig busy (fuelCostPerTick+maintenanceCostPerTick, balance.ts) for 18 more ticks across all 9 holes and draining $188 more than the real click ever did."
       }
     },
     {
@@ -149,8 +149,8 @@
       "role": "player",
       "expect": {
         "increased": ["buildingCount"],
-        "equals": {
-          "cash": 13544
+        "changedBy": {
+          "cash": -8000
         }
       }
     },
@@ -173,8 +173,8 @@
       "role": "player",
       "expect": {
         "increased": ["employeeCount"],
-        "equals": {
-          "cash": 12544
+        "changedBy": {
+          "cash": -1000
         },
         "note": "HIRING_COSTS.driller is 1000 (balance.ts)"
       }

--- a/scripts/scenario-defs/nav-move-costs-visual.json
+++ b/scripts/scenario-defs/nav-move-costs-visual.json
@@ -110,8 +110,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 46128,
           "buildingCount": 1
+        },
+        "changedBy": {
+          "cash": -8000
         }
       }
     },
@@ -135,8 +137,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 21128,
           "vehicleCount": 5
+        },
+        "changedBy": {
+          "cash": -25000
         }
       }
     },
@@ -175,8 +179,8 @@
       "description": "Real click path: select hauler #5 in the 3D scene (#553: the just-bought debris_hauler is the fleet's 5th vehicle under staffed:true, not its 1st), rest the cursor on (5,9), then press the selection bar's MOVE HERE. The old description here claimed no UI drives this command and none should exist -- false since the SelectionBar gained `move_here` (G4), usable with a mouse since ScenePicking started latching `.aim` (47f4fef). The focus point is the tile centre here, which is where the camera ray lands on this flat stretch; it was measured in a real browser (dispatched command read `vehicle move 5 to:5,9`), not assumed -- other tiles need an offset, so re-measure rather than copy.",
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 21128
+        "changedBy": {
+          "cash": 0
         }
       }
     },

--- a/scripts/scenario-defs/nav-path-following-visual.json
+++ b/scripts/scenario-defs/nav-path-following-visual.json
@@ -37,8 +37,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 49000,
           "employeeCount": 1
+        },
+        "changedBy": {
+          "cash": -1000
         }
       }
     },
@@ -57,8 +59,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 48000,
           "employeeCount": 2
+        },
+        "changedBy": {
+          "cash": -1000
         }
       }
     },
@@ -82,8 +86,8 @@
         }
       ],
       "expect": {
-        "equals": {
-          "cash": 48000
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "bootstrap"

--- a/scripts/scenario-defs/nav-pathfinding-visual.json
+++ b/scripts/scenario-defs/nav-pathfinding-visual.json
@@ -163,8 +163,8 @@
         }
       ],
       "expect": {
-        "equals": {
-          "cash": 25000
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "bootstrap"

--- a/scripts/scenario-defs/nav-ramp-routing-visual.json
+++ b/scripts/scenario-defs/nav-ramp-routing-visual.json
@@ -83,8 +83,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 25000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -189,8 +189,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 23960
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -228,8 +228,8 @@
         }
       ],
       "expect": {
-        "equals": {
-          "cash": 22960
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "bootstrap"

--- a/scripts/scenario-defs/needs-collapse-visual.json
+++ b/scripts/scenario-defs/needs-collapse-visual.json
@@ -39,8 +39,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 99000,
           "employeeCount": 1
+        },
+        "changedBy": {
+          "cash": -1000
         }
       }
     },
@@ -59,8 +61,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 97500,
           "employeeCount": 2
+        },
+        "changedBy": {
+          "cash": -1500
         }
       }
     },

--- a/scripts/scenario-defs/needs-cost-visual.json
+++ b/scripts/scenario-defs/needs-cost-visual.json
@@ -37,8 +37,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1000
+        },
         "equals": {
-          "cash": 49000,
           "employeeCount": 1
         }
       }

--- a/scripts/scenario-defs/needs-cycle.json
+++ b/scripts/scenario-defs/needs-cycle.json
@@ -47,8 +47,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 49000,
           "employeeCount": 1
+        },
+        "changedBy": {
+          "cash": -1000
         }
       }
     },
@@ -63,8 +65,10 @@
       "description": "Left unmarked: \"hauler\" isn't a real hire role (commandOutput: \"Usage: employee hire role:(driller|blaster|driver|surveyor|manager)\") -- there is no hire button for it, this step is a genuine no-op in both modes.",
       "expect": {
         "equals": {
-          "cash": 49000,
           "employeeCount": 1
+        },
+        "changedBy": {
+          "cash": 0
         },
         "note": "confirms the fake-role hire is a real no-op, not a silent success"
       },
@@ -85,8 +89,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 47800,
           "employeeCount": 2
+        },
+        "changedBy": {
+          "cash": -1200
         }
       }
     },
@@ -121,8 +127,10 @@
       "description": "Per #526: was `build canteen at:5,5`, a phantom BuildingType (commandOutput: \"Unknown subcommand or building type\") with no catalog row to click -- \"canteen\" maps to the real living_quarters building, which is what all three need gauges (hunger, fatigue, breakNeed) actually replenish against (NEED_REST_BUILDING_TYPES, balance.ts). Converted to a real player click on the Build panel, following building-menu-visual.json's pickTile pattern.",
       "expect": {
         "equals": {
-          "cash": 37800,
           "buildingCount": 1
+        },
+        "changedBy": {
+          "cash": -10000
         },
         "note": "cash 47800 - living_quarters tier-1 constructionCost 10000 (BuildingDefs.ts) = 37800"
       },

--- a/scripts/scenario-defs/needs-drain-visual.json
+++ b/scripts/scenario-defs/needs-drain-visual.json
@@ -37,8 +37,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1000
+        },
         "equals": {
-          "cash": 49000,
           "employeeCount": 1
         }
       }

--- a/scripts/scenario-defs/needs-gauges-visual.json
+++ b/scripts/scenario-defs/needs-gauges-visual.json
@@ -38,8 +38,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 49000,
           "employeeCount": 1
+        },
+        "changedBy": {
+          "cash": -1000
         }
       }
     },
@@ -58,8 +60,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 47500,
           "employeeCount": 2
+        },
+        "changedBy": {
+          "cash": -1500
         }
       }
     },
@@ -78,8 +82,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 46700,
           "employeeCount": 3
+        },
+        "changedBy": {
+          "cash": -800
         }
       }
     },

--- a/scripts/scenario-defs/needs-morale-visual.json
+++ b/scripts/scenario-defs/needs-morale-visual.json
@@ -37,8 +37,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1000
+        },
         "equals": {
-          "cash": 49000,
           "employeeCount": 1
         }
       }

--- a/scripts/scenario-defs/needs-proactive-queue-visual.json
+++ b/scripts/scenario-defs/needs-proactive-queue-visual.json
@@ -38,8 +38,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 49000,
           "employeeCount": 1
+        },
+        "changedBy": {
+          "cash": -1000
         }
       }
     },

--- a/scripts/scenario-defs/needs-replenishment-visual.json
+++ b/scripts/scenario-defs/needs-replenishment-visual.json
@@ -38,8 +38,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 49000,
           "employeeCount": 1
+        },
+        "changedBy": {
+          "cash": -1000
         }
       }
     },

--- a/scripts/scenario-defs/needs-shift-cycle-visual.json
+++ b/scripts/scenario-defs/needs-shift-cycle-visual.json
@@ -37,8 +37,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1000
+        },
         "equals": {
-          "cash": 49000,
           "employeeCount": 1
         }
       }
@@ -73,8 +75,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -10000
+        },
         "equals": {
-          "cash": 39000,
           "buildingCount": 1
         }
       }
@@ -89,8 +93,10 @@
       ],
       "description": "role: player (issue #515): building #1's Upgrade button is present and ENABLED — `upgradeBtn.disabled` (BuildMenu.ts) only checks `nextTier === null` or affordability, not the research lock. A real click intercepts client-side and never even issues `build upgrade 1` — the same observable outcome (buildingCount/cash unchanged) as the console command's own rejection. Not `guard`: the button is reachable, just ineffective while locked.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 39000,
           "buildingCount": 1
         },
         "note": "rejected: Tier 2 living_quarters is not researched — this is Finding #27's root cause, confirmed here in state too"
@@ -115,8 +121,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 39000
+        "changedBy": {
+          "cash": 0
         },
         "note": "the policy applies for real (confirmed via a real dump: 'Policy updated: mode=shift_8h hunger=40 fatigue=25 social=20'), but has no shift-cycle effect to observe since the tier-2 bunkhouse gate is never met (Finding #27)"
       }
@@ -131,8 +137,10 @@
         }
       ],
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 39000,
           "employeeCount": 1
         }
       },

--- a/scripts/scenario-defs/ramp-navigation.json
+++ b/scripts/scenario-defs/ramp-navigation.json
@@ -51,8 +51,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 49000
+        "changedBy": {
+          "cash": -1000
         },
         "note": "10m ramp x RAMP_COST_PER_METER (balance.ts) = 1000; a ramp carves the voxel grid directly rather than creating a tracked entity (no rampCount field exists to check), so a real cash deduction is the strongest state-level proof available that the build actually landed"
       }
@@ -75,9 +75,11 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1200
+        },
         "equals": {
-          "employeeCount": 1,
-          "cash": 47800
+          "employeeCount": 1
         },
         "note": "HIRING_COSTS.surveyor = 1200 (balance.ts)"
       }

--- a/scripts/scenario-defs/research-center-gate.json
+++ b/scripts/scenario-defs/research-center-gate.json
@@ -26,7 +26,8 @@
         { "type": "clickSelector", "selector": "#bs-tile-select-confirm" }
       ],
       "expect": {
-        "equals": { "buildingCount": 1, "cash": 70000 }
+        "equals": { "buildingCount": 1 },
+        "changedBy": { "cash": -10000 }
       }
     },
     {
@@ -37,7 +38,8 @@
         { "type": "clickSelector", "selector": "#bs-build-panel .bs-build-placed-row[data-building-id=\"1\"] .bs-build-research-btn" }
       ],
       "expect": {
-        "equals": { "buildingCount": 1, "cash": 70000 },
+        "equals": { "buildingCount": 1 },
+        "changedBy": { "cash": 0 },
         "note": "Cash unchanged and no research queued proves the click was rejected (#442's prerequisite gate), not silently swallowed."
       }
     },
@@ -53,7 +55,8 @@
         { "type": "clickSelector", "selector": "#bs-tile-select-confirm" }
       ],
       "expect": {
-        "equals": { "buildingCount": 2, "cash": 45000 }
+        "equals": { "buildingCount": 2 },
+        "changedBy": { "cash": -25000 }
       }
     },
     {
@@ -64,7 +67,7 @@
         { "type": "clickSelector", "selector": "#bs-build-panel .bs-build-placed-row[data-building-id=\"1\"] .bs-build-research-btn" }
       ],
       "expect": {
-        "equals": { "cash": 40000 },
+        "changedBy": { "cash": -5000 },
         "note": "Cash dropped by exactly the tier-2 cost-only research price ($5,000, 0 ticks, no conditions per RESEARCH_TASK_DEFS) — the task actually queued this time, purely from clicking."
       }
     },

--- a/scripts/scenario-defs/rock-fragmenter-breaking.json
+++ b/scripts/scenario-defs/rock-fragmenter-breaking.json
@@ -39,8 +39,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "employeeCount": 1,
-          "cash": 149000
+          "employeeCount": 1
+        },
+        "changedBy": {
+          "cash": -1000
         }
       }
     },
@@ -63,8 +65,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "vehicleCount": 1,
-          "cash": 114000
+          "vehicleCount": 1
+        },
+        "changedBy": {
+          "cash": -35000
         }
       }
     },
@@ -80,8 +84,10 @@
       "role": "bootstrap",
       "expect": {
         "equals": {
-          "cash": 114000,
           "qualificationCount": 2
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -146,10 +152,12 @@
       "expect": {
         "equals": {
           "orderedHoleCount": 0,
-          "holeCount": 4,
-          "cash": 108622
+          "holeCount": 4
         },
-        "note": "All 4 holes have landed — none lost, none left ordered forever."
+        "decreased": [
+          "cash"
+        ],
+        "note": "All 4 holes have landed — none lost, none left ordered forever. cash drains from payroll/upkeep across the 80-tick wait; not pinned exactly since interaction mode's real wall-clock ticking (isPaused:false by default) can extend the drain beyond command mode's headless tick N (same class as this file's later tick-block checkpoints)."
       }
     },
     {
@@ -257,8 +265,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "employeeCount": 2,
-          "cash": 107822
+          "employeeCount": 2
+        },
+        "changedBy": {
+          "cash": -800
         },
         "note": "HIRING_COSTS.driver = 800 (balance.ts)"
       }
@@ -308,8 +318,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "vehicleCount": 1,
-          "cash": 82822
+          "vehicleCount": 1
+        },
+        "changedBy": {
+          "cash": -25000
         },
         "note": "debris_hauler tier-1 purchaseCost = 25000 (balance.ts); vehicleCount is 1, not 2, because the blast above destroyed vehicle #1 (the drill_rig)"
       }

--- a/scripts/scenario-defs/safety-projection-visual.json
+++ b/scripts/scenario-defs/safety-projection-visual.json
@@ -48,8 +48,8 @@
       ],
       "description": "Left unmarked, confirmed not equivalent (not merely unverified): Fire.ts's Sound the Horn button (`[data-action=\"sound-horn\"]`) sends `zone clear` using `currentZone = computeDangerZone(state.drillHoles, BLAST_DANGER_MARGIN_M)` -- a rectangle derived from the live drill plan, never a player-typed one. At this point in the file state.drillHoles is empty (the file's only drill_plan step runs later), so computeDangerZone returns null, this.currentZone is null, and the horn button is disabled outright (occupants defaults to [] when zone is null, and hornBtn.disabled = occupants.length === 0) -- soundHorn() itself also no-ops on a null zone (`if (!zone) return;`). A player cannot produce this command by clicking here: not a different rectangle, but a control that doesn't work yet at this point in the scenario. (Later in the file, once the 4x4/spacing:3 grid at (20,20) exists, computeDangerZone's own padding would still produce (5,5,44,44), not this step's literal (5,5,35,35) -- so even a same-moment click would diverge from this explicit rectangle.)",
       "expect": {
-        "equals": {
-          "cash": 250000
+        "changedBy": {
+          "cash": 0
         },
         "note": "no state field exposes zone bounds/status -- proven instead by the zone status observe step's own text output"
       },

--- a/scripts/scenario-defs/sandbox-mode.json
+++ b/scripts/scenario-defs/sandbox-mode.json
@@ -42,10 +42,12 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
           "orderedHoleCount": 4,
-          "holeCount": 0,
-          "cash": 50000
+          "holeCount": 0
         }
       }
     },

--- a/scripts/scenario-defs/save-load-visual.json
+++ b/scripts/scenario-defs/save-load-visual.json
@@ -93,8 +93,8 @@
       ],
       "role": "bootstrap",
       "expect": {
-        "equals": {
-          "cash": 84000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -108,8 +108,8 @@
       ],
       "role": "setup",
       "expect": {
-        "equals": {
-          "cash": 83360
+        "changedBy": {
+          "cash": -640
         },
         "note": "#553: no longer flat -- the driller/drill_rig now on the roster drain payroll/maintenance even while idle, unlike the pre-#553 empty roster this file used to open with."
       }
@@ -134,8 +134,8 @@
       ],
       "role": "setup",
       "expect": {
-        "equals": {
-          "cash": 82720
+        "changedBy": {
+          "cash": -640
         }
       }
     },
@@ -179,8 +179,8 @@
         }
       ],
       "expect": {
-        "equals": {
-          "cash": 82720
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "setup"
@@ -200,8 +200,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 82720
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -224,8 +224,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 82720
+        "changedBy": {
+          "cash": 0
         },
         "note": "the real UI slot_1 here goes through SavesModal.ts's own IndexedDB-backed persistence -- a completely separate backend from the console save/load commands' in-memory quickSaveSlots map used above. This is the actual save the later load step reads back."
       }
@@ -308,9 +308,11 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "chargedCount": 4,
-          "cash": 77994
+          "chargedCount": 4
         }
       }
     },

--- a/scripts/scenario-defs/scene-picking-visual.json
+++ b/scripts/scenario-defs/scene-picking-visual.json
@@ -71,8 +71,8 @@
       "role": "player",
       "expect": {
         "increased": ["buildingCount"],
-        "equals": {
-          "cash": 42000
+        "changedBy": {
+          "cash": -8000
         },
         "note": "management_office tier 1 costs 8000 (BuildingDefs.ts constructionCost)"
       }
@@ -229,8 +229,8 @@
       "role": "player",
       "expect": {
         "increased": ["employeeCount"],
-        "equals": {
-          "cash": 41000
+        "changedBy": {
+          "cash": -1000
         },
         "note": "HIRING_COSTS.driller is 1000 (balance.ts); cash was 42000 after the management_office purchase above"
       }

--- a/scripts/scenario-defs/skill-progression.json
+++ b/scripts/scenario-defs/skill-progression.json
@@ -61,9 +61,11 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1000
+        },
         "equals": {
-          "employeeCount": 1,
-          "cash": 49000
+          "employeeCount": 1
         }
       }
     },

--- a/scripts/scenario-defs/survey-confidence-display.json
+++ b/scripts/scenario-defs/survey-confidence-display.json
@@ -61,9 +61,11 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1200
+        },
         "equals": {
-          "employeeCount": 1,
-          "cash": 48800
+          "employeeCount": 1
         },
         "note": "HIRING_COSTS.surveyor = 1200 (balance.ts)"
       }
@@ -99,9 +101,11 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1200
+        },
         "equals": {
-          "employeeCount": 2,
-          "cash": 47600
+          "employeeCount": 2
         }
       }
     },

--- a/scripts/scenario-defs/survey-confidence-overlay.json
+++ b/scripts/scenario-defs/survey-confidence-overlay.json
@@ -97,9 +97,11 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1200
+        },
         "equals": {
-          "employeeCount": 1,
-          "cash": 48800
+          "employeeCount": 1
         }
       }
     },
@@ -117,9 +119,11 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1200
+        },
         "equals": {
-          "employeeCount": 2,
-          "cash": 47600
+          "employeeCount": 2
         }
       }
     },

--- a/scripts/scenario-defs/survey-execution.json
+++ b/scripts/scenario-defs/survey-execution.json
@@ -62,8 +62,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "employeeCount": 1,
-          "cash": 48800
+          "employeeCount": 1
+        },
+        "changedBy": {
+          "cash": -1200
         }
       }
     },

--- a/scripts/scenario-defs/survey-method-selection.json
+++ b/scripts/scenario-defs/survey-method-selection.json
@@ -61,9 +61,11 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1200
+        },
         "equals": {
-          "employeeCount": 1,
-          "cash": 48800
+          "employeeCount": 1
         }
       }
     },

--- a/scripts/scenario-defs/survey-ore-vein-visibility.json
+++ b/scripts/scenario-defs/survey-ore-vein-visibility.json
@@ -63,8 +63,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "employeeCount": 1,
-          "cash": 198800
+          "employeeCount": 1
+        },
+        "changedBy": {
+          "cash": -1200
         }
       }
     },

--- a/scripts/scenario-defs/survey-overlay-lifecycle.json
+++ b/scripts/scenario-defs/survey-overlay-lifecycle.json
@@ -79,8 +79,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "employeeCount": 1,
-          "cash": 198800
+          "employeeCount": 1
+        },
+        "changedBy": {
+          "cash": -1200
         }
       }
     },
@@ -99,8 +101,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "employeeCount": 2,
-          "cash": 197600
+          "employeeCount": 2
+        },
+        "changedBy": {
+          "cash": -1200
         }
       }
     },

--- a/scripts/scenario-defs/survey-panel-visual.json
+++ b/scripts/scenario-defs/survey-panel-visual.json
@@ -38,8 +38,8 @@
       "role": "player",
       "expect": {
         "increased": ["employeeCount"],
-        "equals": {
-          "cash": 48800
+        "changedBy": {
+          "cash": -1200
         }
       }
     },

--- a/scripts/scenario-defs/survey-post-blast-ore-report.json
+++ b/scripts/scenario-defs/survey-post-blast-ore-report.json
@@ -61,9 +61,11 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1200
+        },
         "equals": {
-          "employeeCount": 1,
-          "cash": 198800
+          "employeeCount": 1
         }
       }
     },

--- a/scripts/scenario-defs/survey-result-visualization.json
+++ b/scripts/scenario-defs/survey-result-visualization.json
@@ -61,9 +61,11 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1200
+        },
         "equals": {
-          "employeeCount": 1,
-          "cash": 48800
+          "employeeCount": 1
         }
       }
     },

--- a/scripts/scenario-defs/survey-seismic-side-effects.json
+++ b/scripts/scenario-defs/survey-seismic-side-effects.json
@@ -62,8 +62,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "employeeCount": 1,
-          "cash": 48800
+          "employeeCount": 1
+        },
+        "changedBy": {
+          "cash": -1200
         }
       }
     },
@@ -98,8 +100,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "employeeCount": 2,
-          "cash": 48000
+          "employeeCount": 2
+        },
+        "changedBy": {
+          "cash": -800
         }
       }
     },

--- a/scripts/scenario-defs/survey-stale-handling.json
+++ b/scripts/scenario-defs/survey-stale-handling.json
@@ -61,9 +61,11 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1200
+        },
         "equals": {
-          "employeeCount": 1,
-          "cash": 48800
+          "employeeCount": 1
         }
       }
     },

--- a/scripts/scenario-defs/survey-then-blast-playthrough.json
+++ b/scripts/scenario-defs/survey-then-blast-playthrough.json
@@ -81,9 +81,11 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1200
+        },
         "equals": {
-          "employeeCount": 1,
-          "cash": 198800
+          "employeeCount": 1
         }
       }
     },
@@ -101,9 +103,11 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1000
+        },
         "equals": {
-          "employeeCount": 2,
-          "cash": 197800
+          "employeeCount": 2
         }
       }
     },
@@ -121,9 +125,11 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1500
+        },
         "equals": {
-          "employeeCount": 3,
-          "cash": 196300
+          "employeeCount": 3
         }
       }
     },

--- a/scripts/scenario-defs/survey-then-blast.json
+++ b/scripts/scenario-defs/survey-then-blast.json
@@ -82,8 +82,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "employeeCount": 1,
-          "cash": 198800
+          "employeeCount": 1
+        },
+        "changedBy": {
+          "cash": -1200
         }
       }
     },

--- a/scripts/scenario-defs/tutorial-playthrough.json
+++ b/scripts/scenario-defs/tutorial-playthrough.json
@@ -36,8 +36,10 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": 188648,
           "timeScale": 2
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -60,8 +62,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 187448,
           "employeeCount": 1
+        },
+        "changedBy": {
+          "cash": -1200
         }
       }
     },
@@ -75,8 +79,8 @@
       ],
       "description": "Left unmarked: hiring already grants the Rookie starting qualification (ROLE_STARTING_QUALIFICATION in Employee.ts); this only raises the level for the scenario's needs -- the player-facing path is `employee train`.",
       "expect": {
-        "equals": {
-          "cash": 187448
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "bootstrap"
@@ -115,8 +119,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 184448
+        "changedBy": {
+          "cash": -3000
         }
       }
     },
@@ -139,8 +143,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 183448,
           "employeeCount": 2
+        },
+        "changedBy": {
+          "cash": -1000
         }
       }
     },
@@ -154,8 +160,8 @@
       ],
       "description": "Left unmarked: hiring already grants the Rookie starting qualification (ROLE_STARTING_QUALIFICATION in Employee.ts); this only raises the level for the scenario's needs -- the player-facing path is `employee train`.",
       "expect": {
-        "equals": {
-          "cash": 183448
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "bootstrap"
@@ -170,8 +176,8 @@
       ],
       "description": "#553: the driller needs the drill_rig licence before any drill_hole action can be assigned to them -- hiring grants only the role's own starting qualification, never a driving licence. Left unmarked for the same reason as the assign_skill steps above: the player-facing path is `employee train` at a driving_center, which tutorial-interactive.json is the file that actually clicks.",
       "expect": {
-        "equals": {
-          "cash": 183448
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "bootstrap"
@@ -196,8 +202,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 148448,
           "vehicleCount": 1
+        },
+        "changedBy": {
+          "cash": -35000
         }
       }
     },
@@ -216,8 +224,8 @@
       "description": "#553: the driller (employee #2) is assigned to the drill_rig. Without a driver the rig is a mesh and the queued drill_hole actions never start.",
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 148448
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -260,8 +268,10 @@
       "expect": {
         "equals": {
           "orderedHoleCount": 9,
-          "holeCount": 0,
-          "cash": 148448
+          "holeCount": 0
+        },
+        "changedBy": {
+          "cash": 0
         },
         "note": "#553: confirming the grid only orders the 9 holes -- they are ghosts until the driller drives the drill_rig to each one, so holeCount is 0 here and the wait is the step below."
       }
@@ -298,8 +308,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "chargedCount": 9,
-          "cash": 126884
+          "chargedCount": 9
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -357,8 +369,10 @@
           "holeCount": 0,
           "chargedCount": 0,
           "sequencedCount": 0,
-          "deathCount": 2,
-          "cash": 126884
+          "deathCount": 2
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -417,8 +431,8 @@
       ],
       "description": "event fire -- test hook: no UI control and none is intended (a player cannot summon an event on demand). Left unmarked (legacy).",
       "expect": {
-        "equals": {
-          "cash": 126884
+        "changedBy": {
+          "cash": 0
         },
         "note": "firing only makes the event pending -- its consequence doesn't apply until the choice below."
       },
@@ -449,8 +463,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 123884
+        "changedBy": {
+          "cash": -3000
         },
         "increased": [
           "wellBeing"
@@ -477,8 +491,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 121884,
           "employeeCount": 3
+        },
+        "changedBy": {
+          "cash": -2000
         }
       }
     },
@@ -492,8 +508,8 @@
       ],
       "description": "Left unmarked: hiring already grants the Rookie starting qualification (ROLE_STARTING_QUALIFICATION in Employee.ts); this only raises the level for the scenario's needs -- the player-facing path is `employee train`.",
       "expect": {
-        "equals": {
-          "cash": 121884
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "bootstrap"
@@ -571,8 +587,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 121084,
           "employeeCount": 4
+        },
+        "changedBy": {
+          "cash": -800
         }
       }
     },
@@ -586,8 +604,8 @@
       ],
       "description": "Left unmarked: hiring already grants the Rookie starting qualification (ROLE_STARTING_QUALIFICATION in Employee.ts); this only raises the level for the scenario's needs -- the player-facing path is `employee train`.",
       "expect": {
-        "equals": {
-          "cash": 121084
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "bootstrap"
@@ -611,8 +629,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 96084,
           "vehicleCount": 1
+        },
+        "changedBy": {
+          "cash": -25000
         }
       }
     },
@@ -630,8 +650,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 96084
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -666,8 +686,10 @@
       "description": "Per #526: was `build storage_depot at:12,8`, a phantom BuildingType (commandOutput: \"Unknown subcommand or building type\") with no catalog row and nothing to click -- \"storage_depot\" maps to the real freight_warehouse building. Converted to the tutorial's own real `build-storage` stage (TUTORIAL_STAGES['build-storage'], tutorialStages.ts), whose region tile is REGION.warehouse = (6,6), not the phantom step's (12,8).",
       "expect": {
         "equals": {
-          "cash": 81084,
           "buildingCount": 1
+        },
+        "changedBy": {
+          "cash": -15000
         },
         "note": "cash 44000 - freight_warehouse tier-1 constructionCost 15000 (BuildingDefs.ts) = 29000. Every later hard-asserted cash value in this file shifts down by the same 15000 delta from the old no-op's 0 cost."
       },
@@ -757,8 +779,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 80084
+        "changedBy": {
+          "cash": -1000
         }
       }
     },
@@ -790,8 +812,8 @@
       ],
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 80084
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -867,8 +889,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 45084,
           "vehicleCount": 2
+        },
+        "changedBy": {
+          "cash": -35000
         }
       }
     },
@@ -892,8 +916,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 44084,
           "employeeCount": 5
+        },
+        "changedBy": {
+          "cash": -1000
         }
       }
     },
@@ -908,8 +934,8 @@
       "description": "#553: the drill_rig licence for the replacement driller, same reason and same unmarked-role justification as the assign_skill for employee #2 above.",
       "role": "bootstrap",
       "expect": {
-        "equals": {
-          "cash": 44084
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -932,8 +958,8 @@
       "description": "#553: the replacement driller (employee #5) takes the replacement rig (vehicle #3). #553-followup (issue #586 CI): added the toolbar vehicles-panel click -- the preceding two steps (employee hire, then a command-only assign_skill bootstrap) leave the Crew panel active, not Fleet, so the vehicle-panel selectors below were never actually visible (`10000ms exceeded` on CI).",
       "role": "player",
       "expect": {
-        "equals": {
-          "cash": 44084
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -976,8 +1002,10 @@
       "expect": {
         "equals": {
           "orderedHoleCount": 4,
-          "holeCount": 0,
-          "cash": 44084
+          "holeCount": 0
+        },
+        "changedBy": {
+          "cash": 0
         },
         "note": "#553: ordering only -- the four holes are ghosts until the driller drives the rig to each one, drained by the step below."
       }

--- a/scripts/scenario-defs/tutorial-steps-visual.json
+++ b/scripts/scenario-defs/tutorial-steps-visual.json
@@ -103,8 +103,10 @@
       "description": "hire-surveyor complete: Crew panel opened, Hire clicked. tutorial_start (step 2) arms the tutorial rail (tutorialStages.ts): a control not on the current stage is inert, so every player-facing step below is a real click gated by waitForTutorialStep, matching tutorial-interactive.json's proven pattern.",
       "expect": {
         "equals": {
-          "cash": 201624,
           "employeeCount": 1
+        },
+        "changedBy": {
+          "cash": -1200
         },
         "tutorialStep": "survey"
       }
@@ -157,8 +159,8 @@
       "role": "player",
       "description": "Target corrected from the file's original x:15 z:15 to x:23 z:23 (Finding #74 follow-up): the tutorial's survey stage gates its picker to REGION.survey, a single exact point at (23,23) (tutorialStages.ts) -- (15,15) is outside that region and the picker would refuse to confirm it under a real click, the same class Finding #42 already found for un-gated drill grids. Result unaffected: nothing downstream reads survey findings by location, only the flat $3,000 survey cost. tutorial_start (step 2) arms the tutorial rail (tutorialStages.ts): a control not on the current stage is inert, so every player-facing step below is a real click gated by waitForTutorialStep, matching tutorial-interactive.json's proven pattern.",
       "expect": {
-        "equals": {
-          "cash": 198624
+        "changedBy": {
+          "cash": -3000
         }
       }
     },
@@ -240,8 +242,10 @@
       "description": "hire-driller complete: Crew panel opened, Hire clicked. tutorial_start (step 2) arms the tutorial rail (tutorialStages.ts): a control not on the current stage is inert, so every player-facing step below is a real click gated by waitForTutorialStep, matching tutorial-interactive.json's proven pattern. #553: the tutorial no longer goes straight from here to box-cut -- drilling became queued, vehicle-gated work, so the script now teaches the driving_center, the drill_rig licence and the rig itself first.",
       "expect": {
         "equals": {
-          "cash": 194344,
           "employeeCount": 2
+        },
+        "changedBy": {
+          "cash": -1000
         },
         "tutorialStep": "build-driving-center"
       }

--- a/scripts/scenario-defs/vehicle-3d-rendering-visual.json
+++ b/scripts/scenario-defs/vehicle-3d-rendering-visual.json
@@ -41,8 +41,10 @@
       "role": "player",
       "description": "Opens the Fleet panel and buys the hauler by clicking its tier-1 dealership row. Every later buy reuses the open panel.",
       "expect": {
+        "changedBy": {
+          "cash": -25000
+        },
         "equals": {
-          "cash": 175000,
           "vehicleCount": 1
         }
       }
@@ -63,8 +65,10 @@
       "role": "player",
       "description": "Real click on the rock_digger tier-1 row: $175,000 in hand against $50,000, so the row is enabled. awaitUsable is the affordability assertion -- FleetPanel disables a tier row on cash < purchaseCost, so an underfunded run fails here instead of buying anyway.",
       "expect": {
+        "changedBy": {
+          "cash": -50000
+        },
         "equals": {
-          "cash": 125000,
           "vehicleCount": 2
         }
       }
@@ -85,8 +89,10 @@
       "role": "player",
       "description": "Real click on the drill_rig tier-1 row: $125,000 in hand against $35,000.",
       "expect": {
+        "changedBy": {
+          "cash": -35000
+        },
         "equals": {
-          "cash": 90000,
           "vehicleCount": 3
         }
       }
@@ -107,8 +113,10 @@
       "role": "player",
       "description": "Real click on the building_destroyer tier-1 row: $90,000 in hand against $30,000.",
       "expect": {
+        "changedBy": {
+          "cash": -30000
+        },
         "equals": {
-          "cash": 60000,
           "vehicleCount": 4
         }
       }
@@ -129,8 +137,10 @@
       "role": "player",
       "description": "Real click on the rock_fragmenter tier-1 row: $60,000 in hand against $32,000. Fifth and last role, so the shots below capture one of every vehicle mesh with the balance still in the black.",
       "expect": {
+        "changedBy": {
+          "cash": -32000
+        },
         "equals": {
-          "cash": 28000,
           "vehicleCount": 5
         }
       }

--- a/scripts/scenario-defs/vehicle-driver-assignment-visual.json
+++ b/scripts/scenario-defs/vehicle-driver-assignment-visual.json
@@ -36,8 +36,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -25000
+        },
         "equals": {
-          "cash": 25000,
           "vehicleCount": 1
         }
       }
@@ -60,8 +62,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -800
+        },
         "equals": {
-          "cash": 24200,
           "employeeCount": 1
         }
       }
@@ -112,8 +116,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 24200,
           "vehicleCount": 1
         },
         "note": "arrival-gated like surveys — the driver walks to the vehicle before boarding, `vehicle list` still shows driver:none right after this click"
@@ -157,8 +163,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -1500
+        },
         "equals": {
-          "cash": 22685,
           "employeeCount": 2
         }
       }
@@ -173,8 +181,10 @@
       ],
       "description": "Left unmarked: vehicle #1 already has a driver, so FleetPanel shows only an Unassign control here, not the assign picker -- and even that picker would never have listed employee #2 (a blaster has no driving.truck licence). Confirmed by the console command itself failing with \"Employee lacks licence for this role\": genuinely unreachable by a click, not a conversion gap.",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 22685,
           "employeeCount": 2
         },
         "note": "rejected: Employee lacks licence for this role"

--- a/scripts/scenario-defs/vehicle-purchase-tier-ui-visual.json
+++ b/scripts/scenario-defs/vehicle-purchase-tier-ui-visual.json
@@ -48,8 +48,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -25000
+        },
         "equals": {
-          "cash": 275000,
           "vehicleCount": 1
         }
       }
@@ -79,8 +81,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -50000
+        },
         "equals": {
-          "cash": 225000,
           "vehicleCount": 2
         }
       }
@@ -100,8 +104,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -50000
+        },
         "equals": {
-          "cash": 175000,
           "vehicleCount": 3
         }
       }
@@ -121,8 +127,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -140000
+        },
         "equals": {
-          "cash": 35000,
           "vehicleCount": 4
         }
       }

--- a/scripts/scenario-defs/vehicle-purchase-visual.json
+++ b/scripts/scenario-defs/vehicle-purchase-visual.json
@@ -51,8 +51,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -25000
+        },
         "equals": {
-          "cash": 75000,
           "vehicleCount": 1
         },
         "note": "real click on the Fleet panel's debris_hauler tier-1 row -- vehicle buy debris_hauler with no tier: arg defaults to tier 1 too (parseVehicleTierArg, vehicle.ts), so command mode and this click target the same purchase"
@@ -101,8 +103,10 @@
       "role": "player",
       "description": "A second real purchase from the same open panel: $75,000 in hand against a $35,000 drill rig, so the dealership row is enabled and clicking it buys the rig. The awaitUsable ahead of the click is the affordability assertion -- the Fleet panel disables a tier row whenever cash < purchaseCost (setTierButtonAffordable, FleetPanel.ts), so a run that had underfunded this step would fail here rather than quietly buying anyway. No toolbar click: the Vehicles panel is already open from the hauler purchase, and re-clicking the toolbar entry would close it.",
       "expect": {
+        "changedBy": {
+          "cash": -35000
+        },
         "equals": {
-          "cash": 40000,
           "vehicleCount": 2
         },
         "note": "$75,000 - $35,000; both purchases stay in the black, which is the whole point of funding the level properly instead of overdrawing"
@@ -133,8 +137,10 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "cash": 40000,
           "vehicleCount": 2
         }
       }

--- a/scripts/scenario-defs/vehicle-roles-panel-visual.json
+++ b/scripts/scenario-defs/vehicle-roles-panel-visual.json
@@ -50,8 +50,10 @@
       "description": "Opens the Fleet panel and buys the hauler by clicking its tier-1 dealership row. Every later buy reuses the open panel.",
       "expect": {
         "equals": {
-          "cash": 175000,
           "vehicleCount": 1
+        },
+        "changedBy": {
+          "cash": -25000
         }
       }
     },
@@ -71,8 +73,10 @@
       "description": "Real click on the rock_digger tier-1 row: $175,000 in hand against $50,000, so the row is enabled. awaitUsable is the affordability assertion -- FleetPanel disables a tier row on cash < purchaseCost, so an underfunded run fails here instead of buying anyway.",
       "expect": {
         "equals": {
-          "cash": 125000,
           "vehicleCount": 2
+        },
+        "changedBy": {
+          "cash": -50000
         }
       }
     },
@@ -92,8 +96,10 @@
       "description": "Real click on the drill_rig tier-1 row: $125,000 in hand against $35,000.",
       "expect": {
         "equals": {
-          "cash": 90000,
           "vehicleCount": 3
+        },
+        "changedBy": {
+          "cash": -35000
         }
       }
     },
@@ -113,8 +119,10 @@
       "description": "Real click on the building_destroyer tier-1 row: $90,000 in hand against $30,000.",
       "expect": {
         "equals": {
-          "cash": 60000,
           "vehicleCount": 4
+        },
+        "changedBy": {
+          "cash": -30000
         }
       }
     },
@@ -134,8 +142,10 @@
       "description": "Real click on the rock_fragmenter tier-1 row: $60,000 in hand against $32,000. Fifth and last role, so the roles-panel shot shows the dealership with one card of every type already owned.",
       "expect": {
         "equals": {
-          "cash": 28000,
           "vehicleCount": 5
+        },
+        "changedBy": {
+          "cash": -32000
         }
       }
     },

--- a/scripts/scenario-defs/vehicle-task-states-visual.json
+++ b/scripts/scenario-defs/vehicle-task-states-visual.json
@@ -38,8 +38,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 75000,
           "vehicleCount": 1
+        },
+        "changedBy": {
+          "cash": -25000
         }
       }
     },
@@ -89,8 +91,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 75000,
           "vehicleCount": 1
+        },
+        "changedBy": {
+          "cash": 0
         },
         "note": "vehicle list confirms idle → moving; no scalar field exists for vehicle task state"
       }

--- a/scripts/scenario-defs/vehicle-traffic-routing-visual.json
+++ b/scripts/scenario-defs/vehicle-traffic-routing-visual.json
@@ -39,8 +39,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 149200,
           "employeeCount": 1
+        },
+        "changedBy": {
+          "cash": -800
         }
       }
     },
@@ -59,8 +61,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 148400,
           "employeeCount": 2
+        },
+        "changedBy": {
+          "cash": -800
         }
       }
     },
@@ -79,8 +83,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 147600,
           "employeeCount": 3
+        },
+        "changedBy": {
+          "cash": -800
         }
       }
     },
@@ -99,8 +105,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 146800,
           "employeeCount": 4
+        },
+        "changedBy": {
+          "cash": -800
         }
       }
     },
@@ -124,8 +132,10 @@
       "description": "Opens the Fleet panel and buys hauler #1 by clicking its tier-1 dealership row. The three buys below reuse the open panel.",
       "expect": {
         "equals": {
-          "cash": 121800,
           "vehicleCount": 1
+        },
+        "changedBy": {
+          "cash": -25000
         }
       }
     },
@@ -145,8 +155,10 @@
       "description": "Hauler #2, bought by clicking the same dealership row again: $121,800 in hand against $25,000. awaitUsable is the affordability assertion -- FleetPanel disables a tier row on cash < purchaseCost, so an underfunded run fails here instead of buying anyway.",
       "expect": {
         "equals": {
-          "cash": 96800,
           "vehicleCount": 2
+        },
+        "changedBy": {
+          "cash": -25000
         }
       }
     },
@@ -166,8 +178,10 @@
       "description": "Hauler #3, same row again: $96,800 in hand against $25,000.",
       "expect": {
         "equals": {
-          "cash": 71800,
           "vehicleCount": 3
+        },
+        "changedBy": {
+          "cash": -25000
         }
       }
     },
@@ -187,8 +201,10 @@
       "description": "Hauler #4, same row again: $71,800 in hand against $25,000. This is the vehicle that makes the jam reachable -- detectTrafficJam needs 3 vehicles waiting on a tile a 4th already occupies.",
       "expect": {
         "equals": {
-          "cash": 46800,
           "vehicleCount": 4
+        },
+        "changedBy": {
+          "cash": -25000
         }
       }
     },

--- a/scripts/scenario-defs/vehicle-traffic.json
+++ b/scripts/scenario-defs/vehicle-traffic.json
@@ -48,8 +48,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -800
+        },
         "equals": {
-          "cash": 149200,
           "employeeCount": 1
         }
       }
@@ -68,8 +70,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -800
+        },
         "equals": {
-          "cash": 148400,
           "employeeCount": 2
         }
       }
@@ -88,8 +92,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -800
+        },
         "equals": {
-          "cash": 147600,
           "employeeCount": 3
         }
       }
@@ -108,8 +114,10 @@
       ],
       "role": "player",
       "expect": {
+        "changedBy": {
+          "cash": -800
+        },
         "equals": {
-          "cash": 146800,
           "employeeCount": 4
         }
       }
@@ -133,8 +141,10 @@
       "role": "player",
       "description": "Opens the Fleet panel and buys hauler #1 by clicking its tier-1 dealership row. The three buys below reuse the open panel.",
       "expect": {
+        "changedBy": {
+          "cash": -25000
+        },
         "equals": {
-          "cash": 121800,
           "vehicleCount": 1
         }
       }
@@ -154,8 +164,10 @@
       "role": "player",
       "description": "Hauler #2, bought by clicking the same dealership row again: $121,800 in hand against $25,000. awaitUsable is the affordability assertion -- FleetPanel disables a tier row on cash < purchaseCost, so an underfunded run fails here instead of buying anyway.",
       "expect": {
+        "changedBy": {
+          "cash": -25000
+        },
         "equals": {
-          "cash": 96800,
           "vehicleCount": 2
         }
       }
@@ -175,8 +187,10 @@
       "role": "player",
       "description": "Hauler #3, same row again: $96,800 in hand against $25,000.",
       "expect": {
+        "changedBy": {
+          "cash": -25000
+        },
         "equals": {
-          "cash": 71800,
           "vehicleCount": 3
         }
       }
@@ -196,8 +210,10 @@
       "role": "player",
       "description": "Hauler #4, same row again: $71,800 in hand against $25,000. Fourth and last, and the fleet the move commands below converge.",
       "expect": {
+        "changedBy": {
+          "cash": -25000
+        },
         "equals": {
-          "cash": 46800,
           "vehicleCount": 4
         }
       }

--- a/scripts/scenario-defs/vibration-budget.json
+++ b/scripts/scenario-defs/vibration-budget.json
@@ -396,19 +396,14 @@
     },
     {
       "command": "finances",
+      "description": "explosive cost is never deducted from cash in this build (ground rule #11) — cash only moves from the #553 driller hire/drill_rig purchase and payroll/upkeep during the drilling wait, not from the file's own $5,000-fine premise (which has nothing to attach to). #553 shared-mechanism note (same root cause as rock-fragmenter-breaking.json/hauling-gate.json/nav-*-visual.json): the drill_plan grid command above was missing diameter: — the real grid-tool confirm always sends the panel's own DEFAULT_DIAMETER_M=0.089 (Drill.ts), while an omitted diameter: fell back to a different console-only default (0.15, mining.ts), and computeDrillHoleDurationTicks scales drill duration by diameter, keeping the drill_rig busy (fuelCostPerTick) for extra ticks command mode never should have spent. #596: cash dropped from this checkpoint's own equals (was a hand-derived 207286) — the same incidental-running-total class this file's own cycle-2/cycle-3 finances checkpoints already treat this way (see their own notes): a read-only `finances` query doesn't move cash itself (before==after for the step), so neither an exact changedBy nor a directional decreased/increased belongs here — the spend already happened in the hire/purchase/tick steps above, which is where a cash assertion belongs.",
       "interaction": [
         {
           "type": "command",
           "command": "finances"
         }
       ],
-      "role": "observe",
-      "expect": {
-        "equals": {
-          "cash": 207286
-        },
-        "note": "explosive cost is never deducted from cash in this build (ground rule #11) — cash only moves from the #553 driller hire/drill_rig purchase and payroll/upkeep during the drilling wait, not from the file's own $5,000-fine premise (which has nothing to attach to). #553 shared-mechanism note (same root cause as rock-fragmenter-breaking.json/hauling-gate.json/nav-*-visual.json): the drill_plan grid command above was missing diameter: — the real grid-tool confirm always sends the panel's own DEFAULT_DIAMETER_M=0.089 (Drill.ts), while an omitted diameter: fell back to a different console-only default (0.15, mining.ts), and computeDrillHoleDurationTicks scales drill duration by diameter, keeping the drill_rig busy (fuelCostPerTick) for extra ticks command mode never should have spent. diameter:0.089 added there; this checkpoint's cash corrected from 207232 to the now-exact 207286."
-      }
+      "role": "observe"
     },
     {
       "command": "employee hire role:driller",

--- a/scripts/scenario-defs/weather-display-visual.json
+++ b/scripts/scenario-defs/weather-display-visual.json
@@ -27,8 +27,8 @@
       ],
       "role": "setup",
       "expect": {
-        "equals": {
-          "cash": 50000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -251,9 +251,11 @@
       ],
       "role": "observe",
       "expect": {
+        "changedBy": {
+          "cash": 0
+        },
         "equals": {
-          "weather": "cold_snap",
-          "cash": 50000
+          "weather": "cold_snap"
         }
       }
     }

--- a/scripts/scenario-defs/weather-flood.json
+++ b/scripts/scenario-defs/weather-flood.json
@@ -28,8 +28,8 @@
       ],
       "role": "setup",
       "expect": {
-        "equals": {
-          "cash": 100000
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -44,8 +44,10 @@
       "description": "Left unmarked: no UI sets weather at all -- grepping src/ui for gameConsole?.(`weather finds zero call sites. This is a real gap, not a conversion shortfall: nothing lets a player change the weather, only `weather set` from the console/scenario harness. Also fixed a scenario bug while here: the command was `weather heavy_rain` (missing `set`), which mining.ts's weatherCommand silently falls through to a plain read for -- the flood test never actually set heavy_rain at all. Corrected to `weather set heavy_rain`.",
       "expect": {
         "equals": {
-          "weather": "heavy_rain",
-          "cash": 100000
+          "weather": "heavy_rain"
+        },
+        "changedBy": {
+          "cash": 0
         }
       },
       "role": "bootstrap"
@@ -61,8 +63,10 @@
       "role": "setup",
       "expect": {
         "equals": {
-          "cash": 100000,
           "tickCount": 5
+        },
+        "changedBy": {
+          "cash": 0
         },
         "note": "confirmed via direct trace: cash stays flat, no employees exist yet to pay"
       }
@@ -105,8 +109,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 99000,
           "employeeCount": 1
+        },
+        "changedBy": {
+          "cash": -1000
         }
       }
     },
@@ -129,8 +135,10 @@
       "role": "player",
       "expect": {
         "equals": {
-          "cash": 64000,
           "vehicleCount": 1
+        },
+        "changedBy": {
+          "cash": -35000
         }
       }
     },
@@ -146,8 +154,10 @@
       "role": "bootstrap",
       "expect": {
         "equals": {
-          "cash": 64000,
           "qualificationCount": 2
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },
@@ -186,8 +196,10 @@
       "expect": {
         "equals": {
           "orderedHoleCount": 9,
-          "holeCount": 0,
-          "cash": 64000
+          "holeCount": 0
+        },
+        "changedBy": {
+          "cash": 0
         }
       }
     },


### PR DESCRIPTION
## Summary

Resolves #600.

Issue #596 landed `expect.changedBy: Record<string, number>` — a step-local delta assertion (`after[field] - before[field]`) that lets an inserted step in the middle of a scenario be evaluated without re-deriving every checkpoint after it. It landed, but adoption didn't follow: a census on `main` found only the 10 files PR #599 touched directly used it — 126 of 129 scenario files still pinned 723 incidental `equals.cash` checkpoints.

This is exactly the ripple #596 exists to prevent. #554 (charging) and every "X is real work" issue chained behind it (#555 digging, #556 construction, #557 evacuation) insert queued-work time into these files. On a file still using a chained absolute, one inserted wait step forces every cash checkpoint after it to be recomputed by hand across the whole file — the single largest cost #553's own migration paid (PR #586's own retrospective).

## What changed

Migrated file by file, dispatched as 14 parallel batches (disjoint file sets, no merge conflicts) covering all 126 files with at least one `equals.cash` checkpoint. For each checkpoint:

- **Converted to `changedBy: {"cash": N}`** when the step's own action has a fixed, deterministic cost/gain worth pinning exactly — hires, purchases, builds, fixed-amount event/contract payouts, and the many zero-cost bootstrap/observe/no-op steps that were needlessly re-chaining an unchanged total.
- **Converted to `decreased`/`increased`** when only direction matters — real wall-clock-sensitive accrual during a tick wait (fuel, maintenance, payroll), matching the convention several files already used elsewhere in the same file.
- **Left as `equals`** only where the figure is genuinely the point: a starting-cash baseline (`new_game`/`campaign start`'s own explicit override has no "before" state to diff against, so it can't use `changedBy` at all), a terminal win/lose/bankruptcy/arrest checkpoint, an affordability-refusal threshold (`insufficient-funds-guards-visual.json`), or a save/load round-trip proof (`site-expansion.json`).

**Net: 723 → 153 remaining `equals.cash` checkpoints**, every one individually justified — mostly per-file starting-cash baselines (126, one per file), plus ~27 genuine terminal/threshold/round-trip checkpoints. Every other `expect` field (`deathCount`, scores, `tickCount`, `employeeCount`, `levelEnded`/`levelEndReason`, `holeCount`, etc.) is untouched — scope was `cash` only, per #600's own body.

## Verification

- `npm run typecheck` — clean.
- `npm run test` — 9362/9362 unit + integration tests pass (311 files).
- `npx vitest run tests/unit/scenario-defs.test.ts` — 3192/3192.
- `npm run scenarios` (command mode) — **129/129 passing**, fully green.
- Interaction mode: not run locally for this PR (JSON-only `expect` changes, no `interaction` arrays touched) — CI's `full-ci`-labeled shards are the practical confirmation that `changedBy`'s step-local delta evaluates identically in both modes for every converted checkpoint.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test` (9362/9362)
- [x] `npm run scenarios` (129/129, command mode)
- [ ] CI interaction-mode shards (`full-ci` labeled)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNtJC5nGAtHoPZ46VcXeYB)_