### PR TITLE
feat: build the ground, not the box — depth-limited terrain skirt + chunk-skip (#560)

### DIFF
--- a/scripts/scenario-defs/blast-execution-visual.json
+++ b/scripts/scenario-defs/blast-execution-visual.json
@@ -1670,6 +1670,248 @@
         }
       ],
       "role": "observe"
+    },
+    {
+      "command": "employee hire role:driller",
+      "description": "#560: 5th cycle appended to drill+blast right at the very edge of the site (this file's world is 64x64 -- new_game's DEFAULT_GRID_SIZE, balance.ts -- so 60..61 sits 2-3 cells from the true boundary at 63), proving the boundary/skirt wall stays closed with no see-through gap at the site's own outer edge, not just the interior-ish edges (20/45/5,45/5,5) cycles 1-4 above already exercise. Own fresh driller so this cycle isn't gated behind whichever of ids 1-11 above happens to still be alive in a given mode -- hireEmployee assigns ids from a monotonic counter that ignores firing/death (grid 2-4's own hire steps above already rely on this: id4 was handed out even though ids 1-3 were fired/spliced first), so the next id is deterministically 12 regardless of mode.",
+      "interaction": [
+        {
+          "type": "clickSelector",
+          "selector": "#bs-toolbar [data-panel=\"employees\"]"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": "#bs-employee-panel [data-role=\"driller\"]"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-employee-panel [data-role=\"driller\"]"
+        }
+      ],
+      "role": "player",
+      "expect": {
+        "decreased": [
+          "cash"
+        ],
+        "changedBy": {
+          "employeeCount": 1
+        }
+      }
+    },
+    {
+      "command": "vehicle buy drill_rig",
+      "interaction": [
+        {
+          "type": "clickSelector",
+          "selector": "#bs-toolbar [data-panel=\"vehicles\"]"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": "#bs-vehicle-panel .bs-fleet-tier-btn[data-vtype=\"drill_rig\"][data-tier=\"1\"]"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-vehicle-panel .bs-fleet-tier-btn[data-vtype=\"drill_rig\"][data-tier=\"1\"]"
+        }
+      ],
+      "role": "player",
+      "expect": {
+        "decreased": [
+          "cash"
+        ],
+        "increased": [
+          "vehicleCount"
+        ]
+      }
+    },
+    {
+      "command": "employee assign_skill 12 skill:driving.drill_rig level:1",
+      "description": "Left unmarked: hiring already grants blasting at Rookie (ROLE_STARTING_QUALIFICATION), but no role starts with driving.drill_rig -- without it the driller could never staff the drill_rig just bought. The player-facing path is training at a driving_center; skipped here since this file isn't about training.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "employee assign_skill 12 skill:driving.drill_rig level:1"
+        }
+      ],
+      "role": "bootstrap"
+    },
+    {
+      "command": "drill_plan grid rows:2 cols:2 spacing:2 depth:6 start:59,59",
+      "description": "#560: right at the very edge of this file's 64x64 world -- holes reach x/z=61, 2-3 cells from the true boundary at 63 -- the same boundary/skirt wall closure #559 already covers at the interior-ish edges cycles 1-4 use (starts 20,20 / 45,20 / 5,45 / 5,5), now proven with a real blast right at the site's own outer edge, where the depth-limited skirt (#560) has the least margin to work with.",
+      "interaction": [
+        {
+          "type": "clickSelector",
+          "selector": "#bs-toolbar [data-panel=\"blast\"]"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-blast-panel [data-step=\"1\"]"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-blast-panel [data-action=\"grid-tool\"]"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": "#bs-tile-select-confirm"
+        },
+        {
+          "type": "dragTiles",
+          "x1": 59,
+          "z1": 59,
+          "x2": 61,
+          "z2": 61
+        },
+        {
+          "type": "screenshot"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-tile-select-confirm"
+        }
+      ],
+      "role": "player",
+      "expect": {
+        "equals": {
+          "orderedHoleCount": 4,
+          "holeCount": 0
+        }
+      }
+    },
+    {
+      "command": "tick 50",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 50"
+        }
+      ],
+      "role": "setup",
+      "expect": {
+        "equals": {
+          "orderedHoleCount": 0,
+          "holeCount": 4
+        }
+      }
+    },
+    {
+      "command": "event choose 0",
+      "interaction": [
+        {
+          "type": "resolveEventIfPending"
+        }
+      ],
+      "role": "player"
+    },
+    {
+      "command": "charge hole:* explosive:boomite amount:5 stemming:2",
+      "interaction": [
+        {
+          "type": "clickSelector",
+          "selector": "#bs-blast-panel [data-step=\"2\"]"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-blast-panel [data-action=\"charge-all\"]"
+        }
+      ],
+      "role": "player",
+      "expect": {
+        "equals": {
+          "chargedCount": 4
+        }
+      }
+    },
+    {
+      "command": "sequence auto delay_step:25",
+      "interaction": [
+        {
+          "type": "clickSelector",
+          "selector": "#bs-blast-panel [data-step=\"3\"]"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-blast-panel [data-action=\"auto-sequence\"]"
+        }
+      ],
+      "role": "player",
+      "expect": {
+        "equals": {
+          "sequencedCount": 4
+        }
+      }
+    },
+    {
+      "command": "blast",
+      "timeout": 30,
+      "frames": 6,
+      "interval": 50,
+      "description": "#560: this step's own default post-step screenshot (plus the 6 extra frames above) is the proof artifact for this cycle -- inspect it for a closed boundary/skirt wall around the crater at the site's true edge, no see-through gap to whatever lies beyond (59,59)-(61,61).",
+      "interaction": [
+        {
+          "type": "clickSelector",
+          "selector": "#bs-blast-panel [data-step=\"5\"]"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-blast-panel [data-action=\"execute\"]"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": ".bs-confirm-overlay .bs-btn-danger"
+        },
+        {
+          "type": "clickSelector",
+          "selector": ".bs-confirm-overlay .bs-btn-danger"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": "[data-action=\"report-close\"]"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "[data-action=\"report-close\"]"
+        }
+      ],
+      "role": "player",
+      "expect": {
+        "equals": {
+          "holeCount": 0,
+          "chargedCount": 0,
+          "sequencedCount": 0
+        },
+        "note": "a fired blast clears the plan back to zero"
+      }
+    },
+    {
+      "command": "fragments",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "fragments"
+        }
+      ],
+      "role": "observe"
+    },
+    {
+      "command": "state full",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "state full"
+        }
+      ],
+      "role": "observe"
+    },
+    {
+      "command": "inspect 60,60,0",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "inspect 60,60,0"
+        }
+      ],
+      "role": "observe"
     }
   ],
   "shots": [

--- a/scripts/scenario-defs/blast-execution-visual.json
+++ b/scripts/scenario-defs/blast-execution-visual.json
@@ -1780,6 +1780,46 @@
     },
     {
       "command": "tick 50",
+      "description": "#560: waitUntil was tried here first and does not fit -- runWaitUntil (command-runner.ts) loops bare `tick 1` calls with no event handling, and tickCommand (events.ts) refuses to advance at all once a random event leaves state.events.pendingEvent set (returns success:false, 'Pending event!...'), so once one fires mid-wait every remaining tick in the budget is a silent no-op and the field never settles no matter how large maxTicks is -- sandbox-confirmed stalled at orderedHoleCount:4 for 300+ ticks. This cycle drills at the site's true edge (start:59,59), far enough from the driller/drill_rig spawn that a single `tick 50` pad (enough for interior cycles 1-4) can still leave holes undrilled if an event happens to fire and eat part of the budget, so it's paired with two more tick/event-choose rounds below (3 total, sandbox-measured to land all 4 holes), mirroring the established pattern the 8x8 grid cycle above already uses for the same reason.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 50"
+        }
+      ],
+      "role": "setup"
+    },
+    {
+      "command": "event choose 0",
+      "interaction": [
+        {
+          "type": "resolveEventIfPending"
+        }
+      ],
+      "role": "player"
+    },
+    {
+      "command": "tick 50",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 50"
+        }
+      ],
+      "role": "setup"
+    },
+    {
+      "command": "event choose 0",
+      "interaction": [
+        {
+          "type": "resolveEventIfPending"
+        }
+      ],
+      "role": "player"
+    },
+    {
+      "command": "tick 50",
+      "description": "#560: third round -- sandbox-measured, a single driller/drill_rig pair takes 3 full tick-50 rounds (~150 ticks total, vs interior cycles 1-4's single round) to land all 4 holes at this corner-of-map location, round-tripping across the site's own outer edge instead of a compact interior cluster.",
       "interaction": [
         {
           "type": "command",

--- a/scripts/scenario-defs/landscape-continuity-visual.json
+++ b/scripts/scenario-defs/landscape-continuity-visual.json
@@ -1,6 +1,6 @@
 {
   "name": "landscape-continuity-visual",
-  "description": "Visual regression for the landscape/playable mesh junction (#491): frames a ridge, a slope, the close and far pit edges, and a material/biome transition on relief terrain, then drills, charges, sequences and blasts right at the pit edge and re-frames it post-blast \u2014 the landscape and the crater must read as one continuous, gap-free, non-overlapping surface throughout, with no hard-edged material snap across the boundary. Confirmed directly (not just via state assertions) by inspecting step-07's pre-blast and step-10's post-blast screenshots: the fresh crater blends into the surrounding terrain with no visible gaps, floating chunks, or hard material seam. See Finding #64.",
+  "description": "Visual regression for the landscape/playable mesh junction (#491): frames a ridge, a slope, the close and far pit edges, and a material/biome transition on relief terrain, then drills, charges, sequences and blasts right at the pit edge and re-frames it post-blast \u2014 the landscape and the crater must read as one continuous, gap-free, non-overlapping surface throughout, with no hard-edged material snap across the boundary. Confirmed directly (not just via state assertions) by inspecting step-07's pre-blast and step-10's post-blast screenshots: the fresh crater blends into the surrounding terrain with no visible gaps, floating chunks, or hard material seam. See Finding #64. #560: adds the 'crater-no-floor-cap' shot below \u2014 a close, low-grazing-angle framing of the fresh crater's exposed cut face, the closest angle the camera rig's own polar clamp (POLAR_MAX in CameraController.ts, camera never goes below the target height) allows toward 'underground' \u2014 proving TerrainMesh no longer seals the bottom of the site into a box: there is no horizontal floor plane visible jutting out beneath the exposed rock, only the boundary/skirt wall closing the sides.",
   "shots": [
     {
       "name": "overview",
@@ -81,6 +81,13 @@
       "pitch": 14,
       "target": [4, 32],
       "distance": 45
+    },
+    {
+      "name": "crater-no-floor-cap",
+      "yaw": 0,
+      "pitch": -30,
+      "target": [4, 24],
+      "distance": 8
     }
   ],
   "steps": [

--- a/src/core/world/VoxelGrid.ts
+++ b/src/core/world/VoxelGrid.ts
@@ -140,6 +140,10 @@ interface VoxelChunk {
   readonly fracture: Float64Array;
   /** Sparse, keyed by chunk-local flat index. Only voxels with ore pay for a Record. */
   readonly ores: Map<number, Record<string, number>>;
+  /** Conservative per-y-slab [min, max] density summary (#560). Index = slabIndex (this
+   *  chunk's own CHUNK_SIZE-tall vertical banding), length = ceil(sizeY / CHUNK_SIZE). */
+  readonly slabMinDensity: Float64Array;
+  readonly slabMaxDensity: Float64Array;
 }
 
 /** Packs a chunk coordinate pair into one collision-free numeric key. Range ±32768 chunks (±524 km). */
@@ -394,6 +398,7 @@ export class VoxelGrid {
 
   private allocateChunk(cx: number, cz: number): VoxelChunk {
     const n = CHUNK_SIZE * this.sizeY * CHUNK_SIZE;
+    const nSlabs = Math.ceil(this.sizeY / CHUNK_SIZE);
     const chunk: VoxelChunk = {
       cx, cz,
       x0: cx * CHUNK_SIZE, z0: cz * CHUNK_SIZE,
@@ -402,6 +407,11 @@ export class VoxelGrid {
       compId: new Uint16Array(n),
       fracture: new Float64Array(n).fill(1.0),
       ores: new Map(),
+      // TODO(#560): implementer decides the correct initial min/max fill
+      // (e.g. min=1/max=0 sentinel vs. 0/0) once touchDensity's widening
+      // convention is implemented.
+      slabMinDensity: new Float64Array(nSlabs),
+      slabMaxDensity: new Float64Array(nSlabs),
     };
     this.chunks.set(chunkKey(cx, cz), chunk);
     this.cacheKey = -1;
@@ -422,6 +432,24 @@ export class VoxelGrid {
       if (chunk.z1 > maxZ) maxZ = chunk.z1;
     }
     this.bMinX = minX; this.bMinZ = minZ; this.bMaxX = maxX; this.bMaxZ = maxZ;
+  }
+
+  // ── Per-chunk density summary (#560) ──
+
+  /**
+   * Conservative [min, max] density observed in chunk (cx, cz)'s y-slab
+   * `slabIndex` (VoxelGrid's own CHUNK_SIZE-tall vertical banding). Widens
+   * monotonically on every voxel write in that slab, never narrowed back down
+   * except on a full reload (#560). Returns null for an unowned chunk or a
+   * slab index past the grid's height.
+   */
+  chunkDensityRange(_cx: number, _cz: number, _slabIndex: number): { min: number; max: number } | null {
+    throw new Error('not implemented');
+  }
+
+  /** Widens chunk's per-slab min/max density summary to include a write of `density` at world y (#560). */
+  private touchDensity(_chunk: VoxelChunk, _y: number, _density: number): void {
+    throw new Error('not implemented');
   }
 
   // ── Dirty tracking — what a save has to store voxel-by-voxel (#473 D4) ──
@@ -519,6 +547,10 @@ export class VoxelGrid {
     if (ores && Object.keys(ores).length > 0) chunk.ores.set(i, { ...ores });
     else chunk.ores.delete(i);
     this.touch(chunk);
+    // TODO(#560): call touchDensity(chunk, y, density) here. Referenced (not
+    // called) below only so the skeleton stub isn't flagged as unused before
+    // implementer wires it in.
+    void this.touchDensity;
   }
 
   setFractureAt(x: number, y: number, z: number, value: number): void {
@@ -569,6 +601,7 @@ export class VoxelGrid {
     if (Object.keys(voxel.oreDensities).length > 0) chunk.ores.set(i, { ...voxel.oreDensities });
     else chunk.ores.delete(i);
     this.touch(chunk);
+    // TODO(#560): call touchDensity(chunk, y, voxel.density) here
   }
 
   clearVoxel(x: number, y: number, z: number): void {
@@ -580,6 +613,7 @@ export class VoxelGrid {
     chunk.fracture[i] = 1.0;
     chunk.ores.delete(i);
     this.touch(chunk);
+    // TODO(#560): call touchDensity(chunk, y, 0) here
   }
 
   // ── Raw chunk storage access — for VoxelGridCodec (save serialization) only ──

--- a/src/core/world/VoxelGrid.ts
+++ b/src/core/world/VoxelGrid.ts
@@ -702,18 +702,32 @@ export class VoxelGrid {
     // that maintain the conservative widening summary, and a save/load
     // shouldn't carry forward stale bounds from before the save — an O(n)
     // rescan is cheap here since restoring the chunk's arrays already was.
+    //
     // Every owned (x, z) column is scanned across the full y range, so each
     // touched position is marked and counted exactly once — chunkDensityRange
     // reports the exact restored min/max for a fully-scanned slab, and
     // honestly falls back to {min:0, max:0} for one no owned column reaches.
+    //
+    // `rect` (and therefore chunk.x0/x1/z0/z1, just assigned above) comes
+    // straight from deserialized save JSON and is never validated against
+    // the grid's real dimensions — a corrupted/hand-edited save with an
+    // absurd rect (e.g. maxX/maxZ ~1e12) must not turn this loop into an
+    // unbounded scan. Clamp to the chunk's actual storage span, the same
+    // defensive clamping forEachInRegion already does against real grid
+    // bounds elsewhere in this file.
+    const zLo = Math.max(chunk.z0, chunk.cz * CHUNK_SIZE);
+    const zHi = Math.min(chunk.z1, chunk.cz * CHUNK_SIZE + CHUNK_SIZE);
+    const xLo = Math.max(chunk.x0, chunk.cx * CHUNK_SIZE);
+    const xHi = Math.min(chunk.x1, chunk.cx * CHUNK_SIZE + CHUNK_SIZE);
+
     chunk.slabMinDensity.fill(Infinity);
     chunk.slabMaxDensity.fill(-Infinity);
     chunk.slabTouchedCount.fill(0);
     chunk.touched.fill(0);
-    for (let z = chunk.z0; z < chunk.z1; z++) {
+    for (let z = zLo; z < zHi; z++) {
       for (let y = 0; y < this.sizeY; y++) {
         const slab = Math.floor(y / CHUNK_SIZE);
-        for (let x = chunk.x0; x < chunk.x1; x++) {
+        for (let x = xLo; x < xHi; x++) {
           const i = VoxelGrid.localIndex(chunk, x, y, z, this.sizeY);
           const d = chunk.density[i]!;
           if (d < chunk.slabMinDensity[slab]!) chunk.slabMinDensity[slab] = d;

--- a/src/core/world/VoxelGrid.ts
+++ b/src/core/world/VoxelGrid.ts
@@ -407,9 +407,9 @@ export class VoxelGrid {
       compId: new Uint16Array(n),
       fracture: new Float64Array(n).fill(1.0),
       ores: new Map(),
-      // TODO(#560): implementer decides the correct initial min/max fill
-      // (e.g. min=1/max=0 sentinel vs. 0/0) once touchDensity's widening
-      // convention is implemented.
+      // Zero-filled (min=0, max=0): honest, not a placeholder — every voxel
+      // in a freshly allocated chunk really is air (density 0) until
+      // generation writes it, and touchDensity only widens from here (#560).
       slabMinDensity: new Float64Array(nSlabs),
       slabMaxDensity: new Float64Array(nSlabs),
     };
@@ -443,13 +443,19 @@ export class VoxelGrid {
    * except on a full reload (#560). Returns null for an unowned chunk or a
    * slab index past the grid's height.
    */
-  chunkDensityRange(_cx: number, _cz: number, _slabIndex: number): { min: number; max: number } | null {
-    throw new Error('not implemented');
+  chunkDensityRange(cx: number, cz: number, slabIndex: number): { min: number; max: number } | null {
+    const chunk = this.chunks.get(chunkKey(cx, cz));
+    if (!chunk) return null;
+    if (slabIndex < 0 || slabIndex >= chunk.slabMinDensity.length) return null;
+    return { min: chunk.slabMinDensity[slabIndex]!, max: chunk.slabMaxDensity[slabIndex]! };
   }
 
   /** Widens chunk's per-slab min/max density summary to include a write of `density` at world y (#560). */
-  private touchDensity(_chunk: VoxelChunk, _y: number, _density: number): void {
-    throw new Error('not implemented');
+  private touchDensity(chunk: VoxelChunk, y: number, density: number): void {
+    const slab = Math.floor(y / CHUNK_SIZE);
+    if (slab < 0 || slab >= chunk.slabMinDensity.length) return;
+    if (density < chunk.slabMinDensity[slab]!) chunk.slabMinDensity[slab] = density;
+    if (density > chunk.slabMaxDensity[slab]!) chunk.slabMaxDensity[slab] = density;
   }
 
   // ── Dirty tracking — what a save has to store voxel-by-voxel (#473 D4) ──
@@ -547,10 +553,7 @@ export class VoxelGrid {
     if (ores && Object.keys(ores).length > 0) chunk.ores.set(i, { ...ores });
     else chunk.ores.delete(i);
     this.touch(chunk);
-    // TODO(#560): call touchDensity(chunk, y, density) here. Referenced (not
-    // called) below only so the skeleton stub isn't flagged as unused before
-    // implementer wires it in.
-    void this.touchDensity;
+    this.touchDensity(chunk, y, density);
   }
 
   setFractureAt(x: number, y: number, z: number, value: number): void {
@@ -601,7 +604,7 @@ export class VoxelGrid {
     if (Object.keys(voxel.oreDensities).length > 0) chunk.ores.set(i, { ...voxel.oreDensities });
     else chunk.ores.delete(i);
     this.touch(chunk);
-    // TODO(#560): call touchDensity(chunk, y, voxel.density) here
+    this.touchDensity(chunk, y, voxel.density);
   }
 
   clearVoxel(x: number, y: number, z: number): void {
@@ -613,7 +616,7 @@ export class VoxelGrid {
     chunk.fracture[i] = 1.0;
     chunk.ores.delete(i);
     this.touch(chunk);
-    // TODO(#560): call touchDensity(chunk, y, 0) here
+    this.touchDensity(chunk, y, 0);
   }
 
   // ── Raw chunk storage access — for VoxelGridCodec (save serialization) only ──
@@ -654,6 +657,33 @@ export class VoxelGrid {
     chunk.ores.clear();
     for (const [i, rec] of ores) chunk.ores.set(i, rec);
     this.recomputeBounds();
+
+    // Exact rescan (#560): this bulk path bypasses the per-voxel mutators
+    // that maintain the conservative widening summary, and a save/load
+    // shouldn't carry forward stale bounds from before the save — an O(n)
+    // rescan is cheap here since restoring the chunk's arrays already was.
+    chunk.slabMinDensity.fill(Infinity);
+    chunk.slabMaxDensity.fill(-Infinity);
+    for (let z = chunk.z0; z < chunk.z1; z++) {
+      for (let y = 0; y < this.sizeY; y++) {
+        const slab = Math.floor(y / CHUNK_SIZE);
+        for (let x = chunk.x0; x < chunk.x1; x++) {
+          const i = VoxelGrid.localIndex(chunk, x, y, z, this.sizeY);
+          const d = chunk.density[i]!;
+          if (d < chunk.slabMinDensity[slab]!) chunk.slabMinDensity[slab] = d;
+          if (d > chunk.slabMaxDensity[slab]!) chunk.slabMaxDensity[slab] = d;
+        }
+      }
+    }
+    // A slab with no owned voxels in this chunk (e.g. a partial edge chunk
+    // whose owned rect doesn't reach that slab) never gets touched above —
+    // report it as all-air (0/0) rather than leaving the sentinel.
+    for (let s = 0; s < chunk.slabMinDensity.length; s++) {
+      if (chunk.slabMinDensity[s] === Infinity) {
+        chunk.slabMinDensity[s] = 0;
+        chunk.slabMaxDensity[s] = 0;
+      }
+    }
   }
 
   /** Get all voxels within a bounding box (inclusive on both ends). Unowned columns are skipped. */

--- a/src/core/world/VoxelGrid.ts
+++ b/src/core/world/VoxelGrid.ts
@@ -726,14 +726,9 @@ export class VoxelGrid {
     chunk.touched.fill(0);
     for (let z = zLo; z < zHi; z++) {
       for (let y = 0; y < this.sizeY; y++) {
-        const slab = Math.floor(y / CHUNK_SIZE);
         for (let x = xLo; x < xHi; x++) {
           const i = VoxelGrid.localIndex(chunk, x, y, z, this.sizeY);
-          const d = chunk.density[i]!;
-          if (d < chunk.slabMinDensity[slab]!) chunk.slabMinDensity[slab] = d;
-          if (d > chunk.slabMaxDensity[slab]!) chunk.slabMaxDensity[slab] = d;
-          chunk.touched[i] = 1;
-          chunk.slabTouchedCount[slab]!++;
+          this.touchDensity(chunk, i, y, chunk.density[i]!);
         }
       }
     }

--- a/src/core/world/VoxelGrid.ts
+++ b/src/core/world/VoxelGrid.ts
@@ -140,10 +140,23 @@ interface VoxelChunk {
   readonly fracture: Float64Array;
   /** Sparse, keyed by chunk-local flat index. Only voxels with ore pay for a Record. */
   readonly ores: Map<number, Record<string, number>>;
-  /** Conservative per-y-slab [min, max] density summary (#560). Index = slabIndex (this
-   *  chunk's own CHUNK_SIZE-tall vertical banding), length = ceil(sizeY / CHUNK_SIZE). */
+  /** True min/max density ever written to a voxel in this y-slab (#560). Seeded at
+   *  +Infinity/-Infinity ("nothing written yet") and only ever widens, exactly like the
+   *  rest of this summary — a voxel later overwritten to a narrower value does not
+   *  shrink it back down. Index = slabIndex (this chunk's own CHUNK_SIZE-tall vertical
+   *  banding), length = ceil(sizeY / CHUNK_SIZE). Not directly what `chunkDensityRange`
+   *  returns — see `slabTouchedCount` for why. */
   readonly slabMinDensity: Float64Array;
   readonly slabMaxDensity: Float64Array;
+  /** Count of distinct voxel positions ever written within this slab (#560), deduped via
+   *  `touched`. Every position not yet written is honestly still air (density 0) — so
+   *  while this is below the slab's true volume, `chunkDensityRange` must still fold in
+   *  that implicit 0. Once it reaches the slab's volume, every voxel has an explicit
+   *  written value and `slabMinDensity`/`slabMaxDensity` are exact on their own. */
+  readonly slabTouchedCount: Uint32Array;
+  /** One byte per voxel in the chunk (all slabs) — 1 once that voxel has been written at
+   *  least once via a mutator, so `slabTouchedCount` counts each position only once. */
+  readonly touched: Uint8Array;
 }
 
 /** Packs a chunk coordinate pair into one collision-free numeric key. Range ±32768 chunks (±524 km). */
@@ -407,11 +420,13 @@ export class VoxelGrid {
       compId: new Uint16Array(n),
       fracture: new Float64Array(n).fill(1.0),
       ores: new Map(),
-      // Zero-filled (min=0, max=0): honest, not a placeholder — every voxel
-      // in a freshly allocated chunk really is air (density 0) until
-      // generation writes it, and touchDensity only widens from here (#560).
-      slabMinDensity: new Float64Array(nSlabs),
-      slabMaxDensity: new Float64Array(nSlabs),
+      // +Infinity/-Infinity sentinels ("nothing written yet") rather than 0/0 —
+      // chunkDensityRange folds in the honest "still air" 0 baseline itself for
+      // any slab that isn't yet fully touched (#560).
+      slabMinDensity: new Float64Array(nSlabs).fill(Infinity),
+      slabMaxDensity: new Float64Array(nSlabs).fill(-Infinity),
+      slabTouchedCount: new Uint32Array(nSlabs),
+      touched: new Uint8Array(n),
     };
     this.chunks.set(chunkKey(cx, cz), chunk);
     this.cacheKey = -1;
@@ -447,15 +462,40 @@ export class VoxelGrid {
     const chunk = this.chunks.get(chunkKey(cx, cz));
     if (!chunk) return null;
     if (slabIndex < 0 || slabIndex >= chunk.slabMinDensity.length) return null;
-    return { min: chunk.slabMinDensity[slabIndex]!, max: chunk.slabMaxDensity[slabIndex]! };
+    const touched = chunk.slabTouchedCount[slabIndex]!;
+    if (touched === 0) return { min: 0, max: 0 }; // nothing written — honestly all air
+    const trueMin = chunk.slabMinDensity[slabIndex]!;
+    const trueMax = chunk.slabMaxDensity[slabIndex]!;
+    if (touched >= this.slabVolume(chunk, slabIndex)) {
+      // Every voxel in this slab has an explicit written value — no implicit
+      // air left unaccounted for, so the true written min/max is exact.
+      return { min: trueMin, max: trueMax };
+    }
+    // Still some untouched positions in this slab — they're honestly air (0),
+    // so fold that baseline in (density is always >= 0, so it never affects max).
+    return { min: Math.min(0, trueMin), max: Math.max(0, trueMax) };
   }
 
-  /** Widens chunk's per-slab min/max density summary to include a write of `density` at world y (#560). */
-  private touchDensity(chunk: VoxelChunk, y: number, density: number): void {
+  /** Voxel count of the owned span of chunk's slab `slabIndex` — the number of
+   *  distinct positions `slabTouchedCount` would need to reach for full coverage (#560). */
+  private slabVolume(chunk: VoxelChunk, slabIndex: number): number {
+    const bandHeight = Math.min(CHUNK_SIZE, this.sizeY - slabIndex * CHUNK_SIZE);
+    if (bandHeight <= 0) return 0;
+    return (chunk.x1 - chunk.x0) * (chunk.z1 - chunk.z0) * bandHeight;
+  }
+
+  /** Widens chunk's per-slab true written min/max density to include a write of
+   *  `density` at local index `i`, world y (#560). Dedupes via `touched` so the
+   *  same position written twice doesn't double-count toward full slab coverage. */
+  private touchDensity(chunk: VoxelChunk, i: number, y: number, density: number): void {
     const slab = Math.floor(y / CHUNK_SIZE);
     if (slab < 0 || slab >= chunk.slabMinDensity.length) return;
     if (density < chunk.slabMinDensity[slab]!) chunk.slabMinDensity[slab] = density;
     if (density > chunk.slabMaxDensity[slab]!) chunk.slabMaxDensity[slab] = density;
+    if (!chunk.touched[i]) {
+      chunk.touched[i] = 1;
+      chunk.slabTouchedCount[slab]!++;
+    }
   }
 
   // ── Dirty tracking — what a save has to store voxel-by-voxel (#473 D4) ──
@@ -553,7 +593,7 @@ export class VoxelGrid {
     if (ores && Object.keys(ores).length > 0) chunk.ores.set(i, { ...ores });
     else chunk.ores.delete(i);
     this.touch(chunk);
-    this.touchDensity(chunk, y, density);
+    this.touchDensity(chunk, i, y, density);
   }
 
   setFractureAt(x: number, y: number, z: number, value: number): void {
@@ -604,7 +644,7 @@ export class VoxelGrid {
     if (Object.keys(voxel.oreDensities).length > 0) chunk.ores.set(i, { ...voxel.oreDensities });
     else chunk.ores.delete(i);
     this.touch(chunk);
-    this.touchDensity(chunk, y, voxel.density);
+    this.touchDensity(chunk, i, y, voxel.density);
   }
 
   clearVoxel(x: number, y: number, z: number): void {
@@ -616,7 +656,7 @@ export class VoxelGrid {
     chunk.fracture[i] = 1.0;
     chunk.ores.delete(i);
     this.touch(chunk);
-    this.touchDensity(chunk, y, 0);
+    this.touchDensity(chunk, i, y, 0);
   }
 
   // ── Raw chunk storage access — for VoxelGridCodec (save serialization) only ──
@@ -662,8 +702,14 @@ export class VoxelGrid {
     // that maintain the conservative widening summary, and a save/load
     // shouldn't carry forward stale bounds from before the save — an O(n)
     // rescan is cheap here since restoring the chunk's arrays already was.
+    // Every owned (x, z) column is scanned across the full y range, so each
+    // touched position is marked and counted exactly once — chunkDensityRange
+    // reports the exact restored min/max for a fully-scanned slab, and
+    // honestly falls back to {min:0, max:0} for one no owned column reaches.
     chunk.slabMinDensity.fill(Infinity);
     chunk.slabMaxDensity.fill(-Infinity);
+    chunk.slabTouchedCount.fill(0);
+    chunk.touched.fill(0);
     for (let z = chunk.z0; z < chunk.z1; z++) {
       for (let y = 0; y < this.sizeY; y++) {
         const slab = Math.floor(y / CHUNK_SIZE);
@@ -672,16 +718,9 @@ export class VoxelGrid {
           const d = chunk.density[i]!;
           if (d < chunk.slabMinDensity[slab]!) chunk.slabMinDensity[slab] = d;
           if (d > chunk.slabMaxDensity[slab]!) chunk.slabMaxDensity[slab] = d;
+          chunk.touched[i] = 1;
+          chunk.slabTouchedCount[slab]!++;
         }
-      }
-    }
-    // A slab with no owned voxels in this chunk (e.g. a partial edge chunk
-    // whose owned rect doesn't reach that slab) never gets touched above —
-    // report it as all-air (0/0) rather than leaving the sentinel.
-    for (let s = 0; s < chunk.slabMinDensity.length; s++) {
-      if (chunk.slabMinDensity[s] === Infinity) {
-        chunk.slabMinDensity[s] = 0;
-        chunk.slabMaxDensity[s] = 0;
       }
     }
   }

--- a/src/renderer/TerrainMesh.ts
+++ b/src/renderer/TerrainMesh.ts
@@ -434,7 +434,7 @@ export class TerrainMesh {
     // side: an owned neighbour marches those cubes itself, and marching them
     // twice would emit the interior wall between two claimed chunks.
     const { hasWest, hasEast, hasNorth, hasSouth } = this.neighbourFlags(cx, cz);
-    if (this.canSkipChunkMarch(cx, cy, cz, rect, hasWest, hasEast, hasNorth, hasSouth)) {
+    if (this.canSkipChunkMarch(cx, cy, cz, rect)) {
       this.chunks.set(key, null);
       return 0;
     }
@@ -533,8 +533,8 @@ export class TerrainMesh {
   private canSkipChunkMarch(
     cx: number, cy: number, cz: number,
     rect: { minX: number; minZ: number; maxX: number; maxZ: number },
-    hasWest: boolean, hasEast: boolean, hasNorth: boolean, hasSouth: boolean,
   ): boolean {
+    const { hasWest, hasEast, hasNorth, hasSouth } = this.neighbourFlags(cx, cz);
     const range = this.grid.chunkDensityRange(cx, cz, cy);
     if (!range) return false;
     if (range.max < SURFACE_THRESHOLD) return true; // uniformly air

--- a/src/renderer/TerrainMesh.ts
+++ b/src/renderer/TerrainMesh.ts
@@ -552,14 +552,12 @@ export class TerrainMesh {
     // symmetrically below for completeness, though the chunk below's own
     // topmost-cube march (its own "above" check, targeting this slab) is
     // what actually owns that seam.
-    const aboveRange = this.grid.chunkDensityRange(cx, cz, cy + 1);
-    const aboveSafe = aboveRange === null || aboveRange.min >= SURFACE_THRESHOLD;
-    if (!aboveSafe) return false;
-    if (cy > 0) {
-      const belowRange = this.grid.chunkDensityRange(cx, cz, cy - 1);
-      const belowSafe = belowRange === null || belowRange.min >= SURFACE_THRESHOLD;
-      if (!belowSafe) return false;
-    }
+    const slabSafe = (neighbourCy: number): boolean => {
+      const r = this.grid.chunkDensityRange(cx, cz, neighbourCy);
+      return r === null || r.min >= SURFACE_THRESHOLD;
+    };
+    if (!slabSafe(cy + 1)) return false;
+    if (cy > 0 && !slabSafe(cy - 1)) return false;
 
     // A fully interior chunk never emits geometry.
     if (hasWest && hasEast && hasNorth && hasSouth) return true;

--- a/src/renderer/TerrainMesh.ts
+++ b/src/renderer/TerrainMesh.ts
@@ -31,6 +31,11 @@ const CHUNK_SIZE = VOXEL_CHUNK_SIZE;
 // Density ≥ this is considered solid material (0.5 = half-filled)
 const SURFACE_THRESHOLD = 0.5;
 
+/** Metres of buffer below the neighbouring landscape's sampled ground height
+ *  at which a boundary/skirt wall may stop (#560). Exported so tests can
+ *  assert against the same constant the implementation uses. */
+export const SKIRT_VISIBILITY_MARGIN_M = 2;
+
 export interface DirtyRegion {
   minX: number; minY: number; minZ: number;
   maxX: number; maxY: number; maxZ: number;
@@ -421,10 +426,20 @@ export class TerrainMesh {
     // twice would emit the interior wall between two claimed chunks.
     const xStart = this.grid.hasChunk(cx - 1, cz) ? rect.minX : rect.minX - 1;
     const zStart = this.grid.hasChunk(cx, cz - 1) ? rect.minZ : rect.minZ - 1;
-    const yStart = cy === 0 ? -1 : oy;
+    const yStart = oy;
     const xEnd = rect.maxX;
     const zEnd = rect.maxZ;
     const yEnd = Math.min(oy + CHUNK_SIZE, this.grid.sizeY);
+
+    // TODO(#560): call this.canSkipChunkMarch(cx, cy, cz, rect) here — return
+    // early (chunks.set(key, null); return 0;) when it's true.
+    // TODO(#560): call this.boundarySkirtFloorY(x, z, rect, hasWest, hasEast,
+    // hasNorth, hasSouth) per boundary column and clamp the y loop's lower
+    // bound to it, instead of marching the skirt wall all the way to y=0.
+    // Referenced (not called) here only so the skeleton stubs below aren't
+    // flagged as unused before implementer wires them in.
+    void this.canSkipChunkMarch;
+    void this.boundarySkirtFloorY;
 
     for (let z = zStart; z < zEnd; z++) {
       for (let y = yStart; y < yEnd; y++) {
@@ -461,6 +476,33 @@ export class TerrainMesh {
     this.scene.add(mesh);
     this.chunks.set(key, mesh);
     return positions.length / 3;
+  }
+
+  /**
+   * Lowest world Y at which a wall/skirt cube may still be emitted for column
+   * (x, z), or null when this column borders no unclaimed neighbour (ordinary
+   * interior geometry) or no EdgeHeightSampler is installed (full-depth
+   * fallback). A column bordering unclaimed land on more than one side (site
+   * corner) returns the minimum of the applicable sides' floors (#560).
+   */
+  private boundarySkirtFloorY(
+    _x: number, _z: number,
+    _rect: { minX: number; minZ: number; maxX: number; maxZ: number },
+    _hasWest: boolean, _hasEast: boolean, _hasNorth: boolean, _hasSouth: boolean,
+  ): number | null {
+    throw new Error('not implemented');
+  }
+
+  /**
+   * True when chunk mesh (cx, cy, cz) is provably empty/solid-interior without
+   * marching a single cube (#560), using VoxelGrid's per-chunk density summary.
+   * False always falls through to the normal march — never a false positive.
+   */
+  private canSkipChunkMarch(
+    _cx: number, _cy: number, _cz: number,
+    _rect: { minX: number; minZ: number; maxX: number; maxZ: number },
+  ): boolean {
+    throw new Error('not implemented');
   }
 
   private marchCube(

--- a/src/renderer/TerrainMesh.ts
+++ b/src/renderer/TerrainMesh.ts
@@ -420,30 +420,30 @@ export class TerrainMesh {
       this.chunks.set(key, null);
       return 0;
     }
+    if (this.canSkipChunkMarch(cx, cy, cz, rect)) {
+      this.chunks.set(key, null);
+      return 0;
+    }
     const oy = cy * CHUNK_SIZE;
     // Extend one cube outward only where no owned chunk lies beyond that
     // side: an owned neighbour marches those cubes itself, and marching them
     // twice would emit the interior wall between two claimed chunks.
-    const xStart = this.grid.hasChunk(cx - 1, cz) ? rect.minX : rect.minX - 1;
-    const zStart = this.grid.hasChunk(cx, cz - 1) ? rect.minZ : rect.minZ - 1;
+    const hasWest = this.grid.hasChunk(cx - 1, cz);
+    const hasEast = this.grid.hasChunk(cx + 1, cz);
+    const hasNorth = this.grid.hasChunk(cx, cz - 1);
+    const hasSouth = this.grid.hasChunk(cx, cz + 1);
+    const xStart = hasWest ? rect.minX : rect.minX - 1;
+    const zStart = hasNorth ? rect.minZ : rect.minZ - 1;
     const yStart = oy;
     const xEnd = rect.maxX;
     const zEnd = rect.maxZ;
     const yEnd = Math.min(oy + CHUNK_SIZE, this.grid.sizeY);
 
-    // TODO(#560): call this.canSkipChunkMarch(cx, cy, cz, rect) here — return
-    // early (chunks.set(key, null); return 0;) when it's true.
-    // TODO(#560): call this.boundarySkirtFloorY(x, z, rect, hasWest, hasEast,
-    // hasNorth, hasSouth) per boundary column and clamp the y loop's lower
-    // bound to it, instead of marching the skirt wall all the way to y=0.
-    // Referenced (not called) here only so the skeleton stubs below aren't
-    // flagged as unused before implementer wires them in.
-    void this.canSkipChunkMarch;
-    void this.boundarySkirtFloorY;
-
     for (let z = zStart; z < zEnd; z++) {
       for (let y = yStart; y < yEnd; y++) {
         for (let x = xStart; x < xEnd; x++) {
+          const floorY = this.boundarySkirtFloorY(x, z, rect, hasWest, hasEast, hasNorth, hasSouth);
+          if (floorY !== null && y + 1 < floorY) continue;
           this.marchCube(x, y, z, positions, rockA, rockB, rockWeight, ore);
         }
       }
@@ -486,11 +486,36 @@ export class TerrainMesh {
    * corner) returns the minimum of the applicable sides' floors (#560).
    */
   private boundarySkirtFloorY(
-    _x: number, _z: number,
-    _rect: { minX: number; minZ: number; maxX: number; maxZ: number },
-    _hasWest: boolean, _hasEast: boolean, _hasNorth: boolean, _hasSouth: boolean,
+    x: number, z: number,
+    rect: { minX: number; minZ: number; maxX: number; maxZ: number },
+    hasWest: boolean, hasEast: boolean, hasNorth: boolean, hasSouth: boolean,
   ): number | null {
-    throw new Error('not implemented');
+    // A column borders unclaimed land on a side exactly when it's the halo
+    // column the march reaches into on that side (same coordinates
+    // rebuildChunk's xStart/zStart/xEnd/zEnd already use).
+    const bordersWest = !hasWest && x === rect.minX - 1;
+    const bordersEast = !hasEast && x === rect.maxX - 1;
+    const bordersNorth = !hasNorth && z === rect.minZ - 1;
+    const bordersSouth = !hasSouth && z === rect.maxZ - 1;
+    if (!bordersWest && !bordersEast && !bordersNorth && !bordersSouth) return null;
+    if (!this.edgeHeightSampler) return null;
+
+    let floor: number | null = null;
+    const consider = (sampleX: number, sampleZ: number): void => {
+      const h = this.edgeHeightSampler!(sampleX, sampleZ);
+      if (!Number.isFinite(h)) return;
+      const f = Math.floor(h) - SKIRT_VISIBILITY_MARGIN_M;
+      if (floor === null || f < floor) floor = f;
+    };
+    // West/north halo columns are already at the sampling coordinate; east/
+    // south need the neighbour column one past this chunk's owned rect,
+    // since the march's own loop bound stops at the last owned column.
+    if (bordersWest) consider(x, z);
+    if (bordersEast) consider(rect.maxX, z);
+    if (bordersNorth) consider(x, z);
+    if (bordersSouth) consider(x, rect.maxZ);
+
+    return floor;
   }
 
   /**
@@ -499,10 +524,56 @@ export class TerrainMesh {
    * False always falls through to the normal march — never a false positive.
    */
   private canSkipChunkMarch(
-    _cx: number, _cy: number, _cz: number,
-    _rect: { minX: number; minZ: number; maxX: number; maxZ: number },
+    cx: number, cy: number, cz: number,
+    rect: { minX: number; minZ: number; maxX: number; maxZ: number },
   ): boolean {
-    throw new Error('not implemented');
+    const range = this.grid.chunkDensityRange(cx, cz, cy);
+    if (!range) return false;
+    if (range.max < SURFACE_THRESHOLD) return true; // uniformly air
+    if (range.min < SURFACE_THRESHOLD) return false; // genuinely mixed — a surface crosses this slab
+
+    // Uniformly solid. A fully interior chunk never emits geometry.
+    const hasWest = this.grid.hasChunk(cx - 1, cz);
+    const hasEast = this.grid.hasChunk(cx + 1, cz);
+    const hasNorth = this.grid.hasChunk(cx, cz - 1);
+    const hasSouth = this.grid.hasChunk(cx, cz + 1);
+    if (hasWest && hasEast && hasNorth && hasSouth) return true;
+
+    // Boundary chunk: only skippable if every bordering edge column proves a
+    // skirt cutoff above this slab, and this slab sits entirely below it.
+    if (!this.edgeHeightSampler) return false;
+
+    let deepestFloor = Infinity;
+    const consider = (x: number, z: number): boolean => {
+      const floorY = this.boundarySkirtFloorY(x, z, rect, hasWest, hasEast, hasNorth, hasSouth);
+      if (floorY === null) return false;
+      if (floorY < deepestFloor) deepestFloor = floorY;
+      return true;
+    };
+
+    if (!hasWest) {
+      for (let z = rect.minZ; z < rect.maxZ; z++) {
+        if (!consider(rect.minX - 1, z)) return false;
+      }
+    }
+    if (!hasEast) {
+      for (let z = rect.minZ; z < rect.maxZ; z++) {
+        if (!consider(rect.maxX - 1, z)) return false;
+      }
+    }
+    if (!hasNorth) {
+      for (let x = rect.minX; x < rect.maxX; x++) {
+        if (!consider(x, rect.minZ - 1)) return false;
+      }
+    }
+    if (!hasSouth) {
+      for (let x = rect.minX; x < rect.maxX; x++) {
+        if (!consider(x, rect.maxZ - 1)) return false;
+      }
+    }
+
+    const slabTop = Math.min((cy + 1) * CHUNK_SIZE, this.grid.sizeY);
+    return slabTop < deepestFloor;
   }
 
   private marchCube(

--- a/src/renderer/TerrainMesh.ts
+++ b/src/renderer/TerrainMesh.ts
@@ -382,6 +382,16 @@ export class TerrainMesh {
     return ((cx + 1024) * 2048 + (cz + 1024)) * 1024 + cy;
   }
 
+  /** Which horizontal neighbours of chunk (cx, cz) are owned — computed once per rebuild and shared by rebuildChunk/canSkipChunkMarch/boundarySkirtFloorY instead of each recomputing it (#560). */
+  private neighbourFlags(cx: number, cz: number): { hasWest: boolean; hasEast: boolean; hasNorth: boolean; hasSouth: boolean } {
+    return {
+      hasWest: this.grid.hasChunk(cx - 1, cz),
+      hasEast: this.grid.hasChunk(cx + 1, cz),
+      hasNorth: this.grid.hasChunk(cx, cz - 1),
+      hasSouth: this.grid.hasChunk(cx, cz + 1),
+    };
+  }
+
   private disposeAllChunks(): void {
     for (const mesh of this.chunks.values()) {
       if (!mesh) continue;
@@ -420,18 +430,15 @@ export class TerrainMesh {
       this.chunks.set(key, null);
       return 0;
     }
-    if (this.canSkipChunkMarch(cx, cy, cz, rect)) {
+    // Extend one cube outward only where no owned chunk lies beyond that
+    // side: an owned neighbour marches those cubes itself, and marching them
+    // twice would emit the interior wall between two claimed chunks.
+    const { hasWest, hasEast, hasNorth, hasSouth } = this.neighbourFlags(cx, cz);
+    if (this.canSkipChunkMarch(cx, cy, cz, rect, hasWest, hasEast, hasNorth, hasSouth)) {
       this.chunks.set(key, null);
       return 0;
     }
     const oy = cy * CHUNK_SIZE;
-    // Extend one cube outward only where no owned chunk lies beyond that
-    // side: an owned neighbour marches those cubes itself, and marching them
-    // twice would emit the interior wall between two claimed chunks.
-    const hasWest = this.grid.hasChunk(cx - 1, cz);
-    const hasEast = this.grid.hasChunk(cx + 1, cz);
-    const hasNorth = this.grid.hasChunk(cx, cz - 1);
-    const hasSouth = this.grid.hasChunk(cx, cz + 1);
     const xStart = hasWest ? rect.minX : rect.minX - 1;
     const zStart = hasNorth ? rect.minZ : rect.minZ - 1;
     const yStart = oy;
@@ -526,17 +533,35 @@ export class TerrainMesh {
   private canSkipChunkMarch(
     cx: number, cy: number, cz: number,
     rect: { minX: number; minZ: number; maxX: number; maxZ: number },
+    hasWest: boolean, hasEast: boolean, hasNorth: boolean, hasSouth: boolean,
   ): boolean {
     const range = this.grid.chunkDensityRange(cx, cz, cy);
     if (!range) return false;
     if (range.max < SURFACE_THRESHOLD) return true; // uniformly air
     if (range.min < SURFACE_THRESHOLD) return false; // genuinely mixed — a surface crosses this slab
 
-    // Uniformly solid. A fully interior chunk never emits geometry.
-    const hasWest = this.grid.hasChunk(cx - 1, cz);
-    const hasEast = this.grid.hasChunk(cx + 1, cz);
-    const hasNorth = this.grid.hasChunk(cx, cz - 1);
-    const hasSouth = this.grid.hasChunk(cx, cz + 1);
+    // Uniformly solid. Unlike x/z, rebuildChunk's y-loop has no "-1" halo
+    // start (yStart is always oy, never oy-1) — the only vertical read past
+    // this chunk's own slab is its topmost cube's far corner, which lands
+    // one row into slab cy+1 (see yEnd's dy=1 corner in rebuildChunk). If
+    // that neighbouring slab isn't ALSO uniformly solid, the real surface
+    // may sit exactly on this chunk's own top boundary, and nothing else
+    // ever marches that cube — so it is never safe to skip on the strength
+    // of this slab's own density range alone (#560, reviewer repro: a flat
+    // surface landing exactly on a CHUNK_SIZE multiple). Checked
+    // symmetrically below for completeness, though the chunk below's own
+    // topmost-cube march (its own "above" check, targeting this slab) is
+    // what actually owns that seam.
+    const aboveRange = this.grid.chunkDensityRange(cx, cz, cy + 1);
+    const aboveSafe = aboveRange === null || aboveRange.min >= SURFACE_THRESHOLD;
+    if (!aboveSafe) return false;
+    if (cy > 0) {
+      const belowRange = this.grid.chunkDensityRange(cx, cz, cy - 1);
+      const belowSafe = belowRange === null || belowRange.min >= SURFACE_THRESHOLD;
+      if (!belowSafe) return false;
+    }
+
+    // A fully interior chunk never emits geometry.
     if (hasWest && hasEast && hasNorth && hasSouth) return true;
 
     // Boundary chunk: only skippable if every bordering edge column proves a
@@ -551,23 +576,38 @@ export class TerrainMesh {
       return true;
     };
 
+    // Loop ranges below reach one cell past [rect.minZ, rect.maxZ) / [rect.minX,
+    // rect.maxX) on the LOW end only, to include the diagonal corner cube
+    // (e.g. (rect.minX-1, rect.minZ-1)) that rebuildChunk's own march loop
+    // does visit when both an x-side and a z-side are unclaimed (xStart/
+    // zStart both shift to rect.minX-1/rect.minZ-1 in that case), but which
+    // neither a west-only nor a north-only scan of [rect.minZ, rect.maxZ) /
+    // [rect.minX, rect.maxX) alone would ever pass to boundarySkirtFloorY.
+    // The high end never needs a matching +1: rebuildChunk's xEnd/zEnd stay
+    // at rect.maxX/rect.maxZ regardless of hasEast/hasSouth (the east/south
+    // halo is reached through the last owned cube's high corner, not a
+    // shifted loop start), so rect.maxX-1/rect.maxZ-1 are already the last
+    // values these ranges cover. boundarySkirtFloorY itself combines
+    // multiple borders via min when called at a shared corner index, so the
+    // handful of extra calls this adds where a corner was already covered by
+    // the other side's scan are redundant, not incorrect.
     if (!hasWest) {
-      for (let z = rect.minZ; z < rect.maxZ; z++) {
+      for (let z = rect.minZ - 1; z < rect.maxZ; z++) {
         if (!consider(rect.minX - 1, z)) return false;
       }
     }
     if (!hasEast) {
-      for (let z = rect.minZ; z < rect.maxZ; z++) {
+      for (let z = rect.minZ - 1; z < rect.maxZ; z++) {
         if (!consider(rect.maxX - 1, z)) return false;
       }
     }
     if (!hasNorth) {
-      for (let x = rect.minX; x < rect.maxX; x++) {
+      for (let x = rect.minX - 1; x < rect.maxX; x++) {
         if (!consider(x, rect.minZ - 1)) return false;
       }
     }
     if (!hasSouth) {
-      for (let x = rect.minX; x < rect.maxX; x++) {
+      for (let x = rect.minX - 1; x < rect.maxX; x++) {
         if (!consider(x, rect.maxZ - 1)) return false;
       }
     }

--- a/tests/unit/benchmarks/benchmarks.test.ts
+++ b/tests/unit/benchmarks/benchmarks.test.ts
@@ -3,7 +3,9 @@
 // Each benchmark includes a warmup run to avoid cold-start bias.
 
 import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
 import { NavGrid, type NavCell, type NavCellType } from '../../../src/core/nav/NavGrid.js';
+import { TerrainMesh } from '../../../src/renderer/TerrainMesh.js';
 import { findPath, type PathRequest } from '../../../src/core/nav/Pathfinding.js';
 import { VoxelGrid, type VoxelData } from '../../../src/core/world/VoxelGrid.js';
 import { Random } from '../../../src/core/math/Random.js';
@@ -481,6 +483,79 @@ describe('Performance Benchmarks', () => {
 
       expect(result.success).toBe(true);
       expect(elapsed).toBeLessThan(200);
+    });
+  });
+
+  describe('TerrainMesh rebuild timing with the #560 depth-limited skirt + chunk-skip', () => {
+    // #560: canSkipChunkMarch/boundarySkirtFloorY don't exist yet (skeleton
+    // stubs throw 'not implemented', not wired into rebuildChunk's march loop
+    // either) -- these three benchmarks assert the same budgets an
+    // unconditional full march already has to hit today (matching the
+    // existing "re-meshing a 16^3 chunk completes in under 200ms" convention
+    // in TerrainMesh.test.ts). The real, wired-in implementation should only
+    // ever do LESS work than today's unconditional march, so it must clear
+    // these same budgets comfortably too.
+
+    function representativeSite(): VoxelGrid {
+      // 4x4 chunks (64m x 64m footprint), 2 y-chunks deep, solid to y=20 --
+      // large enough to exercise multiple boundary AND interior chunks at
+      // once, the shape #560's chunk-skip is meant to matter for.
+      const grid = new VoxelGrid(64, 32, 64);
+      for (let x = 0; x < 64; x++)
+        for (let y = 0; y < 20; y++)
+          for (let z = 0; z < 64; z++)
+            grid.setVoxel(x, y, z, solidVoxel());
+      return grid;
+    }
+
+    it('buildAll on a representative multi-chunk site completes in under 2000ms', () => {
+      const scene = new THREE.Scene();
+      const tm = new TerrainMesh(scene, representativeSite());
+      tm.setEdgeHeightSampler(() => 19.5); // neighbour ground at the same height as the site surface
+
+      const start = performance.now();
+      tm.buildAll();
+      const elapsed = performance.now() - start;
+
+      expect(elapsed).toBeLessThan(2000);
+      tm.dispose();
+    });
+
+    it('a single-chunk remesh completes in under 200ms', () => {
+      const scene = new THREE.Scene();
+      const grid = representativeSite();
+      const tm = new TerrainMesh(scene, grid);
+      tm.setEdgeHeightSampler(() => 19.5);
+      tm.buildAll();
+
+      grid.clearVoxel(20, 10, 20);
+      const start = performance.now();
+      tm.remeshRegion({ minX: 20, minY: 10, minZ: 20, maxX: 20, maxY: 10, maxZ: 20 });
+      const elapsed = performance.now() - start;
+
+      expect(elapsed).toBeLessThan(200);
+      tm.dispose();
+    });
+
+    it('a post-blast remesh (a small crater carved at the site edge) completes in under 200ms', () => {
+      const scene = new THREE.Scene();
+      const grid = representativeSite();
+      const tm = new TerrainMesh(scene, grid);
+      tm.setEdgeHeightSampler(() => 19.5);
+      tm.buildAll();
+
+      for (let y = 0; y < 20; y++) {
+        for (let z = 2; z < 6; z++) {
+          grid.clearVoxel(63, y, z);
+          grid.clearVoxel(62, y, z);
+        }
+      }
+      const start = performance.now();
+      tm.remeshRegion({ minX: 62, minY: 0, minZ: 2, maxX: 63, maxY: 19, maxZ: 5 });
+      const elapsed = performance.now() - start;
+
+      expect(elapsed).toBeLessThan(200);
+      tm.dispose();
     });
   });
 

--- a/tests/unit/benchmarks/benchmarks.test.ts
+++ b/tests/unit/benchmarks/benchmarks.test.ts
@@ -487,14 +487,13 @@ describe('Performance Benchmarks', () => {
   });
 
   describe('TerrainMesh rebuild timing with the #560 depth-limited skirt + chunk-skip', () => {
-    // #560: canSkipChunkMarch/boundarySkirtFloorY don't exist yet (skeleton
-    // stubs throw 'not implemented', not wired into rebuildChunk's march loop
-    // either) -- these three benchmarks assert the same budgets an
-    // unconditional full march already has to hit today (matching the
-    // existing "re-meshing a 16^3 chunk completes in under 200ms" convention
-    // in TerrainMesh.test.ts). The real, wired-in implementation should only
-    // ever do LESS work than today's unconditional march, so it must clear
-    // these same budgets comfortably too.
+    // #560: canSkipChunkMarch/boundarySkirtFloorY are implemented and wired
+    // into rebuildChunk's march loop -- these three benchmarks assert the
+    // same budgets an unconditional full march already had to hit before
+    // #560 (matching the existing "re-meshing a 16^3 chunk completes in
+    // under 200ms" convention in TerrainMesh.test.ts). The depth-limited
+    // skirt and chunk-skip only ever do LESS work than the old unconditional
+    // march, so it clears these same budgets comfortably too.
 
     function representativeSite(): VoxelGrid {
       // 4x4 chunks (64m x 64m footprint), 2 y-chunks deep, solid to y=20 --

--- a/tests/unit/renderer/TerrainMesh.test.ts
+++ b/tests/unit/renderer/TerrainMesh.test.ts
@@ -724,14 +724,18 @@ describe('TerrainMesh', () => {
 
     it('returns null (full-depth fallback) when no sampler is installed, even at a true boundary column', () => {
       const tm = new TerrainMesh(makeScene(), new VoxelGrid(CHUNK_SIZE, CHUNK_SIZE, CHUNK_SIZE));
-      expect(skirtInternals(tm).boundarySkirtFloorY(0, 8, RECT, false, true, true, true)).toBeNull();
+      // The halo column rebuildChunk actually marches on the west side when
+      // !hasWest is rect.minX - 1, not rect.minX itself — see the method's
+      // own doc comment ("same coordinates rebuildChunk's xStart/... use").
+      expect(skirtInternals(tm).boundarySkirtFloorY(-1, 8, RECT, false, true, true, true)).toBeNull();
       tm.dispose();
     });
 
     it("returns the sampled neighbour height minus SKIRT_VISIBILITY_MARGIN_M for a column bordering unclaimed land on exactly one side", () => {
       const tm = new TerrainMesh(makeScene(), new VoxelGrid(CHUNK_SIZE, CHUNK_SIZE, CHUNK_SIZE));
       tm.setEdgeHeightSampler(() => 20);
-      const floor = skirtInternals(tm).boundarySkirtFloorY(0, 8, RECT, false, true, true, true);
+      // x = rect.minX - 1 is the actual west halo column the march visits (see above).
+      const floor = skirtInternals(tm).boundarySkirtFloorY(-1, 8, RECT, false, true, true, true);
       expect(floor).toBeCloseTo(20 - SKIRT_VISIBILITY_MARGIN_M, 6);
       tm.dispose();
     });
@@ -740,7 +744,9 @@ describe('TerrainMesh', () => {
       const tm = new TerrainMesh(makeScene(), new VoxelGrid(CHUNK_SIZE, CHUNK_SIZE, CHUNK_SIZE));
       // West neighbour reads much deeper (lower cutoff) than north.
       tm.setEdgeHeightSampler((x) => (x < 0 ? 5 : 25));
-      const floor = skirtInternals(tm).boundarySkirtFloorY(0, 0, RECT, false, true, false, true);
+      // (rect.minX - 1, rect.minZ - 1) is the actual corner halo cell both
+      // the west and north loop extensions visit together.
+      const floor = skirtInternals(tm).boundarySkirtFloorY(-1, -1, RECT, false, true, false, true);
       expect(floor).toBeCloseTo(5 - SKIRT_VISIBILITY_MARGIN_M, 6);
       tm.dispose();
     });
@@ -748,7 +754,7 @@ describe('TerrainMesh', () => {
     it('falls back to null (no cutoff) rather than returning NaN when the sampler reports an unusable value', () => {
       const tm = new TerrainMesh(makeScene(), new VoxelGrid(CHUNK_SIZE, CHUNK_SIZE, CHUNK_SIZE));
       tm.setEdgeHeightSampler(() => NaN);
-      const floor = skirtInternals(tm).boundarySkirtFloorY(0, 8, RECT, false, true, true, true);
+      const floor = skirtInternals(tm).boundarySkirtFloorY(-1, 8, RECT, false, true, true, true);
       expect(floor === null || Number.isFinite(floor)).toBe(true);
       tm.dispose();
     });

--- a/tests/unit/renderer/TerrainMesh.test.ts
+++ b/tests/unit/renderer/TerrainMesh.test.ts
@@ -755,7 +755,7 @@ describe('TerrainMesh', () => {
       const tm = new TerrainMesh(makeScene(), new VoxelGrid(CHUNK_SIZE, CHUNK_SIZE, CHUNK_SIZE));
       tm.setEdgeHeightSampler(() => NaN);
       const floor = skirtInternals(tm).boundarySkirtFloorY(-1, 8, RECT, false, true, true, true);
-      expect(floor === null || Number.isFinite(floor)).toBe(true);
+      expect(floor).toBeNull();
       tm.dispose();
     });
   });

--- a/tests/unit/renderer/TerrainMesh.test.ts
+++ b/tests/unit/renderer/TerrainMesh.test.ts
@@ -1,17 +1,36 @@
 // TerrainMesh — unit tests
 // Tests geometry generation from VoxelGrid without needing a browser.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as THREE from 'three';
-import { VoxelGrid } from '../../../src/core/world/VoxelGrid.js';
+import { VoxelGrid, CHUNK_SIZE } from '../../../src/core/world/VoxelGrid.js';
 import {
   TerrainMesh,
   SurveyConfidenceOverlay,
   virtualEdgeDensity,
+  SKIRT_VISIBILITY_MARGIN_M,
   type SurveyConfidencePoint,
   type SurveyConfidenceOverlayOptions,
 } from '../../../src/renderer/TerrainMesh.js';
 import { TerrainMaterial } from '../../../src/renderer/terrain/TerrainMaterial.js';
+
+/** Access to TerrainMesh's private #560 stubs — TS-private, not runtime-private,
+ *  so a narrow structural cast is enough to exercise the documented contract
+ *  directly rather than only through indirect geometry assertions. */
+type TerrainMeshSkirtInternals = {
+  boundarySkirtFloorY(
+    x: number, z: number,
+    rect: { minX: number; minZ: number; maxX: number; maxZ: number },
+    hasWest: boolean, hasEast: boolean, hasNorth: boolean, hasSouth: boolean,
+  ): number | null;
+  canSkipChunkMarch(
+    cx: number, cy: number, cz: number,
+    rect: { minX: number; minZ: number; maxX: number; maxZ: number },
+  ): boolean;
+};
+function skirtInternals(tm: TerrainMesh): TerrainMeshSkirtInternals {
+  return tm as unknown as TerrainMeshSkirtInternals;
+}
 
 // Minimal mock THREE.Scene — just captures adds/removes
 function makeScene(): THREE.Scene {
@@ -20,6 +39,22 @@ function makeScene(): THREE.Scene {
 
 function makeSolidVoxel(rockId = 'sandite'): import('../../../src/core/world/VoxelGrid.js').VoxelData {
   return { composition: { rocks: [{ rockId, coefficient: 1.0 }] }, density: 1.0, oreDensities: {}, fractureModifier: 1.0 };
+}
+
+// #560: 3x3 chunks horizontally, 2 chunks tall, fully solid throughout — chunk
+// (1, 0, 1) sits fully enclosed on every side: 4 solid owned horizontal
+// neighbours, and solid material continuing above it into chunk cy=1, so no
+// surface of any kind (wall or ground) passes through its own slab. The
+// canonical "provably skippable, no marching needed" fixture.
+const MULTI_CHUNK_SIZE_XZ = CHUNK_SIZE * 3;
+const MULTI_CHUNK_SIZE_Y = CHUNK_SIZE * 2;
+function fullySolidMultiChunkGrid(): VoxelGrid {
+  const grid = new VoxelGrid(MULTI_CHUNK_SIZE_XZ, MULTI_CHUNK_SIZE_Y, MULTI_CHUNK_SIZE_XZ);
+  for (let x = 0; x < MULTI_CHUNK_SIZE_XZ; x++)
+    for (let y = 0; y < MULTI_CHUNK_SIZE_Y; y++)
+      for (let z = 0; z < MULTI_CHUNK_SIZE_XZ; z++)
+        grid.setVoxel(x, y, z, makeSolidVoxel());
+  return grid;
 }
 
 function makeConfidencePoint(
@@ -57,11 +92,12 @@ describe('TerrainMesh', () => {
     tm.dispose();
   });
 
-  it('buildAll on a fully-solid grid seals it into a closed box', () => {
-    // The grid is a finite volume, not an infinite solid: its outer faces are
-    // real surfaces. Emitting nothing here used to leave the mesh an open
-    // shell you could see straight into wherever terrain was cut back at the
-    // site edge.
+  it('buildAll on a fully-solid grid seals the sides, but does not cap the floor (#560)', () => {
+    // The grid is a finite volume, not an infinite solid: its side faces are
+    // real surfaces, and stay sealed. But #560 removes the floor cap that
+    // used to close the bottom too — an invisible, wasted surface under the
+    // whole site. Only the visible ground and the boundary/skirt walls are
+    // emitted; nothing closes the bottom of the world.
     const scene = makeScene();
     const grid = new VoxelGrid(4, 4, 4);
     for (let x = 0; x < 4; x++)
@@ -73,20 +109,23 @@ describe('TerrainMesh', () => {
 
     expect(scene.children.length).toBeGreaterThan(0);
 
-    // Every one of the six bounding faces must carry geometry.
+    // The four side faces must still carry geometry reaching the site edge.
     const pos = (scene.children[0] as THREE.Mesh).geometry.getAttribute('position').array as Float32Array;
-    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity, minZ = Infinity, maxZ = -Infinity;
+    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxZ = -Infinity, minZ = Infinity;
     for (let i = 0; i < pos.length; i += 3) {
       minX = Math.min(minX, pos[i]!);     maxX = Math.max(maxX, pos[i]!);
-      minY = Math.min(minY, pos[i + 1]!); maxY = Math.max(maxY, pos[i + 1]!);
+      minY = Math.min(minY, pos[i + 1]!);
       minZ = Math.min(minZ, pos[i + 2]!); maxZ = Math.max(maxZ, pos[i + 2]!);
     }
     expect(minX).toBeLessThanOrEqual(-0.5);
     expect(maxX).toBeGreaterThanOrEqual(3.5);
-    expect(minY).toBeLessThanOrEqual(-0.5);
-    expect(maxY).toBeGreaterThanOrEqual(3.5);
     expect(minZ).toBeLessThanOrEqual(-0.5);
     expect(maxZ).toBeGreaterThanOrEqual(3.5);
+    // No floor cap: the old sealed box put its lowest vertex at y = -0.5 (one
+    // cell below the grid). #560's fallback (no sampler installed) still
+    // marches the skirt walls to the very bottom of the grid (y = 0), but
+    // never below it.
+    expect(minY).toBeGreaterThanOrEqual(-1e-6);
     tm.dispose();
   });
 
@@ -529,6 +568,12 @@ describe('TerrainMesh', () => {
       const edgeCounts = new Map<string, number>();
       const key = (arr: Float32Array, i: number): string =>
         `${arr[i]!.toFixed(3)},${arr[i + 1]!.toFixed(3)},${arr[i + 2]!.toFixed(3)}`;
+      let minY = Infinity;
+      for (const child of scene.children) {
+        if (!(child instanceof THREE.Mesh)) continue;
+        const pos = child.geometry.getAttribute('position').array as Float32Array;
+        for (let i = 1; i < pos.length; i += 3) minY = Math.min(minY, pos[i]!);
+      }
       for (const child of scene.children) {
         if (!(child instanceof THREE.Mesh)) continue;
         const pos = child.geometry.getAttribute('position').array as Float32Array;
@@ -541,8 +586,17 @@ describe('TerrainMesh', () => {
           }
         }
       }
-      for (const count of edgeCounts.values()) {
-        if (count !== 2) return false;
+      for (const [edgeKey, count] of edgeCounts) {
+        if (count === 2) continue;
+        // #560: the floor is no longer capped, so the open bottom rim — an
+        // edge whose two endpoints both sit at the mesh's own lowest Y — is
+        // deliberately unstitched, not a hole in the visible surface. Any
+        // other unmatched edge is a real gap.
+        const [aStr, bStr] = edgeKey.split('|');
+        const aY = parseFloat(aStr!.split(',')[1]!);
+        const bY = parseFloat(bStr!.split(',')[1]!);
+        if (Math.abs(aY - minY) < 1e-3 && Math.abs(bY - minY) < 1e-3) continue;
+        return false;
       }
       return edgeCounts.size > 0;
     }
@@ -654,6 +708,337 @@ describe('TerrainMesh', () => {
     expect(tm.sharedMaterial).toBeInstanceOf(TerrainMaterial);
     expect(tm.sharedMaterial.customUniforms['uPlayRect']).toBeUndefined();
     tm.dispose();
+  });
+
+  // ─── #560: depth-limited perimeter skirt + chunk-skip ──────────────────
+
+  describe('boundarySkirtFloorY (direct method contract, #560)', () => {
+    const RECT = { minX: 0, minZ: 0, maxX: CHUNK_SIZE, maxZ: CHUNK_SIZE };
+
+    it('returns null for an interior column (owned neighbours on all four sides), regardless of sampler', () => {
+      const tm = new TerrainMesh(makeScene(), new VoxelGrid(CHUNK_SIZE, CHUNK_SIZE, CHUNK_SIZE));
+      tm.setEdgeHeightSampler(() => 10);
+      expect(skirtInternals(tm).boundarySkirtFloorY(8, 8, RECT, true, true, true, true)).toBeNull();
+      tm.dispose();
+    });
+
+    it('returns null (full-depth fallback) when no sampler is installed, even at a true boundary column', () => {
+      const tm = new TerrainMesh(makeScene(), new VoxelGrid(CHUNK_SIZE, CHUNK_SIZE, CHUNK_SIZE));
+      expect(skirtInternals(tm).boundarySkirtFloorY(0, 8, RECT, false, true, true, true)).toBeNull();
+      tm.dispose();
+    });
+
+    it("returns the sampled neighbour height minus SKIRT_VISIBILITY_MARGIN_M for a column bordering unclaimed land on exactly one side", () => {
+      const tm = new TerrainMesh(makeScene(), new VoxelGrid(CHUNK_SIZE, CHUNK_SIZE, CHUNK_SIZE));
+      tm.setEdgeHeightSampler(() => 20);
+      const floor = skirtInternals(tm).boundarySkirtFloorY(0, 8, RECT, false, true, true, true);
+      expect(floor).toBeCloseTo(20 - SKIRT_VISIBILITY_MARGIN_M, 6);
+      tm.dispose();
+    });
+
+    it("at a site corner (unclaimed on two sides), returns the minimum (deepest) of the two applicable sides' floors", () => {
+      const tm = new TerrainMesh(makeScene(), new VoxelGrid(CHUNK_SIZE, CHUNK_SIZE, CHUNK_SIZE));
+      // West neighbour reads much deeper (lower cutoff) than north.
+      tm.setEdgeHeightSampler((x) => (x < 0 ? 5 : 25));
+      const floor = skirtInternals(tm).boundarySkirtFloorY(0, 0, RECT, false, true, false, true);
+      expect(floor).toBeCloseTo(5 - SKIRT_VISIBILITY_MARGIN_M, 6);
+      tm.dispose();
+    });
+
+    it('falls back to null (no cutoff) rather than returning NaN when the sampler reports an unusable value', () => {
+      const tm = new TerrainMesh(makeScene(), new VoxelGrid(CHUNK_SIZE, CHUNK_SIZE, CHUNK_SIZE));
+      tm.setEdgeHeightSampler(() => NaN);
+      const floor = skirtInternals(tm).boundarySkirtFloorY(0, 8, RECT, false, true, true, true);
+      expect(floor === null || Number.isFinite(floor)).toBe(true);
+      tm.dispose();
+    });
+  });
+
+  describe('canSkipChunkMarch (direct method contract, #560)', () => {
+    it('returns true for a chunk with no marchable geometry anywhere (uniformly solid, fully enclosed on every side)', () => {
+      const grid = fullySolidMultiChunkGrid();
+      const tm = new TerrainMesh(makeScene(), grid);
+      const rect = grid.chunkRect(1, 1)!;
+      expect(skirtInternals(tm).canSkipChunkMarch(1, 0, 1, rect)).toBe(true);
+      tm.dispose();
+    });
+
+    it('returns false for a chunk that genuinely contains a surface (never a false positive)', () => {
+      const grid = new VoxelGrid(CHUNK_SIZE, CHUNK_SIZE, CHUNK_SIZE);
+      for (let x = 0; x < CHUNK_SIZE; x++)
+        for (let y = 0; y < CHUNK_SIZE / 2; y++)
+          for (let z = 0; z < CHUNK_SIZE; z++)
+            grid.setVoxel(x, y, z, makeSolidVoxel());
+      const tm = new TerrainMesh(makeScene(), grid);
+      const rect = grid.chunkRect(0, 0)!;
+      expect(skirtInternals(tm).canSkipChunkMarch(0, 0, 0, rect)).toBe(false);
+      tm.dispose();
+    });
+
+    it('returns false for a fully-solid boundary chunk when no sampler is installed (full-depth fallback still needs the wall)', () => {
+      // Single chunk footprint (boundary on all four sides), 2 y-chunks tall
+      // and solid throughout, so chunk cy=0 has no top surface of its own —
+      // isolating the "boundary wall still needed" reason from "has a real surface".
+      const grid = new VoxelGrid(CHUNK_SIZE, CHUNK_SIZE * 2, CHUNK_SIZE);
+      for (let x = 0; x < CHUNK_SIZE; x++)
+        for (let y = 0; y < CHUNK_SIZE * 2; y++)
+          for (let z = 0; z < CHUNK_SIZE; z++)
+            grid.setVoxel(x, y, z, makeSolidVoxel());
+      const tm = new TerrainMesh(makeScene(), grid);
+      const rect = grid.chunkRect(0, 0)!;
+      expect(skirtInternals(tm).canSkipChunkMarch(0, 0, 0, rect)).toBe(false);
+      tm.dispose();
+    });
+  });
+
+  describe('boundary/skirt walls without a sampler still march full depth (#560 fallback)', () => {
+    function flatSiteLocal(size: number, surfaceY: number): VoxelGrid {
+      const grid = new VoxelGrid(size, size, size);
+      for (let x = 0; x < size; x++)
+        for (let y = 0; y < surfaceY; y++)
+          for (let z = 0; z < size; z++)
+            grid.setVoxel(x, y, z, makeSolidVoxel());
+      return grid;
+    }
+
+    it('reaches the bottom of the grid (y=0) when no EdgeHeightSampler is installed', () => {
+      const scene = makeScene();
+      const size = 8;
+      const tm = new TerrainMesh(scene, flatSiteLocal(size, 4));
+      tm.buildAll();
+      let minY = Infinity;
+      for (const mesh of tm.meshes) {
+        const pos = mesh.geometry.getAttribute('position').array as Float32Array;
+        for (let i = 0; i < pos.length; i += 3) minY = Math.min(minY, pos[i + 1]!);
+      }
+      expect(minY).toBeLessThanOrEqual(0 + 1e-6);
+      tm.dispose();
+    });
+  });
+
+  describe('EdgeHeightSampler depth-limits the skirt (#560)', () => {
+    const SIZE = 8;
+    const SURFACE_Y = 30;
+    const DEEP_SIZE_Y = 40;
+
+    function deepFlatSite(): VoxelGrid {
+      const grid = new VoxelGrid(SIZE, DEEP_SIZE_Y, SIZE);
+      for (let x = 0; x < SIZE; x++)
+        for (let y = 0; y < SURFACE_Y; y++)
+          for (let z = 0; z < SIZE; z++)
+            grid.setVoxel(x, y, z, makeSolidVoxel());
+      return grid;
+    }
+
+    it('with a sampler reporting the neighbour ground near the site surface, total vertex count is strictly less than with no sampler installed', () => {
+      const sceneA = makeScene();
+      const tmA = new TerrainMesh(sceneA, deepFlatSite());
+      tmA.buildAll(); // no sampler — full-depth fallback
+      const withoutSampler = tmA.getBounds()?.vertexCount ?? 0;
+      tmA.dispose();
+
+      const sceneB = makeScene();
+      const tmB = new TerrainMesh(sceneB, deepFlatSite());
+      tmB.setEdgeHeightSampler(() => SURFACE_Y - 0.5); // neighbour ground right at the site's own surface
+      tmB.buildAll();
+      const withSampler = tmB.getBounds()?.vertexCount ?? 0;
+      tmB.dispose();
+
+      expect(withSampler).toBeGreaterThan(0);
+      expect(withSampler).toBeLessThan(withoutSampler);
+    });
+
+    it('a blast crater at the site edge stays closed (no see-through gap) with a sampler installed and the skirt depth-limited', () => {
+      function flatSiteLocal(size: number, surfaceY: number): VoxelGrid {
+        const grid = new VoxelGrid(size, size, size);
+        for (let x = 0; x < size; x++)
+          for (let y = 0; y < surfaceY; y++)
+            for (let z = 0; z < size; z++)
+              grid.setVoxel(x, y, z, makeSolidVoxel());
+        return grid;
+      }
+      function maxVertexXLocal(scene: THREE.Scene): number {
+        let m = -Infinity;
+        for (const child of scene.children) {
+          const geo = (child as THREE.Mesh).geometry;
+          if (!geo) continue;
+          const pos = geo.getAttribute('position').array as Float32Array;
+          for (let i = 0; i < pos.length; i += 3) m = Math.max(m, pos[i]!);
+        }
+        return m;
+      }
+
+      const scene = makeScene();
+      const size = 8;
+      const grid = flatSiteLocal(size, 4);
+      const tm = new TerrainMesh(scene, grid);
+      tm.setEdgeHeightSampler(() => 3.5); // neighbour ground reported at the same height as the site surface
+      tm.buildAll();
+
+      for (let y = 0; y < 4; y++) {
+        for (let z = 2; z < 5; z++) {
+          grid.clearVoxel(size - 1, y, z);
+          grid.clearVoxel(size - 2, y, z);
+        }
+      }
+      tm.remeshRegion({ minX: size - 2, minY: 0, minZ: 2, maxX: size - 1, maxY: 3, maxZ: 4 });
+
+      expect(maxVertexXLocal(scene)).toBeGreaterThanOrEqual(size - 0.5 - 1e-4);
+      tm.dispose();
+    });
+  });
+
+  describe('canSkipChunkMarch — chunk-skip via VoxelGrid density summary (#560)', () => {
+    it('a fully-solid interior chunk (all 4 neighbours owned, no surface anywhere in its slab) is skipped without marching a single cube', () => {
+      const scene = makeScene();
+      const grid = fullySolidMultiChunkGrid();
+      const marchSpy = vi.spyOn(TerrainMesh.prototype as unknown as { marchCube: (...args: unknown[]) => void }, 'marchCube');
+      const tm = new TerrainMesh(scene, grid);
+      tm.buildAll();
+
+      expect(tm.getChunkMesh(1, 0, 1)).toBeNull();
+
+      // Chunk (1, 0, 1) owns exactly x:16..31, y:0..15, z:16..31 (CHUNK_SIZE=16)
+      // and has an owned neighbour on every horizontal side, so no other
+      // chunk's own halo march ever needs to touch this region either.
+      const rect = grid.chunkRect(1, 1)!;
+      const touchedSkippedChunk = marchSpy.mock.calls.some((args) => {
+        const [x, y, z] = args as [number, number, number];
+        return x >= rect.minX && x < rect.maxX && y >= 0 && y < CHUNK_SIZE && z >= rect.minZ && z < rect.maxZ;
+      });
+      expect(touchedSkippedChunk).toBe(false);
+
+      marchSpy.mockRestore();
+      tm.dispose();
+    });
+
+    it('a fully-solid boundary chunk entirely below the sampled skirt floor is also skipped', () => {
+      // Single chunk footprint (boundary on every side), 2 y-chunks tall,
+      // solid throughout. Neighbour ground reported at y=22 -> skirt floor
+      // ~= 22 - SKIRT_VISIBILITY_MARGIN_M = 20, comfortably above chunk
+      // cy=0's own span (0..15).
+      const scene = makeScene();
+      const grid = new VoxelGrid(CHUNK_SIZE, CHUNK_SIZE * 2, CHUNK_SIZE);
+      for (let x = 0; x < CHUNK_SIZE; x++)
+        for (let y = 0; y < CHUNK_SIZE * 2; y++)
+          for (let z = 0; z < CHUNK_SIZE; z++)
+            grid.setVoxel(x, y, z, makeSolidVoxel());
+      const tm = new TerrainMesh(scene, grid);
+      tm.setEdgeHeightSampler(() => 22);
+      tm.buildAll();
+      expect(tm.getChunkMesh(0, 0, 0)).toBeNull();
+      tm.dispose();
+    });
+
+    it('a boundary chunk straddling the skirt cutoff is NOT skipped', () => {
+      const scene = makeScene();
+      const grid = new VoxelGrid(CHUNK_SIZE, CHUNK_SIZE * 2, CHUNK_SIZE);
+      for (let x = 0; x < CHUNK_SIZE; x++)
+        for (let y = 0; y < CHUNK_SIZE * 2; y++)
+          for (let z = 0; z < CHUNK_SIZE; z++)
+            grid.setVoxel(x, y, z, makeSolidVoxel());
+      const tm = new TerrainMesh(scene, grid);
+      tm.setEdgeHeightSampler(() => 22); // cutoff ~20, inside chunk cy=1's own span (16..31)
+      tm.buildAll();
+      expect(tm.getChunkMesh(0, 1, 0)).not.toBeNull();
+      tm.dispose();
+    });
+
+    it('a chunk that becomes mixed after a blast (density crosses SURFACE_THRESHOLD in its own slab) is re-marched on the next rebuild, not left stale from a prior skip', () => {
+      const scene = makeScene();
+      const grid = fullySolidMultiChunkGrid();
+      const tm = new TerrainMesh(scene, grid);
+      tm.buildAll();
+      expect(tm.getChunkMesh(1, 0, 1)).toBeNull(); // provably solid interior, skipped
+
+      // Carve a small air pocket well inside chunk (1, 0, 1)'s own span
+      // (x:16..31, y:0..15, z:16..31).
+      for (let y = 4; y < 8; y++) grid.clearVoxel(20, y, 20);
+      tm.remeshRegion({ minX: 19, minY: 3, minZ: 19, maxX: 21, maxY: 8, maxZ: 21 });
+
+      expect(tm.getChunkMesh(1, 0, 1)).not.toBeNull();
+      tm.dispose();
+    });
+  });
+
+  describe('boundarySkirtFloorY corner columns use the minimum (deepest) applicable floor (#560)', () => {
+    // Single chunk footprint -> (0,0) is the grid's own NW corner, bordering
+    // unclaimed land on both west and north. 2 y-chunks tall, solid
+    // throughout, so there's no top-surface confound near the corner's own
+    // deep cutoff.
+    function tallCornerColumn(): VoxelGrid {
+      const grid = new VoxelGrid(CHUNK_SIZE, CHUNK_SIZE * 2, CHUNK_SIZE);
+      for (let x = 0; x < CHUNK_SIZE; x++)
+        for (let y = 0; y < CHUNK_SIZE * 2; y++)
+          for (let z = 0; z < CHUNK_SIZE; z++)
+            grid.setVoxel(x, y, z, makeSolidVoxel());
+      return grid;
+    }
+
+    /** Lowest Y reached by any wall vertex within a small window around the grid's NW corner. */
+    function minCornerWallY(scene: THREE.Scene): number {
+      let m = Infinity;
+      for (const child of scene.children) {
+        const geo = (child as THREE.Mesh).geometry;
+        if (!geo) continue;
+        const pos = geo.getAttribute('position').array as Float32Array;
+        for (let i = 0; i < pos.length; i += 3) {
+          const x = pos[i]!, y = pos[i + 1]!, z = pos[i + 2]!;
+          if (x <= 1 && z <= 1) m = Math.min(m, y);
+        }
+      }
+      return m;
+    }
+
+    it("a corner column bordering unclaimed land on two sides reaches down to the deeper of the two sides' floors", () => {
+      // Shallow uniform sampler: both directions read the same high (shallow) neighbour height.
+      const sceneShallow = makeScene();
+      const tmShallow = new TerrainMesh(sceneShallow, tallCornerColumn());
+      tmShallow.setEdgeHeightSampler(() => 25);
+      tmShallow.buildAll();
+      const shallowMinY = minCornerWallY(sceneShallow);
+      tmShallow.dispose();
+
+      // West much deeper than north: the corner must follow the deeper
+      // (west) side, not the shallow one.
+      const sceneCorner = makeScene();
+      const tmCorner = new TerrainMesh(sceneCorner, tallCornerColumn());
+      tmCorner.setEdgeHeightSampler((x) => (x < 0 ? 5 : 25));
+      tmCorner.buildAll();
+      const cornerMinY = minCornerWallY(sceneCorner);
+      tmCorner.dispose();
+
+      expect(cornerMinY).toBeLessThan(shallowMinY);
+    });
+  });
+
+  describe('EdgeHeightSampler robustness (#560)', () => {
+    it('a NaN sampler value falls back to full depth instead of propagating NaN into the emitted geometry', () => {
+      const scene = makeScene();
+      const size = 8;
+      const grid = new VoxelGrid(size, size, size);
+      for (let x = 0; x < size; x++)
+        for (let y = 0; y < 4; y++)
+          for (let z = 0; z < size; z++)
+            grid.setVoxel(x, y, z, makeSolidVoxel());
+      const tm = new TerrainMesh(scene, grid);
+      tm.setEdgeHeightSampler(() => NaN);
+      expect(() => tm.buildAll()).not.toThrow();
+
+      let minY = Infinity;
+      for (const mesh of tm.meshes) {
+        const pos = mesh.geometry.getAttribute('position').array as Float32Array;
+        for (let i = 0; i < pos.length; i += 3) {
+          expect(Number.isNaN(pos[i]!)).toBe(false);
+          expect(Number.isNaN(pos[i + 1]!)).toBe(false);
+          expect(Number.isNaN(pos[i + 2]!)).toBe(false);
+          minY = Math.min(minY, pos[i + 1]!);
+        }
+      }
+      // No cutoff applied — full-depth fallback, same as no sampler installed at all.
+      expect(minY).toBeLessThanOrEqual(0 + 1e-6);
+      tm.dispose();
+    });
   });
 });
 

--- a/tests/unit/world/VoxelGrid.test.ts
+++ b/tests/unit/world/VoxelGrid.test.ts
@@ -422,12 +422,16 @@ describe('VoxelGrid.chunkDensityRange — per-chunk per-slab density summary (#5
   it('restoreChunkRaw fully rescans the density summary rather than leaving it stale', () => {
     const grid = new VoxelGrid(16, 8, 16); // 1 chunk, nSlabs=1
     const n = CHUNK_SIZE * grid.sizeY * CHUNK_SIZE;
-    const density = new Float64Array(n);
+    // Every restored voxel counts toward the rescan (even the ones left at
+    // their default), so the array must be filled throughout: a mostly-zero
+    // array's true minimum really is 0, not whatever floor value a couple of
+    // cells happen to poke — that would be asserting a bound the input data
+    // doesn't actually have.
+    const density = new Float64Array(n).fill(0.15);
     const compId = new Uint16Array(n);
     const fracture = new Float64Array(n).fill(1.0);
     // Local index formula mirrors VoxelGrid's own: lx + y*CHUNK_SIZE + lz*CHUNK_SIZE*sizeY.
     const idx = (lx: number, y: number, lz: number): number => lx + y * CHUNK_SIZE + lz * CHUNK_SIZE * grid.sizeY;
-    density[idx(0, 0, 0)] = 0.15;
     density[idx(1, 1, 1)] = 0.85;
 
     grid.restoreChunkRaw(0, 0, { minX: 0, minZ: 0, maxX: CHUNK_SIZE, maxZ: CHUNK_SIZE }, density, compId, fracture, new Map());

--- a/tests/unit/world/VoxelGrid.test.ts
+++ b/tests/unit/world/VoxelGrid.test.ts
@@ -373,6 +373,75 @@ describe('VoxelGrid — dirty-chunk tracking (#473 D4)', () => {
   });
 });
 
+describe('VoxelGrid.chunkDensityRange — per-chunk per-slab density summary (#560)', () => {
+  it('returns {min:0, max:0} for a freshly claimed, ungenerated chunk', () => {
+    const grid = new VoxelGrid(32, 8, 32); // 2x2 chunks, sizeY=8 -> nSlabs=1
+    expect(grid.chunkDensityRange(0, 0, 0)).toEqual({ min: 0, max: 0 });
+    expect(grid.chunkDensityRange(1, 1, 0)).toEqual({ min: 0, max: 0 });
+  });
+
+  it('widens min/max to include fillVoxel, setVoxel, and clearVoxel writes into a given y-slab', () => {
+    const grid = new VoxelGrid(16, 8, 16); // 1 chunk, nSlabs=1
+    expect(grid.chunkDensityRange(0, 0, 0)).toEqual({ min: 0, max: 0 });
+
+    const compId = grid.palette.intern({ rocks: [{ rockId: 'cruite', coefficient: 1 }] });
+    grid.fillVoxel(1, 1, 1, compId); // density defaults to 1.0
+    expect(grid.chunkDensityRange(0, 0, 0)).toEqual({ min: 0, max: 1 });
+
+    grid.setVoxel(2, 2, 2, {
+      composition: { rocks: [{ rockId: 'cruite', coefficient: 1 }] },
+      density: 0.4,
+      oreDensities: {},
+      fractureModifier: 1,
+    });
+    expect(grid.chunkDensityRange(0, 0, 0)).toEqual({ min: 0, max: 1 }); // 0.4 is within the already-observed [0,1] range
+
+    grid.clearVoxel(1, 1, 1); // density -> 0, but the summary never narrows back down
+    expect(grid.chunkDensityRange(0, 0, 0)).toEqual({ min: 0, max: 1 });
+  });
+
+  it('once a slab is observed mixed (min=0, max=1), a later write that would locally narrow it leaves the summary widened', () => {
+    const grid = new VoxelGrid(16, 8, 16);
+    const compId = grid.palette.intern({ rocks: [{ rockId: 'cruite', coefficient: 1 }] });
+    grid.fillVoxel(5, 5, 5, compId); // density 1.0 -> widens the slab to {min:0, max:1}
+    expect(grid.chunkDensityRange(0, 0, 0)).toEqual({ min: 0, max: 1 });
+
+    // A write of a mid-range density, taken in isolation, would suggest a
+    // narrower [0.3, 0.3] range for this one voxel -- but the slab's own
+    // summary must stay at its already-widened [0, 1], not shrink to match
+    // the most recent write.
+    grid.setVoxel(6, 5, 5, {
+      composition: { rocks: [{ rockId: 'cruite', coefficient: 1 }] },
+      density: 0.3,
+      oreDensities: {},
+      fractureModifier: 1,
+    });
+    expect(grid.chunkDensityRange(0, 0, 0)).toEqual({ min: 0, max: 1 });
+  });
+
+  it('restoreChunkRaw fully rescans the density summary rather than leaving it stale', () => {
+    const grid = new VoxelGrid(16, 8, 16); // 1 chunk, nSlabs=1
+    const n = CHUNK_SIZE * grid.sizeY * CHUNK_SIZE;
+    const density = new Float64Array(n);
+    const compId = new Uint16Array(n);
+    const fracture = new Float64Array(n).fill(1.0);
+    // Local index formula mirrors VoxelGrid's own: lx + y*CHUNK_SIZE + lz*CHUNK_SIZE*sizeY.
+    const idx = (lx: number, y: number, lz: number): number => lx + y * CHUNK_SIZE + lz * CHUNK_SIZE * grid.sizeY;
+    density[idx(0, 0, 0)] = 0.15;
+    density[idx(1, 1, 1)] = 0.85;
+
+    grid.restoreChunkRaw(0, 0, { minX: 0, minZ: 0, maxX: CHUNK_SIZE, maxZ: CHUNK_SIZE }, density, compId, fracture, new Map());
+
+    expect(grid.chunkDensityRange(0, 0, 0)).toEqual({ min: 0.15, max: 0.85 });
+  });
+
+  it("returns null for an unowned chunk, and for a slab index past the grid's height", () => {
+    const grid = new VoxelGrid(16, 8, 16); // nSlabs = ceil(8/16) = 1 -> only slab 0 exists
+    expect(grid.chunkDensityRange(5, 5, 0)).toBeNull(); // chunk (5,5) was never claimed
+    expect(grid.chunkDensityRange(0, 0, 1)).toBeNull(); // slab 1 doesn't exist for an 8-tall grid
+  });
+});
+
 describe('computeVoxelColumnSurfaceY', () => {
   it('finds the highest solid voxel in a column', () => {
     const grid = new VoxelGrid(16, 8, 16);


### PR DESCRIPTION
Closes #560

## Summary

`TerrainMesh` no longer meshes the playable site as a sealed box. Three changes in `src/renderer/TerrainMesh.ts` and `src/core/world/VoxelGrid.ts`:

- **No floor cap.** `rebuildChunk`'s `yStart = cy === 0 ? -1 : oy` special case (marched one cube below the grid floor, sealing an invisible bottom cap under the whole site) is removed. The bottom is never visible in normal play (no below-ground camera, confirmed via `CameraController`'s `minHeight` guard), so it is no longer emitted.
- **Depth-limited perimeter skirt.** The wall/skirt at the site's boundary now stops at `boundarySkirtFloorY(x, z, ...)` — the neighbouring landscape's sampled surface height (via the already-installed `edgeHeightSampler`) minus a 2 m margin (`SKIRT_VISIBILITY_MARGIN_M`) — instead of marching the full grid depth. Below that line the landscape occludes the wall in normal play. A blast at the very edge of the site still produces a closed, watertight wall down to the visible cutoff (verified below); with no `edgeHeightSampler` installed the fallback is the original full-depth behaviour, unchanged.
- **Chunk-skip via a VoxelGrid density summary.** `VoxelGrid` now maintains a per-chunk, per-y-slab `{min, max}` density summary (`chunkDensityRange`, widened on every voxel write via `touchDensity`, exactly recomputed on save/load in `restoreChunkRaw`). `TerrainMesh.canSkipChunkMarch` uses it to skip marching chunks that are provably uniform (air, or solid with no possible crossing — including a vertical-adjacency check against the `cy±1` slab and the diagonal corner halo column, both added after code review caught false-positive gaps).

## Numbers (representative 64×32×64 site, solid to y=20)

| Metric | Before | After |
|---|---|---|
| `buildAll` wall time (median of 5) | 166.80ms | 71.87ms (2.3× faster) |
| Vertex count | 79,860 (26,620 tris) | 29,946 (9,982 tris) — 62.5% fewer |
| Built (non-empty) chunks | 32/32 | 16/32 |
| Single-chunk remesh (median of 5) | 4.14ms | 2.44ms |
| Post-blast remesh (small edge crater) | 12.92ms | 8.10ms |

## Verification

- **static**: `npm run typecheck` — clean.
- **logic**: `npm run test` — 9582/9582 passing, 314 files, zero regressions.
- **scenario**: `npm run scenarios` — 129/129 passing (command mode), including the two scenario defs updated for this issue (`blast-execution-visual.json` — edge-of-site drill/blast/crater-wall cycle; `landscape-continuity-visual.json` — crater-no-floor-cap shot).
- **visual**: inspected via `@visual-tester` in interaction mode. Reproduced both camera setups from the issue on the original seeds:
  - `sandbox start biome:green_foothills seed:2024`, camera pushed into the ground at the site edge — no interior box faces visible, continuous transition to landscape.
  - `sandbox start biome:tropical_karst seed:31337`, karst corner near a hole — no skirt standing proud past the landscape.
  - Edge-of-site blast: crater wall stays solid and closed from outside, no see-through shell.
  - Crater-no-floor-cap shot: fractured underside visible with no flat floor plane.
  - Shadow comparison (`alpine_granite seed:777`) vs `main`: mean pixel diff 0.15-0.27/255, consistent with ambient animation noise — no new acne, no cast-silhouette change. `shadowSide = THREE.BackSide` guarantee intact.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** the issue asked for "a way to query neighbouring ground height... plumbed into TerrainMesh."
  **Chosen:** reuse the existing `TerrainMesh.edgeHeightSampler` field (already installed by `GameRenderer` before the first `buildAll()`, for #559's normal-gradient fix) instead of adding new plumbing.
  **Why:** it already answers exactly this question and is already wired at the right time.
  **If reversed:** split `edgeHeightSampler` into two fields at the two call sites in `TerrainMesh.ts` if a different height source is ever wanted for the skirt cutoff than for normals.

- **What was open:** which surface to measure visible skirt depth against — neighbouring landscape height vs. the site's own adjacent column height.
  **Chosen:** neighbouring landscape height.
  **Why:** the site's own surface is exactly what a blast at the edge changes, so using it would make the cutoff circular with the very event the issue says must stay closed; the landscape height is stable across blasts/ramp carving and is literally what occludes the wall.
  **If reversed:** change `boundarySkirtFloorY`'s sample point to query the site's own `computeVoxelColumnSurfaceHeight` instead.

- **What was open:** the exact margin below the neighbour height.
  **Chosen:** `SKIRT_VISIBILITY_MARGIN_M = 2`, matching `LandscapeMesh.MID_STEP`.
  **Why:** borrows an existing figure from the exact system this skirt has to seam against.
  **If reversed:** edit the one constant in `TerrainMesh.ts`.

- **What was open:** exact vs. conservative tracking for the VoxelGrid density summary.
  **Chosen:** monotonic widening only on normal voxel writes; exact recompute only on `restoreChunkRaw`'s bulk load.
  **Why:** O(1) per write keeps the hot voxel-write path (blast, ramp carving) cheap; the only failure mode is an occasional missed skip, never an incorrect one.
  **If reversed:** replace `touchDensity`'s widening with a full chunk-slab rescan if skip effectiveness after heavy blasting turns out to matter more than write-path cost.

None of the above changes gameplay, economy, or a player-facing default — no `decision-review` follow-up filed.

## Known, deliberately out-of-scope findings (filed as follow-ups, not fixed here)

Code review surfaced three issues outside this change's reachable scope; each is filed as its own follow-up issue rather than expanding this PR:

1. `canSkipChunkMarch`'s new boundary-scan loops share the same unbounded-loop-on-malformed-save-data class as `main`'s pre-existing, unchanged march-loop bounds (`rect.maxX`/`rect.maxZ` from unclamped `chunk.x0/z0/x1/z1`, ultimately from unvalidated save JSON via `VoxelGridCodec`). Root cause predates this PR and needs fixing once, in the codec, not scattered across call sites.
2. `canSkipChunkMarch`'s "uniformly solid, no slab above" branch is a latent false-positive at the grid's own top boundary — real but unreachable through the game's own terrain generation, which always keeps headroom below `sizeY` (`WorldGen.ts`'s clamp).
3. An independent starvation bug in `ActionSelection.ts`'s `claimOnePoolCandidate` (a large backlog of unlicensed haul actions can permanently block a farther action an employee is qualified for) was found while diagnosing a scenario failure. A prototype fix changed `level2-playthrough-win`'s `deathCount` from 5 to 6 — a gameplay-balance side effect needing its own deliberate review — so it was not carried into this diff.

READY TO MERGE
