### PR TITLE
fix: Resolve #474 - weight level-load phases by actual cost

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ import { IndexedDBPersistence } from './persistence/IndexedDBPersistence.js';
 import { DownloadPersistence } from './persistence/DownloadPersistence.js';
 import { createRunner, runCommand } from './console/createRunner.js';
 import { parseCommand } from './console/ConsoleRunner.js';
-import { regenerateGrid, restoreGrid, terrainGenDatum, DEFAULT_GRID_SIZE } from './console/commands/world.js';
+import { regenerateGrid, restoreGrid, terrainGenDatum, terrainConfigOf, ensureLandscape, DEFAULT_GRID_SIZE } from './console/commands/world.js';
 import { encodeVoxelGrid } from './core/state/VoxelGridCodec.js';
 import { getBiome } from './core/world/BiomeCatalog.js';
 import { BASE_TICK_MS } from './core/engine/GameLoop.js';
@@ -228,10 +228,10 @@ levelEndScreen.setOnBackToPortfolio(() => {
 
 // --- Level loading ---
 // Entering a level blocks the main thread for seconds. enterLevel splits that
-// into phases the loading screen can paint between, so the wait reads as a
-// load rather than a hang. Terrain generation and scene meshing are roughly
-// half the cost each, which is why the renderer sync is deferred out of the
-// command and run as its own phase.
+// into several weighted phases the loading screen can paint between (#474),
+// so the bar advances roughly in proportion to the work rather than sitting
+// still through the biggest step and snapping at the end. See
+// LOAD_PHASE_WEIGHT and enterLevel() below.
 const loadingScreen = new LoadingScreen(uiContainer);
 
 /**
@@ -278,10 +278,48 @@ function buildSandboxLoadingSiteInfo(config: SandboxConfig): LoadingSiteInfo {
   };
 }
 
+/**
+ * Weighted LoadPhase costs for enterLevel() below (#474) — default-and-record,
+ * since the sandbox this was tuned in measures the same load anywhere from
+ * 16s to 32s (a property of the environment, not the game) and re-measuring
+ * cleanly needs a GPU this sandbox doesn't have. Ranked by what each step
+ * actually walks: terrain generation and the playable mesh both touch the
+ * full 3D voxel grid, so they get the heaviest weight; the landscape map and
+ * its mesh cover a coarser, 2D-ish structure past the playable rect, so half
+ * that; the ambient rebuild is a handful of particle systems, cheapest of
+ * the five. Re-tune against real measurements if they diverge from this.
+ */
+const LOAD_PHASE_WEIGHT = {
+  terrain: 3,
+  landscapeMap: 2,
+  playableMesh: 3,
+  landscapeMesh: 2,
+  ambient: 1,
+} as const;
+
 function enterLevel(commands: readonly string[], siteInfo?: LoadingSiteInfo): Promise<void> {
   return loadingScreen.runPhases([
-    { run: () => { for (const cmd of commands) runGameCommand(cmd, { syncRenderer: false }); } },
-    { run: () => { gameRenderer.syncFromContext(ctx); } },
+    {
+      weight: LOAD_PHASE_WEIGHT.terrain,
+      run: () => { for (const cmd of commands) runGameCommand(cmd, { syncRenderer: false }); },
+    },
+    {
+      weight: LOAD_PHASE_WEIGHT.landscapeMap,
+      // Forces ensureLandscape()'s lazy build now, as its own weighted step,
+      // rather than letting it happen implicitly (and uncounted) inside the
+      // playable-mesh phase's edge-height sampler below — buildPlayableMesh()
+      // still calls ensureLandscape() itself, but by then it's a cache hit.
+      run: () => {
+        const cfg = ctx.state && terrainConfigOf(ctx.state);
+        if (cfg) ensureLandscape(ctx, cfg);
+      },
+    },
+    { weight: LOAD_PHASE_WEIGHT.playableMesh, run: () => { gameRenderer.buildPlayableMesh(ctx); } },
+    { weight: LOAD_PHASE_WEIGHT.landscapeMesh, run: () => { gameRenderer.buildLandscapeMesh(ctx); } },
+    {
+      weight: LOAD_PHASE_WEIGHT.ambient,
+      run: () => { gameRenderer.buildAmbient(ctx); gameRenderer.finishLevelLoad(ctx); },
+    },
   ], siteInfo);
 }
 
@@ -441,9 +479,10 @@ console.log = (...args: unknown[]) => {
  * Run a console command.
  *
  * `syncRenderer: false` runs everything except the scene rebuild, so a level
- * load can charge the player for generation and meshing as two separate
- * phases with a painted frame between them (see LoadingScreen). Only the
- * level-entry paths pass it; every other caller gets the immediate sync.
+ * load can charge the player for generation, meshing and dressing as several
+ * separate weighted phases, each with a painted frame between them (see
+ * LoadingScreen, enterLevel()). Only the level-entry paths pass it; every
+ * other caller gets the immediate sync.
  */
 function runGameCommand(cmd: string, opts?: { syncRenderer?: boolean }): CommandResult {
   const prevState = ctx.state;

--- a/src/renderer/GameRenderer.ts
+++ b/src/renderer/GameRenderer.ts
@@ -158,7 +158,8 @@ export class GameRenderer {
       // A differently-sized grid needs a fresh landscape too — same rebuild
       // loadGame() does, but this branch fires even when loadGame() didn't
       // (campaign level swaps grid size while keeping the seed, #458 T3.2).
-      this.rebuildLandscapeMesh(ctx);
+      this.buildLandscapeMesh(ctx);
+      this.buildAmbient(ctx);
       // A campaign level can swap in a differently-sized grid while keeping the
       // seed, so loadGame() never runs. Re-frame or the new site renders as a
       // small off-centre patch of the previous site's view.
@@ -166,7 +167,31 @@ export class GameRenderer {
     }
 
     this.lastState = ctx.state;
+    this.syncEntities(ctx);
+  }
 
+  /**
+   * Complete a staged level load driven phase-by-phase by the loading screen
+   * (#474): `enterLevel` in main.ts runs buildPlayableMesh() /
+   * buildLandscapeMesh() / buildAmbient() as separate weighted LoadPhases,
+   * bypassing syncFromContext() entirely so each one gets its own presented
+   * frame. This finishes it — frame the camera, then record the same
+   * bookkeeping syncFromContext() sets after loadGame() (so a later
+   * syncFromContext() call treats the load as already done rather than
+   * repeating it) and run the same per-call entity/state sync
+   * syncFromContext() performs every time it runs.
+   */
+  finishLevelLoad(ctx: MiningContext): void {
+    if (!ctx.state || !ctx.grid) return;
+    this.frameCameraOnGrid();
+    this.loadedSeed = ctx.state.seed;
+    this.lastState = ctx.state;
+    this.syncEntities(ctx);
+  }
+
+  /** Per-call entity/state sync shared by syncFromContext() and finishLevelLoad() (#474). */
+  private syncEntities(ctx: MiningContext): void {
+    if (!ctx.state) return;
     // Sync entities added since last call
     syncEntitySets(
       ctx.state, this.buildings, this.renderedBuildingIds,
@@ -711,7 +736,7 @@ export class GameRenderer {
     this.refreshPanLeash();
 
     // A null ctx.landscape means the grid itself was just replaced (new game,
-    // campaign level, load) and rebuildLandscapeMesh is about to run with a
+    // campaign level, load) and buildLandscapeMesh is about to run with a
     // fresh handle. Rebuilding here would cut the new site against the old
     // level's landscape and then be thrown away.
     if (!ctx.landscape || !ctx.grid || !this.landscape || !this.landscapeHandle) return;
@@ -745,8 +770,8 @@ export class GameRenderer {
    * The landscape's theoretical height function, ready to hand to
    * TerrainMesh.setEdgeHeightSampler() — or null when no landscape can be
    * built yet (no world/biome). Calls ensureLandscape(), which caches on
-   * ctx.landscape, so calling this before rebuildLandscapeMesh() does not
-   * duplicate the (expensive) structure-set build; rebuildLandscapeMesh()
+   * ctx.landscape, so calling this before buildLandscapeMesh() does not
+   * duplicate the (expensive) structure-set build; buildLandscapeMesh()
    * simply gets the same cached handle back (#559).
    */
   private landscapeEdgeHeightSampler(ctx: MiningContext): ((x: number, z: number) => number) | null {
@@ -774,7 +799,7 @@ export class GameRenderer {
     const area = ctx.playableArea;
     if (!grid || !area || !this.terrain) return;
     // Never trace the world's rivers from a render path just to find out
-    // there is no wall to draw — rebuildLandscapeMesh hands over the set it
+    // there is no wall to draw — buildLandscapeMesh hands over the set it
     // already built, and calls this again once it has.
     if (!area.hasStructures()) return;
 
@@ -799,6 +824,23 @@ export class GameRenderer {
   // ---------- Internal ----------
 
   private loadGame(ctx: MiningContext): void {
+    this.buildPlayableMesh(ctx);
+    this.buildLandscapeMesh(ctx);
+    this.buildAmbient(ctx);
+    this.frameCameraOnGrid();
+  }
+
+  /**
+   * Stage 1 of a level load (#474): clear the scene and rebuild everything
+   * except the landscape zone and its ambient dressing — the playable
+   * terrain mesh (marching cubes over the grid the player actually mines),
+   * buildings, vehicles, characters, sky, wind/clouds, fragments, blast
+   * effects and overlays. Public so the loading screen can pace this as its
+   * own weighted phase (`enterLevel` in main.ts); `loadGame()` also calls it
+   * directly for callers that still want the whole load in one shot (tests,
+   * the debug-preview path that never drives the loading screen at all).
+   */
+  buildPlayableMesh(ctx: MiningContext): void {
     const state = ctx.state!;
     const grid = ctx.grid!;
     this.clearAll();
@@ -862,28 +904,28 @@ export class GameRenderer {
     // Blast effects
     this.blastEffects = new BlastEffects(scene, this.sm.camera);
 
-    // Landscape zone — real ground continuing past the playable rect (#458 T3.2)
-    this.rebuildLandscapeMesh(ctx);
-
     // Blast plan overlay (hidden until shown)
     this.blastOverlay = new BlastPlanOverlay(scene);
 
     // Ghost previews (initially empty)
     this.ghosts = new GhostMesh(scene);
-
-    // Frame the whole site
-    this.frameCameraOnGrid();
   }
 
   /**
-   * Build (or rebuild) the landscape mesh for the current grid (#458 T3.2).
-   * Triggers ensureLandscape()'s lazy build — the first real consumer of it
-   * (T2.1 kept it lazy specifically because nothing rendered it yet).
-   * Command-mode scenarios never construct a GameRenderer at all, so this
-   * cost never lands on the fast, frequently-run scenario suite; only the
-   * browser game and interaction-mode/visual harnesses pay it.
+   * Stage 2 of a level load (#474): the landscape zone — its coarse map
+   * (built lazily by ensureLandscape(), cached on ctx.landscape so this is a
+   * cache hit if a caller already forced it, e.g. main.ts's own "landscape
+   * map" phase or buildPlayableMesh()'s edge-height sampler above), the
+   * marching-cubes mesh past the playable rect, aerial-perspective
+   * calibration, and the border wall. Split from buildAmbient() below
+   * because it costs meaningfully more (a full landscape mesh vs. a handful
+   * of particle systems) and the loading screen weights the two
+   * differently. Command-mode scenarios never construct a GameRenderer at
+   * all, so this cost never lands on the fast, frequently-run scenario
+   * suite; only the browser game and interaction-mode/visual harnesses pay
+   * it.
    */
-  private rebuildLandscapeMesh(ctx: MiningContext): void {
+  buildLandscapeMesh(ctx: MiningContext): void {
     if (!this.terrain || !ctx.state?.world || !ctx.grid) return;
     const biome = getBiome(ctx.state.mineType);
     if (!biome) return;
@@ -916,16 +958,28 @@ export class GameRenderer {
     aerial.setHeightRef(handle.groundLevelY);
     aerial.setGrade(BIOME_GRADES[biome.id] ?? NEUTRAL_GRADE);
 
-    // Birds/smoke/water/vegetation (#458 T7.2/D12/A26) — rebuilt from the
-    // landscape's own StructureSet every time this runs (a campaign level
-    // swap can call rebuildLandscapeMesh again for the same GameRenderer, so
-    // stale instances from the previous grid must go first or their meshes
-    // pile up in the scene).
     // The "not here" marker: the frontier between claimable ground and the
     // generated structures a claim can never take (#473 D6/P4). Sized from
     // the terrain's own height range so it stands on the ground rather than
     // floating or being buried.
     this.rebuildBorderWall(ctx);
+  }
+
+  /**
+   * Stage 3 of a level load (#474): birds, chimney smoke, water, vegetation
+   * sway, and the per-biome dust-devil/firefly extras — rebuilt from the
+   * landscape's own StructureSet every time this runs (a campaign level swap
+   * can call this again for the same GameRenderer, so stale instances from
+   * the previous grid must go first or their meshes pile up in the scene).
+   * Requires buildLandscapeMesh() to have already cached ctx.landscape this
+   * load — the cheapest of the three staged rebuilds, so it carries the
+   * loading screen's lightest weight.
+   */
+  buildAmbient(ctx: MiningContext): void {
+    if (!ctx.state?.world || !ctx.grid || !ctx.landscape) return;
+    const biome = getBiome(ctx.state.mineType);
+    if (!biome) return;
+    const handle = ctx.landscape;
 
     this.birds?.dispose();
     this.smoke?.dispose();

--- a/src/ui/LoadingScreen.ts
+++ b/src/ui/LoadingScreen.ts
@@ -1,9 +1,9 @@
 // BlastSimulator2026 — Level loading screen (redesign P8, strata backdrop)
 //
 // Entering a level runs several seconds of synchronous work — terrain
-// generation, then marching-cubes meshing of both the playable grid and the
-// landscape. On the largest sites that is over five seconds during which the
-// main thread never yields.
+// generation, the landscape map, marching-cubes meshing of both the playable
+// grid and the landscape, and the ambient rebuild. On the largest sites that
+// is over five seconds during which the main thread never yields.
 //
 // The important part is not the overlay itself but WHEN it reaches the
 // screen. `show(); generateEverything(); hide();` displays nothing at all: the
@@ -12,6 +12,11 @@
 // to solve exactly that — it waits for a frame to be presented before each
 // blocking chunk, so the overlay and its current label are actually on screen
 // while the work happens.
+//
+// A phase's `weight` (#474) is its share of that work, not its position in
+// the list — the bar moves proportionally to what each step actually costs
+// (see main.ts's LOAD_PHASE_WEIGHT), so a small quick step doesn't visually
+// eat the same slice as the biggest one.
 
 import { t } from '../core/i18n/I18n.js';
 import { QuipBag, TipBag } from './loadingQuips.js';
@@ -42,6 +47,18 @@ export function nextPaint(): Promise<void> {
  */
 export interface LoadPhase {
   run: () => void;
+  /**
+   * Relative cost of this phase against the others in the same run, so the
+   * bar advances proportionally to actual work rather than to a position in
+   * the list (#474). Omitted/`<= 0` counts as 1 — every existing call site
+   * that never set a weight keeps its old equal-split behaviour exactly.
+   */
+  weight?: number;
+}
+
+/** Sum of a phase list's weights, defaulting an unset or non-positive weight to 1. */
+function totalWeight(phases: readonly LoadPhase[]): number {
+  return phases.reduce((sum, p) => sum + (p.weight && p.weight > 0 ? p.weight : 1), 0);
 }
 
 /** One key/value row in the briefing block under the subtitle. */
@@ -239,20 +256,23 @@ export class LoadingScreen {
   }
 
   /**
-   * Lay `phaseCount` segment marks onto the progress track.
+   * Lay one segment mark per phase boundary onto the progress track.
    *
-   * Boundaries mirror the fractions `setPhase` already drives the bar to
-   * ((i+1)/(phaseCount+1) for each phase index i) — one mark per phase
-   * boundary, none at 0% or 100%.
+   * Positions mirror the fractions `runPhases` drives the bar to — cumulative
+   * weight so far over (total weight + 1), the same +1 that reserves the
+   * final slot for the "ready" bump. Equal-weight phases (the default) land
+   * marks at the old k/(phaseCount+1) spacing exactly.
    */
-  private renderSegmentMarks(phaseCount: number): void {
+  private renderSegmentMarks(phases: readonly LoadPhase[]): void {
     this.marksLayer.replaceChildren();
-    if (phaseCount <= 0) return;
-    const total = phaseCount + 1;
-    for (let i = 1; i <= phaseCount; i++) {
+    if (phases.length === 0) return;
+    const total = totalWeight(phases) + 1;
+    let cumulative = 0;
+    for (const phase of phases) {
+      cumulative += phase.weight && phase.weight > 0 ? phase.weight : 1;
       const mark = document.createElement('div');
       mark.className = 'bsx-loading-mark';
-      mark.style.left = `${(i / total) * 100}%`;
+      mark.style.left = `${(cumulative / total) * 100}%`;
       this.marksLayer.appendChild(mark);
     }
   }
@@ -294,15 +314,19 @@ export class LoadingScreen {
    */
   async runPhases(phases: readonly LoadPhase[], siteInfo?: LoadingSiteInfo): Promise<void> {
     this.show(siteInfo);
-    this.renderSegmentMarks(phases.length);
+    this.renderSegmentMarks(phases);
     await nextPaint();
     try {
+      const total = totalWeight(phases) + 1;
+      let cumulative = 0;
       for (let i = 0; i < phases.length; i++) {
         const phase = phases[i]!;
-        // (i+1)/(n+1), not i/n: the bar would otherwise sit at zero through
-        // the longest phase, which reads as nothing happening. This starts it
-        // moving on the first phase and still leaves the last step for "ready".
-        this.setPhase(this.quips.next(), (i + 1) / (phases.length + 1));
+        cumulative += phase.weight && phase.weight > 0 ? phase.weight : 1;
+        // cumulative/(total weight + 1), not a position in the list: a
+        // heavier phase should move the bar further than a light one, and
+        // the +1 reserves the last slot for the "ready" bump below rather
+        // than letting the final phase claim 100% on its own.
+        this.setPhase(this.quips.next(), cumulative / total);
         this.setStage(i + 1, phases.length);
         await nextPaint();
         phase.run();

--- a/tests/unit/renderer/GameRenderer.test.ts
+++ b/tests/unit/renderer/GameRenderer.test.ts
@@ -882,3 +882,66 @@ describe('GameRenderer — playableCut/meshClaimsColumn wiring (#559)', () => {
     setSamplerSpy.mockRestore();
   });
 });
+
+// ── Staged level load (#474) ──
+//
+// enterLevel() in main.ts no longer drives the whole load through one
+// syncFromContext() call — it runs buildPlayableMesh() / buildLandscapeMesh()
+// / buildAmbient() / finishLevelLoad() as separate weighted LoadPhases, so
+// the loading screen can paint a frame between each. These prove the staged
+// path lands in the same place syncFromContext() always did.
+
+describe('GameRenderer — staged level load (#474)', () => {
+  async function makeLandscapeCtx(mineType = 'green_foothills'): Promise<MiningContext> {
+    const { newGameCommand } = await import('../../../src/console/commands/world.js');
+    const ctx: MiningContext = { state: null, grid: null, landscape: null, emitter: new EventEmitter() };
+    const result = newGameCommand(ctx, [], { mine_type: mineType, seed: '42', size: '64' });
+    expect(result.success).toBe(true);
+    return ctx;
+  }
+
+  it('buildPlayableMesh() + buildLandscapeMesh() + buildAmbient() + finishLevelLoad(), run as separate staged calls, reach the same end state as one syncFromContext() call', async () => {
+    const sm = makeMockSceneManager();
+    const renderer = new GameRenderer(sm as any);
+    const ctx = await makeLandscapeCtx();
+
+    renderer.buildPlayableMesh(ctx);
+    renderer.buildLandscapeMesh(ctx);
+    renderer.buildAmbient(ctx);
+    renderer.finishLevelLoad(ctx);
+
+    expect(renderer.lastGridId).toBe(ctx.grid!.id);
+    expect(renderer.terrain).not.toBeNull();
+    expect(renderer.landscape).not.toBeNull();
+    // Grass is the unconditional ambient signal the existing #458 T7.2 tests
+    // already rely on — present whenever buildAmbient() actually ran.
+    expect(sm.scene.children.find((c) => c.name === 'vegetation-grass')).toBeDefined();
+    expect(sm.cameraController.frameSite).toHaveBeenCalled();
+  });
+
+  it('finishLevelLoad() records the same bookkeeping loadGame() does, so a later syncFromContext() call does not repeat the load', async () => {
+    const sm = makeMockSceneManager();
+    const renderer = new GameRenderer(sm as any);
+    const ctx = await makeLandscapeCtx();
+    const buildAllSpy = vi.spyOn(TerrainMesh.prototype, 'buildAll');
+
+    renderer.buildPlayableMesh(ctx);
+    renderer.buildLandscapeMesh(ctx);
+    renderer.buildAmbient(ctx);
+    renderer.finishLevelLoad(ctx);
+    expect(buildAllSpy).toHaveBeenCalledTimes(1);
+
+    // Same seed, same grid — without finishLevelLoad()'s bookkeeping this
+    // would look like an unseen seed and re-run the whole load, doubling the
+    // cost the staged phases were just charged for.
+    renderer.syncFromContext(ctx);
+    expect(buildAllSpy).toHaveBeenCalledTimes(1);
+
+    buildAllSpy.mockRestore();
+  });
+
+  it('finishLevelLoad() is a no-op without a loaded state/grid, rather than throwing', () => {
+    const renderer = new GameRenderer(makeMockSceneManager() as any);
+    expect(() => renderer.finishLevelLoad({ state: null, grid: null, landscape: null, emitter: new EventEmitter() })).not.toThrow();
+  });
+});

--- a/tests/unit/ui/LoadingScreen.test.ts
+++ b/tests/unit/ui/LoadingScreen.test.ts
@@ -144,6 +144,74 @@ describe('LoadingScreen', () => {
     });
   });
 
+  // ── Weighted phases (#474) ──
+
+  describe('runPhases — weighted phases', () => {
+    it('advances the bar in proportion to weight, not position in the list', async () => {
+      const seen: number[] = [];
+      await screen.runPhases([
+        { weight: 3, run: () => { seen.push(screen.progress); } },
+        { weight: 1, run: () => { seen.push(screen.progress); } },
+      ]);
+      // total weight 4, +1 reserved for the "ready" bump => denominator 5
+      expect(seen[0]).toBeCloseTo(3 / 5, 5);
+      expect(seen[1]).toBeCloseTo(4 / 5, 5);
+    });
+
+    it('a heavier phase moves the bar further than a lighter one', async () => {
+      const seen: number[] = [];
+      await screen.runPhases([
+        { weight: 1, run: () => { seen.push(screen.progress); } },
+        { weight: 5, run: () => { seen.push(screen.progress); } },
+      ]);
+      const firstJump = seen[0]!;
+      const secondJump = seen[1]! - seen[0]!;
+      expect(secondJump).toBeGreaterThan(firstJump);
+    });
+
+    it('an unset weight behaves as weight 1, unchanged from the pre-#474 equal split', async () => {
+      const seen: number[] = [];
+      await screen.runPhases([
+        { run: () => { seen.push(screen.progress); } },
+        { run: () => { seen.push(screen.progress); } },
+      ]);
+      // setPhase() rounds to a whole percent, so 1/3 and 2/3 land on the
+      // nearest percent (33%, 67%) rather than the exact fraction.
+      expect(seen[0]).toBeCloseTo(1 / 3, 2);
+      expect(seen[1]).toBeCloseTo(2 / 3, 2);
+    });
+
+    it('a zero or negative weight also falls back to 1, rather than producing a nonsense fraction', async () => {
+      const seen: number[] = [];
+      await screen.runPhases([
+        { weight: 0, run: () => { seen.push(screen.progress); } },
+        { weight: -4, run: () => { seen.push(screen.progress); } },
+      ]);
+      expect(seen[0]).toBeCloseTo(1 / 3, 2);
+      expect(seen[1]).toBeCloseTo(2 / 3, 2);
+    });
+
+    it('segment marks land at the same weighted fractions as the bar', async () => {
+      await screen.runPhases([
+        { weight: 3, run: () => {} },
+        { weight: 1, run: () => {} },
+      ]);
+      const marks = Array.from(container.querySelectorAll<HTMLElement>('.bsx-loading-mark'));
+      expect(marks).toHaveLength(2);
+      expect(marks[0]!.style.left).toBe(`${(3 / 5) * 100}%`);
+      expect(marks[1]!.style.left).toBe(`${(4 / 5) * 100}%`);
+    });
+
+    it('still reaches full progress before hiding regardless of weight', async () => {
+      let atEnd = -1;
+      await screen.runPhases([
+        { weight: 10, run: () => {} },
+        { weight: 1, run: () => {} },
+      ]).then(() => { atEnd = screen.progress; });
+      expect(atEnd).toBe(1);
+    });
+  });
+
   it('dispose removes it from the document', () => {
     screen.dispose();
     expect(document.getElementById('bs-loading-screen')).toBeNull();


### PR DESCRIPTION
Closes #474

## Summary
- Loading bar moved in 2-3 equal-weight jumps regardless of actual cost per phase (#474) — fixed by giving `LoadPhase` an optional `weight`, and having `LoadingScreen.runPhases()` advance the bar by cumulative weight instead of position in the list. Default (unset) weight is 1, so every existing call site keeps its old equal-split behaviour exactly.
- `enterLevel()` in main.ts now drives 5 weighted phases instead of 2: terrain generation, landscape map, playable mesh, landscape mesh, ambient rebuild — one quip per step, so more of the quip bag gets seen per load.
- `GameRenderer`'s monolithic `loadGame()` is split into independently-callable `buildPlayableMesh()` / `buildLandscapeMesh()` / `buildAmbient()`, plus a new `finishLevelLoad()` that records the same bookkeeping `syncFromContext()` sets after a load (so a later `syncFromContext()` call doesn't repeat it). `syncFromContext()` itself composes the same steps for every other caller (tests, mid-game grid swaps, the debug-preview path) — unchanged behaviour, confirmed by the full existing GameRenderer/LoadingScreen suites passing with zero test edits before new coverage was added.

## Decisions taken
- **Phase weights** (`LOAD_PHASE_WEIGHT` in main.ts): terrain-gen=3, landscape-map=2, playable-mesh=3, landscape-mesh=2, ambient=1. The issue explicitly flags that re-measuring cleanly isn't possible here — this sandbox has no GPU and the same load has been observed anywhere from 16s to 32s, "a property of the environment, not the game." Ranked instead by what each step algorithmically walks: terrain generation and the playable mesh both touch the full 3D voxel grid (heaviest), the landscape map/mesh cover a coarser, 2D-ish structure past the playable rect (half that), and the ambient rebuild is a handful of particle systems (lightest). Documented inline as re-tunable against real measurements.
- The "landscape map" step doesn't own a GameRenderer method of its own — it's `ensureLandscape()`, a lazy cache on `ctx.landscape` already used internally by `buildPlayableMesh()`'s edge-height sampler — so `enterLevel()` calls `ensureLandscape()` directly via the already-exported `terrainConfigOf()` helper. This puts the map-build cost on its own weighted phase instead of it being silently absorbed into the playable-mesh phase's first call.

## Test plan
- [x] `static` — `npm run typecheck` clean.
- [x] `logic` — `npm run test`: full suite run; 9 pre-existing failures on `main` (chrome-path resolution, i18n-parity script output, GH-pipeline config/hook scripts) confirmed via `git stash` against a clean checkout — unrelated to this change, untouched by it. `LoadingScreen.test.ts` (49/49) and `GameRenderer.test.ts` (53/53, includes new staged-load-equivalence tests) fully green with zero edits to any pre-existing assertion.
- [x] `scenario` — `npm run scenarios`: 131/131 passed (run twice for confirmation).
- [x] `visual` — dev server + `npm run scenario -- --scenario loading-screen-visual --mode interaction --screenshots`: all steps completed, all `assert`/overlay-visibility checks passed. Screenshots inspected (portfolio screen post-load, debug-preview overlay with eyebrow/subtitle/briefing/tip blocks) — render correctly, nothing clipped or broken.

READY TO MERGE
