### PR TITLE
fix: Resolve #614 — factor duplicated cells->ticks conversion into one helper

### DIFF
--- a/src/core/engine/ActionSelection.ts
+++ b/src/core/engine/ActionSelection.ts
@@ -90,7 +90,7 @@ export function seedTaskTimerFields(state: GameState, employee: Employee, action
  * resolveActionCost (pathfinding) (#614).
  */
 function cellsToTravelTicks(cells: number): number {
-  throw new Error('not implemented');
+  return cells / AGENT_WALK_SPEED;
 }
 
 /**
@@ -102,7 +102,7 @@ function cellsToTravelTicks(cells: number): number {
  * NavGrid has been built yet.
  */
 function estimateTravelTicks(employee: Employee, action: PendingAction): number {
-  return octileHeuristic(employee.x, employee.z, action.targetX, action.targetZ) / AGENT_WALK_SPEED;
+  return cellsToTravelTicks(octileHeuristic(employee.x, employee.z, action.targetX, action.targetZ));
 }
 
 /**
@@ -145,7 +145,7 @@ export function resolveActionCost(state: GameState, employee: Employee, action: 
 
   if (!path.found) return null;
 
-  const travelTicks = path.totalCost / AGENT_WALK_SPEED;
+  const travelTicks = cellsToTravelTicks(path.totalCost);
   return { totalTicks: travelTicks + workTicks };
 }
 

--- a/src/core/engine/ActionSelection.ts
+++ b/src/core/engine/ActionSelection.ts
@@ -84,6 +84,16 @@ export function seedTaskTimerFields(state: GameState, employee: Employee, action
 }
 
 /**
+ * Converts a grid-cell distance (from either the octile-heuristic estimate
+ * or a real findPath's totalCost) into ticks, at AGENT_WALK_SPEED cells per
+ * tick. Single source of truth for both estimateTravelTicks (heuristic) and
+ * resolveActionCost (pathfinding) (#614).
+ */
+function cellsToTravelTicks(cells: number): number {
+  throw new Error('not implemented');
+}
+
+/**
  * Straight-line (octile-heuristic) travel ticks for `employee` to reach
  * `action`'s target — see `octileHeuristic` in `Pathfinding.ts`. Shared by
  * `estimateActionCost` (always uses this direct-line estimate) and

--- a/tests/unit/engine/ActionSelection.test.ts
+++ b/tests/unit/engine/ActionSelection.test.ts
@@ -27,7 +27,7 @@ import { NavGrid, type NavCell, type NavCellType } from '../../../src/core/nav/N
 import { createEmployeeState, hireEmployee, killEmployee, assignSkill, type Employee, type SkillCategory } from '../../../src/core/entities/Employee.js';
 import { placeBuilding } from '../../../src/core/entities/Building.js';
 import { Random } from '../../../src/core/math/Random.js';
-import { ACTION_SELECTION_MAX_PATH_ATTEMPTS, BASE_TASK_DURATION_TICKS, NEED_REST_DURATIONS, LIVING_QUARTERS_WELLBEING_MULTIPLIERS } from '../../../src/core/config/balance.js';
+import { ACTION_SELECTION_MAX_PATH_ATTEMPTS, AGENT_WALK_SPEED, BASE_TASK_DURATION_TICKS, NEED_REST_DURATIONS, LIVING_QUARTERS_WELLBEING_MULTIPLIERS } from '../../../src/core/config/balance.js';
 
 // ── NavGrid helpers (mirrors tests/unit/nav/Pathfinding.test.ts) ───────────
 
@@ -167,6 +167,62 @@ describe('resolveActionCost', () => {
     const result = resolveActionCost(state, emp, action);
 
     expect(result).toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// cells -> ticks conversion consistency (#614)
+//
+// distance / AGENT_WALK_SPEED is computed twice in this file today: once
+// inside estimateTravelTicks (octileHeuristic-based) and once inline inside
+// resolveActionCost (path.totalCost-based). Both are meant to route through
+// the same cellsToTravelTicks(cells) helper so a future change to the
+// conversion cannot drift between the two call sites unnoticed. These tests
+// isolate each branch's travel component (total cost minus
+// computeActionWorkTicks, which is identical and already directly tested
+// above) and pin it to distance / AGENT_WALK_SPEED, and to each other.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('cells -> ticks conversion consistency (#614)', () => {
+  it('heuristic-based (estimateActionCost) and pathfinding-based (resolveActionCost) travel components agree with each other and with distance / AGENT_WALK_SPEED (happy path)', () => {
+    const state = makeState();
+    const emp = makeEmployee(state, 0, 0);
+    // Straight line along x on a flat, fully-walkable grid: octileHeuristic
+    // and a real findPath's totalCost both reduce to the raw cell distance
+    // (no diagonal component, every cell's moveCost is 1.0), so both branches
+    // must agree on a single known distance.
+    const distance = 10;
+    const action = makeAction({ id: 1, targetX: distance, targetZ: 0 });
+    const expectedTravelTicks = distance / AGENT_WALK_SPEED;
+
+    const workTicks = computeActionWorkTicks(state, emp, action);
+
+    const heuristicTravelTicks = estimateActionCost(state, emp, action) - workTicks;
+
+    const resolved = resolveActionCost(state, emp, action);
+    expect(resolved).not.toBeNull();
+    const pathTravelTicks = resolved!.totalTicks - workTicks;
+
+    expect(heuristicTravelTicks).toBeCloseTo(expectedTravelTicks, 10);
+    expect(pathTravelTicks).toBeCloseTo(expectedTravelTicks, 10);
+    expect(heuristicTravelTicks).toBeCloseTo(pathTravelTicks, 10);
+  });
+
+  it('employee already standing on the target — travel component is exactly zero for both branches (boundary: zero distance)', () => {
+    const state = makeState();
+    const emp = makeEmployee(state, 5, 5);
+    const action = makeAction({ id: 1, targetX: 5, targetZ: 5 });
+
+    const workTicks = computeActionWorkTicks(state, emp, action);
+
+    const heuristicTravelTicks = estimateActionCost(state, emp, action) - workTicks;
+
+    const resolved = resolveActionCost(state, emp, action);
+    expect(resolved).not.toBeNull();
+    const pathTravelTicks = resolved!.totalTicks - workTicks;
+
+    expect(heuristicTravelTicks).toBe(0);
+    expect(pathTravelTicks).toBe(0);
   });
 });
 


### PR DESCRIPTION
Closes #614

## Summary

`src/core/engine/ActionSelection.ts` computed `distance / AGENT_WALK_SPEED` in two independent places — `estimateTravelTicks` (heuristic-based, octile distance) and inline inside `resolveActionCost` (pathfinding-based, `path.totalCost`). Extracted both into a single private helper `cellsToTravelTicks(cells: number): number`; both call sites now route through it. Factoring-only — same formula, same numeric result, no exported API change.

## Verification

- `static` — `npm run typecheck`: clean, 0 errors.
- `logic` — `npm run test`: 9870 tests passed, 0 failed (317 test files). Includes 2 new consistency tests in `tests/unit/engine/ActionSelection.test.ts` pinning the heuristic and pathfinding branches to the same conversion (happy-path straight-line distance, and zero-distance boundary).
- `scenario` — `npm run scenarios`: 131/131 scenarios passed, 0 failed. Confirms no regression in action-selection/travel-cost behavior across the full command-mode suite.
- `build` — `npx vite build`: succeeded.
- `visual` — not applicable: backend-only change confined to `src/core/engine/`, no renderer/UI/console touch.

Reading `ActionSelection.ts` after the change: exactly one place performs the `cells / AGENT_WALK_SPEED` division (inside `cellsToTravelTicks`); both `estimateTravelTicks` and `resolveActionCost` call it instead of repeating the expression.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** whether `cellsToTravelTicks` should be exported for a standalone unit test, per core-purity's convention of testing exported functions directly.
  **Chosen:** kept it module-private, exercised only transitively through `estimateActionCost`/`resolveActionCost`.
  **Why:** matches the file's existing convention — `estimateTravelTicks` itself is non-exported and has no standalone test, covered only via its two public entry points. `cellsToTravelTicks` is strictly narrower, so the same rationale applies. Exporting it would add public surface the issue didn't ask for.
  **If reversed:** add `export` to the function and a dedicated `describe('cellsToTravelTicks', ...)` block; no call-site changes needed.

9870 tests — all passing.

READY TO MERGE
