### PR TITLE
fix: Resolve #571 — Blast Report modal reopens after save/load

### DIFF
--- a/scripts/scenario-defs/blast-report-save-load-visual.json
+++ b/scripts/scenario-defs/blast-report-save-load-visual.json
@@ -1,0 +1,306 @@
+{
+  "name": "blast-report-save-load-visual",
+  "description": "Regression coverage for #571: a Blast Report modal, dismissed by a real click, must stay closed after a save+load round trip -- even past the ~3s real-time delay (BLAST_REPORT_DELAY_MS, BlastReportModal.ts) that would otherwise re-arm it. Before the fix, `load` replaced ctx.state wholesale with a *new* state.lastBlastReport object (deep-cloned from the save), and the modal's identity check (report !== lastShownReport) treated that new reference as a fresh, never-shown report -- reopening it ~3s later over whatever panel the player had moved on to. The fix stamps lastShownReport from the swapped-in state inside reset() (closeStaleLevelOverlays), so a report identical in content to one already dismissed does not re-arm. Sanity checks bracket the regression check: the modal must still genuinely open for a real new report (step 'blast'), and must still genuinely close on a real click (step 'dismiss report').",
+  "steps": [
+    {
+      "command": "new_game seed:42 staffed:true",
+      "timeout": 15,
+      "description": "Staffed opening (#551): a driller with blasting + drill_rig licence, plus an unmanned drill_rig, are hired/purchased for free at game-open.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "new_game seed:42 staffed:true"
+        }
+      ],
+      "role": "setup",
+      "expect": {
+        "equals": {
+          "cash": 50000,
+          "holeCount": 0
+        }
+      }
+    },
+    {
+      "command": "drill_plan grid rows:2 cols:2 spacing:5 depth:6 start:15,15",
+      "description": "Two increment clicks on the spacing stepper raise it 3->5m before dragging, so the (15,15)-(20,20) rectangle computes the declared 2x2 instead of the default-spacing 3x3.",
+      "interaction": [
+        {
+          "type": "clickSelector",
+          "selector": "#bs-toolbar [data-panel=\"blast\"]"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-blast-panel [data-action=\"grid-tool\"]"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": "#bs-tile-select-confirm"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-param-strip [data-field=\"spacing\"] .bsx-stepper-btn:last-child"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-param-strip [data-field=\"spacing\"] .bsx-stepper-btn:last-child"
+        },
+        {
+          "type": "dragTiles",
+          "x1": 15,
+          "z1": 15,
+          "x2": 20,
+          "z2": 20
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-tile-select-confirm"
+        }
+      ],
+      "role": "player",
+      "expect": {
+        "equals": {
+          "orderedHoleCount": 4,
+          "holeCount": 0
+        },
+        "note": "2 rows x 2 cols = 4 holes ordered (ghosts), none drilled yet (#553)"
+      }
+    },
+    {
+      "command": "tick 90",
+      "description": "#553: drain the ordered plan -- the staffed driller/drill_rig lands all 4 holes well inside this pad.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 90"
+        }
+      ],
+      "role": "setup",
+      "expect": {
+        "equals": {
+          "orderedHoleCount": 0,
+          "holeCount": 4
+        }
+      }
+    },
+    {
+      "command": "charge hole:* explosive:boomite amount:5 stemming:2",
+      "interaction": [
+        {
+          "type": "clickSelector",
+          "selector": "#bs-blast-panel [data-action=\"charge-all\"]"
+        }
+      ],
+      "role": "player",
+      "expect": {
+        "increased": [
+          "orderedChargeCount"
+        ]
+      }
+    },
+    {
+      "command": "wait_until field:orderedChargeCount equals:0 max_ticks:3000",
+      "timeout": 125,
+      "description": "#554: drain the charge order(s) queued by the step above (charging is real work, not instant) before continuing.",
+      "interaction": [
+        {
+          "type": "awaitUsable",
+          "selector": "#bs-hud-top .bs-speed-btn button[data-speed=\"8\"]"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-hud-top .bs-speed-btn button[data-speed=\"8\"]"
+        },
+        {
+          "type": "waitUntil",
+          "field": "orderedChargeCount",
+          "equals": 0,
+          "maxTicks": 3000,
+          "timeoutMs": 120000
+        }
+      ],
+      "role": "setup",
+      "expect": {
+        "equals": {
+          "chargedCount": 4,
+          "orderedChargeCount": 0
+        }
+      }
+    },
+    {
+      "command": "sequence auto delay_step:25",
+      "interaction": [
+        {
+          "type": "clickSelector",
+          "selector": "#bs-blast-panel [data-action=\"auto-sequence\"]"
+        }
+      ],
+      "role": "player",
+      "expect": {
+        "equals": {
+          "sequencedCount": 4
+        }
+      }
+    },
+    {
+      "command": "blast",
+      "timeout": 30,
+      "description": "Fires the blast and waits out BLAST_REPORT_DELAY_MS (3000ms, BlastReportModal.ts) in real time so the report modal genuinely opens -- sanity check that the fix did not just disable the modal outright.",
+      "interaction": [
+        {
+          "type": "clickSelector",
+          "selector": "#bs-blast-panel [data-action=\"execute\"]"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": ".bs-confirm-overlay .bs-btn-danger"
+        },
+        {
+          "type": "clickSelector",
+          "selector": ".bs-confirm-overlay .bs-btn-danger"
+        },
+        {
+          "type": "wait",
+          "durationMs": 1000
+        },
+        {
+          "type": "wait",
+          "durationMs": 2500
+        },
+        {
+          "type": "screenshot"
+        }
+      ],
+      "role": "player",
+      "expect": {
+        "equals": {
+          "holeCount": 0,
+          "chargedCount": 0,
+          "sequencedCount": 0
+        },
+        "usable": "[data-action=\"report-close\"]",
+        "note": "sanity check: a genuinely new blast report opens the modal for real"
+      }
+    },
+    {
+      "command": "state",
+      "description": "Dismiss the report through its real CLOSE button (data-action=report-close), not a console command -- the command field stays the inert `state` read since command mode has no DOM/modal to dismiss.",
+      "interaction": [
+        {
+          "type": "clickSelector",
+          "selector": "[data-action=\"report-close\"]"
+        }
+      ],
+      "role": "player",
+      "expect": {
+        "blocked": "[data-action=\"report-close\"]",
+        "note": "sanity check: the real click actually closes the modal"
+      }
+    },
+    {
+      "command": "state",
+      "description": "Save to real UI slot_1 via the Saves modal (SavesModal.ts) -- a separate, IndexedDB-backed path from the console save/load commands' in-memory slots. Command field stays inert; this step's real effect only exists through the clicks.",
+      "interaction": [
+        {
+          "type": "clickSelector",
+          "selector": "#bs-saveload-btn"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": "#bs-saves-modal"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-saves-modal [data-slot=\"slot_1\"] [data-action=\"save-here\"]"
+        },
+        {
+          "type": "wait",
+          "durationMs": 300
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-saves-modal > div > div:first-child button"
+        }
+      ],
+      "role": "player",
+      "expect": {
+        "changedBy": {
+          "cash": 0
+        },
+        "blocked": "[data-action=\"report-close\"]",
+        "note": "the report modal, already dismissed above, stays closed through the save itself"
+      }
+    },
+    {
+      "command": "state",
+      "description": "#571: load slot_1 back via the Saves modal's own Load button (main.ts's setOnLoad -> load command -> uiManager.closeStaleLevelOverlays), the click-driven path this whole scenario exists to exercise. This swaps ctx.state wholesale, giving state.lastBlastReport a brand-new object identity even though its content is the same already-dismissed report.",
+      "interaction": [
+        {
+          "type": "clickSelector",
+          "selector": "#bs-saveload-btn"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": "#bs-saves-modal"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-saves-modal [data-slot=\"slot_1\"] [data-action=\"load\"]"
+        },
+        {
+          "type": "wait",
+          "durationMs": 300
+        },
+        {
+          "type": "screenshot"
+        }
+      ],
+      "role": "player",
+      "expect": {
+        "equals": {
+          "holeCount": 0
+        },
+        "blocked": "[data-action=\"report-close\"]",
+        "note": "reset() runs synchronously inside the load dispatch, so the modal is already closed the instant load finishes -- this alone does not yet prove the regression fixed, see the next step"
+      }
+    },
+    {
+      "command": "state",
+      "description": "#571's actual regression check: wait out BLAST_REPORT_DELAY_MS again in real time with no further player action after load, then screenshot. Before the fix, BlastReportModal.update() saw the freshly-deserialized state.lastBlastReport as a never-shown report (reference != lastShownReport) and re-armed its 3s open delay right here, popping the CLOSE-already-clicked report back over whatever the player had moved on to.",
+      "interaction": [
+        {
+          "type": "wait",
+          "durationMs": 1500
+        },
+        {
+          "type": "wait",
+          "durationMs": 2000
+        },
+        {
+          "type": "screenshot"
+        }
+      ],
+      "role": "player",
+      "expect": {
+        "blocked": "[data-action=\"report-close\"]",
+        "note": "#571: modal must NOT have reopened -- this is the bug's own repro window"
+      }
+    },
+    {
+      "command": "state full",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "state full"
+        }
+      ],
+      "role": "observe"
+    }
+  ],
+  "shots": [
+    {
+      "name": "overview",
+      "yaw": 0,
+      "pitch": 45
+    }
+  ]
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -473,9 +473,9 @@ function runGameCommand(cmd: string, opts?: { syncRenderer?: boolean }): Command
   // state (e.g. BlastReportModal left open from an earlier site's last
   // blast) — a second `sandbox start` otherwise left that site's "Rating:
   // Perfect" dialog covering the new site's terrain (#504).
-  if (enteredNewLevel) {
+  if (enteredNewLevel && ctx.state) {
     mainMenu.hide();
-    uiManager.closeStaleLevelOverlays();
+    uiManager.closeStaleLevelOverlays(ctx.state);
   }
 
   // (Re)seed the weather cycle whenever ctx.state was replaced with a new

--- a/src/main.ts
+++ b/src/main.ts
@@ -992,6 +992,12 @@ savesModal.setOnLoad((state) => {
     };
     regenerateGrid(ctx, { seed: state.seed, climateBias: biome.climateCenter, sizeX, sizeY, sizeZ });
   }
+  // Close any overlay whose visibility is a stale carry-over from the
+  // previous session's ended state (e.g. BlastReportModal left open from an
+  // earlier blast) — same fixup runGameCommand's enteredNewLevel branch does
+  // for the console `load` command; this is the Saves modal's Load button,
+  // the only other real path that swaps ctx.state (#571).
+  uiManager.closeStaleLevelOverlays(ctx.state);
   gameRenderer.syncFromContext(ctx);
 });
 

--- a/src/ui/UIManager.ts
+++ b/src/ui/UIManager.ts
@@ -322,8 +322,14 @@ export class UIManager {
    * so a level transition mid-dialog is not this bug's shape. LevelEndScreen
    * is excluded too — its update() already closes itself the instant
    * state.levelEndReason reads null, which a fresh level's state always is.
+   *
+   * `state` is the freshly-swapped-in GameState (#571) — TODO: implement
+   * threading state.lastBlastReport through to BlastReportModal.reset so a
+   * later save/load that structurally re-creates the same report doesn't
+   * re-arm the modal.
    */
-  closeStaleLevelOverlays(): void {
+  closeStaleLevelOverlays(state: GameState): void {
+    void state;
     this.blastReportModal.reset();
   }
 

--- a/src/ui/UIManager.ts
+++ b/src/ui/UIManager.ts
@@ -311,9 +311,13 @@ export class UIManager {
    * Close overlays whose visibility is a stale carry-over from a previous
    * level's ended state, not something the player is mid-answering. Call
    * whenever ctx.state is replaced with a new object (new_game, campaign
-   * transition, sandbox start) — a fresh GameState's lastBlastReport is
-   * always null, so BlastReportModal.update() never re-closes itself on its
-   * own (it only ever opens on a new report; see BlastReportModal#update).
+   * transition, sandbox start, `load`) — a fresh new_game/campaign-transition
+   * state's lastBlastReport is always null, but a `load`-ed state's is
+   * whatever was last set before saving, structurally equal to but a
+   * different reference from anything BlastReportModal has already shown.
+   * Forwarding state.lastBlastReport into reset() stamps it as
+   * already-shown, so BlastReportModal.update() doesn't mistake it for a
+   * new report on its very next tick and re-arm (#571).
    * reset() drops both a visible report and a pending/armed-but-not-yet-open
    * one (#545) — a report queued right before a transition must not survive
    * into the next level's state.
@@ -322,15 +326,9 @@ export class UIManager {
    * so a level transition mid-dialog is not this bug's shape. LevelEndScreen
    * is excluded too — its update() already closes itself the instant
    * state.levelEndReason reads null, which a fresh level's state always is.
-   *
-   * `state` is the freshly-swapped-in GameState (#571) — TODO: implement
-   * threading state.lastBlastReport through to BlastReportModal.reset so a
-   * later save/load that structurally re-creates the same report doesn't
-   * re-arm the modal.
    */
   closeStaleLevelOverlays(state: GameState): void {
-    void state;
-    this.blastReportModal.reset();
+    this.blastReportModal.reset(state.lastBlastReport);
   }
 
   /** Read-only accessor for tests (#504) — whether the BlastReportModal is currently open. */

--- a/src/ui/panels/BlastReportModal.ts
+++ b/src/ui/panels/BlastReportModal.ts
@@ -105,15 +105,19 @@ export class BlastReportModal {
 
   /**
    * Discard any in-flight deferred report and close the modal (#545).
-   * `currentReport` is accepted so a caller replacing ctx.state (#571) can
-   * pass the new state's lastBlastReport — TODO: implement wiring it into
-   * lastShownReport so re-arming after a state swap is suppressed.
+   * `currentReport` is the replacing state's lastBlastReport, e.g. from a
+   * caller swapping ctx.state wholesale (#571, `load`): stamping it into
+   * lastShownReport means a later update() tick that sees that same-identity
+   * report treats it as already-shown and does not re-arm the delay timer,
+   * even though the new state object's reference differs from whatever was
+   * shown before the swap. Defaults to null, matching a fresh level's
+   * lastBlastReport (new_game, campaign transition).
    */
   reset(currentReport: BlastReport | null = null): void {
-    void currentReport;
     this.pendingReport = null;
     this.pendingDeadlineMs = null;
     this.hide();
+    this.lastShownReport = currentReport;
   }
 
   update(state: GameState): void {

--- a/src/ui/panels/BlastReportModal.ts
+++ b/src/ui/panels/BlastReportModal.ts
@@ -103,8 +103,14 @@ export class BlastReportModal {
   /** Whether a report has arrived but is still waiting out its open delay (#545). */
   get pending(): boolean { return this.pendingReport !== null; }
 
-  /** Discard any in-flight deferred report and close the modal (#545). */
-  reset(): void {
+  /**
+   * Discard any in-flight deferred report and close the modal (#545).
+   * `currentReport` is accepted so a caller replacing ctx.state (#571) can
+   * pass the new state's lastBlastReport — TODO: implement wiring it into
+   * lastShownReport so re-arming after a state swap is suppressed.
+   */
+  reset(currentReport: BlastReport | null = null): void {
+    void currentReport;
     this.pendingReport = null;
     this.pendingDeadlineMs = null;
     this.hide();

--- a/tests/integration/blast-report-modal-save-load.integration.test.ts
+++ b/tests/integration/blast-report-modal-save-load.integration.test.ts
@@ -1,0 +1,255 @@
+// @vitest-environment jsdom
+// BlastSimulator2026 — Integration: BlastReportModal does not re-arm after a
+// save/load round trip once already dismissed (#571)
+//
+// Bug: BlastReportModal.reset() never stamped lastShownReport. main.ts's
+// enteredNewLevel guard (ctx.state !== prevState) fires on any ctx.state
+// identity change — including `load`, whose loadCommand (saveload.ts)
+// deserializes into a fresh state object whose lastBlastReport is
+// structurally identical to, but a different reference than, the one that
+// was already dismissed before saving — and calls
+// uiManager.closeStaleLevelOverlays(ctx.state). Because reset() dropped the
+// report it was handed on the floor, the very next update() tick treated the
+// reloaded report as new (reference inequality against the untouched
+// lastShownReport) and re-armed the modal, popping it back open ~3s
+// (BLAST_REPORT_DELAY_MS) after the load with no blast having actually
+// happened.
+//
+// This test drives the real console command layer (createRunner, real
+// ticks) exactly the way src/main.ts does, then replicates main.ts's own
+// enteredNewLevel branch by hand (see runGameCommand in src/main.ts) rather
+// than instantiating the full renderer, matching the established pattern in
+// tests/integration/tutorial-pause.integration.test.ts.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createRunner } from '../../src/console/createRunner.js';
+import type { MiningContext } from '../../src/console/commands/mining.js';
+import { UIManager } from '../../src/ui/UIManager.js';
+import { MiniMap } from '../../src/ui/MiniMap.js';
+import { BLAST_REPORT_DELAY_MS } from '../../src/ui/panels/BlastReportModal.js';
+import type { ConsoleRunner } from '../../src/console/ConsoleRunner.js';
+import type { BlastReport } from '../../src/core/mining/BlastExecution.js';
+
+/**
+ * Fires one real blast through the console command layer — drill, charge,
+ * sequence, blast — draining the queued PendingActions between each planning
+ * command the same way tests/integration/tutorial-pause.integration.test.ts's
+ * haul-debris test does (#552/#554: drilling and charging are real,
+ * worker-gated work, not instant). Needs are topped up every tick so a solo
+ * staffed crew can't be derailed by a needs collapse mid-drive.
+ */
+function fireBlast(runner: ConsoleRunner, ctx: MiningContext): void {
+  expect(runner.run('new_game seed:42 size:32 staffed:true').success).toBe(true);
+  expect(runner.run('drill_plan grid rows:2 cols:2 spacing:5 depth:6 start:14,14').success).toBe(true);
+  for (let i = 0; i < 400 && ctx.state!.plannedDrillHoles.length > 0; i++) {
+    for (const emp of ctx.state!.employees.employees) {
+      emp.hunger = 100;
+      emp.fatigue = 100;
+      emp.breakNeed = 100;
+    }
+    runner.run('tick 1');
+  }
+  expect(ctx.state!.plannedDrillHoles.length).toBe(0);
+
+  expect(runner.run('charge hole:* explosive:boomite amount:5 stemming:2').success).toBe(true);
+  for (let i = 0; i < 400 && Object.keys(ctx.state!.plannedChargesByHole).length > 0; i++) {
+    for (const emp of ctx.state!.employees.employees) {
+      emp.hunger = 100;
+      emp.fatigue = 100;
+      emp.breakNeed = 100;
+    }
+    runner.run('tick 1');
+  }
+  expect(Object.keys(ctx.state!.plannedChargesByHole).length).toBe(0);
+
+  expect(runner.run('sequence auto delay_step:25').success).toBe(true);
+  expect(runner.run('blast').success).toBe(true);
+  expect(ctx.state!.lastBlastReport).not.toBeNull();
+}
+
+/**
+ * Replicates main.ts's runGameCommand enteredNewLevel branch by hand:
+ * whenever ctx.state's identity changes (new_game/campaign/sandbox entry —
+ * and `load`), main.ts calls uiManager.closeStaleLevelOverlays(ctx.state).
+ */
+function simulateEnteredNewLevel(uiManager: UIManager, ctx: MiningContext): void {
+  uiManager.closeStaleLevelOverlays(ctx.state!);
+}
+
+describe('BlastReportModal — does not re-arm after save/load once dismissed (#571)', () => {
+  let container: HTMLDivElement;
+  let uiManager: UIManager;
+
+  afterEach(() => {
+    uiManager?.dispose();
+    container?.remove();
+    vi.restoreAllMocks();
+  });
+
+  it('dismiss → save → load → advancing real time past the open delay leaves the modal closed', () => {
+    // jsdom has no real canvas backend (no `canvas` npm package) — stub
+    // MiniMap.update() the same way tests/unit/ui/UIManager.test.ts does,
+    // since UIManager.update() unconditionally drives the minimap.
+    vi.spyOn(MiniMap.prototype, 'update').mockImplementation(() => {});
+    const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(0);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    uiManager = new UIManager(container);
+
+    const { runner, ctx } = createRunner();
+    fireBlast(runner, ctx);
+
+    // Arm + open the report the same way main.ts's per-frame uiManager.update(ctx.state) does.
+    uiManager.update(ctx.state!);
+    nowSpy.mockReturnValue(BLAST_REPORT_DELAY_MS);
+    uiManager.update(ctx.state!);
+    expect(uiManager.blastReportModalVisible).toBe(true);
+
+    // Player dismisses before saving.
+    (container.querySelector('[data-action="report-close"]') as HTMLButtonElement).click();
+    expect(uiManager.blastReportModalVisible).toBe(false);
+
+    expect(runner.run('save').success).toBe(true);
+
+    const prevState = ctx.state;
+    expect(runner.run('load').success).toBe(true);
+    expect(ctx.state).not.toBe(prevState); // loadCommand replaced the object
+    expect(ctx.state!.lastBlastReport).not.toBeNull();
+    expect(ctx.state!.lastBlastReport).not.toBe(prevState!.lastBlastReport); // reference-distinct
+    expect(ctx.state!.lastBlastReport).toEqual(prevState!.lastBlastReport); // structurally identical
+
+    simulateEnteredNewLevel(uiManager, ctx);
+
+    // Advance real time well past the open delay across several frames, the
+    // way the render loop's per-frame update() calls do.
+    nowSpy.mockReturnValue(BLAST_REPORT_DELAY_MS * 2);
+    uiManager.update(ctx.state!);
+    nowSpy.mockReturnValue(BLAST_REPORT_DELAY_MS * 10);
+    uiManager.update(ctx.state!);
+
+    expect(uiManager.blastReportModalPending).toBe(false);
+    expect(uiManager.blastReportModalVisible).toBe(false);
+  });
+
+  it('a genuinely new blast fired after the save/load round trip still arms and opens on its normal delay', () => {
+    vi.spyOn(MiniMap.prototype, 'update').mockImplementation(() => {});
+    const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(0);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    uiManager = new UIManager(container);
+
+    const { runner, ctx } = createRunner();
+    fireBlast(runner, ctx);
+
+    uiManager.update(ctx.state!);
+    nowSpy.mockReturnValue(BLAST_REPORT_DELAY_MS);
+    uiManager.update(ctx.state!);
+    (container.querySelector('[data-action="report-close"]') as HTMLButtonElement).click();
+
+    expect(runner.run('save').success).toBe(true);
+    expect(runner.run('load').success).toBe(true);
+    simulateEnteredNewLevel(uiManager, ctx);
+
+    // A genuinely new blast landing on the reloaded state — a fresh,
+    // reference-distinct BlastReport object (buildBlastReport, mining.ts,
+    // always returns a new object per blast; constructed directly here
+    // rather than re-running a full worker-driven drill/charge/blast cycle,
+    // which is already covered end-to-end by fireBlast() above and by
+    // tests/integration/blast-enhanced.integration.test.ts — this test's
+    // concern is the modal's reaction to the state transition, not the
+    // blast pipeline itself).
+    const newReport: BlastReport = {
+      ...(ctx.state!.lastBlastReport as BlastReport),
+      tick: (ctx.state!.lastBlastReport as BlastReport).tick + 50,
+      fragmentCount: 3,
+    };
+    ctx.state!.lastBlastReport = newReport;
+
+    nowSpy.mockReturnValue(BLAST_REPORT_DELAY_MS * 100);
+    uiManager.update(ctx.state!); // arms the new report
+    expect(uiManager.blastReportModalVisible).toBe(false);
+    expect(uiManager.blastReportModalPending).toBe(true);
+
+    nowSpy.mockReturnValue(BLAST_REPORT_DELAY_MS * 100 + BLAST_REPORT_DELAY_MS);
+    uiManager.update(ctx.state!);
+
+    expect(uiManager.blastReportModalVisible).toBe(true);
+  });
+
+  it('entering a fresh level (lastBlastReport === null) leaves the modal closed/non-pending — unchanged from current behavior', () => {
+    vi.spyOn(MiniMap.prototype, 'update').mockImplementation(() => {});
+    const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(0);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    uiManager = new UIManager(container);
+
+    const { runner, ctx } = createRunner();
+    expect(runner.run('new_game seed:7 size:32 staffed:true').success).toBe(true);
+    expect(ctx.state!.lastBlastReport).toBeNull();
+
+    simulateEnteredNewLevel(uiManager, ctx);
+    uiManager.update(ctx.state!);
+    nowSpy.mockReturnValue(BLAST_REPORT_DELAY_MS * 10);
+    uiManager.update(ctx.state!);
+
+    expect(uiManager.blastReportModalPending).toBe(false);
+    expect(uiManager.blastReportModalVisible).toBe(false);
+  });
+
+  it('a save/load round trip while the report is still open (not yet dismissed) closes it and does not reopen', () => {
+    vi.spyOn(MiniMap.prototype, 'update').mockImplementation(() => {});
+    const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(0);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    uiManager = new UIManager(container);
+
+    const { runner, ctx } = createRunner();
+    fireBlast(runner, ctx);
+
+    uiManager.update(ctx.state!);
+    nowSpy.mockReturnValue(BLAST_REPORT_DELAY_MS);
+    uiManager.update(ctx.state!);
+    expect(uiManager.blastReportModalVisible).toBe(true); // never dismissed
+
+    expect(runner.run('save').success).toBe(true);
+    expect(runner.run('load').success).toBe(true);
+    simulateEnteredNewLevel(uiManager, ctx);
+
+    expect(uiManager.blastReportModalVisible).toBe(false);
+    expect(uiManager.blastReportModalPending).toBe(false);
+
+    nowSpy.mockReturnValue(BLAST_REPORT_DELAY_MS * 10);
+    uiManager.update(ctx.state!);
+
+    expect(uiManager.blastReportModalPending).toBe(false);
+    expect(uiManager.blastReportModalVisible).toBe(false);
+  });
+
+  it('a save/load round trip while the report is still pending (arrived, not yet opened) closes it and does not reopen', () => {
+    vi.spyOn(MiniMap.prototype, 'update').mockImplementation(() => {});
+    const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(0);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    uiManager = new UIManager(container);
+
+    const { runner, ctx } = createRunner();
+    fireBlast(runner, ctx);
+
+    uiManager.update(ctx.state!); // arms, still waiting out its delay
+    expect(uiManager.blastReportModalPending).toBe(true);
+    expect(uiManager.blastReportModalVisible).toBe(false);
+
+    expect(runner.run('save').success).toBe(true);
+    expect(runner.run('load').success).toBe(true);
+    simulateEnteredNewLevel(uiManager, ctx);
+
+    expect(uiManager.blastReportModalPending).toBe(false);
+    expect(uiManager.blastReportModalVisible).toBe(false);
+
+    nowSpy.mockReturnValue(BLAST_REPORT_DELAY_MS * 10);
+    uiManager.update(ctx.state!);
+
+    expect(uiManager.blastReportModalPending).toBe(false);
+    expect(uiManager.blastReportModalVisible).toBe(false);
+  });
+});

--- a/tests/unit/ui/UIManager.test.ts
+++ b/tests/unit/ui/UIManager.test.ts
@@ -17,7 +17,7 @@ import { VoxelGrid } from '../../../src/core/world/VoxelGrid.js';
 import { t, setLocale, getLocale } from '../../../src/core/i18n/I18n.js';
 import type { BlastReport } from '../../../src/core/mining/BlastExecution.js';
 import type { Vehicle } from '../../../src/core/entities/Vehicle.js';
-import { BLAST_REPORT_DELAY_MS } from '../../../src/ui/panels/BlastReportModal.js';
+import { BlastReportModal, BLAST_REPORT_DELAY_MS } from '../../../src/ui/panels/BlastReportModal.js';
 import { setupEvents } from '../../../src/core/events/index.js';
 
 setupEvents();
@@ -405,7 +405,10 @@ describe('UIManager — closeStaleLevelOverlays (#504)', () => {
     uiManager.update(state); // delay elapsed — report opens
     expect(uiManager.blastReportModalVisible).toBe(true);
 
-    uiManager.closeStaleLevelOverlays();
+    // A second site's freshly-entered state — mirrors main.ts's
+    // enteredNewLevel guard, which always passes the newly-swapped-in
+    // ctx.state, never the stale one that was just replaced.
+    uiManager.closeStaleLevelOverlays(createGame({ seed: 2, mineType: 'desert' }));
 
     expect(uiManager.blastReportModalVisible).toBe(false);
   });
@@ -414,7 +417,7 @@ describe('UIManager — closeStaleLevelOverlays (#504)', () => {
     uiManager = new UIManager(container);
     expect(uiManager.blastReportModalVisible).toBe(false);
 
-    expect(() => uiManager.closeStaleLevelOverlays()).not.toThrow();
+    expect(() => uiManager.closeStaleLevelOverlays(createGame({ seed: 1, mineType: 'desert' }))).not.toThrow();
 
     expect(uiManager.blastReportModalVisible).toBe(false);
   });
@@ -429,19 +432,123 @@ describe('UIManager — closeStaleLevelOverlays (#504)', () => {
     expect(uiManager.blastReportModalPending).toBe(true);
     expect(uiManager.blastReportModalVisible).toBe(false);
 
-    uiManager.closeStaleLevelOverlays();
-
-    expect(uiManager.blastReportModalPending).toBe(false);
-
     // Level-transition semantics: a genuinely fresh GameState, whose
     // lastBlastReport starts null (mirrors the real enteredNewLevel guard) —
     // not a reuse of the same stale state object.
     const freshState = createGame({ seed: 1, mineType: 'desert' });
+    uiManager.closeStaleLevelOverlays(freshState);
+
+    expect(uiManager.blastReportModalPending).toBe(false);
+
     nowSpy.mockReturnValue(BLAST_REPORT_DELAY_MS * 10);
     uiManager.update(freshState);
 
     expect(uiManager.blastReportModalPending).toBe(false);
     expect(uiManager.blastReportModalVisible).toBe(false);
+  });
+});
+
+// ── closeStaleLevelOverlays threads state.lastBlastReport into
+// BlastReportModal.reset so a save/load round trip doesn't re-arm the
+// modal (#571) ───────────────────────────────────────────────────────────
+//
+// loadCommand (src/console/commands/saveload.ts) deserializes into a fresh
+// GameState object whose lastBlastReport is structurally identical to, but a
+// different reference than, the one that was already dismissed. main.ts's
+// enteredNewLevel guard fires on any ctx.state identity change — including
+// `load` — and calls closeStaleLevelOverlays(ctx.state). Before the fix,
+// reset() ignored the report it was handed, so the very next update() tick
+// saw a "new" report (by reference) and re-armed the modal.
+
+describe('UIManager — closeStaleLevelOverlays threads state.lastBlastReport into reset (#571)', () => {
+  let container: HTMLDivElement;
+  let uiManager: UIManager;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    uiManager?.dispose();
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it('forwards state.lastBlastReport to BlastReportModal.reset()', () => {
+    const resetSpy = vi.spyOn(BlastReportModal.prototype, 'reset');
+    uiManager = new UIManager(container);
+    const state = makeStateWithReport(10);
+
+    uiManager.closeStaleLevelOverlays(state);
+
+    expect(resetSpy).toHaveBeenCalledWith(state.lastBlastReport);
+  });
+
+  it('forwards null when the freshly-entered state has no blast report yet (new_game/campaign/sandbox entry)', () => {
+    const resetSpy = vi.spyOn(BlastReportModal.prototype, 'reset');
+    uiManager = new UIManager(container);
+    const freshState = createGame({ seed: 1, mineType: 'desert' });
+
+    uiManager.closeStaleLevelOverlays(freshState);
+
+    expect(resetSpy).toHaveBeenCalledWith(null);
+  });
+
+  it('a same-identity report re-observed after closeStaleLevelOverlays(state) does not re-arm the modal — the save/load bug, reproduced at UIManager level', () => {
+    vi.spyOn(MiniMap.prototype, 'update').mockImplementation(() => {});
+    const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(0);
+    uiManager = new UIManager(container);
+    const state = makeStateWithReport(10);
+    uiManager.update(state); // arms
+    nowSpy.mockReturnValue(BLAST_REPORT_DELAY_MS);
+    uiManager.update(state); // opens
+    expect(uiManager.blastReportModalVisible).toBe(true);
+
+    (container.querySelector('[data-action="report-close"]') as HTMLButtonElement).click();
+    expect(uiManager.blastReportModalVisible).toBe(false);
+
+    // Simulate a save/load round trip: a fresh GameState whose
+    // lastBlastReport is structurally identical to, but a different
+    // reference than, the one just dismissed.
+    const reloadedState = createGame({ seed: 1, mineType: 'desert' });
+    reloadedState.lastBlastReport = makeBlastReport(10);
+
+    uiManager.closeStaleLevelOverlays(reloadedState);
+
+    nowSpy.mockReturnValue(BLAST_REPORT_DELAY_MS * 10);
+    uiManager.update(reloadedState);
+
+    expect(uiManager.blastReportModalPending).toBe(false);
+    expect(uiManager.blastReportModalVisible).toBe(false);
+  });
+
+  it('a genuinely NEW blast report on the same reloaded state still arms and opens on its normal delay', () => {
+    vi.spyOn(MiniMap.prototype, 'update').mockImplementation(() => {});
+    const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(0);
+    uiManager = new UIManager(container);
+    const state = makeStateWithReport(10);
+    uiManager.update(state);
+    nowSpy.mockReturnValue(BLAST_REPORT_DELAY_MS);
+    uiManager.update(state);
+    (container.querySelector('[data-action="report-close"]') as HTMLButtonElement).click();
+
+    const reloadedState = createGame({ seed: 1, mineType: 'desert' });
+    reloadedState.lastBlastReport = makeBlastReport(10);
+    uiManager.closeStaleLevelOverlays(reloadedState);
+
+    // A brand-new blast fires on the reloaded state — a fresh object, never
+    // shown before.
+    reloadedState.lastBlastReport = makeBlastReport(20);
+    nowSpy.mockReturnValue(BLAST_REPORT_DELAY_MS * 10);
+    uiManager.update(reloadedState); // arms the new report
+    expect(uiManager.blastReportModalVisible).toBe(false);
+    expect(uiManager.blastReportModalPending).toBe(true);
+
+    nowSpy.mockReturnValue(BLAST_REPORT_DELAY_MS * 10 + BLAST_REPORT_DELAY_MS);
+    uiManager.update(reloadedState);
+
+    expect(uiManager.blastReportModalVisible).toBe(true);
   });
 });
 

--- a/tests/unit/ui/panels/BlastReportModal.test.ts
+++ b/tests/unit/ui/panels/BlastReportModal.test.ts
@@ -291,6 +291,94 @@ describe('BlastReportModal', () => {
     expect(modal.visible).toBe(false);
   });
 
+  // ── reset(currentReport) threads state.lastBlastReport through so a
+  // save/load round trip doesn't re-arm the modal (#571) ─────────────────
+  //
+  // Bug: reset() never stamped lastShownReport, so closeStaleLevelOverlays()
+  // (called whenever ctx.state is replaced — including after `load`, whose
+  // deserialized state carries a reference-distinct but structurally
+  // identical lastBlastReport) left the modal thinking it had never shown
+  // that report, and the very next update() tick re-armed it.
+
+  it('reset(currentReport) stamps lastShownReport so a subsequent update() call with that same-identity report does not re-arm (#571)', () => {
+    const { modal, setNow } = makeModal();
+    const state = makeState();
+    const original = makeReport({ tick: 100 });
+    state.lastBlastReport = original;
+    openReport(modal, state, setNow);
+    (modal.root.querySelector('[data-action="report-close"]') as HTMLButtonElement).click();
+    expect(modal.visible).toBe(false);
+
+    // Simulate closeStaleLevelOverlays(newState) passing the freshly
+    // deserialized state's lastBlastReport — a reference-distinct but
+    // structurally identical report, mirroring a save/load round trip.
+    const reloaded = makeReport({ tick: 100 });
+    modal.reset(reloaded);
+
+    expect(modal.pending).toBe(false);
+    expect(modal.visible).toBe(false);
+
+    const newState = makeState();
+    newState.lastBlastReport = reloaded; // same reference just passed to reset()
+    modal.update(newState);
+
+    expect(modal.pending).toBe(false);
+    expect(modal.visible).toBe(false);
+
+    // Stays closed even once the report's would-be open delay fully elapses.
+    setNow(BLAST_REPORT_DELAY_MS * 20);
+    modal.update(newState);
+
+    expect(modal.pending).toBe(false);
+    expect(modal.visible).toBe(false);
+  });
+
+  it('reset() with no argument leaves lastShownReport at null, same as before — a later new report still arms and opens normally (#571)', () => {
+    const { modal, setNow } = makeModal();
+    const state = makeState();
+    state.lastBlastReport = makeReport({ tick: 100 });
+    modal.update(state); // arms it (pending)
+
+    modal.reset(); // no argument — the pre-#571 call shape
+
+    expect(modal.pending).toBe(false);
+    expect(modal.visible).toBe(false);
+
+    const freshState = makeState();
+    freshState.lastBlastReport = makeReport({ tick: 999 }); // genuinely new report
+    modal.update(freshState);
+    expect(modal.pending).toBe(true); // arms normally — nothing was wrongly suppressed
+
+    setNow(BLAST_REPORT_DELAY_MS);
+    modal.update(freshState);
+    expect(modal.visible).toBe(true);
+  });
+
+  it('reset(currentReport) discards an actively pending report outright — it does not resurrect once discarded, even when currentReport is that exact pending report (#571)', () => {
+    const { modal, setNow } = makeModal();
+    const state = makeState();
+    const pending = makeReport({ tick: 50 });
+    state.lastBlastReport = pending;
+    modal.update(state); // arms `pending`, still waiting out its delay
+    expect(modal.pending).toBe(true);
+
+    // A level transition / save-load lands mid-delay: currentReport here is
+    // that exact same pending report reference (e.g. an immediate reload
+    // before the report ever had a chance to open) — it must never surface.
+    modal.reset(pending);
+
+    expect(modal.pending).toBe(false);
+    expect(modal.visible).toBe(false);
+
+    // Even once its original deadline would have elapsed, on the same state
+    // object with the same report reference, it stays suppressed.
+    setNow(BLAST_REPORT_DELAY_MS);
+    modal.update(state);
+
+    expect(modal.pending).toBe(false);
+    expect(modal.visible).toBe(false);
+  });
+
   it('refreshLocale() does not throw', () => {
     const { modal } = makeModal();
     expect(() => modal.refreshLocale()).not.toThrow();


### PR DESCRIPTION
Closes #571

## Summary

The Blast Report modal, once dismissed via `report-close`, was reopening ~3 seconds later after a `save`+`load` round trip (or any state-identity swap), silently covering whatever panel the player had moved on to.

Root cause: `BlastReportModal.reset()` cleared `pendingReport`/`pendingDeadlineMs` and hid the modal, but never updated `lastShownReport`. `UIManager.closeStaleLevelOverlays()` calls `reset()` whenever `ctx.state`'s identity changes — including on load, which deserializes a fresh state object with a structurally-equal-but-reference-distinct `lastBlastReport`. On the next `update()` tick, `report !== this.lastShownReport` was true again (different reference, same content), re-arming the 3-second deferred-open timer.

## Fix

- `src/ui/panels/BlastReportModal.ts` — `reset(currentReport)` now stamps `this.lastShownReport = currentReport` after clearing pending state, so a state-identity swap alone doesn't re-arm an already-dismissed report.
- `src/ui/UIManager.ts` — `closeStaleLevelOverlays(state)` forwards `state.lastBlastReport` into `reset()`.
- `src/main.ts` — wired into both real entry points that swap `ctx.state`: the console-command dispatcher's `enteredNewLevel` branch (covers the console `load` command, `new_game`, campaign transitions, sandbox start) **and** the Saves modal's `setOnLoad` callback (covers the actual player-facing Load button — this second site was found missing by browser-based interaction testing after the first fix passed all command/unit-level verification but still reproduced the bug live).

## Decisions taken

Defaulted under `agentic-decision-autonomy`:

- **What was open:** the issue didn't specify what should happen if save/load occurs *while* the report modal is still open or pending (not yet dismissed).
  **Chosen:** the state-identity swap always closes/discards whatever was open or pending and stamps `lastShownReport` regardless — it does not resurrect or preserve an in-flight report across the swap.
  **Why:** matches `closeStaleLevelOverlays`'s existing, already-shipped behavior for every other identity-swap trigger (`new_game`, campaign transition, sandbox start), which already unconditionally drops an in-flight report. Load reuses the same code path rather than getting new special-case logic.
  **If reversed:** in `BlastReportModal.reset()`, skip stamping `lastShownReport` when a report was actively open/pending at reset time; no call-site changes needed either way.

Not opened as a `decision-review` follow-up — this only affects a narrow, rare edge case (state swap at the exact moment a report is open) with no gameplay/economy impact.

## Verification

- **static** — `npm run typecheck`: clean, 0 errors.
- **logic** — `npm run test`: 317 test files, 9818 tests, all passing. New coverage: `tests/unit/ui/panels/BlastReportModal.test.ts`, `tests/unit/ui/UIManager.test.ts`, `tests/integration/blast-report-modal-save-load.integration.test.ts` (drives the real console save/load flow end to end).
- **visual** — interaction-mode scenario `scripts/scenario-defs/blast-report-save-load-visual.json` (added during this run) drives the real player flow: fire blast → dismiss via real click → save via real UI clicks → load via the Saves modal's real Load button → wait past the 3-second delay. First run against the console-only fix caught the missing Saves-modal wiring (`VISUAL: FAIL`, screenshot showed the modal reopened after a real Load click); re-run after the fix passed clean (`VISUAL: PASS`) — screenshots confirm the modal stays closed post-load-and-wait, while still opening normally for a genuinely new blast report.
- Code review: 5 parallel specialist reviewers (security, quality, i18n, duplication, semantic), 2 rounds, all clean — 2 non-blocking suggestions noted (a possible shared helper for the two `closeStaleLevelOverlays` call sites; a call-ordering consistency note) left as-is, both cosmetic.
- `full-ci` label applied: the new interaction-mode scenario definition exercises this exact fix and should run in CI's browser job.

READY TO MERGE