### PR TITLE
Widen agentic-issue-creation skill to cover editing existing issues

### DIFF
--- a/.claude/skills/agentic-issue-creation/SKILL.md
+++ b/.claude/skills/agentic-issue-creation/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: agentic-issue-creation
-description: Create GitHub issues formatted for agentic pipeline consumption with complete context, files, test files, dependencies, and verification criteria. Use when creating issues for autonomous coding agents.
+description: Create or edit GitHub issues for agentic pipeline consumption — context, files, test files, dependencies (setting or reading a blocked_by relationship), labels, and verification criteria. Use when creating an issue for autonomous coding agents, or when editing an existing one's dependencies, labels, or lifecycle state.
 ---
 
 # Skill: agentic-issue-creation
 
 ## When to Use
 
-Use when creating a GitHub issue that an autonomous run will pick up. An issue is the only input the pipeline takes, so it has to stand on its own — the run starts with the issue body and the codebase, and nothing else.
+Use when creating a GitHub issue that an autonomous run will pick up, or when editing an already-filed one's dependencies, labels, or lifecycle state. An issue is the only input the pipeline takes, so it has to stand on its own — the run starts with the issue body and the codebase, and nothing else. Setting a `blocked_by` relationship on an existing issue is this skill's task exactly as much as authoring a new one is — see "Setting a dependency" below.
 
 Two shapes are valid, and they differ in how much of the answer is already known:
 

--- a/.github/skills/agentic-issue-creation/SKILL.md
+++ b/.github/skills/agentic-issue-creation/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: agentic-issue-creation
-description: Create GitHub issues formatted for agentic pipeline consumption with complete context, files, test files, dependencies, and verification criteria. Use when creating issues for autonomous coding agents.
+description: Create or edit GitHub issues for agentic pipeline consumption — context, files, test files, dependencies (setting or reading a blocked_by relationship), labels, and verification criteria. Use when creating an issue for autonomous coding agents, or when editing an existing one's dependencies, labels, or lifecycle state.
 ---
 
 # Skill: agentic-issue-creation
 
 ## When to Use
 
-Use when creating a GitHub issue that an autonomous run will pick up. An issue is the only input the pipeline takes, so it has to stand on its own — the run starts with the issue body and the codebase, and nothing else.
+Use when creating a GitHub issue that an autonomous run will pick up, or when editing an already-filed one's dependencies, labels, or lifecycle state. An issue is the only input the pipeline takes, so it has to stand on its own — the run starts with the issue body and the codebase, and nothing else. Setting a `blocked_by` relationship on an existing issue is this skill's task exactly as much as authoring a new one is — see "Setting a dependency" below.
 
 Two shapes are valid, and they differ in how much of the answer is already known:
 

--- a/.opencode/skills/agentic-issue-creation/SKILL.md
+++ b/.opencode/skills/agentic-issue-creation/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: agentic-issue-creation
-description: Create GitHub issues formatted for agentic pipeline consumption with complete context, files, test files, dependencies, and verification criteria. Use when creating issues for autonomous coding agents.
+description: Create or edit GitHub issues for agentic pipeline consumption — context, files, test files, dependencies (setting or reading a blocked_by relationship), labels, and verification criteria. Use when creating an issue for autonomous coding agents, or when editing an existing one's dependencies, labels, or lifecycle state.
 ---
 
 # Skill: agentic-issue-creation
 
 ## When to Use
 
-Use when creating a GitHub issue that an autonomous run will pick up. An issue is the only input the pipeline takes, so it has to stand on its own — the run starts with the issue body and the codebase, and nothing else.
+Use when creating a GitHub issue that an autonomous run will pick up, or when editing an already-filed one's dependencies, labels, or lifecycle state. An issue is the only input the pipeline takes, so it has to stand on its own — the run starts with the issue body and the codebase, and nothing else. Setting a `blocked_by` relationship on an existing issue is this skill's task exactly as much as authoring a new one is — see "Setting a dependency" below.
 
 Two shapes are valid, and they differ in how much of the answer is already known:
 


### PR DESCRIPTION
## Summary

Small, standalone context-file fix, unrelated to the CI-gate hardening work in PR #638 — kept separate so that PR stays scoped to its own subject.

While setting a `blocked_by` dependency on two already-filed issues (#556, #557 → #631), I initially concluded the native GitHub relationship couldn't be set because no MCP tool exposes it, and fell back to a body-only `## Blocked by` section. That was wrong: `agentic-issue-creation`'s own "Setting a dependency" section documents the REST path (`gh api .../dependencies/blocked_by`, or `curl` with `$GITHUB_TOKEN` when `gh` isn't available) and explicitly warns against exactly this conclusion — *"Never downgrade to a body-only dependency because the transport looked unavailable."*

The skill has the right answer. It just didn't get read, because its description and "When to Use" both frame it as creation-only ("Create GitHub issues... Use when creating issues for autonomous coding agents"), so editing an existing issue's dependency didn't pattern-match to it.

## Change

Widens the frontmatter `description` and the body's "When to Use" opener to name editing an existing issue's dependencies, labels, or lifecycle state as squarely this skill's task — not just authoring a new one. No procedural content changed.

Considered and rejected: an unscoped rule in `.claude/rules/` reminding sessions to check this skill before any issue write. Rejected because rules in this repo only support `paths`-based scoping (confirmed against `agentic-context-edition`); an unscoped rule loads every session regardless of relevance, which is exactly the always-on cost a sentence in `CLAUDE.md` would carry too. The skill's own `description` is the only mechanism this project has for "load on demand, by relevance, zero cost when not applicable" — so that's the lever that actually fits.

## Verification

- `npm run validate:context` — clean.
- All three runtime copies (`.claude/`, `.github/`, `.opencode/`) confirmed byte-identical.
- Applied retroactively: #556 and #557 now carry the real `blocked_by` relationship against #631 (set via the documented REST path, read back to confirm).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VC83ruTUVAwmoPdiYg6WHq)_