### PR TITLE
fix: Resolve #609 — clamp untrusted chunk rect bounds against corrupted saves

### DIFF
--- a/src/core/state/VoxelGridCodec.ts
+++ b/src/core/state/VoxelGridCodec.ts
@@ -11,7 +11,7 @@
 // therefore grow without the save growing with it: save size tracks play, not
 // level size.
 
-import { VoxelGrid, CHUNK_SIZE, type VoxelRockComposition } from '../world/VoxelGrid.js';
+import { VoxelGrid, CHUNK_SIZE, clampChunkRectToTile, type VoxelRockComposition } from '../world/VoxelGrid.js';
 import { buildTerrainContext, generateTerrainRegion, type TerrainConfig } from '../world/TerrainGen.js';
 import { bytesToBase64, base64ToBytes } from './Base64.js';
 
@@ -239,8 +239,15 @@ export function decodeVoxelGrid(payload: AnySerializedVoxels): VoxelGrid {
     };
     const terrain = buildTerrainContext(config);
     for (const [cx, cz, minX, minZ, maxX, maxZ] of payload.pristine) {
-      grid.addChunkWithRect(cx, cz, { minX, minZ, maxX, maxZ });
-      generateTerrainRegion(grid, terrain, config, { minX, minZ, maxX, maxZ });
+      // The tuple comes straight from untrusted save JSON — clamp it once,
+      // here, and hand the SAME clamped rect to both consumers below.
+      // addChunkWithRect also clamps internally, but returns void, so its
+      // clamped rect never reaches this caller; without this, an extreme
+      // raw value (e.g. 1e12) would reach generateTerrainRegion's column
+      // loop directly and hang it (#609).
+      const clamped = clampChunkRectToTile(cx, cz, { minX, minZ, maxX, maxZ });
+      grid.addChunkWithRect(cx, cz, clamped);
+      generateTerrainRegion(grid, terrain, config, clamped);
       grid.markChunkPristine(cx, cz);
     }
   }

--- a/src/core/world/VoxelGrid.ts
+++ b/src/core/world/VoxelGrid.ts
@@ -126,14 +126,36 @@ export function chunkIndexOf(worldCoord: number): number {
  * Clamp a chunk's owned sub-rect to the chunk's own tile bounds — i.e. to
  * `[cx*CHUNK_SIZE, cx*CHUNK_SIZE + CHUNK_SIZE) × [cz*CHUNK_SIZE, cz*CHUNK_SIZE + CHUNK_SIZE)`.
  *
- * STUB — no logic yet, will be implemented by @implementer.
+ * This is the one place untrusted save data (a chunk's `x0/z0/x1/z1` rect,
+ * read straight from parsed JSON) gets validated before it reaches
+ * `VoxelGrid` storage — every downstream consumer (TerrainMesh's marching
+ * cubes loops, etc.) then only ever sees bounds already inside the tile, so
+ * a corrupted/hand-edited save (e.g. a rect of `1e12`) can't turn a render
+ * loop into an unbounded scan (#609).
  */
 export function clampChunkRectToTile(
-  _cx: number, _cz: number,
-  _rect: { minX: number; minZ: number; maxX: number; maxZ: number },
+  cx: number, cz: number,
+  rect: { minX: number; minZ: number; maxX: number; maxZ: number },
 ): { minX: number; minZ: number; maxX: number; maxZ: number } {
-  // TODO: implement
-  throw new Error('not implemented');
+  const tileX0 = cx * CHUNK_SIZE;
+  const tileX1 = tileX0 + CHUNK_SIZE;
+  const tileZ0 = cz * CHUNK_SIZE;
+  const tileZ1 = tileZ0 + CHUNK_SIZE;
+
+  const clampAxis = (value: number, lo: number, hi: number, fallback: number): number => {
+    if (!Number.isFinite(value)) return fallback;
+    return Math.max(lo, Math.min(hi, Math.round(value)));
+  };
+
+  let minX = clampAxis(rect.minX, tileX0, tileX1, tileX0);
+  let maxX = clampAxis(rect.maxX, tileX0, tileX1, tileX1);
+  let minZ = clampAxis(rect.minZ, tileZ0, tileZ1, tileZ0);
+  let maxZ = clampAxis(rect.maxZ, tileZ0, tileZ1, tileZ1);
+
+  if (maxX < minX) maxX = minX;
+  if (maxZ < minZ) maxZ = minZ;
+
+  return { minX, minZ, maxX, maxZ };
 }
 
 /**
@@ -407,7 +429,8 @@ export class VoxelGrid {
    */
   addChunkWithRect(cx: number, cz: number, rect: { minX: number; minZ: number; maxX: number; maxZ: number }): void {
     const chunk = this.chunks.get(chunkKey(cx, cz)) ?? this.allocateChunk(cx, cz);
-    chunk.x0 = rect.minX; chunk.z0 = rect.minZ; chunk.x1 = rect.maxX; chunk.z1 = rect.maxZ;
+    const clamped = clampChunkRectToTile(cx, cz, rect);
+    chunk.x0 = clamped.minX; chunk.z0 = clamped.minZ; chunk.x1 = clamped.maxX; chunk.z1 = clamped.maxZ;
     this.recomputeBounds();
   }
 
@@ -704,7 +727,8 @@ export class VoxelGrid {
   ): void {
     let chunk = this.chunks.get(chunkKey(cx, cz));
     if (!chunk) chunk = this.allocateChunk(cx, cz);
-    chunk.x0 = rect.minX; chunk.z0 = rect.minZ; chunk.x1 = rect.maxX; chunk.z1 = rect.maxZ;
+    const clamped = clampChunkRectToTile(cx, cz, rect);
+    chunk.x0 = clamped.minX; chunk.z0 = clamped.minZ; chunk.x1 = clamped.maxX; chunk.z1 = clamped.maxZ;
     chunk.density.set(density);
     chunk.compId.set(compId);
     chunk.fracture.set(fracture);
@@ -723,12 +747,12 @@ export class VoxelGrid {
     // honestly falls back to {min:0, max:0} for one no owned column reaches.
     //
     // `rect` (and therefore chunk.x0/x1/z0/z1, just assigned above) comes
-    // straight from deserialized save JSON and is never validated against
-    // the grid's real dimensions — a corrupted/hand-edited save with an
-    // absurd rect (e.g. maxX/maxZ ~1e12) must not turn this loop into an
-    // unbounded scan. Clamp to the chunk's actual storage span, the same
-    // defensive clamping forEachInRegion already does against real grid
-    // bounds elsewhere in this file.
+    // straight from deserialized save JSON — `clampChunkRectToTile` above is
+    // the load-bearing guard against an absurd rect (e.g. maxX/maxZ ~1e12)
+    // reaching chunk.x0/x1/z0/z1 at all (#609). This extra clamp to the
+    // chunk's actual storage span is now harmless defense-in-depth left over
+    // from before that guard existed, matching forEachInRegion's own
+    // defensive clamping elsewhere in this file.
     const zLo = Math.max(chunk.z0, chunk.cz * CHUNK_SIZE);
     const zHi = Math.min(chunk.z1, chunk.cz * CHUNK_SIZE + CHUNK_SIZE);
     const xLo = Math.max(chunk.x0, chunk.cx * CHUNK_SIZE);

--- a/src/core/world/VoxelGrid.ts
+++ b/src/core/world/VoxelGrid.ts
@@ -123,6 +123,20 @@ export function chunkIndexOf(worldCoord: number): number {
 }
 
 /**
+ * Clamp a chunk's owned sub-rect to the chunk's own tile bounds — i.e. to
+ * `[cx*CHUNK_SIZE, cx*CHUNK_SIZE + CHUNK_SIZE) × [cz*CHUNK_SIZE, cz*CHUNK_SIZE + CHUNK_SIZE)`.
+ *
+ * STUB — no logic yet, will be implemented by @implementer.
+ */
+export function clampChunkRectToTile(
+  _cx: number, _cz: number,
+  _rect: { minX: number; minZ: number; maxX: number; maxZ: number },
+): { minX: number; minZ: number; maxX: number; maxZ: number } {
+  // TODO: implement
+  throw new Error('not implemented');
+}
+
+/**
  * One chunk of storage: CHUNK_SIZE × sizeY × CHUNK_SIZE voxels, plus the
  * sub-rect of it the site actually owns.
  *

--- a/tests/unit/state/VoxelGridCodec.test.ts
+++ b/tests/unit/state/VoxelGridCodec.test.ts
@@ -187,6 +187,66 @@ describe('encodeVoxelGrid dirty-chunk selection (#473 D4)', () => {
   });
 });
 
+// #609: a corrupted/hand-edited save (e.g. r: [0, 0, 1e12, 1e12]) must not
+// reach TerrainMesh's chunk-iteration loops unclamped -- VoxelGrid clamps at
+// its own two save-facing entry points (restoreChunkRaw / addChunkWithRect),
+// so decodeVoxelGrid ends up with a grid whose chunk rects are always sane
+// regardless of what the JSON claimed.
+describe('decodeVoxelGrid — corrupted chunk rects are clamped, not trusted verbatim (#609)', () => {
+  it('a corrupted chunks[].r (matching the issue\'s literal repro) is clamped to the chunk\'s real tile', () => {
+    const grid = new VoxelGrid(16, 4, 16);
+    const payload = encodeVoxelGrid(grid); // no `gen` -> every owned chunk stored dirty, with a real r
+    expect(payload.chunks).toHaveLength(1);
+
+    const corrupted: SerializedVoxels = {
+      ...payload,
+      chunks: [{ ...payload.chunks[0]!, r: [0, 0, 1e12, 1e12] }],
+    };
+
+    // decodeChunkInto's own arrays are sized from sizeY alone (unrelated to
+    // `r`), and restoreChunkRaw's internal rescan is already bounded against
+    // the chunk's real storage span independently of this fix -- so this
+    // path was never actually at hang risk; what was wrong is that the
+    // corrupted rect survived into the grid's own x0/z0/x1/z1 state
+    // unclamped, which is what TerrainMesh iterates directly over.
+    const decoded = decodeVoxelGrid(corrupted);
+
+    expect(decoded.chunkRect(0, 0)).toEqual({ minX: 0, minZ: 0, maxX: 16, maxZ: 16 });
+  });
+
+  // Planner note (#609): decodeVoxelGrid's pristine loop below calls
+  // `generateTerrainRegion(grid, terrain, config, { minX, minZ, maxX, maxZ })`
+  // with the RAW tuple values it just destructured from `payload.pristine` --
+  // not with the rect VoxelGrid.addChunkWithRect actually clamped internally
+  // (addChunkWithRect returns void, so the clamped rect never comes back to
+  // this caller). The planned fix only touches VoxelGrid.ts, so that
+  // `generateTerrainRegion` call keeps walking the *unclamped* range
+  // regardless of this fix -- a magnitude anywhere near the issue's literal
+  // 1e12 repro would make that synchronous, single-threaded column loop
+  // genuinely un-interruptible (no vitest timeout preempts a running
+  // for-loop). This test therefore uses a much smaller out-of-tile
+  // magnitude: large enough to prove the corruption reached the pristine
+  // path and that VoxelGrid's own state (chunkRect) ends up clamped either
+  // way, small enough to never risk hanging the suite regardless of whether
+  // decodeVoxelGrid itself is ever also updated to clamp before calling
+  // generateTerrainRegion.
+  it('a corrupted pristine tuple is clamped for the grid\'s own state via addChunkWithRect, proving that entry point is covered too', () => {
+    const gen = { seed: 42, climateBias: [0, 0] as [number, number], sizeX: 16, sizeY: 4, sizeZ: 16 };
+    const grid = generateTerrain({ ...gen });
+    const payload = encodeVoxelGrid(grid, gen);
+    expect(payload.pristine).toEqual([[0, 0, 0, 0, 16, 16]]);
+
+    const corrupted: SerializedVoxels = {
+      ...payload,
+      pristine: [[0, 0, 0, 0, 40, 40]], // well outside (0,0)'s real [0,16) tile, but bounded (see note above)
+    };
+
+    const decoded = decodeVoxelGrid(corrupted);
+
+    expect(decoded.chunkRect(0, 0)).toEqual({ minX: 0, minZ: 0, maxX: 16, maxZ: 16 });
+  });
+});
+
 describe('decodeVoxelGrid — v6 upgrade path (#473 P3)', () => {
   it('loads a v6 dense payload at the same coordinates, mutations intact', () => {
     const v6: SerializedVoxelsV6 = {

--- a/tests/unit/world/VoxelGrid.test.ts
+++ b/tests/unit/world/VoxelGrid.test.ts
@@ -7,6 +7,7 @@ import {
   computeVoxelColumnSurfaceHeight,
   setVoxelBoundsReporter,
   chunkIndexOf,
+  clampChunkRectToTile,
   CHUNK_SIZE,
 } from '../../../src/core/world/VoxelGrid.js';
 
@@ -130,6 +131,175 @@ describe('chunkIndexOf', () => {
   it('ignores the fractional part of a continuous coordinate', () => {
     expect(chunkIndexOf(17.9)).toBe(1);
     expect(chunkIndexOf(-0.5)).toBe(-1);
+  });
+});
+
+// #609: VoxelGridCodec.decodeChunkInto forwards `chunk.r` from parsed save
+// JSON straight into VoxelGrid with no validation against the grid's real
+// dimensions. clampChunkRectToTile is the one shared function that validates
+// a chunk's owned sub-rect against its own tile before VoxelGrid accepts it
+// from untrusted save data (restoreChunkRaw / addChunkWithRect below).
+describe('clampChunkRectToTile', () => {
+  it('leaves a well-formed rect already inside the chunk\'s own tile unchanged', () => {
+    const rect = { minX: 0, minZ: 0, maxX: CHUNK_SIZE, maxZ: CHUNK_SIZE };
+    expect(clampChunkRectToTile(0, 0, rect)).toEqual({ minX: 0, minZ: 0, maxX: CHUNK_SIZE, maxZ: CHUNK_SIZE });
+  });
+
+  it('leaves a legitimately partial edge-chunk rect unchanged', () => {
+    const rect = { minX: 0, minZ: 0, maxX: 9, maxZ: CHUNK_SIZE };
+    expect(clampChunkRectToTile(0, 0, rect)).toEqual({ minX: 0, minZ: 0, maxX: 9, maxZ: CHUNK_SIZE });
+  });
+
+  it('#609: clamps the issue\'s literal repro (maxX/maxZ ~1e12) down to the chunk\'s own tile', () => {
+    const rect = { minX: 0, minZ: 0, maxX: 1e12, maxZ: 1e12 };
+    expect(clampChunkRectToTile(0, 0, rect)).toEqual({ minX: 0, minZ: 0, maxX: CHUNK_SIZE, maxZ: CHUNK_SIZE });
+  });
+
+  it('clamps a bound far below the tile up to the tile\'s own low edge, not to 0', () => {
+    const rect = { minX: -1e12, minZ: 0, maxX: CHUNK_SIZE, maxZ: CHUNK_SIZE };
+    expect(clampChunkRectToTile(0, 0, rect).minX).toBe(0);
+  });
+
+  it('a chunk far from the origin clamps a below-range minX up to THAT chunk\'s own tile edge, not to 0', () => {
+    const rect = { minX: -1e12, minZ: 32, maxX: 48, maxZ: 48 };
+    const result = clampChunkRectToTile(2, 2, rect); // chunk (2,2)'s tile is x/z in [32, 48)
+    expect(result.minX).toBe(32);
+  });
+
+  it('forces maxX to equal minX (never inverted) when independent clamping leaves maxX < minX', () => {
+    const rect = { minX: 20, minZ: 0, maxX: 5, maxZ: CHUNK_SIZE };
+    const result = clampChunkRectToTile(0, 0, rect);
+    // minX: round(20) clamped into [0,16] -> 16. maxX: round(5) clamped into [0,16] -> 5.
+    // 5 < 16, so maxX is forced up to minX rather than staying inverted.
+    expect(result.minX).toBe(16);
+    expect(result.maxX).toBe(16);
+  });
+
+  it('forces maxZ to equal minZ symmetrically', () => {
+    const rect = { minX: 0, minZ: 20, maxX: CHUNK_SIZE, maxZ: 5 };
+    const result = clampChunkRectToTile(0, 0, rect);
+    expect(result.minZ).toBe(16);
+    expect(result.maxZ).toBe(16);
+  });
+
+  describe('non-finite bounds fall back to their own tile edge, independently, per axis', () => {
+    it('NaN minX falls back to the tile\'s low X edge', () => {
+      const rect = { minX: NaN, minZ: 0, maxX: CHUNK_SIZE, maxZ: CHUNK_SIZE };
+      expect(clampChunkRectToTile(0, 0, rect).minX).toBe(0);
+    });
+    it('NaN maxX falls back to the tile\'s high X edge', () => {
+      const rect = { minX: 0, minZ: 0, maxX: NaN, maxZ: CHUNK_SIZE };
+      expect(clampChunkRectToTile(0, 0, rect).maxX).toBe(CHUNK_SIZE);
+    });
+    it('NaN minZ falls back to the tile\'s low Z edge', () => {
+      const rect = { minX: 0, minZ: NaN, maxX: CHUNK_SIZE, maxZ: CHUNK_SIZE };
+      expect(clampChunkRectToTile(0, 0, rect).minZ).toBe(0);
+    });
+    it('NaN maxZ falls back to the tile\'s high Z edge', () => {
+      const rect = { minX: 0, minZ: 0, maxX: CHUNK_SIZE, maxZ: NaN };
+      expect(clampChunkRectToTile(0, 0, rect).maxZ).toBe(CHUNK_SIZE);
+    });
+    it('NaN in all four positions falls back to the full tile, never propagating NaN into the result', () => {
+      const rect = { minX: NaN, minZ: NaN, maxX: NaN, maxZ: NaN };
+      const result = clampChunkRectToTile(0, 0, rect);
+      expect(Number.isNaN(result.minX)).toBe(false);
+      expect(Number.isNaN(result.minZ)).toBe(false);
+      expect(Number.isNaN(result.maxX)).toBe(false);
+      expect(Number.isNaN(result.maxZ)).toBe(false);
+      expect(result).toEqual({ minX: 0, minZ: 0, maxX: CHUNK_SIZE, maxZ: CHUNK_SIZE });
+    });
+  });
+
+  describe('Infinity / -Infinity bounds fall back exactly like NaN', () => {
+    it('+Infinity minX falls back to the tile\'s low X edge', () => {
+      const rect = { minX: Infinity, minZ: 0, maxX: CHUNK_SIZE, maxZ: CHUNK_SIZE };
+      expect(clampChunkRectToTile(0, 0, rect).minX).toBe(0);
+    });
+    it('-Infinity minX also falls back to the tile\'s low X edge (not to -Infinity clamped)', () => {
+      const rect = { minX: -Infinity, minZ: 0, maxX: CHUNK_SIZE, maxZ: CHUNK_SIZE };
+      expect(clampChunkRectToTile(0, 0, rect).minX).toBe(0);
+    });
+    it('+Infinity maxX falls back to the tile\'s high X edge', () => {
+      const rect = { minX: 0, minZ: 0, maxX: Infinity, maxZ: CHUNK_SIZE };
+      expect(clampChunkRectToTile(0, 0, rect).maxX).toBe(CHUNK_SIZE);
+    });
+    it('-Infinity maxX also falls back to the tile\'s high X edge (not to the low edge)', () => {
+      const rect = { minX: 0, minZ: 0, maxX: -Infinity, maxZ: CHUNK_SIZE };
+      expect(clampChunkRectToTile(0, 0, rect).maxX).toBe(CHUNK_SIZE);
+    });
+    it('+Infinity minZ falls back to the tile\'s low Z edge', () => {
+      const rect = { minX: 0, minZ: Infinity, maxX: CHUNK_SIZE, maxZ: CHUNK_SIZE };
+      expect(clampChunkRectToTile(0, 0, rect).minZ).toBe(0);
+    });
+    it('-Infinity maxZ falls back to the tile\'s high Z edge', () => {
+      const rect = { minX: 0, minZ: 0, maxX: CHUNK_SIZE, maxZ: -Infinity };
+      expect(clampChunkRectToTile(0, 0, rect).maxZ).toBe(CHUNK_SIZE);
+    });
+  });
+
+  it('rounds a non-integer minX via Math.round before clamping (round vs. truncate diverge here)', () => {
+    // round(15.6) = 16 (stays 16 after clamping to [0,16]); Math.trunc(15.6)
+    // would give 15 instead -- a different final value, so this assertion is
+    // only meaningful under Math.round.
+    const rect = { minX: 15.6, minZ: 0, maxX: CHUNK_SIZE, maxZ: CHUNK_SIZE };
+    expect(clampChunkRectToTile(0, 0, rect).minX).toBe(16);
+  });
+
+  it('rounds a non-integer maxX via Math.round before clamping, independently of minX', () => {
+    // round(7.6) = 8; Math.trunc(7.6) would give 7 instead -- both values sit
+    // within [0,16], so the final clamped result differs by which is used.
+    const rect = { minX: 0, minZ: 0, maxX: 7.6, maxZ: CHUNK_SIZE };
+    expect(clampChunkRectToTile(0, 0, rect).maxX).toBe(8);
+  });
+
+  it('clamps a rect that is a valid finite rect for a DIFFERENT chunk\'s tile into this chunk\'s own tile, rather than accepting it as-is', () => {
+    // {minX:16,...,maxX:32,...} is exactly chunk (1,1)'s own tile, not (0,0)'s.
+    const rect = { minX: 16, minZ: 16, maxX: 32, maxZ: 32 };
+    const result = clampChunkRectToTile(0, 0, rect);
+    expect(result).toEqual({ minX: 16, minZ: 16, maxX: 16, maxZ: 16 }); // collapsed onto (0,0)'s own high edge
+  });
+
+  it('treats a non-number value at runtime (corrupted JSON bypassing TS types) as non-finite and falls back to the tile edge', () => {
+    const rect = {
+      minX: ('16' as unknown as number),
+      minZ: 0,
+      maxX: CHUNK_SIZE,
+      maxZ: CHUNK_SIZE,
+    };
+    expect(clampChunkRectToTile(0, 0, rect).minX).toBe(0);
+  });
+});
+
+// #609: restoreChunkRaw and addChunkWithRect are the two entry points
+// untrusted save data reaches VoxelGrid through -- both must route their
+// `rect` argument through clampChunkRectToTile before assigning it onto the
+// chunk, so a corrupted save rect can never leave chunk.x0/z0/x1/z1 wider
+// than the chunk's own CHUNK_SIZE tile.
+describe('VoxelGrid — clamps untrusted rects reaching restoreChunkRaw / addChunkWithRect (#609)', () => {
+  it('restoreChunkRaw clamps a corrupted rect (matching the issue\'s repro) into the chunk\'s own tile', () => {
+    const grid = new VoxelGrid(16, 4, 16);
+    const n = CHUNK_SIZE * grid.sizeY * CHUNK_SIZE;
+    const density = new Float64Array(n);
+    const compId = new Uint16Array(n);
+    const fracture = new Float64Array(n).fill(1.0);
+
+    grid.restoreChunkRaw(0, 0, { minX: 0, minZ: 0, maxX: 1e12, maxZ: 1e12 }, density, compId, fracture, new Map());
+
+    expect(grid.chunkRect(0, 0)).toEqual({ minX: 0, minZ: 0, maxX: CHUNK_SIZE, maxZ: CHUNK_SIZE });
+  });
+
+  it('addChunkWithRect clamps a corrupted rect into the chunk\'s own tile', () => {
+    const grid = new VoxelGrid(0, 4, 0); // empty shell, same starting point decodeVoxelGrid builds
+    grid.addChunkWithRect(0, 0, { minX: 0, minZ: 0, maxX: 1e12, maxZ: 1e12 });
+
+    expect(grid.chunkRect(0, 0)).toEqual({ minX: 0, minZ: 0, maxX: CHUNK_SIZE, maxZ: CHUNK_SIZE });
+  });
+
+  it('addChunkWithRect on an already-owned chunk also clamps, not just on first allocation', () => {
+    const grid = new VoxelGrid(16, 4, 16); // owns chunk (0,0) already, full tile
+    grid.addChunkWithRect(0, 0, { minX: -1e12, minZ: 0, maxX: CHUNK_SIZE, maxZ: CHUNK_SIZE });
+
+    expect(grid.chunkRect(0, 0)).toEqual({ minX: 0, minZ: 0, maxX: CHUNK_SIZE, maxZ: CHUNK_SIZE });
   });
 });
 


### PR DESCRIPTION
Closes #609

## Summary

`VoxelGridCodec` and `VoxelGrid` accepted a chunk's rect bounds (`x0/z0/x1/z1`) straight from parsed save-file JSON with no validation against the grid's real dimensions. A corrupted or hand-edited save (e.g. `r: [0, 0, 1e12, 1e12]`) could reach unbounded loops in `TerrainMesh.rebuildChunk` and `TerrainMesh.canSkipChunkMarch`, hanging the renderer on load.

Adds `clampChunkRectToTile(cx, cz, rect)`, a pure exported function in `src/core/world/VoxelGrid.ts`, and routes every point where `VoxelGrid` receives untrusted rect data through it before storing `chunk.x0/z0/x1/z1`:

- `VoxelGrid.restoreChunkRaw` — the `chunk.r` path named in the issue.
- `VoxelGrid.addChunkWithRect` — the `payload.pristine` tuple path, reachable the same way but not named in the issue text.

While implementing, a second hang vector surfaced beyond the issue's own framing: `VoxelGridCodec.decodeVoxelGrid`'s pristine-chunk loop also calls `generateTerrainRegion` with the same raw untrusted tuple, and `addChunkWithRect`'s internal clamp (returning `void`) never reached that call. `generateTerrainRegion`'s column loop (`src/core/world/TerrainGen.ts`) is unbounded in exactly the same way `TerrainMesh`'s loops were. Fixed by clamping once in the codec's pristine loop and threading the same clamped rect to both `generateTerrainRegion` and `addChunkWithRect`.

`TerrainMesh.rebuildChunk` and `canSkipChunkMarch` needed no changes — both read bounds exclusively via `grid.chunkRect()`, which now only ever returns tile-bounded values.

## Verification

- `static` — `npm run typecheck`: clean.
- `logic` — `npm run test`: 9845/9845 passing (full suite), including 25 new tests covering the clamp function (happy path, the issue's literal `1e12` repro, negative/inverted/NaN/Infinity/non-integer/wrong-tile bounds) and both `VoxelGrid` entry points plus the codec pristine-loop path.
- `scenario`/`visual` — not applicable: change is confined to `src/core/`, no renderer/UI surface, no gameplay/player-facing flow.
- `build` — `npm run build`: succeeds.
- 5 parallel code reviews (security, quality, i18n, duplication, semantic): 0 critical, 0 warning findings across all five; 5 low/medium suggestions, none blocking (tracked below, not acted on in this run — see Decisions taken).

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** the issue names two acceptable validation points — inside `VoxelGridCodec.decodeChunkInto`, or inside `VoxelGrid.restoreChunkRaw`/`addChunkWithRect`.
  **Chosen:** validate inside `VoxelGrid`, as one shared exported function called from both `restoreChunkRaw` and `addChunkWithRect`.
  **Why:** `addChunkWithRect`'s only caller reads its own untrusted tuple from save JSON, the same shape as `chunk.r` — a codec-only fix at `decodeChunkInto` would leave that second entry point unguarded.
  **If reversed:** move the two call sites from `VoxelGrid.ts` into `VoxelGridCodec.ts`'s two decode call sites instead.

- **What was open:** clamp vs. reject an out-of-range rect.
  **Chosen:** clamp per-axis into the chunk's own tile, never throw/reject.
  **Why:** matches the precedent already set by `restoreChunkRaw`'s pre-existing defensive rescan clamp (added during #560's review) — a corrupted save degrades to a locally-bounded chunk rather than aborting the whole load.
  **If reversed:** change `clampChunkRectToTile`'s fallback values to throw, and handle the exception at both call sites.

- **What was open:** what a non-finite/non-numeric bound falls back to.
  **Chosen:** that bound's own tile edge (full ownership on that side), not zero-width or 0.
  **Why:** most conservative assumption that still keeps every downstream loop bounded; uses `Number.isFinite` (not global `isFinite`) so a corrupted string value isn't wrongly treated as valid.
  **If reversed:** change the two `fallback` arguments in `clampAxis`.

None of these change gameplay, economy, or a player-facing default (defensive robustness fix against corrupted saves, low severity per the issue) — no `decision-review` follow-up issue opened.

## Review suggestions not acted on (non-blocking, tracked here for visibility)

- `minX`/`minZ` locals in `clampChunkRectToTile` could be `const` instead of `let` (style).
- `clampAxis`'s NaN-safe-clamp-with-fallback formula is semantically similar to `Sandbox.ts`'s `clampNumber` — a shared `src/core/math/` helper could unify them.
- `restoreChunkRaw`'s density-summary rescan clamp is now a self-documented no-op (comment already says so).
- A test comment in `VoxelGridCodec.test.ts` explaining the pristine-tuple test's magnitude choice (`40` vs. `1e12`) is stale relative to the final implementation, which does clamp before `generateTerrainRegion`.

READY TO MERGE
