### PR TITLE
fix(pipeline): an agent session cannot end a turn waiting on a background command

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -77,7 +77,30 @@ Four independent channels prove a change works. Each catches what the others mis
 
 ## ▶ Claude Code only — some channels belong to CI, not to your session
 
-**Deliberately not mirrored into `.github/copilot-instructions.md` or `.opencode/AGENTS.md`.** Entry points are the one layer whose bodies are allowed to diverge — each runtime holds its own, and `validate:context` checks only that all three name the same gates and channels, not that they read alike. This section describes how *this* runtime executes: long-running processes it starts in the background and watches across turns. The other two runtimes drive their harnesses differently, so their authors decide their own wording. Its absence there is intentional; do not sync it.
+**Deliberately not mirrored into `.github/copilot-instructions.md` or `.opencode/AGENTS.md`.** Entry points are the one layer whose bodies are allowed to diverge — each runtime holds its own, and `validate:context` checks only that all three name the same gates and channels, not that they read alike. This section describes how *this* runtime executes: which channels it runs itself, which it hands to CI, and how it runs a command that outlives one Bash call. The other two runtimes drive their harnesses differently, so their authors decide their own wording. Its absence there is intentional; do not sync it.
+
+### ▶ There is no later turn — how to run a command that outlives one Bash call
+
+**A backgrounded command whose result you plan to collect later is a lost run.** The Bash tool caps one foreground call at 600 000 ms, and three of the commands this project requires sit at or past that ceiling — `npm run scenarios` is ~9 m 20 s in a sandbox and slower on a 2-core runner, `npm run ci:await` waits as long as CI takes. So they have to be detached. *How* you come back for the result is what decides whether the run survives.
+
+An unattended session — a GitHub Actions runner, Claude Code on the web — gets **one turn**. When that turn ends the process exits. A background-task notification is delivered on a later turn, and there is no later turn, so it is never delivered at all. Everything not yet pushed dies with the VM. This is the same rule that already governs delegation (`require-foreground-agents.sh`, issues #404 and #406), arriving through the shell instead of through a sub-agent. It cost three runs in four days:
+
+| PR | How the turn ended | Cost |
+|----|--------------------|------|
+| #604 | "Scenario verification is running in the background — pausing here until it reports back." | 3 h 11 m and $30.55 of finished TDD work, discarded. Its retry repeated it in 2 m 51 s. |
+| #594 | "Waiting for the background vitest run — will be notified automatically." | Both attempts, same sentence. |
+| #603 | Never ended the turn — hand-rolled `timeout 280 bash -c 'until ! ps -p <pid>…'` 40+ times instead. | The whole 360-minute job budget spent polling, then the job timeout, with no budget left to retry. |
+
+**The rule.** Run it in the foreground when it fits — pass an explicit `timeout` up to 600000. When it does not fit, use the one wrapper that can be waited on inside this turn:
+
+```bash
+npm run long -- start scenarios -- npm run scenarios
+npm run long -- wait scenarios      # blocks one bounded slice
+```
+
+`wait` exits `75` while the command is still going. **That is not a failure and not a verdict** — call `wait` again, in this same turn, as many times as it takes, until it prints `FINISHED` and the command's own exit code. Then act on that code.
+
+Two hooks enforce this, because prose did not hold: `require-foreground-bash.sh` refuses a `run_in_background` Bash call or raw `nohup`/`setsid`/`disown`/trailing-`&` detach, and `require-settled-turn.sh` refuses to let a turn (or a sub-agent's turn) end while a `npm run long` handle is unfinished. A human at an interactive CLI, where a later turn genuinely exists, can set `AGENTIC_ALLOW_BACKGROUND_BASH=1`; no pipeline workflow sets it.
 
 Without a GPU the terrain material costs ~6 s **per frame** in software rasterisation (#475). Loading a level is cheap — a `new_game` is ~4 s and a campaign start ~16 s. What is expensive is *waiting on frames*: the browser harnesses poll the page over CDP, and every such call waits a full frame, so a single player action costs tens of seconds and an interaction-mode scenario beat costs minutes. That is long enough that a session watching one concludes it hung, kills it, and reports a stall that never happened.
 
@@ -100,7 +123,7 @@ A channel that belongs to CI is **covered**, never pending: an autonomous run ma
 
 **Covered means the report gets read, not that you may leave before it arrives.** A red CI is announced to nobody: `agentic-auto-merge.yml` declines a failed CI run, and the watchdog skips any issue with a linked PR. So an autonomous run's last step is `npm run ci:await -- --pr <number>`, which blocks until every workflow run on the PR head reports — green ends the run, red is work on the same branch. PR #581 is what skipping it costs: green on every channel its session ran, marked, two interaction shards red, and issue #552 held the queue until a human looked. `agentic-pipeline-finalization` holds the step and its bounded fix loop; `agentic-pipeline-ci-fix` is the pipeline for a red CI handed back to a later session.
 
-**While any browser-driven run is in flight: change no file** (Vite reloads the page and kills the run with `Execution context was destroyed`, which looks like a game bug and is not), **start no second browser harness**, and **wait for the run's own terminal line**. Slow is not stuck. A run you interrupted produced no result — report the channel as pending CI, never as passed.
+**While any browser-driven run is in flight: change no file** (Vite reloads the page and kills the run with `Execution context was destroyed`, which looks like a game bug and is not), **start no second browser harness**, and **wait for the run's own terminal line** — in this turn, through `npm run long -- wait`, never by ending the turn on it. Slow is not stuck. A run you interrupted produced no result — report the channel as pending CI, never as passed.
 
 ## ▶ Capability Gate
 

--- a/.claude/hooks/require-foreground-bash.sh
+++ b/.claude/hooks/require-foreground-bash.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Reject a backgrounded shell command.
+# Registered as a PreToolUse hook (matcher: "Bash") in `.claude/settings.json`.
+# Claude Code passes tool input as JSON on stdin.
+#
+# The sibling of `require-foreground-agents.sh`, closing the same hole one layer
+# down. That hook stopped a run from losing its work to a backgrounded sub-agent
+# (#404, #406). The identical failure then came back through the shell instead:
+#
+#   PR #604  `npm run scenarios` backgrounded, then "pausing here until it
+#            reports back". Turn over. 3h11m of finished TDD work discarded with
+#            the runner VM, and the retry repeated it inside three minutes.
+#   PR #594  "Waiting for the background vitest run (task `bip2e4izv`) to
+#            complete — will be notified automatically." Both attempts.
+#
+# A backgrounded command reports through a notification delivered on a later
+# turn. An unattended run gets exactly one turn, so that notification never
+# arrives: the run ends with its branches unpushed and no PR, and the job's own
+# rescue step opens a draft nobody asked for.
+#
+# The answer is not "never detach" — `npm run scenarios` is ~9m20s in a sandbox
+# and longer on a 2-core runner, and `npm run ci:await` waits on CI for as long
+# as CI takes, both past the Bash tool's 600s ceiling. It is "detach through the
+# one wrapper that can be waited on inside this turn": `npm run long`. That
+# wrapper is also what `require-settled-turn.sh` reads, so a run started through
+# it cannot be abandoned by ending the turn either. Detaching any other way is
+# invisible to both guards, which is what this hook is for.
+#
+# Blocking is the default, and that is the safe direction: a runner cannot lose a
+# run to an environment variable that failed to arrive. A human at an interactive
+# CLI, where a later turn genuinely exists, exports
+# AGENTIC_ALLOW_BACKGROUND_BASH=1. No pipeline workflow sets it.
+#
+# Exit 2 = block the tool call and show stderr to the agent.
+# Exit 0 = allow.
+
+set -uo pipefail
+
+raw=$(cat)
+
+case "${AGENTIC_ALLOW_BACKGROUND_BASH:-}" in
+    1 | true | TRUE | yes)
+        exit 0
+        ;;
+esac
+
+# Absent python3 we cannot read the payload, and blocking every shell command
+# would halt the pipeline outright. Fail open: CLAUDE.md still carries the rule,
+# `require-settled-turn.sh` still catches the turn that tries to end on it, and
+# `npm run validate:context` proves this hook is wired up.
+if ! command -v python3 >/dev/null 2>&1; then
+    exit 0
+fi
+
+# Two ways a Bash call detaches, and both have to be caught:
+#
+#   run_in_background: true  — the tool's own flag. Unlike the Agent tool this
+#                              defaults to false, so only an explicit true is a
+#                              backgrounding request.
+#   detach syntax            — `nohup`, `setsid`, `disown`, or a trailing `&` in
+#                              the command itself, which the flag never sees.
+#
+# `&&` and `2>&1` are not backgrounding and must keep working, so the trailing-&
+# test is anchored per line and refuses a preceding `&` or `>`.
+verdict=$(printf '%s' "$raw" | python3 -c '
+import json, re, sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    print("unreadable"); raise SystemExit(0)
+
+tool_input = data.get("tool_input") or {}
+command = tool_input.get("command") or ""
+
+# The two allowances are checked before anything else, because both describe a
+# command that is *meant* to outlive the call and neither can lose a result.
+
+# The sanctioned wrapper detaches on purpose and is waitable.
+if re.search(r"\bnpm run long\b", command):
+    print("allowed"); raise SystemExit(0)
+
+# A server is not a result. What this hook exists to stop is a turn ending to
+# collect an answer that will never be delivered; a dev server is started so the
+# browser has something to talk to, it produces no verdict, and nothing ever
+# waits on its exit code. The visual channel cannot run without one, and
+# `npm run dev &` is the incantation this project already documents in
+# `dev-visual-testing`, `rendering.md`, `visual-tester` and `verify-env`.
+#
+# Narrow on purpose, and it has to stay that way or naming `npm run dev`
+# launders anything typed after it:
+#   - anchored at the start, so `setsid npm run dev` is not a dev-server start
+#   - no `;`, `|` or further `&` past the one that backgrounds it, so
+#     `npm run dev & npx vitest run &` is not one either
+# Redirections are blanked first, otherwise the `&` in the entirely ordinary
+# `npm run dev > /tmp/dev.log 2>&1 &` would read as a second command.
+redirectless = re.sub(r"(\d?>&\d?|&>|>>|[<>])", " ", command.strip())
+if re.match(r"^(npm run dev|npx vite|vite)\b[^;|&]*&?$", redirectless):
+    print("allowed"); raise SystemExit(0)
+
+if tool_input.get("run_in_background") is True:
+    print("flag"); raise SystemExit(0)
+
+if re.search(r"(^|[;&|(]|\s)(nohup|setsid)\s", command):
+    print("detach"); raise SystemExit(0)
+if re.search(r"(^|[;&|(]|\s)disown(\s|$)", command):
+    print("detach"); raise SystemExit(0)
+
+for line in command.split("\n"):
+    if re.search(r"(?<![&>])&[ \t]*$", line.rstrip()):
+        print("detach"); raise SystemExit(0)
+
+print("foreground")
+')
+
+case "$verdict" in
+    foreground|allowed|unreadable)
+        exit 0
+        ;;
+esac
+
+if [ "$verdict" = "flag" ]; then
+    reason="run_in_background was set to true"
+else
+    reason="the command detaches itself (nohup, setsid, disown, or a trailing \`&\`)"
+fi
+
+cat >&2 <<EOF
+Blocked: this command would run in the background — $reason.
+
+A backgrounded command reports on a later turn, and an unattended run gets
+exactly one turn. Ending your turn to wait for it discards everything this run
+has done: PR #604 lost 3h11m of finished work that way, and PR #594 lost two
+attempts to it.
+
+If the command fits in one Bash call, run it in the foreground with an explicit
+timeout (the ceiling is 600000 ms):
+
+    npm run test          # ~3m
+    npm run typecheck
+
+If it does not fit — \`npm run scenarios\` is ~9m20s and slower on a runner,
+\`npm run ci:await\` waits on CI for as long as CI takes — use the wrapper that
+can be waited on inside this turn:
+
+    npm run long -- start scenarios -- npm run scenarios
+    npm run long -- wait scenarios          # repeat while it exits 75
+
+\`wait\` blocks for one bounded slice and returns 75 meaning "still going, ask
+again". Keep calling it in this same turn until it reports FINISHED, then act on
+the exit code it prints. Never end the turn with one outstanding.
+
+Starting the dev server the visual channel needs is not what this blocks — a
+server produces no result anybody collects. \`npm run dev &\` is allowed as it
+always was; it is the tool's own \`run_in_background\` flag that is not.
+EOF
+exit 2

--- a/.claude/hooks/require-settled-turn.sh
+++ b/.claude/hooks/require-settled-turn.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Refuse to end a turn while a long run is still going.
+# Registered as a Stop and a SubagentStop hook in `.claude/settings.json`.
+# Claude Code passes the stop payload as JSON on stdin.
+#
+# The last line of defence, and the only one that acts at the moment the run is
+# actually lost. `require-foreground-bash.sh` decides what may be started;
+# this decides whether the turn may end. Both exist because prose did not hold:
+# CLAUDE.md, the orchestrator definition and the retry prompt all already said
+# every result must arrive inside the turn that asked for it, and three runs in
+# four days ended on a sentence promising to wait — #604 ("pausing here until it
+# reports back"), #594 ("will be notified automatically"), and their retries.
+#
+# What it reads is `.agentic/long/`, the handle directory `npm run long` writes.
+# A handle with a live pid and no exit file is a command whose result nobody has
+# read yet, and ending the turn on it throws that result away along with
+# everything the run has not yet pushed.
+#
+# ▶ The brake. Blocking forever is its own outage: a job that cannot end never
+# reaches the rescue step, so the branch dies with the VM instead of becoming a
+# draft PR somebody can finish. So this is a counter with a bound, not a wall —
+# after AGENTIC_STOP_BLOCK_LIMIT consecutive refusals it lets the turn end and
+# says so in the log. Reaching the brake means the agent ignored the block four
+# times, which is a finding, not a routine outcome.
+#
+# Exit 2 = refuse the stop; stderr goes back to the agent as the reason.
+# Exit 0 = let the turn end.
+
+set -uo pipefail
+
+raw=$(cat)
+
+case "${AGENTIC_ALLOW_UNSETTLED_TURN:-}" in
+    1 | true | TRUE | yes)
+        exit 0
+        ;;
+esac
+
+project="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+long_dir="${project}/.agentic/long"
+counter="${long_dir}/.stop-blocks"
+limit="${AGENTIC_STOP_BLOCK_LIMIT:-4}"
+
+# Nothing was ever started through the wrapper: there is nothing this hook can
+# say anything about.
+[ -d "$long_dir" ] || exit 0
+
+# Fail open without python3, for the same reason the sibling hook does: an
+# unreadable payload must not be able to wedge a turn shut.
+if ! command -v python3 >/dev/null 2>&1; then
+    exit 0
+fi
+
+# A pid file with no exit file beside it, whose process is still alive. The exit
+# file is written by the detached shell itself, so it is authoritative and it
+# outlives the process — checked first, so a command that finished a moment ago
+# reads as finished rather than as gone.
+pending=$(python3 - "$long_dir" <<'PY'
+import os, sys
+
+directory = sys.argv[1]
+live = []
+try:
+    names = os.listdir(directory)
+except OSError:
+    sys.exit(0)
+
+for name in names:
+    if not name.endswith('.pid'):
+        continue
+    label = name[:-4]
+    if os.path.exists(os.path.join(directory, label + '.exit')):
+        continue
+    try:
+        with open(os.path.join(directory, name)) as handle:
+            pid = int(handle.read().strip())
+    except (OSError, ValueError):
+        continue
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        continue
+    except PermissionError:
+        pass
+    live.append(label)
+
+print(' '.join(sorted(live)))
+PY
+)
+
+if [ -z "${pending// /}" ]; then
+    rm -f "$counter"
+    exit 0
+fi
+
+blocked=0
+[ -f "$counter" ] && blocked=$(cat "$counter" 2>/dev/null || echo 0)
+case "$blocked" in
+    ''|*[!0-9]*) blocked=0 ;;
+esac
+blocked=$((blocked + 1))
+printf '%s' "$blocked" > "$counter"
+
+if [ "$blocked" -gt "$limit" ]; then
+    rm -f "$counter"
+    echo "::warning::Turn ended with long run(s) still going: ${pending}. The stop guard refused ${limit} times and released on its brake — the result of those commands was never read." >&2
+    exit 0
+fi
+
+cat >&2 <<EOF
+Blocked: you are ending this turn while a long run is still going — ${pending}.
+
+There is no later turn. This session is unattended: when the turn ends the
+process exits, the notification you are waiting for is never delivered, and
+everything this run has not pushed dies with the runner. PR #604 ended exactly
+here, on "pausing here until it reports back", after 3h11m of finished work.
+
+Wait for it now, in this turn:
+
+$(for label in ${pending}; do echo "    npm run long -- wait ${label}"; done)
+
+That call blocks for one bounded slice and exits 75 if the command is still
+going — which is not a failure. Call it again, as many times as it takes, until
+it prints FINISHED, then act on the exit code. Only then is this turn finished.
+EOF
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,11 +48,40 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/require-foreground-bash.sh"
+          }
+        ]
+      },
+      {
         "matcher": "AskUserQuestion",
         "hooks": [
           {
             "type": "command",
             "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/no-ask-user-question.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/require-settled-turn.sh"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/require-settled-turn.sh"
           }
         ]
       }

--- a/.github/workflows/claude-runner.yml
+++ b/.github/workflows/claude-runner.yml
@@ -146,8 +146,24 @@ jobs:
           # OpenCode's `default_agent`. The entity reference leads the argument
           # so the fork still knows what it is working on even if the multi-line
           # context that follows does not survive argument substitution.
+          #
+          # The one-turn warning is on the FIRST attempt, not only on the retry
+          # below. It used to be the retry's alone, and the first attempt is the
+          # one that holds the whole job budget: PRs #594, #603 and #604 each
+          # lost theirs to a turn that ended waiting on a background command,
+          # and by the time the retry read the warning there were minutes left,
+          # not hours.
           prompt: |
             /agentic-run ${{ steps.context.outputs.entity }}
+            ▶ THIS SESSION GETS ONE TURN. Nobody will reply to you, and when this turn ends the
+            process exits. Any result you arrange to collect "later" is never collected: a
+            backgrounded sub-agent, a backgrounded shell command, a task notification. Every
+            delegation is synchronous — parallel means several delegations in ONE message, all
+            awaited in that same turn. For a command too long for one Bash call (`npm run
+            scenarios`, `npm run ci:await`), start it with `npm run long -- start <label> -- <cmd>`
+            and then call `npm run long -- wait <label>` repeatedly in this same turn; exit code 75
+            means still going, not failed. Never end your turn while one is outstanding.
+
             ${{ steps.context.outputs.prompt }}
           # No permission prompts. The runner is a throwaway VM with no access
           # beyond this checkout and the job's own scoped tokens, and there is
@@ -221,10 +237,13 @@ jobs:
             before deciding: continue the furthest one that is sound, or rebuild from `main`.
             Either way this attempt owes the same terminal outcome as any other run.
 
-            The most likely reason the last attempt ended early is a delegation that did not
-            return inside the turn that issued it. Every delegation is synchronous. Parallel
-            means several delegations in ONE message, all awaited in that same turn — never
-            work launched now and collected later, because there is no later turn.
+            The most likely reason the last attempt ended early is work that did not return
+            inside the turn that issued it — a delegation, or a backgrounded shell command whose
+            result it meant to collect later. Every delegation is synchronous. Parallel means
+            several delegations in ONE message, all awaited in that same turn — never work
+            launched now and collected later, because there is no later turn. For a command too
+            long for one Bash call, `npm run long -- start <label> -- <cmd>` then
+            `npm run long -- wait <label>` until it stops exiting 75, all inside this turn.
 
             ${{ steps.context.outputs.prompt }}
           claude_args: '--permission-mode bypassPermissions --model claude-sonnet-5'

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ npm-debug.log*
 
 # Save files (local persistence)
 saves/
+
+# `npm run long` handles — runner-local pid/log/exit files, never a deliverable
+.agentic/

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/user/BlastSimulator2026/node_modules

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "console": "tsx src/console.ts",
+    "long": "tsx scripts/long-run.ts",
     "validate": "tsc --noEmit && npm run test:coverage && npm run test:integration && npm run test:scenarios && vite build",
     "typecheck": "tsc --noEmit && tsc --noEmit --project scripts/tsconfig.json",
     "test:coverage": "vitest run --coverage",

--- a/scripts/long-run.ts
+++ b/scripts/long-run.ts
@@ -1,0 +1,383 @@
+/**
+ * BlastSimulator2026 — Run a command longer than one Bash call, inside one turn
+ *
+ * The Bash tool caps a foreground call at 600s. Three of this project's own
+ * required commands sit past that cap or close enough to it that a slower runner
+ * crosses it:
+ *
+ *   npm run test      ~186s   fits
+ *   npm run scenarios ~559s   fits in a sandbox, not on a 2-core runner
+ *   npm run ci:await  minutes to tens of minutes, by design — it waits on CI
+ *
+ * So an agent that must run one of these has to detach it and come back. The way
+ * it came back is what cost this project three runs in four days. PRs #594, #603
+ * and #604 were all rescued branches, and every one of them died on the same
+ * shape:
+ *
+ *   #604  `npm run scenarios` backgrounded, then: "pausing here until it reports
+ *         back." The turn ended. 3h11m and $30.55 of completed TDD work, gone.
+ *         Its retry repeated the move in 2m51s: "Waiting on test run results
+ *         (background monitor armed)."
+ *   #594  "Waiting for the background vitest run (task `bip2e4izv`) to complete
+ *         — will be notified automatically." It will not. Both attempts.
+ *   #603  Avoided ending the turn by hand-rolling
+ *         `timeout 280 bash -c 'until ! ps -p <pid>; do sleep 5; done'` — 40+
+ *         times. Structurally right, and it still burned the whole 360-minute
+ *         job budget polling instead of working, then died on the job timeout
+ *         with no budget left for a retry.
+ *
+ * An unattended run gets one turn. A notification delivered on a later turn is
+ * never delivered, because there is no later turn — the same rule
+ * `require-foreground-agents.sh` already enforces for delegation (#404, #406),
+ * arriving through a shell command instead of through a sub-agent.
+ *
+ * This is the supported way to do it. `start` detaches and returns immediately;
+ * `wait` blocks in the foreground for a bounded slice and reports whether the
+ * command finished. A slice that expires is not a verdict — it exits 75, which
+ * means *ask again, in this same turn*, and the caller loops on it. Nothing here
+ * decides anything on a duration: the verdict is always the command's own exit
+ * code, read from disk.
+ *
+ * Usage:
+ *   npm run long -- start scenarios -- npm run scenarios
+ *   npm run long -- wait scenarios                    # repeat until it is not 75
+ *   npm run long -- wait scenarios --budget-seconds 300
+ *   npm run long -- status                            # what is still unfinished
+ *   npm run long -- clean                             # drop finished handles
+ *
+ * Exit codes — the caller branches on these:
+ *   0   DONE      the command finished, exit code 0
+ *   1   FAILED    the command finished non-zero, or died without reporting
+ *   75  RUNNING   this slice is spent and the command is still going. Not a
+ *                 verdict. Call `wait` again in this same turn
+ *   4   USAGE     bad arguments
+ *
+ * @module long-run
+ */
+
+import { spawn } from 'child_process';
+import {
+  existsSync,
+  mkdirSync,
+  openSync,
+  closeSync,
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  rmSync,
+} from 'fs';
+import { join, resolve } from 'path';
+
+/** Where handles live. Gitignored: these are runner-local, never a deliverable. */
+export const LONG_DIR = resolve(process.cwd(), '.agentic/long');
+
+/**
+ * Default seconds a single `wait` blocks before reporting RUNNING.
+ *
+ * Not a timeout and not a threshold anything is decided on — it is how much of
+ * one Bash call this spends before handing the turn back a still-running answer.
+ * Under the tool's own 600s ceiling with room for process startup, so a `wait`
+ * always gets to print its own line rather than being killed mid-poll. Raising
+ * or lowering it changes how many `wait` calls a long command costs, and nothing
+ * else.
+ */
+export const DEFAULT_BUDGET_SECONDS = 540;
+
+/** How often `wait` looks at the exit file. Cadence, not a verdict. */
+const POLL_MS = 2000;
+
+/** Exit code meaning "still running, ask again". `EX_TEMPFAIL`, by convention. */
+export const EXIT_RUNNING = 75;
+
+/** A label has to be safe as a filename and readable in a log. */
+export const LABEL_PATTERN = /^[a-z0-9][a-z0-9._-]*$/i;
+
+export interface Handle {
+  label: string;
+  pidPath: string;
+  logPath: string;
+  exitPath: string;
+  cmdPath: string;
+}
+
+/**
+ * Quotes one argv element for `bash -c`.
+ *
+ * The command arrives as argv, and joining it with spaces would hand the shell a
+ * different command than the caller wrote: `bash -c 'echo hi; exit 3'` joined
+ * raw becomes four separate statements. Single quotes with the standard
+ * `'\''` escape keep every element exactly one word.
+ */
+export function shellQuote(argument: string): string {
+  return `'${argument.replace(/'/g, `'\\''`)}'`;
+}
+
+export function handleFor(label: string, dir: string = LONG_DIR): Handle {
+  return {
+    label,
+    pidPath: join(dir, `${label}.pid`),
+    logPath: join(dir, `${label}.log`),
+    exitPath: join(dir, `${label}.exit`),
+    cmdPath: join(dir, `${label}.cmd`),
+  };
+}
+
+/** True when the process is still alive. Signal 0 tests without delivering. */
+export function isAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means it exists and belongs to somebody else — alive either way.
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+export type State =
+  | { kind: 'unknown' }
+  | { kind: 'running'; pid: number }
+  | { kind: 'finished'; code: number }
+  /** Gone without writing an exit code: killed, or the runner reaped it. */
+  | { kind: 'died'; pid: number };
+
+/**
+ * Reads a handle's state off disk.
+ *
+ * The exit file is written by the detached shell itself, so it is authoritative
+ * and it outlives the process. It is checked before liveness deliberately: a
+ * command that finished microseconds ago is finished, not dead.
+ */
+export function readState(handle: Handle): State {
+  if (existsSync(handle.exitPath)) {
+    const raw = readFileSync(handle.exitPath, 'utf8').trim();
+    const code = Number.parseInt(raw, 10);
+    return { kind: 'finished', code: Number.isNaN(code) ? 1 : code };
+  }
+  if (!existsSync(handle.pidPath)) return { kind: 'unknown' };
+  const pid = Number.parseInt(readFileSync(handle.pidPath, 'utf8').trim(), 10);
+  return isAlive(pid) ? { kind: 'running', pid } : { kind: 'died', pid };
+}
+
+/** Every handle that has been started and has not reported an exit code. */
+export function unfinished(dir: string = LONG_DIR): string[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((name) => name.endsWith('.pid'))
+    .map((name) => name.slice(0, -'.pid'.length))
+    .filter((label) => readState(handleFor(label, dir)).kind === 'running')
+    .sort();
+}
+
+function tail(path: string, lines: number): string {
+  if (!existsSync(path)) return '(no output yet)';
+  const content = readFileSync(path, 'utf8').split('\n');
+  const slice = content.slice(-lines).join('\n').trimEnd();
+  return slice === '' ? '(no output yet)' : slice;
+}
+
+function usage(message: string): number {
+  console.error(`${message}
+
+Usage:
+  npm run long -- start <label> -- <command...>
+  npm run long -- wait <label> [--budget-seconds N]
+  npm run long -- status
+  npm run long -- clean`);
+  return 4;
+}
+
+function start(label: string, command: string[]): number {
+  if (!LABEL_PATTERN.test(label)) {
+    return usage(`Not a usable label: \`${label}\`. Letters, digits, dot, dash, underscore.`);
+  }
+  if (command.length === 0) {
+    return usage('No command given. Everything after `--` is the command to run.');
+  }
+
+  mkdirSync(LONG_DIR, { recursive: true });
+  const handle = handleFor(label);
+
+  const state = readState(handle);
+  if (state.kind === 'running') {
+    console.error(
+      `\`${label}\` is already running (pid ${state.pid}). ` +
+      `Wait for it, or start it under another label.`
+    );
+    return 4;
+  }
+
+  // A previous run under this label is replaced, not appended to: a stale exit
+  // code left in place would make the next `wait` report success instantly.
+  for (const path of [handle.exitPath, handle.logPath, handle.pidPath]) {
+    rmSync(path, { force: true });
+  }
+
+  const line = command.map(shellQuote).join(' ');
+  const fd = openSync(handle.logPath, 'a');
+
+  // The detached shell writes its own exit file. No supervisor process is
+  // involved, so nothing has to outlive this call for the result to survive —
+  // which is the whole point: `start` returns now, the answer lands on disk
+  // whenever the command is done, and `wait` can be called from any later tool
+  // call in this turn.
+  //
+  // The command runs in a subshell so that a command which calls `exit` itself
+  // cannot skip the two lines after it. Without the parentheses that exit
+  // replaces the wrapper, no exit file is ever written, and `wait` reports DIED
+  // for a command that in fact ran to completion.
+  const script =
+    `( ${line} )\nstatus=$?\nprintf '%s' "$status" > ${shellQuote(handle.exitPath)}\nexit $status\n`;
+  const child = spawn('bash', ['-c', script], {
+    detached: true,
+    stdio: ['ignore', fd, fd],
+    cwd: process.cwd(),
+  });
+  child.unref();
+  closeSync(fd);
+
+  if (child.pid === undefined) {
+    console.error(`Could not start \`${line}\`.`);
+    return 1;
+  }
+
+  writeFileSync(handle.pidPath, String(child.pid));
+  writeFileSync(handle.cmdPath, line);
+
+  console.log(
+    `LONG RUN ${label} STARTED pid=${child.pid}\n` +
+    `  command: ${line}\n` +
+    `  log:     ${handle.logPath}\n` +
+    `▶ This turn is not finished until you have waited for it:\n` +
+    `  npm run long -- wait ${label}\n` +
+    `  Repeat that call while it exits ${EXIT_RUNNING}. Do not end your turn first — ` +
+    `an unattended run has no later turn to be notified in.`
+  );
+  return 0;
+}
+
+async function wait(label: string, budgetSeconds: number): Promise<number> {
+  const handle = handleFor(label);
+  if (!existsSync(handle.pidPath) && !existsSync(handle.exitPath)) {
+    return usage(`No long run called \`${label}\`. Started ones: ${
+      existsSync(LONG_DIR)
+        ? readdirSync(LONG_DIR).filter((n) => n.endsWith('.pid')).map((n) => n.slice(0, -4)).join(', ') || '(none)'
+        : '(none)'
+    }`);
+  }
+
+  const startedAt = Date.now();
+  const command = existsSync(handle.cmdPath) ? readFileSync(handle.cmdPath, 'utf8') : label;
+
+  for (;;) {
+    const state = readState(handle);
+
+    if (state.kind === 'finished') {
+      const elapsed = Math.round((Date.now() - startedAt) / 1000);
+      console.log(tail(handle.logPath, 200));
+      console.log(
+        `\nLONG RUN ${label} FINISHED exit=${state.code} (waited ${elapsed}s in this call)\n` +
+        `  command: ${command}\n` +
+        `  log:     ${handle.logPath}`
+      );
+      return state.code === 0 ? 0 : 1;
+    }
+
+    if (state.kind === 'died' || state.kind === 'unknown') {
+      console.log(tail(handle.logPath, 200));
+      console.log(
+        `\nLONG RUN ${label} DIED — the process is gone and wrote no exit code.\n` +
+        `  command: ${command}\n` +
+        `  Treat this as a failure of that command, not as a result. Re-run it.`
+      );
+      return 1;
+    }
+
+    if (Date.now() - startedAt >= budgetSeconds * 1000) {
+      const elapsed = Math.round((Date.now() - startedAt) / 1000);
+      console.log(tail(handle.logPath, 40));
+      console.log(
+        `\nLONG RUN ${label} STILL RUNNING after ${elapsed}s of this call (pid ${state.pid}).\n` +
+        `  command: ${command}\n` +
+        `▶ Not a verdict — nothing has failed. Call \`npm run long -- wait ${label}\` ` +
+        `again, in this same turn, until it reports FINISHED.`
+      );
+      return EXIT_RUNNING;
+    }
+
+    await new Promise((done) => setTimeout(done, POLL_MS));
+  }
+}
+
+function status(): number {
+  const pending = unfinished();
+  if (pending.length === 0) {
+    console.log('No long run is unfinished.');
+    return 0;
+  }
+  console.log(`Unfinished long run(s): ${pending.join(', ')}`);
+  for (const label of pending) {
+    const handle = handleFor(label);
+    const command = existsSync(handle.cmdPath) ? readFileSync(handle.cmdPath, 'utf8') : '(unknown)';
+    console.log(`  ${label}: ${command}`);
+  }
+  return 1;
+}
+
+function clean(): number {
+  if (!existsSync(LONG_DIR)) return 0;
+  const pending = new Set(unfinished());
+  let removed = 0;
+  for (const name of readdirSync(LONG_DIR)) {
+    const label = name.replace(/\.(pid|log|exit|cmd)$/, '');
+    if (pending.has(label)) continue;
+    rmSync(join(LONG_DIR, name), { force: true });
+    removed += 1;
+  }
+  console.log(`Removed ${removed} finished handle file(s).`);
+  return 0;
+}
+
+export async function main(argv: string[]): Promise<number> {
+  const [subcommand, ...rest] = argv;
+
+  switch (subcommand) {
+    case 'start': {
+      const separator = rest.indexOf('--');
+      if (separator === -1) {
+        return usage('`start` needs `--` between the label and the command.');
+      }
+      const [label, ...extra] = rest.slice(0, separator);
+      if (label === undefined || extra.length > 0) {
+        return usage('`start` takes exactly one label before `--`.');
+      }
+      return start(label, rest.slice(separator + 1));
+    }
+    case 'wait': {
+      const label = rest[0];
+      if (label === undefined) return usage('`wait` needs a label.');
+      let budget = DEFAULT_BUDGET_SECONDS;
+      const flag = rest.indexOf('--budget-seconds');
+      if (flag !== -1) {
+        const value = Number.parseInt(rest[flag + 1] ?? '', 10);
+        if (!Number.isFinite(value) || value <= 0) {
+          return usage('`--budget-seconds` needs a positive number of seconds.');
+        }
+        budget = value;
+      }
+      return wait(label, budget);
+    }
+    case 'status':
+      return status();
+    case 'clean':
+      return clean();
+    default:
+      return usage(subcommand === undefined ? 'No subcommand given.' : `Unknown subcommand: ${subcommand}`);
+  }
+}
+
+// Guarded so the unit tests can import the helpers above without running a poll
+// loop, matching `await-pr-ci.ts`'s own entry guard.
+if (process.argv[1] !== undefined && process.argv[1].endsWith('long-run.ts')) {
+  main(process.argv.slice(2)).then((code) => process.exit(code));
+}

--- a/scripts/validate-context.ts
+++ b/scripts/validate-context.ts
@@ -418,6 +418,37 @@ const SETTINGS_HOOKS = [
       'guard never ran, and issue #406 lost its run to a backgrounded sub-agent',
   },
   {
+    script: '.claude/hooks/require-foreground-bash.sh',
+    event: 'PreToolUse',
+    /** Every shell command has to pass it, so the matcher must cover `Bash`. */
+    tools: ['Bash'],
+    why:
+      'the same one-turn rule as the delegation guard above, arriving through the shell: a ' +
+      'backgrounded command reports on a turn that never comes. PRs #594, #603 and #604 were ' +
+      'all rescued branches, and every one of them ended on a sentence promising to wait for ' +
+      'a background task — #604 threw away 3h11m of finished work that way',
+  },
+  {
+    script: '.claude/hooks/require-settled-turn.sh',
+    event: 'Stop',
+    /** Stop carries no tool name; registration itself is the whole check. */
+    tools: [],
+    why:
+      'it is the only guard that acts at the moment the work is actually lost — the turn ' +
+      'ending while a `npm run long` handle is still unfinished. Prose did not hold here: ' +
+      'CLAUDE.md, the orchestrator definition and the retry prompt all already said results ' +
+      'must arrive inside the turn that asked for them',
+  },
+  {
+    script: '.claude/hooks/require-settled-turn.sh',
+    event: 'SubagentStop',
+    tools: [],
+    why:
+      'a specialist is what actually runs `npm run scenarios`, so a sub-agent ending its own ' +
+      'turn on an unfinished long run loses the result exactly the same way the main session ' +
+      'does — `Stop` alone never sees it',
+  },
+  {
     script: '.claude/hooks/no-ask-user-question.sh',
     event: 'PreToolUse',
     tools: ['AskUserQuestion'],

--- a/tests/unit/config/autonomy-loop.test.ts
+++ b/tests/unit/config/autonomy-loop.test.ts
@@ -989,3 +989,84 @@ describe('a pipeline PR that is neither marked nor draft', () => {
     );
   });
 });
+
+// An unattended session gets one turn. When it ends the process exits, so any
+// result the run arranged to collect "later" — a backgrounded sub-agent, a
+// backgrounded shell command, a task notification — is never collected, and
+// everything not yet pushed dies with the runner VM.
+//
+// `require-foreground-agents.sh` closed this for delegation after #404 and #406.
+// It came back through the shell and cost three runs in four days, all rescued
+// as draft PRs nobody asked for:
+//
+//   #604  "Scenario verification is running in the background — pausing here
+//         until it reports back."  3h11m and $30.55 of finished TDD work gone,
+//         and the retry repeated it inside 2m51s.
+//   #594  "Waiting for the background vitest run — will be notified
+//         automatically."  Both attempts.
+//   #603  Polled `ps -p` in 280s slices 40+ times instead, spending the whole
+//         360-minute job budget without finishing, then died on the job clock.
+//
+// Three layers hold it now and each fails differently: a hook on what may be
+// started, a hook on whether the turn may end, and the runner prompt that tells
+// the session the rule before it has to be enforced. These pin all three.
+describe('a run cannot end waiting on work that reports after the turn', () => {
+  const settings = JSON.parse(
+    readFileSync(join(ROOT, '.claude/settings.json'), 'utf8')
+  ) as {
+    hooks?: Record<string, { matcher?: string; hooks?: { command?: string }[] }[]>;
+  };
+
+  const registered = (event: string, script: string) =>
+    (settings.hooks?.[event] ?? []).filter((entry) =>
+      (entry.hooks ?? []).some((hook) => (hook.command ?? '').endsWith(script))
+    );
+
+  // In settings.json, never in agent frontmatter: a frontmatter hook registers
+  // only for an agent started through the `Agent` tool, and `/agentic-run`
+  // forks into the orchestrator without one. That is how the delegation guard
+  // sat inert while #406 died 58 seconds in.
+  it('blocks a backgrounded Bash call, from settings.json', () => {
+    const entries = registered('PreToolUse', 'require-foreground-bash.sh');
+    expect(
+      entries.length,
+      'require-foreground-bash.sh is not a PreToolUse hook — a backgrounded command ' +
+      'reports on a turn that never comes'
+    ).toBeGreaterThan(0);
+    expect(entries.some((entry) => /(^|\|)Bash(\||$)/.test(entry.matcher ?? ''))).toBe(true);
+  });
+
+  // Stop is the only guard that acts at the moment the work is actually lost,
+  // and SubagentStop matters just as much: a specialist is what runs
+  // `npm run scenarios`, so its own turn can end on an unfinished handle.
+  it.each(['Stop', 'SubagentStop'])('refuses to end a %s with a long run unfinished', (event) => {
+    expect(
+      registered(event, 'require-settled-turn.sh').length,
+      `require-settled-turn.sh is not registered on ${event}`
+    ).toBeGreaterThan(0);
+  });
+
+  it('keeps the delegation guard that closed #404 and #406', () => {
+    expect(registered('PreToolUse', 'require-foreground-agents.sh').length).toBeGreaterThan(0);
+  });
+
+  // The warning used to be the retry's alone. The first attempt is the one
+  // holding the whole 360-minute budget — by the time #604's retry read it,
+  // there were three minutes left, and it made the same move again.
+  it('warns the first attempt, not only the retry', () => {
+    const runner = workflow('claude-runner.yml');
+    const first = runner.slice(
+      runner.indexOf('- name: Run Claude Code'),
+      runner.indexOf('- name: Did the run settle its issue?')
+    );
+    expect(first).toContain('THIS SESSION GETS ONE TURN');
+    expect(first).toContain('npm run long -- wait');
+  });
+
+  it('tells the retry the same rule', () => {
+    const runner = workflow('claude-runner.yml');
+    const retry = runner.slice(runner.indexOf('- name: Retry the run when the first attempt'));
+    expect(retry).toContain('there is no later turn');
+    expect(retry).toContain('npm run long -- wait');
+  });
+});

--- a/tests/unit/config/long-run.test.ts
+++ b/tests/unit/config/long-run.test.ts
@@ -1,0 +1,318 @@
+// BlastSimulator2026 — The long-run wrapper and the two hooks around it
+//
+// `npm run long` exists because an unattended session gets one turn and three of
+// this project's required commands do not fit in one 600s Bash call. It is the
+// only sanctioned way to detach, and `require-settled-turn.sh` reads its handle
+// directory to decide whether a turn may end — so a wrong answer here is a lost
+// run, the failure that produced PRs #594, #603 and #604.
+//
+// Three things have to hold, and each broke once while this was being written:
+//   - a command's real exit code survives, including when the command calls
+//     `exit` itself (the first cut wrapped it without a subshell and reported a
+//     finished command as DIED)
+//   - argv survives the trip through `bash -c` (the first cut joined on spaces,
+//     turning one command into four statements)
+//   - `&&` and `2>&1` are not backgrounding and must keep working
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { shellQuote, handleFor, readState, unfinished, EXIT_RUNNING } from '../../../scripts/long-run';
+
+const ROOT = join(import.meta.dirname, '../../..');
+const read = (path: string): string => readFileSync(path, 'utf8');
+const SCRIPT = join(ROOT, 'scripts/long-run.ts');
+
+/** Runs the CLI in an isolated cwd so handles never touch the repo's own. */
+function long(cwd: string, args: string[]): { code: number; out: string } {
+  const result = spawnSync('npx', ['tsx', SCRIPT, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env },
+  });
+  return { code: result.status ?? -1, out: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+}
+
+describe('shellQuote', () => {
+  it('keeps a command with shell metacharacters as one word', () => {
+    expect(shellQuote('echo hi; exit 3')).toBe(`'echo hi; exit 3'`);
+  });
+
+  it('survives an embedded single quote', () => {
+    expect(shellQuote(`it's`)).toBe(`'it'\\''s'`);
+  });
+});
+
+describe('npm run long', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'longrun-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reports the command exit code even when the command exits itself', () => {
+    // The `exit 3` is the point: without the subshell in the wrapper it replaces
+    // the shell that was going to write the exit file, and a command that ran
+    // fine gets reported as DIED.
+    expect(long(dir, ['start', 'probe', '--', 'bash', '-c', 'echo hello; exit 3']).code).toBe(0);
+    const waited = long(dir, ['wait', 'probe']);
+    expect(waited.out).toContain('FINISHED exit=3');
+    expect(waited.out).toContain('hello');
+    expect(waited.code).toBe(1);
+  });
+
+  it('exits 0 when the command succeeded', () => {
+    long(dir, ['start', 'ok', '--', 'bash', '-c', 'echo fine']);
+    const waited = long(dir, ['wait', 'ok']);
+    expect(waited.out).toContain('FINISHED exit=0');
+    expect(waited.code).toBe(0);
+  });
+
+  it('exits 75 — not a failure — while the command is still going', () => {
+    long(dir, ['start', 'slow', '--', 'bash', '-c', 'sleep 30']);
+    const waited = long(dir, ['wait', 'slow', '--budget-seconds', '1']);
+    expect(waited.out).toContain('STILL RUNNING');
+    expect(waited.out).toContain('Not a verdict');
+    expect(waited.code).toBe(EXIT_RUNNING);
+  });
+
+  it('refuses a second start under a label already running', () => {
+    long(dir, ['start', 'busy', '--', 'bash', '-c', 'sleep 30']);
+    expect(long(dir, ['start', 'busy', '--', 'bash', '-c', 'echo x']).code).toBe(4);
+  });
+
+  it('status answers what is unfinished, and exits non-zero while any is', () => {
+    long(dir, ['start', 'pending', '--', 'bash', '-c', 'sleep 30']);
+    const running = long(dir, ['status']);
+    expect(running.out).toContain('pending');
+    expect(running.code).toBe(1);
+
+    long(dir, ['start', 'quick', '--', 'bash', '-c', 'true']);
+    long(dir, ['wait', 'quick']);
+    // `pending` is still going, so status must still say so.
+    expect(long(dir, ['status']).code).toBe(1);
+  });
+
+  it('rejects a missing `--`, a missing label and an unknown subcommand', () => {
+    expect(long(dir, ['start', 'label']).code).toBe(4);
+    expect(long(dir, ['wait']).code).toBe(4);
+    expect(long(dir, ['sprint']).code).toBe(4);
+  });
+});
+
+describe('readState / unfinished', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'longstate-'));
+    mkdirSync(dir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('treats a written exit code as authoritative over liveness', () => {
+    const handle = handleFor('x', dir);
+    // A pid that is alive (this process) plus an exit file: finished wins, so a
+    // command that completed a moment ago never reads as still running.
+    writeFileSync(handle.pidPath, String(process.pid));
+    writeFileSync(handle.exitPath, '0');
+    expect(readState(handle)).toEqual({ kind: 'finished', code: 0 });
+    expect(unfinished(dir)).toEqual([]);
+  });
+
+  it('calls a gone process with no exit code died, not finished', () => {
+    const handle = handleFor('y', dir);
+    writeFileSync(handle.pidPath, '2147483646');
+    expect(readState(handle).kind).toBe('died');
+    expect(unfinished(dir)).toEqual([]);
+  });
+
+  it('lists a live handle with no exit code as unfinished', () => {
+    writeFileSync(handleFor('z', dir).pidPath, String(process.pid));
+    expect(unfinished(dir)).toEqual(['z']);
+  });
+});
+
+/** Feeds a PreToolUse payload to a hook and returns its exit code. */
+function hook(script: string, payload: unknown, env: NodeJS.ProcessEnv = {}): number {
+  const result = spawnSync(join(ROOT, '.claude/hooks', script), [], {
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+  return result.status ?? -1;
+}
+
+const bash = (command: string, background?: boolean) => ({
+  tool_input: background === undefined ? { command } : { command, run_in_background: background },
+});
+
+describe('require-foreground-bash.sh', () => {
+  it.each([
+    ['a plain command', bash('npm run test')],
+    ['an explicit foreground call', bash('npm run test', false)],
+    ['a && chain', bash('npm run typecheck && npm run test')],
+    ['a 2>&1 redirect', bash('npm run test 2>&1 | tail -20')],
+    ['the sanctioned wrapper', bash('npm run long -- start scenarios -- npm run scenarios')],
+    // A server is not a result. The visual channel cannot run without one, and
+    // `npm run dev &` is what `dev-visual-testing`, `rendering.md`,
+    // `visual-tester` and `verify-env` all already tell a session to type.
+    ['the dev server the visual channel needs', bash('npm run dev &')],
+    ['the dev server on an explicit port', bash('npm run dev -- --port 5173 &')],
+    ['vite directly', bash('npx vite &')],
+    ['the dev server with its output redirected', bash('npm run dev > /tmp/dev.log 2>&1 &')],
+    ['the dev server through the background flag', bash('npm run dev', true)],
+  ])('allows %s', (_label, payload) => {
+    expect(hook('require-foreground-bash.sh', payload)).toBe(0);
+  });
+
+  it.each([
+    ['run_in_background: true', bash('npm run scenarios', true)],
+    ['nohup', bash('nohup npx tsx scripts/run-all-scenarios.ts > /tmp/o 2>&1 &')],
+    ['a trailing &', bash('npx vitest run &')],
+    ['setsid', bash('setsid npm run scenarios')],
+    // The dev-server carve-out is anchored at the start of the command, so a
+    // detach wrapper in front of one is still a detach.
+    ['a dev server behind a detach wrapper', bash('setsid npm run dev')],
+    ['disown', bash('npm run dev & disown')],
+    ['a backgrounded line inside a multi-line command', bash('cd /tmp\nnpm run dev &\necho started')],
+    // The dev-server allowance covers one simple command and nothing chained
+    // onto it — otherwise naming `npm run dev` would launder anything after it.
+    ['a real background command chained onto a dev server', bash('npm run dev & npx vitest run &')],
+    ['a nohup hidden behind a dev server', bash('npm run dev & sleep 3; nohup npm run scenarios &')],
+  ])('blocks %s', (_label, payload) => {
+    expect(hook('require-foreground-bash.sh', payload)).toBe(2);
+  });
+
+  it('names the wrapper in the reason it gives back', () => {
+    const result = spawnSync(join(ROOT, '.claude/hooks/require-foreground-bash.sh'), [], {
+      input: JSON.stringify(bash('npm run scenarios', true)),
+      encoding: 'utf8',
+    });
+    expect(result.stderr).toContain('npm run long -- start');
+    expect(result.stderr).toContain('75');
+  });
+
+  // A human at an interactive CLI genuinely has a later turn. No pipeline
+  // workflow sets this — blocking stays the default so a runner cannot lose a
+  // run to an environment variable that failed to arrive.
+  it('lets a human opt out', () => {
+    expect(
+      hook('require-foreground-bash.sh', bash('npm run dev &'), { AGENTIC_ALLOW_BACKGROUND_BASH: '1' })
+    ).toBe(0);
+  });
+
+  it('fails open on an unreadable payload rather than wedging every command', () => {
+    const result = spawnSync(join(ROOT, '.claude/hooks/require-foreground-bash.sh'), [], {
+      input: 'not json at all',
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(0);
+  });
+});
+
+describe('require-settled-turn.sh', () => {
+  let dir: string;
+
+  const stop = (env: NodeJS.ProcessEnv = {}): number =>
+    spawnSync(join(ROOT, '.claude/hooks/require-settled-turn.sh'), [], {
+      input: '{}',
+      encoding: 'utf8',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: dir, ...env },
+    }).status ?? -1;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'stophook-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('lets a turn end when nothing was ever started', () => {
+    expect(stop()).toBe(0);
+  });
+
+  it('lets a turn end when every long run reported', () => {
+    const handles = join(dir, '.agentic/long');
+    mkdirSync(handles, { recursive: true });
+    writeFileSync(join(handles, 'done.pid'), String(process.pid));
+    writeFileSync(join(handles, 'done.exit'), '0');
+    expect(stop()).toBe(0);
+  });
+
+  it('refuses the turn while a long run is still going', () => {
+    const handles = join(dir, '.agentic/long');
+    mkdirSync(handles, { recursive: true });
+    writeFileSync(join(handles, 'scenarios.pid'), String(process.pid));
+    expect(stop()).toBe(2);
+  });
+
+  it('names the wait command in the reason it gives back', () => {
+    const handles = join(dir, '.agentic/long');
+    mkdirSync(handles, { recursive: true });
+    writeFileSync(join(handles, 'scenarios.pid'), String(process.pid));
+    const result = spawnSync(join(ROOT, '.claude/hooks/require-settled-turn.sh'), [], {
+      input: '{}',
+      encoding: 'utf8',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: dir },
+    });
+    expect(result.stderr).toContain('npm run long -- wait scenarios');
+  });
+
+  // Blocking forever is its own outage: a job that cannot end never reaches the
+  // rescue step, so the branch dies with the VM instead of becoming a draft
+  // somebody can finish. A counter with a bound, not a wall.
+  it('releases on its brake after the configured number of refusals', () => {
+    const handles = join(dir, '.agentic/long');
+    mkdirSync(handles, { recursive: true });
+    writeFileSync(join(handles, 'stuck.pid'), String(process.pid));
+    expect([stop(), stop()]).toEqual([2, 2]);
+    expect(stop({ AGENTIC_STOP_BLOCK_LIMIT: '2' })).toBe(0);
+  });
+
+  it('forgets its count once nothing is outstanding', () => {
+    const handles = join(dir, '.agentic/long');
+    mkdirSync(handles, { recursive: true });
+    writeFileSync(join(handles, 'again.pid'), String(process.pid));
+    expect(stop()).toBe(2);
+    writeFileSync(join(handles, 'again.exit'), '0');
+    expect(stop()).toBe(0);
+    expect(existsSync(join(handles, '.stop-blocks'))).toBe(false);
+  });
+
+  it('lets a human opt out', () => {
+    const handles = join(dir, '.agentic/long');
+    mkdirSync(handles, { recursive: true });
+    writeFileSync(join(handles, 'x.pid'), String(process.pid));
+    expect(stop({ AGENTIC_ALLOW_UNSETTLED_TURN: '1' })).toBe(0);
+  });
+});
+
+describe('the wrapper is reachable the way the context files name it', () => {
+  it('is wired as `npm run long`', () => {
+    const pkg = JSON.parse(read(join(ROOT, 'package.json'))) as {
+      scripts: Record<string, string>;
+    };
+    expect(pkg.scripts.long).toBe('tsx scripts/long-run.ts');
+  });
+
+  it('keeps its handles out of the repository', () => {
+    expect(read(join(ROOT, '.gitignore'))).toContain('.agentic/');
+  });
+
+  it('is what CLAUDE.md tells a session to use', () => {
+    const claudeMd = read(join(ROOT, '.claude/CLAUDE.md'));
+    expect(claudeMd).toContain('npm run long -- wait');
+    expect(claudeMd).toContain('There is no later turn');
+  });
+});


### PR DESCRIPTION
## What happened

Every open PR right now — #594, #603, #604 — is an `agentic-rescue` draft, not a deliverable. Three of the last four pipeline runs ended without opening their own PR, and the runner logs show one root cause, not three.

**An unattended session gets one turn.** When the turn ends the process exits, so a background-task notification is delivered to nobody. Each run backgrounded a verification command and then ended its turn to wait for it:

| Run | How the turn ended | Cost |
|-----|--------------------|------|
| [#604](https://github.com/Nico2398/BlastSimulator2026/actions/runs/31998367014) | `"Scenario verification (npm run scenarios) is running in the background — pausing here until it reports back."` | 3h11m and **$30.55** of finished TDD work discarded. The retry repeated it in 2m51s: `"Waiting on test run results (background monitor armed)."` |
| [#594](https://github.com/Nico2398/BlastSimulator2026/actions/runs/31771764602) | `"Waiting for the background vitest run (task bip2e4izv) to complete — will be notified automatically."` | Both attempts, same sentence. |
| [#603](https://github.com/Nico2398/BlastSimulator2026/actions/runs/31979473983) | Never ended the turn — hand-rolled `timeout 280 bash -c 'until ! ps -p <pid>; do sleep 5; done'` 40+ times instead. | The whole 360-minute job budget spent polling, then the job timeout. Cancelled jobs skip the retry gate, so there was no second attempt. |

This is the rule `require-foreground-agents.sh` already enforces for delegation (#404, #406), arriving through the shell instead of through a sub-agent. Nothing was watching that door — and CLAUDE.md's own runtime section described this harness as one that "starts long-running processes in the background and watches them across turns", which is true interactively and fatal on a runner.

## Why it could not just be "stop backgrounding things"

The Bash tool caps one foreground call at 600 000 ms, and the commands involved genuinely do not fit. Measured on this branch:

- `npm run test` — **186s**, fits
- `npm run scenarios` — **559s**, fits in a sandbox and not on a 2-core runner
- `npm run ci:await` — waits as long as CI takes, by design, and CLAUDE.md makes it every autonomous run's last step

So detaching is necessary. *How the result is collected* is what was broken, and there was no supported way to do it right.

## The fix

**`scripts/long-run.ts`, wired as `npm run long`** — detach, and still collect the result inside the turn.

```bash
npm run long -- start scenarios -- npm run scenarios
npm run long -- wait scenarios      # exit 75 = still going, call it again
```

`start` detaches and writes a handle; the detached shell writes its own exit file, so the result survives without a supervisor. `wait` blocks one bounded slice and exits `75` meaning *ask again* — not a verdict, and the caller loops on it in the same turn. The verdict is always the command's own exit code, read from disk. The command runs in a subshell so a command that calls `exit` itself cannot skip the exit-file write, and argv is shell-quoted so one command does not become four statements.

**`require-foreground-bash.sh`** (PreToolUse / `Bash`) — refuses `run_in_background: true` and raw `nohup` / `setsid` / `disown` / trailing `&`, and points at the wrapper. `&&` and `2>&1` keep working. A dev server is carved out: it produces no result anybody collects, and the visual channel cannot run without one. The carve-out is anchored at the start of the command and rejects anything chained on, so naming `npm run dev` cannot launder `npm run dev & npx vitest run &`.

**`require-settled-turn.sh`** (Stop + SubagentStop) — refuses to end a turn while a handle is unfinished. `SubagentStop` matters as much as `Stop`: a specialist is what actually runs `npm run scenarios`. Bounded by a counter, not a wall — after 4 refusals it releases, because a job that can never end also never reaches its rescue step.

Both hooks are registered in `settings.json`, never in agent frontmatter — that is the trap #406 fell into — and `validate-context.ts` now fails if either goes unregistered.

**`claude-runner.yml`** — the one-turn warning moves onto the **first** attempt, not only the retry. The first attempt holds the whole 360-minute budget; by the time #604's retry read the warning there were three minutes left, and it made the same move again.

Both hooks honour an env-var opt-out for a human at an interactive CLI, where a later turn genuinely exists. No pipeline workflow sets either.

## Second commit — unrelated, called out rather than buried

`chore: untrack the self-referential node_modules symlink`.

`node_modules` was committed in 8f86ff4 as a symlink pointing at its own absolute path (`node_modules -> /home/user/BlastSimulator2026/node_modules`), against this repository's own `.gitignore`, whose second line is `node_modules/`. It resolves nowhere, so every checkout that installs dependencies replaces it with a real directory and every session opens with a dirty tree reporting `D node_modules`. Removed with `--cached`: the index entry goes, the installed directory on disk is untouched.

It has nothing to do with the pipeline fix and is separated into its own commit so it can be dropped independently.

## Decisions taken

- **A dev server is allowed to detach.** The guard's purpose is preventing a lost *result*; a server is started so the browser has something to talk to and nothing waits on its exit code. Blocking it would have broken the visual channel and contradicted `dev-visual-testing`, `rendering.md`, `visual-tester` and `verify-env`, which all already say `npm run dev &`.
- **The Stop guard has a brake rather than blocking forever.** An unbounded refusal is its own outage: the job never reaches `agentic-rescue` and the branch dies with the VM instead of becoming a draft somebody can finish. Reaching the brake is a finding, and it says so in the log.
- **`wait`'s slice budget is not a clock in the sense `.claude/rules/github-workflows.md` forbids.** It decides nothing — exit 75 explicitly means *no verdict yet*. It is the same shape as `ci:await`'s poll interval, and it lives in `scripts/`, not the Actions layer.
- **The three stranded PRs are left alone.** Their issues are labelled `blocked`, and each rescue PR says resuming is a human decision. This change makes a re-run survive; it does not re-run them.

## Verification

| Channel | Result |
|---------|--------|
| `static` | `npm run typecheck` green; CI *TypeScript type check* ✅ |
| `logic` | `npm run test` — **313 files, 9526 tests green**, including 43 new tests covering the wrapper, both hooks, every carve-out boundary and the brake; CI *Unit & integration tests* ✅ |
| `scenario` | `npm run scenarios` — **129/129 passed**; CI *Scenarios (command mode)* ✅ |
| `visual` | Not run, and not applicable: this change touches no `src/`, no renderer, no UI and no scenario definition. |

`npm run validate:context` green with both hooks registered. CI green on both pushed heads.

The last two channels were run **through the new wrapper**, and `npm run scenarios` exercised the two-slice path — the first `wait` returned 75 at 541s, the second returned the exit code. That is the exact point at which #604's session ended its turn.

Two bugs were found this way and fixed before landing: a command calling `exit` itself was reported as `DIED` (missing subshell), and argv joined on spaces turned one command into four statements. Both are pinned by tests. The `Bash` guard also fired live during development — on a heredoc containing the word `setsid` — which is a safe false positive and confirmed the hook is genuinely active in a real session.
