### PR TITLE
fix: dead employees no longer skew living-roster aggregates (#592)

### DIFF
--- a/scripts/scenario-defs/economy-full-loop.json
+++ b/scripts/scenario-defs/economy-full-loop.json
@@ -465,7 +465,7 @@
           "selector": "#bs-employee-panel [data-role=\"driver\"]"
         }
       ],
-      "description": "#553: qualificationCount/proficiencyTotal bumped by 1 each over the pre-#553 baseline -- the driller (employee #2) now also carries the driving.drill_rig licence added above.",
+      "description": "#553: qualificationCount/proficiencyTotal bumped by 1 each over the pre-#553 baseline -- the driller (employee #2) now also carries the driving.drill_rig licence added above. #592: qualificationCount/proficiencyTotal dropped from 4/12 to 2/6 -- the blast a few steps above kills the driller (employee #2, holding blasting:5 + driving.drill_rig:1 -- confirmed via direct trace: `alive:false` on employee #2 immediately after the `blast` step), and qualificationCount/proficiencyTotal are now computed over living employees only (issue #592 -- a dead employee's frozen qualifications used to permanently pollute this aggregate). Only the surveyor (geology:5) is alive going into this hire, so 5 + this new driver's own driving.truck:1 = 6.",
       "role": "player",
       "expect": {
         "decreased": [
@@ -473,8 +473,8 @@
         ],
         "equals": {
           "employeeCount": 3,
-          "qualificationCount": 4,
-          "proficiencyTotal": 12
+          "qualificationCount": 2,
+          "proficiencyTotal": 6
         }
       }
     },
@@ -486,13 +486,13 @@
           "command": "employee assign_skill 3 skill:driving.truck level:5"
         }
       ],
-      "description": "Left unmarked: hiring already grants the Rookie starting qualification (ROLE_STARTING_QUALIFICATION in Employee.ts); this only raises the level for the scenario's needs -- the player-facing path is `employee train`.",
+      "description": "Left unmarked: hiring already grants the Rookie starting qualification (ROLE_STARTING_QUALIFICATION in Employee.ts); this only raises the level for the scenario's needs -- the player-facing path is `employee train`. #592: proficiencyTotal dropped from 16 to 10 -- same living-employees-only computation as the hire step just above (6 + this level bump from 1 to 5, i.e. +4, = 10); the dead driller's frozen qualifications no longer count.",
       "expect": {
         "changedBy": {
           "cash": 0
         },
         "equals": {
-          "proficiencyTotal": 16
+          "proficiencyTotal": 10
         }
       },
       "role": "bootstrap"
@@ -551,7 +551,7 @@
           "selector": "#bs-employee-panel [data-role=\"driver\"]"
         }
       ],
-      "description": "#553: this file's charge (amount:3kg boomite at spacing:4) always left some oversized boulders alongside the haulable rubble -- pre-#553, blast landed at tick 0 so the single debris_hauler driver's cost-ranked action window (ACTION_SELECTION_MAX_PATH_ATTEMPTS=5, ActionSelection.ts) never filled with fragment_debris the driver could never claim (no rock_fragmenter existed). Post-#553 the drilling wait shifts nothing about the blast's own geometry, but empirically the closest 5 pending actions to a debris_hauler driver's hire position are fragment_debris, and with no rock_fragmenter ever able to claim them they never clear -- permanently starving the driver's own haul_debris candidates out of its bounded top-5 window. A second driver crewing a rock_fragmenter (bought below, before the debris_hauler) clears that oversized boulder backlog so the debris_hauler's window actually reaches a haul_debris action. Employee #4.",
+      "description": "#553: this file's charge (amount:3kg boomite at spacing:4) always left some oversized boulders alongside the haulable rubble -- pre-#553, blast landed at tick 0 so the single debris_hauler driver's cost-ranked action window (ACTION_SELECTION_MAX_PATH_ATTEMPTS=5, ActionSelection.ts) never filled with fragment_debris the driver could never claim (no rock_fragmenter existed). Post-#553 the drilling wait shifts nothing about the blast's own geometry, but empirically the closest 5 pending actions to a debris_hauler driver's hire position are fragment_debris, and with no rock_fragmenter ever able to claim them they never clear -- permanently starving the driver's own haul_debris candidates out of its bounded top-5 window. A second driver crewing a rock_fragmenter (bought below, before the debris_hauler) clears that oversized boulder backlog so the debris_hauler's window actually reaches a haul_debris action. Employee #4. #592: qualificationCount/proficiencyTotal dropped from 5/17 to 3/11 -- same living-employees-only computation as the two steps above (the dead driller's blasting:5 + driving.drill_rig:1 still excluded): 2 living quals (surveyor geology:5, driver#3 driving.truck:5 -- profTotal 10) + this new driver's own driving.truck:1 = 3 quals / 11 proficiency.",
       "role": "player",
       "expect": {
         "decreased": [
@@ -559,8 +559,8 @@
         ],
         "equals": {
           "employeeCount": 4,
-          "qualificationCount": 5,
-          "proficiencyTotal": 17
+          "qualificationCount": 3,
+          "proficiencyTotal": 11
         }
       }
     },
@@ -572,14 +572,14 @@
           "command": "employee assign_skill 4 skill:driving.excavator level:5"
         }
       ],
-      "description": "Unlike the driving.truck bootstrap above, this one grants a licence from nothing: employee #4 was hired as a driver (ROLE_STARTING_QUALIFICATION driving.truck only), and driving.excavator (the rock_fragmenter's licence) belongs to no hiring role at all -- the real path is training at a driving_center (see employee-training.json's own conversion of that exact flow, and rock-fragmenter-breaking.json's identical bootstrap). Left as a test-only bootstrap since this file's focus is the hauling/contract loop, not re-proving excavator licensing.",
+      "description": "Unlike the driving.truck bootstrap above, this one grants a licence from nothing: employee #4 was hired as a driver (ROLE_STARTING_QUALIFICATION driving.truck only), and driving.excavator (the rock_fragmenter's licence) belongs to no hiring role at all -- the real path is training at a driving_center (see employee-training.json's own conversion of that exact flow, and rock-fragmenter-breaking.json's identical bootstrap). Left as a test-only bootstrap since this file's focus is the hauling/contract loop, not re-proving excavator licensing. #592: proficiencyTotal dropped from 22 to 16 -- same living-employees-only computation as the steps above; this adds a brand-new qualification (11 + 5 = 16) rather than raising an existing one.",
       "role": "bootstrap",
       "expect": {
         "changedBy": {
           "cash": 0
         },
         "equals": {
-          "proficiencyTotal": 22
+          "proficiencyTotal": 16
         }
       }
     },

--- a/scripts/scenario-defs/employee-training.json
+++ b/scripts/scenario-defs/employee-training.json
@@ -543,6 +543,7 @@
     },
     {
       "command": "state full",
+      "description": "#592: qualificationCount/proficiencyTotal dropped from 4/6 to 0/0 -- this file's only employee (Chuck Miner, the driller hired at step 1) dies in the `blast` step above (confirmed via direct trace: `alive:false` immediately after), and both fields are now computed over living employees only (issue #592 -- a dead employee's frozen qualifications used to permanently pollute this aggregate). With nobody left alive, both are genuinely 0 -- not a bug, the earlier `tick 32` step (qualificationCount:4) already proved the training landed before the blast.",
       "interaction": [
         {
           "type": "command",
@@ -552,8 +553,8 @@
       "role": "observe",
       "expect": {
         "equals": {
-          "qualificationCount": 4,
-          "proficiencyTotal": 6
+          "qualificationCount": 0,
+          "proficiencyTotal": 0
         }
       }
     }

--- a/scripts/scenario-defs/level1-win-efficient.json
+++ b/scripts/scenario-defs/level1-win-efficient.json
@@ -2939,6 +2939,7 @@
     },
     {
       "command": "scores",
+      "description": "#592: ecology dropped from 50 to 44.99999999999943 -- ActionSelection.ts's living-quarters overcapacity multiplier is now computed against living headcount rather than raw headcount (issue #592), which shifts task durations (and so tick-by-tick timing of blast/vibration events) whenever a living-quarters building was near bed capacity and an employee died -- exactly this run's own trajectory, with 4 deaths against a small crew. tickCount/deathCount/employeeCount stay unchanged (491/4/7): the fix reshuffles *when* things happen inside those same 491 ticks, not the final headcount or death toll. wellBeing/safety/nuisance stay exact -- confirmed unaffected by direct trace.",
       "interaction": [
         {
           "type": "command",
@@ -2955,13 +2956,14 @@
           "surveyCount": 2,
           "wellBeing": 0,
           "safety": 0,
-          "ecology": 50,
+          "ecology": 44.99999999999943,
           "nuisance": 50
         }
       }
     },
     {
       "command": "stats",
+      "description": "#592: ecology dropped here too -- same reasoning and same reused snapshot as the scores step just above.",
       "interaction": [
         {
           "type": "command",
@@ -2978,14 +2980,14 @@
           "surveyCount": 2,
           "wellBeing": 0,
           "safety": 0,
-          "ecology": 50,
+          "ecology": 44.99999999999943,
           "nuisance": 50
         }
       }
     },
     {
       "command": "campaign status",
-      "description": "#553 Findings, final, updated for the Employee.ts morale fix (see step 115's own note for the mechanism): the level ends in a permanent worker revolt at tick 491, not the pre-fix file's 458/471 -- but pattern 2 now finishes all 25 of its own holes before the revolt fires (holeCount: 25, orderedHoleCount: 0), where the pre-fix file found it abandoned 10 holes short. deathCount stays at 4 (all from blast 1) -- the revolt is a mass walkout, not a mass casualty (WorkerRevolt.ts never touches damage.deathCount), matching a direct trace through this exact sequence. Cash ends at $2,029,295, down from the $3,000,000 opening bump, spent on: 6 tier-3 drill_rigs ($840,000), 6 driller hires + 1 surveyor ($7,200), 419 ticks (72->491) of payroll/fuel/maintenance for a 4-to-7-person roster, and two punitive random events (an ore-name lawsuit -$20,000 at tick 130, a union strike -$25,000 at tick 278) -- no lucky_strike bonus landed this run, unlike the pre-#553 version of this file. Like every other file in this batch, no hauling vehicle (debris_hauler, rock_digger, rock_fragmenter, building_destroyer) is ever bought, so both accepted contracts sit at 0.0 kg stored the whole file and expire for their full penalty before pattern 2 even lands its third hole -- the file's other, narrower point ('no hauling infrastructure means no delivery ever succeeds') holds exactly as before. What #553 changes is the premise one level up: this was never going to be an efficient $80,000 win, and it is no longer even a survivable one -- automated drilling costs enough goodwill, on top of enough cash, that the workforce quits before the level can be won, even once pattern 2's own drilling genuinely finishes.",
+      "description": "#553 Findings, final, updated for the Employee.ts morale fix (see step 115's own note for the mechanism): the level ends in a permanent worker revolt at tick 491, not the pre-fix file's 458/471 -- but pattern 2 now finishes all 25 of its own holes before the revolt fires (holeCount: 25, orderedHoleCount: 0), where the pre-fix file found it abandoned 10 holes short. deathCount stays at 4 (all from blast 1) -- the revolt is a mass walkout, not a mass casualty (WorkerRevolt.ts never touches damage.deathCount), matching a direct trace through this exact sequence. Cash ends at $2,029,295, down from the $3,000,000 opening bump, spent on: 6 tier-3 drill_rigs ($840,000), 6 driller hires + 1 surveyor ($7,200), 419 ticks (72->491) of payroll/fuel/maintenance for a 4-to-7-person roster, and two punitive random events (an ore-name lawsuit -$20,000 at tick 130, a union strike -$25,000 at tick 278) -- no lucky_strike bonus landed this run, unlike the pre-#553 version of this file. Like every other file in this batch, no hauling vehicle (debris_hauler, rock_digger, rock_fragmenter, building_destroyer) is ever bought, so both accepted contracts sit at 0.0 kg stored the whole file and expire for their full penalty before pattern 2 even lands its third hole -- the file's other, narrower point ('no hauling infrastructure means no delivery ever succeeds') holds exactly as before. What #553 changes is the premise one level up: this was never going to be an efficient $80,000 win, and it is no longer even a survivable one -- automated drilling costs enough goodwill, on top of enough cash, that the workforce quits before the level can be won, even once pattern 2's own drilling genuinely finishes. #592: ecology dropped from 50 to 44.99999999999943 -- same living-quarters-overcapacity-multiplier trajectory shift as the scores/stats steps above; tickCount/deathCount/employeeCount/holeCount/orderedHoleCount and the level's own outcome (worker_revolt at 491) are all unchanged, only the intermediate tick-by-tick timing that ecology's decay/vibration deltas landed on.",
       "interaction": [
         {
           "type": "command",
@@ -3002,7 +3004,7 @@
           "surveyCount": 2,
           "wellBeing": 0,
           "safety": 0,
-          "ecology": 50,
+          "ecology": 44.99999999999943,
           "nuisance": 50,
           "bankrupt": false,
           "levelEnded": true,

--- a/src/console-api.ts
+++ b/src/console-api.ts
@@ -5,6 +5,7 @@ import { createRunner, type RunnerWithContext } from './console/createRunner.js'
 import type { CommandResult } from './console/ConsoleRunner.js';
 import type { MiningContext } from './console/commands/mining.js';
 import { summariseMuckPile, type MuckPileSummary } from './core/mining/MuckPileSummary.js';
+import { getLivingEmployees } from './core/entities/Employee.js';
 
 export { createRunner };
 export type { RunnerWithContext, CommandResult, MiningContext };
@@ -44,6 +45,7 @@ export interface SerializableGameState {
   pendingActionCount: number;
   buildingCount: number;
   vehicleCount: number;
+  /** Raw roster size, dead included — deliberate: `killEmployee` never splices `employees` (only `fireEmployee` does), so this stays a total-ever-hired count. `deathCount` tracks how many of them died; the six fields below this one filter to the living roster instead. */
   employeeCount: number;
   /** Qualifications the roster holds — proves a skill was actually obtained, not just clicked at. */
   qualificationCount: number;
@@ -82,6 +84,7 @@ export interface SerializableGameState {
 export function serializeGameState(ctx: MiningContext): SerializableGameState | null {
   const s = ctx.state;
   if (!s) return null;
+  const livingEmployees = getLivingEmployees(s.employees.employees);
   return {
     seed: s.seed,
     time: s.time,
@@ -107,14 +110,14 @@ export function serializeGameState(ctx: MiningContext): SerializableGameState | 
     buildingCount: s.buildings.buildings.length,
     vehicleCount: s.vehicles.vehicles.length,
     employeeCount: s.employees.employees.length,
-    qualificationCount: s.employees.employees
+    qualificationCount: livingEmployees
       .reduce((n, e) => n + e.qualifications.length, 0),
-    proficiencyTotal: s.employees.employees
+    proficiencyTotal: livingEmployees
       .reduce((n, e) => n + e.qualifications.reduce((m, q) => m + q.proficiencyLevel, 0), 0),
-    trainingCount: s.employees.employees.filter(e => e.trainingState !== null).length,
-    collapsedCount: s.employees.employees.filter(e => e.collapsing).length,
-    minFatigue: s.employees.employees.reduce((m, e) => Math.min(m, e.fatigue), 100),
-    stuckEmployeeCount: s.employees.employees.filter(e => e.isMoveStuck).length,
+    trainingCount: livingEmployees.filter(e => e.trainingState !== null).length,
+    collapsedCount: livingEmployees.filter(e => e.collapsing).length,
+    minFatigue: livingEmployees.reduce((m, e) => Math.min(m, e.fatigue), 100),
+    stuckEmployeeCount: livingEmployees.filter(e => e.isMoveStuck).length,
     activeContractCount: s.contracts.active.length,
     deathCount: s.damage.deathCount,
     levelEnded: s.levelEnded,

--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -67,7 +67,7 @@ function deductExpense(
 }
 
 /** Build the EventContext from the current GameState. */
-function buildEventContext(ctx: GameContext): EventContext {
+export function buildEventContext(ctx: GameContext): EventContext {
   const s = ctx.state!;
   return {
     scores: s.scores,

--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -17,7 +17,7 @@ import {
 } from '../../core/economy/Corruption.js';
 import { addExpense, addIncome, type ExpenseCategory } from '../../core/economy/Finance.js';
 import { formatMoney } from '../../core/economy/formatMoney.js';
-import { processPayCycle, computeAverageMorale } from '../../core/entities/Employee.js';
+import { processPayCycle, computeAverageMorale, getLivingEmployees } from '../../core/entities/Employee.js';
 import { tickTraining } from '../../core/entities/EmployeeTraining.js';
 import { tickResearch, getTotalOperatingCost } from '../../core/entities/Building.js';
 import { getVehicleCostsPerTick } from '../../core/entities/Vehicle.js';
@@ -71,7 +71,7 @@ export function buildEventContext(ctx: GameContext): EventContext {
   const s = ctx.state!;
   return {
     scores: s.scores,
-    employeeCount: s.employees.employees.length,
+    employeeCount: getLivingEmployees(s.employees.employees).length,
     deathCount: s.damage.deathCount,
     corruptionLevel: s.corruption.level,
     hasBuilding: (type: string) => s.buildings.buildings.some(b => b.type === type),

--- a/src/core/engine/ActionSelection.ts
+++ b/src/core/engine/ActionSelection.ts
@@ -6,6 +6,7 @@
 
 import type { GameState, PendingAction } from '../state/GameState.js';
 import type { Employee, NeedKey } from '../entities/Employee.js';
+import { getLivingEmployees } from '../entities/Employee.js';
 import { octileHeuristic, findPath } from '../nav/Pathfinding.js';
 import { computeTaskDuration } from '../entities/EmployeeTaskDuration.js';
 import { getNeedMultiplier } from '../entities/EmployeeNeeds.js';
@@ -53,7 +54,7 @@ export function computeActionWorkTicks(state: GameState, employee: Employee, act
     : undefined;
   const level = qual?.proficiencyLevel ?? 1;
   const needMult = getNeedMultiplier(employee);
-  const lqMult = getLivingQuartersWellbeingMultiplier(state.buildings, state.employees.employees.length);
+  const lqMult = getLivingQuartersWellbeingMultiplier(state.buildings, getLivingEmployees(state.employees.employees).length);
   return computeTaskDuration(BASE_TASK_DURATION_TICKS, level, needMult, lqMult, 1);
 }
 

--- a/src/core/entities/Employee.ts
+++ b/src/core/entities/Employee.ts
@@ -320,6 +320,19 @@ export function calculateSalary(employee: Employee): number {
 }
 
 /**
+ * The living roster — every employee still `alive`. Shared filter for any
+ * aggregate/threshold computed over the roster (headcount-style stats,
+ * event-eligibility gates, living-quarters capacity) so a death doesn't
+ * silently skew it — see computeAverageMorale's own doc comment above for
+ * the shape of the bug this closes. `killEmployee` never splices
+ * `employees` (only `fireEmployee` does), so a corpse's frozen fields stay
+ * in the array forever unless the reader excludes them explicitly.
+ */
+export function getLivingEmployees(employees: readonly Employee[]): Employee[] {
+  return employees.filter(e => e.alive);
+}
+
+/**
  * Average morale across the LIVING roster, for feeding ScoreManager's
  * wellBeing input. A dead employee is never spliced from `employees` (only
  * fireEmployee does that — killEmployee just sets alive:false, same as

--- a/src/core/entities/Employee.ts
+++ b/src/core/entities/Employee.ts
@@ -345,7 +345,7 @@ export function getLivingEmployees(employees: readonly Employee[]): Employee[] {
  * zero-employee default the caller already relied on.
  */
 export function computeAverageMorale(employees: readonly Employee[]): number {
-  const living = employees.filter(e => e.alive);
+  const living = getLivingEmployees(employees);
   if (living.length === 0) return 50;
   return living.reduce((sum, e) => sum + e.morale, 0) / living.length;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ import { regenerateGrid, restoreGrid, terrainGenDatum, DEFAULT_GRID_SIZE } from 
 import { encodeVoxelGrid } from './core/state/VoxelGridCodec.js';
 import { getBiome } from './core/world/BiomeCatalog.js';
 import { BASE_TICK_MS } from './core/engine/GameLoop.js';
+import { getLivingEmployees } from './core/entities/Employee.js';
 import { probeUiActions, probeSelector } from './ui/uiActionProbe.js';
 import { t, getLocale, setLocale, type Locale } from './core/i18n/I18n.js';
 import { ScenePicking } from './ui/scene/ScenePicking.js';
@@ -533,6 +534,7 @@ window.__gameConsole = (cmd: string) => runGameCommand(cmd);
 window.__gameState = () => {
   if (!ctx.state) return null;
   const s = ctx.state;
+  const livingEmployees = getLivingEmployees(s.employees.employees);
   return {
     seed: s.seed,
     time: s.time,
@@ -566,19 +568,23 @@ window.__gameState = () => {
     pendingActionCount: s.pendingActions.length,
     buildingCount: s.buildings.buildings.length,
     vehicleCount: s.vehicles.vehicles.length,
+    // Raw roster size, dead included — deliberate: `killEmployee` never
+    // splices `employees` (only `fireEmployee` does), so this stays a
+    // total-ever-hired count. `deathCount` tracks how many of them died; the
+    // six fields below this one filter to the living roster instead.
     employeeCount: s.employees.employees.length,
     // Qualifications the roster holds, so an interaction-mode check can prove
     // a skill was actually obtained rather than that a button merely looked clickable.
-    qualificationCount: s.employees.employees
+    qualificationCount: livingEmployees
       .reduce((n, e) => n + e.qualifications.length, 0),
-    proficiencyTotal: s.employees.employees
+    proficiencyTotal: livingEmployees
       .reduce((n, e) => n + e.qualifications.reduce((m, q) => m + q.proficiencyLevel, 0), 0),
-    trainingCount: s.employees.employees.filter(e => e.trainingState !== null).length,
+    trainingCount: livingEmployees.filter(e => e.trainingState !== null).length,
     // Needs mechanics: proves fatigue actually built up and collapse actually
     // fired, rather than a scenario guessing at it from a screenshot alone.
-    collapsedCount: s.employees.employees.filter(e => e.collapsing).length,
-    minFatigue: s.employees.employees.reduce((m, e) => Math.min(m, e.fatigue), 100),
-    stuckEmployeeCount: s.employees.employees.filter(e => e.isMoveStuck).length,
+    collapsedCount: livingEmployees.filter(e => e.collapsing).length,
+    minFatigue: livingEmployees.reduce((m, e) => Math.min(m, e.fatigue), 100),
+    stuckEmployeeCount: livingEmployees.filter(e => e.isMoveStuck).length,
     activeContractCount: s.contracts.active.length,
     deathCount: s.damage.deathCount,
     levelEnded: s.levelEnded,

--- a/tests/unit/console-api.test.ts
+++ b/tests/unit/console-api.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { createRunner, serializeGameState } from '../../src/console-api.js';
 import type { MiningContext } from '../../src/console-api.js';
+import { killEmployee } from '../../src/core/entities/Employee.js';
 
 /**
  * Field set window.__gameState() emits, restricted to the state-derived
@@ -306,6 +307,46 @@ describe('console-api', () => {
 
       expect(state.deathCount).toBe(1);
       expect(state.employeeCount).toBe(1);
+    });
+
+    it('computes qualificationCount/proficiencyTotal/trainingCount/collapsedCount/minFatigue/stuckEmployeeCount over the living roster only, excluding a corpse\'s frozen state (#592)', () => {
+      runner.runner.run('new_game mine_type:desert seed:42');
+      runner.runner.run('employee hire role:driller');
+      runner.runner.run('employee hire role:driller');
+      const [survivor, corpse] = runner.ctx.state!.employees.employees;
+
+      // Survivor: alive, ordinary fatigue, only its starting qualification —
+      // none of the extra states below.
+      survivor!.fatigue = 40;
+
+      // Corpse: carries every one of these states at the moment of death — a
+      // second qualification, an in-progress training course, collapsing,
+      // near-zero fatigue, and stuck pathfinding — then killEmployee flips
+      // alive:false without clearing any of it (killEmployee, Employee.ts,
+      // only touches alive/injured). A reader that doesn't filter to the
+      // living roster keeps counting all of this forever, exactly like the
+      // avgMorale bug this issue is a sibling of.
+      runner.runner.run(`employee assign_skill ${corpse!.id} skill:geology level:3`);
+      corpse!.trainingState = { buildingId: 1, skill: 'blasting', ticksRemaining: 5, fee: 500 };
+      corpse!.collapsing = true;
+      corpse!.fatigue = 5;
+      corpse!.isMoveStuck = true;
+      killEmployee(runner.ctx.state!.employees, corpse!.id);
+
+      const state = serializeGameState(runner.ctx as MiningContext)!;
+
+      // employeeCount is intentionally NOT filtered — the flat headcount
+      // includes the corpse.
+      expect(state.employeeCount).toBe(2);
+      // Every other aggregate below should reflect the survivor alone.
+      expect(state.qualificationCount).toBe(survivor!.qualifications.length);
+      expect(state.proficiencyTotal).toBe(
+        survivor!.qualifications.reduce((sum, q) => sum + q.proficiencyLevel, 0),
+      );
+      expect(state.trainingCount).toBe(0);
+      expect(state.collapsedCount).toBe(0);
+      expect(state.minFatigue).toBe(40);
+      expect(state.stuckEmployeeCount).toBe(0);
     });
 
     it('reports zero surveyCount for a fresh game with no surveys run', () => {

--- a/tests/unit/console/events-command.test.ts
+++ b/tests/unit/console/events-command.test.ts
@@ -1,0 +1,33 @@
+// BlastSimulator2026 — Unit tests: buildEventContext (#592)
+//
+// buildEventContext (src/console/commands/events.ts) feeds EventContext to the
+// event prerequisite/weighting system. Its employeeCount field used to read
+// state.employees.employees.length unfiltered — same class of bug as
+// avgMorale (Employee.ts's computeAverageMorale): killEmployee never splices
+// the roster, only flips alive:false, so a corpse permanently inflated the
+// count fed to every event's canFire/weightCoeff check.
+
+import { describe, it, expect } from 'vitest';
+import { createRunner } from '../../../src/console/createRunner.js';
+import { buildEventContext } from '../../../src/console/commands/events.js';
+import { killEmployee } from '../../../src/core/entities/Employee.js';
+
+describe('buildEventContext (#592)', () => {
+  it('reports employeeCount over the living roster only, excluding a killed employee still physically present in the array', () => {
+    const { runner, ctx } = createRunner();
+    runner.run('new_game mine_type:desert seed:42');
+    runner.run('employee hire role:driller');
+    runner.run('employee hire role:driller');
+    runner.run('employee hire role:driller');
+    const employees = ctx.state!.employees.employees;
+    killEmployee(ctx.state!.employees, employees[1]!.id);
+
+    // killEmployee only flips alive:false — the roster still physically
+    // holds all 3 entries.
+    expect(ctx.state!.employees.employees).toHaveLength(3);
+
+    const eventCtx = buildEventContext(ctx);
+
+    expect(eventCtx.employeeCount).toBe(2);
+  });
+});

--- a/tests/unit/engine/ActionSelection.test.ts
+++ b/tests/unit/engine/ActionSelection.test.ts
@@ -23,9 +23,10 @@ import {
 } from '../../../src/core/engine/ActionSelection.js';
 import { createGame, type GameState, type PendingAction } from '../../../src/core/state/GameState.js';
 import { NavGrid, type NavCell, type NavCellType } from '../../../src/core/nav/NavGrid.js';
-import { createEmployeeState, hireEmployee, assignSkill, type Employee, type SkillCategory } from '../../../src/core/entities/Employee.js';
+import { createEmployeeState, hireEmployee, killEmployee, assignSkill, type Employee, type SkillCategory } from '../../../src/core/entities/Employee.js';
+import { placeBuilding } from '../../../src/core/entities/Building.js';
 import { Random } from '../../../src/core/math/Random.js';
-import { ACTION_SELECTION_MAX_PATH_ATTEMPTS, BASE_TASK_DURATION_TICKS, NEED_REST_DURATIONS } from '../../../src/core/config/balance.js';
+import { ACTION_SELECTION_MAX_PATH_ATTEMPTS, BASE_TASK_DURATION_TICKS, NEED_REST_DURATIONS, LIVING_QUARTERS_WELLBEING_MULTIPLIERS } from '../../../src/core/config/balance.js';
 
 // ── NavGrid helpers (mirrors tests/unit/nav/Pathfinding.test.ts) ───────────
 
@@ -463,6 +464,36 @@ describe('computeActionWorkTicks (#549)', () => {
     const ticks = computeActionWorkTicks(state, employee, action);
 
     expect(ticks).toBe(BASE_TASK_DURATION_TICKS);
+  });
+
+  it('does not apply the living-quarters overcapacity penalty from a corpse still counted in the raw headcount (#592)', () => {
+    const state = makeGame();
+    // Tier 1 living_quarters — 20-bed capacity (BUILDING_DEFS).
+    placeBuilding(state.buildings, 'living_quarters', 0, 0, 100, 100);
+
+    const rng = new Random(SEED);
+    const { employee: testSubject } = hireEmployee(state.employees, 'driller', rng);
+    for (let i = 0; i < 19; i++) {
+      hireEmployee(state.employees, 'driller', rng);
+    }
+    // One more hire, then killed — the raw (alive+dead) headcount is now 21,
+    // over the 20-bed capacity, but the LIVING headcount is still exactly 20
+    // (at capacity, not over it). computeActionWorkTicks must pass the LIVING
+    // count into getLivingQuartersWellbeingMultiplier, not
+    // state.employees.employees.length.
+    const { employee: corpse } = hireEmployee(state.employees, 'driller', rng);
+    killEmployee(state.employees, corpse.id);
+    expect(state.employees.employees).toHaveLength(21);
+
+    const action = makeWorkAction({ type: 'general_work', requiredSkill: 'blasting' });
+    const ticks = computeActionWorkTicks(state, testSubject, action);
+
+    // Non-overcapacity tier-1 multiplier (0.90):
+    // ceil(20 * 1.00 / (1.0 * 0.90 * 1)) = 23. The overcapacity-buggy value
+    // (raw 21 > 20 beds, penalty applied, multiplier 0.80) would instead
+    // compute ceil(20 / 0.80) = 25.
+    const expectedTicks = Math.max(1, Math.ceil(BASE_TASK_DURATION_TICKS / LIVING_QUARTERS_WELLBEING_MULTIPLIERS.t1));
+    expect(ticks).toBe(expectedTicks);
   });
 });
 

--- a/tests/unit/entities/Employee.test.ts
+++ b/tests/unit/entities/Employee.test.ts
@@ -13,6 +13,7 @@ import {
   gainXp,
   calculateSalary,
   computeAverageMorale,
+  getLivingEmployees,
   BASE_SALARIES,
   PAY_CYCLE_TICKS,
   HIRING_COSTS,
@@ -568,6 +569,40 @@ describe('computeAverageMorale()', () => {
     // average if computeAverageMorale did not filter on alive.
     expect(state.employees).toHaveLength(2);
     expect(computeAverageMorale(state.employees)).toBe(100);
+  });
+});
+
+describe('getLivingEmployees()', () => {
+  // ── Test 1 (happy path) ────────────────────────────────────────────────────
+  it('returns only the alive employees, in original roster order', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee: a } = hireEmployee(state, 'driller', rng);
+    const { employee: b } = hireEmployee(state, 'blaster', rng);
+    const { employee: c } = hireEmployee(state, 'surveyor', rng);
+    killEmployee(state, b.id);
+
+    // killEmployee only flips alive:false — b is still physically present in
+    // state.employees, at its original index between a and c.
+    expect(state.employees).toHaveLength(3);
+    expect(getLivingEmployees(state.employees)).toEqual([a, c]);
+  });
+
+  // ── Test 2 (boundary) ──────────────────────────────────────────────────────
+  it('returns an empty array for an empty roster', () => {
+    expect(getLivingEmployees([])).toEqual([]);
+  });
+
+  // ── Test 3 (boundary) ──────────────────────────────────────────────────────
+  it('returns an empty array when every employee on the roster is dead', () => {
+    const state = createEmployeeState();
+    const rng = new Random(1);
+    const { employee: a } = hireEmployee(state, 'driller', rng);
+    const { employee: b } = hireEmployee(state, 'blaster', rng);
+    killEmployee(state, a.id);
+    killEmployee(state, b.id);
+
+    expect(getLivingEmployees(state.employees)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Closes #592

## Summary

`avgMorale`'s dead-employees-skew-the-average bug (the one #592 opens with) was already fixed on `main` prior to this run, via `computeAverageMorale()` in `src/core/entities/Employee.ts` (commit `a5b21d7`), which filters to `e.alive`. This PR does the audit #592's Task explicitly also demands ("audit the handful of other unfiltered `state.employees.employees` reads ... rather than fixing only the one this issue names") and fixes every other site with the same bug shape: a current-state per-employee field (`qualifications`, `trainingState`, `collapsing`, `fatigue`, `isMoveStuck`) that `killEmployee` never clears, so a corpse permanently pollutes the aggregate.

**New shared helper:** `getLivingEmployees(employees)` in `src/core/entities/Employee.ts` — the codebase's existing convention for "the living roster" (a dozen `.filter(e => e.alive)` call sites already exist across `src/ui/panels/*`); `computeAverageMorale` now uses it internally too, no behavior change.

**Fixed (now filtered to living employees):**
- `src/console-api.ts` / `src/main.ts` (kept byte-identical, per existing project convention): `qualificationCount`, `proficiencyTotal`, `trainingCount`, `collapsedCount`, `minFatigue`, `stuckEmployeeCount`
- `src/console/commands/events.ts`: `buildEventContext`'s `employeeCount` (event-eligibility gating for mafia/union/lawsuit thresholds)
- `src/core/engine/ActionSelection.ts`: living-quarters overcapacity multiplier now checks living headcount against bed capacity, not raw headcount

**Deliberately left unfiltered, by existing documented design (strengthened doc comments, no behavior change):**
- `employeeCount` in `console-api.ts` / `main.ts` / `console/commands/state.ts` — flat headcount including the dead, on purpose; `deathCount` is the dedicated field for tracking deaths (existing regression test at `tests/unit/console-api.test.ts:274-309` already pins this and was left untouched)
- `ScoreInputs.employeeCount` in `events.ts`'s `tickCommand` — dead/unused field, never read by `ScoreManager.updateScores`

**Sentinel-on-death alternative** (issue asked this be weighed): rejected — a sentinel value still dilutes the living roster's true average rather than excluding the corpse, and would require touching the core `killEmployee` mutation to fix what is fundamentally a read-side aggregation bug. Filtering at the read site is the existing, correct convention.

## Test plan

- `tests/unit/entities/Employee.test.ts`: 3 new tests for `getLivingEmployees` (happy path, empty roster, all-dead roster); existing `computeAverageMorale` tests (4) unmodified, still pass.
- `tests/unit/console-api.test.ts`: new test — two employees, one killed while carrying qualifications/training/collapsing/low-fatigue/stuck state, asserts the six audited fields reflect only the living employee; existing flat-`employeeCount` regression test untouched.
- `tests/unit/console/events-command.test.ts` (new file): direct unit test of the now-exported `buildEventContext`, asserts `employeeCount` excludes a dead employee.
- `tests/unit/engine/ActionSelection.test.ts`: new case proving a dead employee no longer counts toward living-quarters bed occupancy.
- 3 scenario checkpoints (`economy-full-loop`, `employee-training`, `level1-win-efficient`) updated — each was pinning the old, buggy, unfiltered aggregate values; traced each death/timing shift by hand before updating (see below).

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** the issue named `qualificationCount`/`proficiencyTotal` and payroll explicitly but asked for a broader audit without naming every affected call site.
  **Chosen:** filter `trainingCount`, `collapsedCount`, `minFatigue`, `stuckEmployeeCount` (console-api.ts/main.ts), `buildEventContext`'s `employeeCount` (events.ts), and `ActionSelection.ts`'s living-quarters headcount to `getLivingEmployees`; leave `employeeCount` (console-api.ts, main.ts, state.ts) and the unused `ScoreInputs.employeeCount` (events.ts) unfiltered.
  **Why:** each filtered field reads a *current-state* per-employee flag that `killEmployee` never clears, so a corpse permanently corrupts the aggregate — the same shape of bug `computeAverageMorale` already fixed. `employeeCount` proper is deliberately flat by existing, tested, documented design; reinterpreting it would contradict a passing regression test that exists specifically to pin that design. `payroll` (`processPayCycle`) was independently confirmed to already filter to alive — no change needed there.
  **If reversed:** revert the two `getLivingEmployees` call sites in `events.ts`/`ActionSelection.ts` back to raw `.length`, or drop the six-field filter block in `console-api.ts`/`main.ts` back to the raw array; no other file moves.

- **What was open:** issue floated "clear morale to a defined sentinel on death" as a real alternative to filtering, even though `main` had already implemented filtering.
  **Chosen:** filtering (already in place via `computeAverageMorale`, now backed by the shared `getLivingEmployees` helper); sentinel rejected.
  **Why:** a sentinel still leaves a fake data point diluting the living roster's true average; filtering at the read site matches the dozen existing `.filter(e => e.alive)` sites already in `src/ui/panels/*` and avoids touching the core `killEmployee` mutation.
  **If reversed:** would need a `MORALE_SENTINEL_ON_DEATH` constant in `src/core/config/`, setting `emp.morale` to it in `killEmployee`, and removing the `e.alive` filter — materially larger and riskier than the current fix.

- **What was open:** 3 scenario checkpoints broke after the fix — needed to determine bug-in-implementation vs. correct-checkpoint-needed-updating.
  **Chosen:** traced each: `economy-full-loop` and `employee-training` both have an employee die (via the scenario's own `blast` step) before the failing checkpoint, so the qualification/proficiency drop is the expected, correct consequence of excluding the corpse. `level1-win-efficient`'s `ecology` score shift (50 → 44.99999999999943) traces to the living-quarters multiplier fix changing task-duration timing given that scenario's 4 deaths; `tickCount`/`deathCount`/`employeeCount`/outcome are all unchanged, only the exact `ecology` float moved. All 3 checkpoints updated to the new correct values.
  **Why:** each was pinning the pre-fix, buggy, unfiltered behavior as "expected" — updating them is closing the gap the issue describes, not introducing new behavior.
  **If reversed:** would mean re-introducing the unfiltered read at the relevant call site, which reopens #592.

## Verification

- `static` — `npm run typecheck`: clean.
- `logic` — `npm run test`: 314 test files, 9532 tests, all passing.
- `scenario` — `npm run scenarios`: 129/129 passing (3 checkpoints updated, traced and justified above).
- `visual` — not applicable: this is a backend-only change confined to `src/core/`, `src/console/`, `src/console-api.ts`, `src/main.ts`'s state-serialization mirror. No renderer/UI/player-facing surface touched; `static`+`logic`+`scenario` prove it end to end.

Code review: 5/5 parallel reviewers (security, quality, i18n, duplication, semantic) — all PASS/Clean. Two non-blocking suggestions noted (a perf micro-nit in `ActionSelection.ts`, and an opportunity to fold `processPayCycle`'s existing manual alive-filter into the new `getLivingEmployees` helper) — both out of #592's scope, left as-is.

READY TO MERGE
