### PR TITLE
feat: Resolve #613 — fresnel rim-light on ghost preview holograms

### DIFF
--- a/scripts/scenario-defs/ghost-fresnel-rim-visual.json
+++ b/scripts/scenario-defs/ghost-fresnel-rim-visual.json
@@ -1,0 +1,186 @@
+{
+  "name": "ghost-fresnel-rim-visual",
+  "description": "Issue #613: verifies the fresnel-based rim-light shader on pending-action ghost previews (GhostMesh.ts) renders visibly, and reads distinctly between an unclaimed ghost (brighter, faster opacity pulse) and a claimed ghost (dimmer, slower pulse, #547) in the same frame. Exactly one surveyor is hired so the first dispatch tick claims exactly one of two queued survey targets and leaves the other queued -- deterministic without needing precise nearest-of-two distance tuning (contrast action-queue-dispatch.json's two-surveyor setup, which exists to prove cost-based *dispatch correctness* rather than to hold a claimed/unclaimed pair still for a screenshot).",
+  "steps": [
+    {
+      "command": "new_game seed:42 mine_type:desert size:32",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "new_game seed:42 mine_type:desert size:32"
+        }
+      ],
+      "role": "setup",
+      "expect": {
+        "equals": {
+          "cash": 50000,
+          "employeeCount": 0
+        }
+      }
+    },
+    {
+      "command": "time resume",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "time resume"
+        }
+      ],
+      "role": "setup"
+    },
+    {
+      "command": "employee hire role:surveyor",
+      "description": "Single surveyor, spawns near world centre (16,16) -- see action-queue-dispatch.json's own comment on hireEmployee's spawn placement.",
+      "interaction": [
+        {
+          "type": "clickSelector",
+          "selector": "#bs-toolbar [data-panel=\"employees\"]"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": "#bs-employee-panel [data-role=\"surveyor\"]"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-employee-panel [data-role=\"surveyor\"]"
+        }
+      ],
+      "role": "player",
+      "expect": {
+        "changedBy": {
+          "cash": -1200
+        },
+        "equals": {
+          "employeeCount": 1
+        }
+      }
+    },
+    {
+      "command": "survey seismic x:12 z:12",
+      "description": "Target A -- queued first, so the single surveyor's first dispatch tick claims this one (lower id, ties broken by id per ActionSelection.ts).",
+      "interaction": [
+        {
+          "type": "clickSelector",
+          "selector": "#bs-toolbar [data-panel=\"survey\"]"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-survey-panel [data-method=\"seismic\"]"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-survey-run"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": "#bs-tile-select-confirm"
+        },
+        {
+          "type": "pickTile",
+          "x": 12,
+          "z": 12
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-tile-select-confirm"
+        }
+      ],
+      "role": "player",
+      "expect": {
+        "decreased": [
+          "cash"
+        ],
+        "increased": [
+          "pendingActionCount"
+        ]
+      }
+    },
+    {
+      "command": "survey core_sample x:20 z:20",
+      "description": "Target B -- queued second. The lone surveyor is only ever available to claim one action per tick, so this stays queued (unclaimed ghost) once Target A is claimed below.",
+      "interaction": [
+        {
+          "type": "clickSelector",
+          "selector": "#bs-survey-panel [data-method=\"core_sample\"]"
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-survey-run"
+        },
+        {
+          "type": "waitForSelector",
+          "selector": "#bs-tile-select-confirm"
+        },
+        {
+          "type": "pickTile",
+          "x": 20,
+          "z": 20
+        },
+        {
+          "type": "clickSelector",
+          "selector": "#bs-tile-select-confirm"
+        }
+      ],
+      "role": "player",
+      "expect": {
+        "decreased": [
+          "cash"
+        ],
+        "equals": {
+          "pendingActionCount": 2,
+          "surveyCount": 0
+        }
+      }
+    },
+    {
+      "command": "tick 1",
+      "description": "One dispatch tick -- long enough for tickEmployees to claim Target A, not long enough for travel or work to finish on either. Both actions stay in pendingActions (#547: a claimed action stays until it completes) so both ghosts render this step -- Target A's claimed (dim/slow), Target B's unclaimed (bright/fast). This is the frame the rim-light shader is inspected against.",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 1"
+        }
+      ],
+      "role": "setup",
+      "expect": {
+        "equals": {
+          "pendingActionCount": 2,
+          "surveyCount": 0
+        }
+      }
+    },
+    {
+      "command": "state full",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "state full"
+        }
+      ],
+      "role": "observe"
+    }
+  ],
+  "shots": [
+    {
+      "name": "closeup-a",
+      "yaw": 45,
+      "pitch": 20,
+      "target": [12, 12],
+      "distance": 5
+    },
+    {
+      "name": "closeup-b",
+      "yaw": 135,
+      "pitch": 20,
+      "target": [20, 20],
+      "distance": 5
+    },
+    {
+      "name": "edge-on-a",
+      "yaw": 2,
+      "pitch": 3,
+      "target": [12, 12],
+      "distance": 2.2
+    }
+  ]
+}

--- a/src/renderer/GhostMesh.ts
+++ b/src/renderer/GhostMesh.ts
@@ -23,10 +23,18 @@ const CLAIMED_OPACITY_MIN = 0.10;        // dimmest pulse value, claimed
 const CLAIMED_OPACITY_MAX = 0.30;        // brightest pulse value, claimed
 const CLAIMED_PULSE_SPEED = 1.1;         // radians / second, claimed
 
+// Fresnel-based holographic rim-light (#613) — edges facing away from the
+// camera glow brighter than faces facing it, layered on top of the existing
+// pulse-opacity behaviour above. Same blue as GHOST_COLOR in both ghost
+// states — no second color.
+const RIM_COLOR     = new THREE.Color(GHOST_COLOR); // reuses ghost base color
+const RIM_POWER     = 2.0;               // fresnel exponent
+const RIM_INTENSITY = 1.0;               // additive glow multiplier
+
 /** Builds a ghost mesh material at the given starting opacity — the unclaimed
  *  and claimed materials differ only in that value (#547 review). */
 function createGhostMaterial(opacity: number): THREE.MeshPhongMaterial {
-  return new THREE.MeshPhongMaterial({
+  const material = new THREE.MeshPhongMaterial({
     color: GHOST_COLOR,
     emissive: EMISSIVE_COLOR,
     emissiveIntensity: 0.5,
@@ -35,6 +43,19 @@ function createGhostMaterial(opacity: number): THREE.MeshPhongMaterial {
     depthWrite: false,
     side: THREE.DoubleSide,
   });
+
+  // Fresnel rim-light shader injection (#613). Stub only — GLSL injection is
+  // implementer's job.
+  material.onBeforeCompile = (shader) => {
+    // TODO(#613): implement rim fresnel injection
+    void shader;
+    void RIM_COLOR;
+    void RIM_POWER;
+    void RIM_INTENSITY;
+  };
+  material.customProgramCacheKey = () => 'ghost-rim-v1';
+
+  return material;
 }
 
 // ---------- Main class ----------

--- a/src/renderer/GhostMesh.ts
+++ b/src/renderer/GhostMesh.ts
@@ -65,17 +65,18 @@ function createGhostMaterial(opacity: number): THREE.MeshPhongMaterial {
     shader.uniforms['rimColor'] = { value: RIM_COLOR };
     shader.uniforms['rimPower'] = { value: RIM_POWER };
     shader.uniforms['rimIntensity'] = { value: RIM_INTENSITY };
+    shader.uniforms['rimOpacityFloor'] = { value: RIM_OPACITY_FLOOR };
 
     shader.fragmentShader = shader.fragmentShader
       .replace(
         '#include <common>',
-        '#include <common>\nuniform vec3 rimColor;\nuniform float rimPower;\nuniform float rimIntensity;',
+        '#include <common>\nuniform vec3 rimColor;\nuniform float rimPower;\nuniform float rimIntensity;\nuniform float rimOpacityFloor;',
       )
       .replace(
         '#include <emissivemap_fragment>',
         '#include <emissivemap_fragment>\n' +
           'float rimFresnel = pow(1.0 - clamp(dot(normalize(vViewPosition), normal), 0.0, 1.0), rimPower);\n' +
-          `float rimOpacityCompensation = 1.0 / max(opacity, ${RIM_OPACITY_FLOOR.toFixed(2)});\n` +
+          'float rimOpacityCompensation = 1.0 / max(opacity, rimOpacityFloor);\n' +
           'totalEmissiveRadiance += rimColor * rimIntensity * rimFresnel * rimOpacityCompensation;',
       );
   };

--- a/src/renderer/GhostMesh.ts
+++ b/src/renderer/GhostMesh.ts
@@ -27,9 +27,22 @@ const CLAIMED_PULSE_SPEED = 1.1;         // radians / second, claimed
 // camera glow brighter than faces facing it, layered on top of the existing
 // pulse-opacity behaviour above. Same blue as GHOST_COLOR in both ghost
 // states — no second color.
-const RIM_COLOR     = new THREE.Color(GHOST_COLOR); // reuses ghost base color
-const RIM_POWER     = 2.0;               // fresnel exponent
-const RIM_INTENSITY = 1.0;               // additive glow multiplier
+//
+// The rim term is added into totalEmissiveRadiance, which the standard
+// transparent alpha-blend then multiplies by the material's (pulsing,
+// 0.10-0.60) `opacity` uniform before it reaches the screen — exactly where
+// the rim should read strongest (thin grazing-angle sliver), the ghost is
+// also most see-through, diluting it. RIM_OPACITY_FLOOR compensates: the rim
+// contribution is divided by max(opacity, RIM_OPACITY_FLOOR) in-shader so its
+// on-screen brightness stays roughly independent of the opacity pulse
+// (floored rather than divided by raw opacity so it can't blow up as opacity
+// approaches 0). Original tuning (RIM_INTENSITY 1.0, no compensation) pixel-
+// sampled only a ~6-8% grazing-angle brightness delta — imperceptible at
+// normal viewing distance (#613 visual feedback).
+const RIM_COLOR         = new THREE.Color(GHOST_COLOR); // reuses ghost base color
+const RIM_POWER         = 1.5;           // fresnel exponent — widened vs 2.0 so the glow band reads as an edge, not a sliver
+const RIM_INTENSITY     = 2.2;           // additive glow multiplier
+const RIM_OPACITY_FLOOR = 0.25;          // floor for the opacity-compensation divisor (caps compensation at 4x)
 
 /** Builds a ghost mesh material at the given starting opacity — the unclaimed
  *  and claimed materials differ only in that value (#547 review). */
@@ -62,7 +75,8 @@ function createGhostMaterial(opacity: number): THREE.MeshPhongMaterial {
         '#include <emissivemap_fragment>',
         '#include <emissivemap_fragment>\n' +
           'float rimFresnel = pow(1.0 - clamp(dot(normalize(vViewPosition), normal), 0.0, 1.0), rimPower);\n' +
-          'totalEmissiveRadiance += rimColor * rimIntensity * rimFresnel;',
+          `float rimOpacityCompensation = 1.0 / max(opacity, ${RIM_OPACITY_FLOOR.toFixed(2)});\n` +
+          'totalEmissiveRadiance += rimColor * rimIntensity * rimFresnel * rimOpacityCompensation;',
       );
   };
   material.customProgramCacheKey = () => 'ghost-mesh-fresnel-v1';

--- a/src/renderer/GhostMesh.ts
+++ b/src/renderer/GhostMesh.ts
@@ -44,16 +44,28 @@ function createGhostMaterial(opacity: number): THREE.MeshPhongMaterial {
     side: THREE.DoubleSide,
   });
 
-  // Fresnel rim-light shader injection (#613). Stub only — GLSL injection is
-  // implementer's job.
+  // Fresnel rim-light shader injection (#613) — edges facing away from the
+  // camera glow brighter than faces facing it, layered on top of the
+  // opacity pulse driven from update(). Identical GLSL for both claimed and
+  // unclaimed materials; only opacity/pulse-speed differ between them.
   material.onBeforeCompile = (shader) => {
-    // TODO(#613): implement rim fresnel injection
-    void shader;
-    void RIM_COLOR;
-    void RIM_POWER;
-    void RIM_INTENSITY;
+    shader.uniforms['rimColor'] = { value: RIM_COLOR };
+    shader.uniforms['rimPower'] = { value: RIM_POWER };
+    shader.uniforms['rimIntensity'] = { value: RIM_INTENSITY };
+
+    shader.fragmentShader = shader.fragmentShader
+      .replace(
+        '#include <common>',
+        '#include <common>\nuniform vec3 rimColor;\nuniform float rimPower;\nuniform float rimIntensity;',
+      )
+      .replace(
+        '#include <emissivemap_fragment>',
+        '#include <emissivemap_fragment>\n' +
+          'float rimFresnel = pow(1.0 - clamp(dot(normalize(vViewPosition), normal), 0.0, 1.0), rimPower);\n' +
+          'totalEmissiveRadiance += rimColor * rimIntensity * rimFresnel;',
+      );
   };
-  material.customProgramCacheKey = () => 'ghost-rim-v1';
+  material.customProgramCacheKey = () => 'ghost-mesh-fresnel-v1';
 
   return material;
 }

--- a/tests/unit/renderer/GhostMesh.test.ts
+++ b/tests/unit/renderer/GhostMesh.test.ts
@@ -224,4 +224,135 @@ describe('GhostMesh', () => {
       gm.dispose();
     });
   });
+
+  // ── #613: fresnel rim-light on ghost materials ──────────────────────────
+  // Edges facing away from the camera should glow brighter than faces facing
+  // it, layered on top of the existing pulse-opacity behaviour. Vitest has no
+  // WebGL context, so onBeforeCompile is never invoked by a real compile —
+  // these tests invoke the hook directly with a hand-built minimal fake
+  // shader object, matching the standard Phong fresnel-into-emissive
+  // injection point (#common / #emissivemap_fragment chunks).
+
+  describe('fresnel rim-light (#613)', () => {
+    function makeFakeShader() {
+      return {
+        uniforms: {} as Record<string, { value: unknown }>,
+        vertexShader: 'void main() {}',
+        fragmentShader: '#include <common>\nvoid main() {\n#include <emissivemap_fragment>\n}',
+      };
+    }
+
+    it('unclaimed and claimed materials stay MeshPhongMaterial with an onBeforeCompile hook assigned', () => {
+      const scene = new THREE.Scene();
+      const gm = new GhostMesh(scene);
+      gm.sync([makePreview(1, { claimed: false }), makePreview(2, { claimed: true })]);
+
+      const unclaimedMesh = scene.children.find(c => (c as THREE.Mesh).position.x === 3) as THREE.Mesh;
+      const claimedMesh = scene.children.find(c => (c as THREE.Mesh).position.x === 6) as THREE.Mesh;
+      const unclaimedMat = unclaimedMesh.material as THREE.MeshPhongMaterial;
+      const claimedMat = claimedMesh.material as THREE.MeshPhongMaterial;
+
+      expect(unclaimedMat).toBeInstanceOf(THREE.MeshPhongMaterial);
+      expect(claimedMat).toBeInstanceOf(THREE.MeshPhongMaterial);
+      expect(typeof unclaimedMat.onBeforeCompile).toBe('function');
+      expect(typeof claimedMat.onBeforeCompile).toBe('function');
+      gm.dispose();
+    });
+
+    it('onBeforeCompile injects rim uniforms (color, fresnel power, intensity) into the shader', () => {
+      const scene = new THREE.Scene();
+      const gm = new GhostMesh(scene);
+      gm.sync([makePreview(1)]);
+      const mat = (scene.children[0] as THREE.Mesh).material as THREE.MeshPhongMaterial;
+
+      const shader = makeFakeShader();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mat.onBeforeCompile!(shader as any, {} as any);
+
+      expect(shader.uniforms.rimColor).toBeDefined();
+      expect(shader.uniforms.rimPower).toBeDefined();
+      expect(shader.uniforms.rimIntensity).toBeDefined();
+      gm.dispose();
+    });
+
+    it('rim uniform values carry the configured fresnel power/intensity, and the rim color is blue-dominant', () => {
+      const scene = new THREE.Scene();
+      const gm = new GhostMesh(scene);
+      gm.sync([makePreview(1)]);
+      const mat = (scene.children[0] as THREE.Mesh).material as THREE.MeshPhongMaterial;
+
+      const shader = makeFakeShader();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mat.onBeforeCompile!(shader as any, {} as any);
+
+      const rimColor = shader.uniforms.rimColor.value as THREE.Color;
+      expect(rimColor.b).toBeGreaterThan(rimColor.r);
+      expect(typeof shader.uniforms.rimPower.value).toBe('number');
+      expect(shader.uniforms.rimPower.value).toBeGreaterThan(0);
+      expect(typeof shader.uniforms.rimIntensity.value).toBe('number');
+      expect(shader.uniforms.rimIntensity.value).toBeGreaterThan(0);
+      gm.dispose();
+    });
+
+    it('onBeforeCompile injects fresnel GLSL into the fragment shader, changing it from the original', () => {
+      const scene = new THREE.Scene();
+      const gm = new GhostMesh(scene);
+      gm.sync([makePreview(1)]);
+      const mat = (scene.children[0] as THREE.Mesh).material as THREE.MeshPhongMaterial;
+
+      const shader = makeFakeShader();
+      const originalFragmentShader = shader.fragmentShader;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mat.onBeforeCompile!(shader as any, {} as any);
+
+      expect(shader.fragmentShader).not.toBe(originalFragmentShader);
+      // The fresnel term is a dot-product of view direction and normal — its
+      // presence is the signature of a real fresnel injection, not just any
+      // string append.
+      expect(shader.fragmentShader).toContain('dot(');
+      gm.dispose();
+    });
+
+    it('unclaimed and claimed materials get the same rim treatment — rim color/power/intensity do not diverge by claimed state', () => {
+      const scene = new THREE.Scene();
+      const gm = new GhostMesh(scene);
+      gm.sync([makePreview(1, { claimed: false }), makePreview(2, { claimed: true })]);
+
+      const unclaimedMesh = scene.children.find(c => (c as THREE.Mesh).position.x === 3) as THREE.Mesh;
+      const claimedMesh = scene.children.find(c => (c as THREE.Mesh).position.x === 6) as THREE.Mesh;
+      const unclaimedMat = unclaimedMesh.material as THREE.MeshPhongMaterial;
+      const claimedMat = claimedMesh.material as THREE.MeshPhongMaterial;
+
+      const unclaimedShader = makeFakeShader();
+      const claimedShader = makeFakeShader();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      unclaimedMat.onBeforeCompile!(unclaimedShader as any, {} as any);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      claimedMat.onBeforeCompile!(claimedShader as any, {} as any);
+
+      const unclaimedColor = unclaimedShader.uniforms.rimColor.value as THREE.Color;
+      const claimedColor = claimedShader.uniforms.rimColor.value as THREE.Color;
+      expect(claimedColor.r).toBeCloseTo(unclaimedColor.r);
+      expect(claimedColor.g).toBeCloseTo(unclaimedColor.g);
+      expect(claimedColor.b).toBeCloseTo(unclaimedColor.b);
+      expect(claimedShader.uniforms.rimPower.value).toBe(unclaimedShader.uniforms.rimPower.value);
+      expect(claimedShader.uniforms.rimIntensity.value).toBe(unclaimedShader.uniforms.rimIntensity.value);
+      gm.dispose();
+    });
+
+    it('update(dt) still only animates opacity — material base color is untouched by the pulse', () => {
+      const scene = new THREE.Scene();
+      const gm = new GhostMesh(scene);
+      gm.sync([makePreview(1)]);
+      const mat = (scene.children[0] as THREE.Mesh).material as THREE.MeshPhongMaterial;
+
+      const colorBefore = mat.color.clone();
+      for (let i = 0; i < 60; i++) {
+        gm.update(1 / 60);
+      }
+      expect(mat.color.equals(colorBefore)).toBe(true);
+      expect(mat.transparent).toBe(true);
+      gm.dispose();
+    });
+  });
 });

--- a/tests/unit/renderer/GhostMesh.test.ts
+++ b/tests/unit/renderer/GhostMesh.test.ts
@@ -310,6 +310,19 @@ describe('GhostMesh', () => {
       // presence is the signature of a real fresnel injection, not just any
       // string append.
       expect(shader.fragmentShader).toContain('dot(');
+      // A dot-product alone proves nothing if the result is never used —
+      // assert it actually accumulates into totalEmissiveRadiance, the line
+      // Three's Phong shader reads to make emissive glow visible on screen.
+      // A no-op that computes rimFresnel but discards it would still pass
+      // the assertions above; this one closes that loophole.
+      expect(shader.fragmentShader).toContain('totalEmissiveRadiance += rimColor * rimIntensity * rimFresnel * rimOpacityCompensation;');
+      // The injection must land immediately after the emissivemap_fragment
+      // chunk — that's the point in Three's Phong fragment shader where
+      // totalEmissiveRadiance exists and is still open to additive terms.
+      const emissiveChunkIndex = shader.fragmentShader.indexOf('#include <emissivemap_fragment>');
+      const rimTermIndex = shader.fragmentShader.indexOf('totalEmissiveRadiance += rimColor');
+      expect(emissiveChunkIndex).toBeGreaterThanOrEqual(0);
+      expect(rimTermIndex).toBeGreaterThan(emissiveChunkIndex);
       gm.dispose();
     });
 


### PR DESCRIPTION
Closes #613

## Summary

Adds a fresnel-based holographic rim-light effect to the pending-action ghost preview materials in `src/renderer/GhostMesh.ts` — edges facing away from the camera glow brighter than faces facing the camera, layered on top of the existing pulse-opacity behaviour (not replacing it). Applies identically to both the unclaimed (`this.material`) and claimed (`this.claimedMaterial`) ghost materials; the claimed/unclaimed distinction stays a pre-existing opacity/pulse-speed difference (#574), unchanged and still reading clearly with the rim applied. Ghosts stay blue in both states — no second color introduced.

Implementation: `onBeforeCompile` GLSL injection on the existing `THREE.MeshPhongMaterial` (no material-class swap), matching the established shader-injection idiom already used in `src/renderer/ambient/WaterSurface.ts` / `VegetationSway.ts` / `src/renderer/terrain/TerrainMaterial.ts`. New uniforms `rimColor`/`rimPower`/`rimIntensity`/`rimOpacityFloor`; fresnel term (`pow(1.0 - dot(viewDir, normal), rimPower)`) added to `totalEmissiveRadiance`, divided by `max(opacity, rimOpacityFloor)` to compensate for alpha-blend dilution of the rim at the ghost's low base opacity (first implementation was correct in the shader math but visually imperceptible — ~6-8% brightness delta — until this compensation was added following visual feedback). `update(dt)` untouched; ghosts stay on raw `dt` per `.claude/rules/rendering.md`.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** issue didn't specify rim color/exponent/intensity values.
  **Chosen:** rim color reuses the existing `GHOST_COLOR` constant directly (no new color introduced); `RIM_POWER = 1.5`, `RIM_INTENSITY = 2.2`, `RIM_OPACITY_FLOOR = 0.25` (tuned iteratively against real screenshots, not guessed once).
  **Why:** reusing `GHOST_COLOR` satisfies the explicit "ghosts stay blue, no second color" convention from #547/#574 with zero drift risk. The power/intensity/floor values were set by running the visual feedback loop against real screenshots — first pass (power 2.0, intensity 1.0, no floor) was mathematically correct but visually imperceptible (~6-8% brightness delta, diluted by alpha blend through the ghost's low base opacity); the tuned values were confirmed by an independent visual-tester re-inspection to read as a clear, legible holographic rim on both claimed and unclaimed ghosts without overshooting into an opaque glow.
  **If reversed:** change `RIM_POWER`/`RIM_INTENSITY`/`RIM_OPACITY_FLOOR` constants at the top of `src/renderer/GhostMesh.ts`; no call site moves.

- **What was open:** issue didn't say whether the rim itself should differ between claimed and unclaimed beyond the pre-existing opacity/pulse-speed split.
  **Chosen:** identical rim uniforms on both materials — only the pre-existing `opacity` differs, exactly as before.
  **Why:** the issue frames the rim as layered on top of the existing pulse-opacity mechanism, not a second independent state-encoding axis; adding rim-intensity divergence would risk the two visual cues fighting each other and was out of the issue's stated scope.
  **If reversed:** thread a second parameter through `createGhostMaterial(opacity, rimIntensity)`, mirroring the existing `CLAIMED_OPACITY_MIN`/`MAX` pattern.

- **What was open:** `onBeforeCompile` shader injection on the existing `MeshPhongMaterial` vs. swapping to `THREE.ShaderMaterial`.
  **Chosen:** `onBeforeCompile` injection, material class unchanged.
  **Why:** matches the only existing shader-injection precedent in `src/renderer/`, and is least disruptive to existing material-typed tests and to `GameRenderer.ts` (no call-site changes needed); a `ShaderMaterial` swap would require hand-reimplementing Phong lighting/emissive/fog handling this material currently gets for free.
  **If reversed:** no numeric knob — would require rewriting `createGhostMaterial` around `ShaderMaterial`.

## Verification

- **static** — `npm run typecheck`: clean, 0 errors.
- **logic** — `npm run test`: 317 files / 9868 tests, all passing (includes the new `fresnel rim-light (#613)` describe block in `tests/unit/renderer/GhostMesh.test.ts`, strengthened during refactor to assert the fresnel term actually lands in `totalEmissiveRadiance` rather than being satisfiable by a no-op).
- **visual** — `npm run scenario -- --scenario ghost-fresnel-rim-visual --mode interaction --screenshots` (new scenario added at `scripts/scenario-defs/ghost-fresnel-rim-visual.json`, producing a simultaneous claimed + unclaimed ghost pair). Screenshots inspected via the Read tool across two iterations: iteration 1 found the rim present in pixel data but visually imperceptible (FAIL, fed back to implementer); iteration 2, after the opacity-floor fix, confirmed a clearly visible pale rim/edge glow on both ghost boxes distinct from the flat pulsing look, claimed/unclaimed distinction intact, translucency preserved, no second color — `VISUAL: PASS`.
- **build** — `npm run build`: clean production build.
- Code review: 5 parallel reviewers (security, quality, i18n, duplication, semantic) — all PASS/APPROVE. One medium test-coverage finding (semantic reviewer) addressed in the refactor commit.
- `scenario` (command-mode, full `npm run scenarios`) not run — this is a cosmetic renderer-only change with no gameplay/console/economy/campaign state involved, so that channel isn't owed here per the verification gate's own criteria.

READY TO MERGE
