### PR TITLE
fix: Resolve #610 — guard the grid's topmost y-slab against wrongly-skippable march

### DIFF
--- a/src/renderer/TerrainMesh.ts
+++ b/src/renderer/TerrainMesh.ts
@@ -540,8 +540,15 @@ export class TerrainMesh {
     if (range.max < SURFACE_THRESHOLD) return true; // uniformly air
     if (range.min < SURFACE_THRESHOLD) return false; // genuinely mixed — a surface crosses this slab
 
-    // #610: topmost-slab guard belongs here — before the "Uniformly solid"
-    // slabSafe logic below. See issue #610.
+    // #610: the grid's own topmost y-slab has no slab above it to read —
+    // chunkDensityRange(cx, cz, cy+1) returns null there because cy+1 is
+    // past the grid's own height, not because there's nothing to worry
+    // about. Out-of-bounds voxel reads (VoxelGrid.ownerOf/densityAt) always
+    // come back as air, so this slab's own top row of march cubes always
+    // samples a real solid/air crossing at y = sizeY, regardless of how
+    // solid or boxed-in the slab is. Never skippable.
+    const topmostSlabIndex = Math.ceil(this.grid.sizeY / CHUNK_SIZE) - 1;
+    if (cy === topmostSlabIndex) return false;
 
     // Uniformly solid. Unlike x/z, rebuildChunk's y-loop has no "-1" halo
     // start (yStart is always oy, never oy-1) — the only vertical read past

--- a/src/renderer/TerrainMesh.ts
+++ b/src/renderer/TerrainMesh.ts
@@ -540,6 +540,9 @@ export class TerrainMesh {
     if (range.max < SURFACE_THRESHOLD) return true; // uniformly air
     if (range.min < SURFACE_THRESHOLD) return false; // genuinely mixed — a surface crosses this slab
 
+    // #610: topmost-slab guard belongs here — before the "Uniformly solid"
+    // slabSafe logic below. See issue #610.
+
     // Uniformly solid. Unlike x/z, rebuildChunk's y-loop has no "-1" halo
     // start (yStart is always oy, never oy-1) — the only vertical read past
     // this chunk's own slab is its topmost cube's far corner, which lands

--- a/tests/unit/renderer/TerrainMesh.test.ts
+++ b/tests/unit/renderer/TerrainMesh.test.ts
@@ -795,6 +795,44 @@ describe('TerrainMesh', () => {
       expect(skirtInternals(tm).canSkipChunkMarch(0, 0, 0, rect)).toBe(false);
       tm.dispose();
     });
+
+    it('returns false for the topmost y-slab even when uniformly solid, sizeY an exact multiple of CHUNK_SIZE (#610)', () => {
+      // fullySolidMultiChunkGrid: 3x3 chunks horizontally, sizeY = CHUNK_SIZE*2
+      // (32 with CHUNK_SIZE=16), solid from y=0 through y=sizeY-1 with zero
+      // headroom above the last written row. Topmost slab index is
+      // ceil(32/16)-1 = 1. chunkDensityRange(1, 1, cy=2) is out of range and
+      // returns null, so an unpatched slabSafe(null) treats "no data above"
+      // as "safe to skip" — wrong, because the topmost slab's own top row of
+      // march cubes always samples an out-of-bounds y=sizeY corner, which
+      // VoxelGrid.ownerOf reads as air, guaranteeing a real surface crossing
+      // there. The topmost slab must never be treated as skippable.
+      const grid = fullySolidMultiChunkGrid();
+      const tm = new TerrainMesh(makeScene(), grid);
+      const rect = grid.chunkRect(1, 1)!;
+      const topmostSlabIndex = Math.ceil(MULTI_CHUNK_SIZE_Y / CHUNK_SIZE) - 1;
+      expect(skirtInternals(tm).canSkipChunkMarch(1, topmostSlabIndex, 1, rect)).toBe(false);
+      tm.dispose();
+    });
+
+    it('returns false for the topmost y-slab even when uniformly solid, sizeY NOT a multiple of CHUNK_SIZE (#610)', () => {
+      // Same 3x3 horizontal footprint, but sizeY = CHUNK_SIZE + 4 (20 with
+      // CHUNK_SIZE=16): the topmost slab is partial, spanning only y=16..19
+      // (4 rows, not a full 16). Still solid throughout with zero headroom at
+      // the array's own ceiling. Topmost slab index is ceil(20/16)-1 = 1 —
+      // same failure mode as the exact-multiple case above.
+      const sizeXZ = CHUNK_SIZE * 3;
+      const sizeY = CHUNK_SIZE + 4;
+      const grid = new VoxelGrid(sizeXZ, sizeY, sizeXZ);
+      for (let x = 0; x < sizeXZ; x++)
+        for (let y = 0; y < sizeY; y++)
+          for (let z = 0; z < sizeXZ; z++)
+            grid.setVoxel(x, y, z, makeSolidVoxel());
+      const tm = new TerrainMesh(makeScene(), grid);
+      const rect = grid.chunkRect(1, 1)!;
+      const topmostSlabIndex = Math.ceil(sizeY / CHUNK_SIZE) - 1;
+      expect(skirtInternals(tm).canSkipChunkMarch(1, topmostSlabIndex, 1, rect)).toBe(false);
+      tm.dispose();
+    });
   });
 
   describe('boundary/skirt walls without a sampler still march full depth (#560 fallback)', () => {


### PR DESCRIPTION
Closes #610

## Summary

`TerrainMesh.canSkipChunkMarch`'s "uniformly solid" skip branches (added in #560/PR #608 to fix a real vanishing-terrain bug) checked the vertically-adjacent chunk slab before declaring a chunk skippable, treating a `null` return from `chunkDensityRange(cx, cz, cy+1)` as "safe to skip." That `null` is ambiguous: it means either "no slab data" or "slab index past the grid's own height." For the grid's own topmost y-slab, `cy+1` is always the latter — and a uniformly-solid topmost slab always has a real surface crossing at its own top row, because `VoxelGrid.ownerOf`/`densityAt` reads any out-of-bounds `y` as air. The old logic silently skipped marching real top-cap geometry in that case.

Fix: an explicit guard in `canSkipChunkMarch` — `topmostSlabIndex = Math.ceil(this.grid.sizeY / CHUNK_SIZE) - 1; if (cy === topmostSlabIndex) return false;` — fires unconditionally for the grid's topmost slab, regardless of what `chunkDensityRange` returns. Placed before the existing neighbour-slab (`slabSafe`) logic runs. The deliberate bottom-slab asymmetry from #560 (an unmarched exposed bottom face is tolerated by design) is untouched — the guard only equals `cy=0` in a single-slab grid.

Not reachable through the game's own terrain generation today (`WorldGen.ts`'s `heightToVoxelY` always clamps to `sizeY - 1`, keeping headroom), same as noted in the issue — this closes the latent bug rather than a live one.

## Changes

- `src/renderer/TerrainMesh.ts` — add topmost-slab guard in `canSkipChunkMarch` (10 lines).
- `tests/unit/renderer/TerrainMesh.test.ts` — 2 new regression tests: `sizeY` an exact multiple of `CHUNK_SIZE`, and `sizeY` not a multiple (partial topmost slab) — both construct a zero-headroom, uniformly-solid grid and assert the topmost interior chunk is never reported skippable. Both fail on pre-fix code (verified by semantic reviewer reverting the fix locally) and pass on post-fix code.

## Decisions taken

Defaulted under `agentic-decision-autonomy`, per the issue's own explicit (a)/(b) choice — no blocker.

- **What was open:** issue asked for either (a) an explicit code guard, or (b) an assertion/documentation of the headroom invariant `WorldGen` already relies on.
- **Chosen:** (a), an explicit guard.
- **Why:** an assertion only documents today's `WorldGen` invariant and does nothing the day a level config, hand-built grid, or future world-gen change violates it — it would still silently drop real geometry with no test ever catching it. A guard is a real, narrowly-scoped fix (one early-return, before the existing neighbour-slab logic, confined to the topmost-slab case only) independent of reachability, and does not touch the bottom-slab asymmetry #560 already established — so it does not carry the "asymmetric special-casing sprawl" risk the issue's own "why not fixed in #560" section flagged; that risk was about broadly complicating the function, not about one provably-correct, well-isolated branch.
- **If reversed:** delete the `if (cy === topmostSlabIndex) return false;` block in `src/renderer/TerrainMesh.ts`'s `canSkipChunkMarch`; no other call site changes.

## Verification

- **static** (`npm run typecheck`): PASS — 0 errors.
- **logic** (`npm run test`): PASS — 9859 tests passed, 0 failed, full suite (317 files), including the 2 new regression tests.
- **build** (`npx vite build`): PASS — succeeds, no new warnings.
- **visual**: PASS — dev server + browser confirmed READY, screenshot of a normal desert level (`new_game mine_type:desert seed:42`) inspected: terrain renders correctly, no vanishing/missing chunks, no visual regression. Consistent with the fix's scope: the guard only fires on a grid shape (zero headroom at the array's own ceiling) that `WorldGen` never produces, so no observable difference is expected or was found on any real level.
- **scenario**: not separately run — this is a pure rendering-correctness fix with no gameplay/economy/campaign state change; `logic` and `visual` already cover it end to end.
- Code review: 5 parallel specialist reviewers (security, quality, i18n, duplication, semantic) — all PASS. Two reviewers independently noted a non-blocking style suggestion (reuse the existing `this.ncy` field instead of recomputing the topmost-slab index inline); left as-is per the bug-fix pipeline's deliberate `skip_refactorer` policy and the issue's own caution against additional changes to this specific function, which had two real regressions found and fixed in the same review cycle during #560.

No `full-ci` label: no interaction-mode scenario drives this internal rendering-optimization guard (it is unreachable through actual game content), and the `visual` channel above already directly verified rendering is unaffected. No `build-check` label: no build-config or dependency change.

READY TO MERGE