### PR TITLE
ci: drop ready_for_review from CI's pull_request trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,11 @@ on:
     # overall run still reports `success` and agentic-auto-merge treats it as
     # green. PR #615 merged exactly that way; #616 only got its interaction
     # shards because of 30 unrelated follow-up pushes (each a `synchronize`)
-    # after the label landed. `ready_for_review` closes the same gap for a
-    # draft PR labeled before going ready.
-    types: [opened, synchronize, reopened, labeled, ready_for_review]
+    # after the label landed. `labeled` fires the same regardless of draft
+    # state and its check run attaches to the head SHA, so a label applied
+    # while the PR is still draft is already covered by the time it goes
+    # ready -- no `ready_for_review` type needed on top.
+    types: [opened, synchronize, reopened, labeled]
   schedule:
     # Weekly full run (Monday 4am UTC) to catch regressions
     - cron: '0 4 * * 1'

--- a/tests/unit/config/autonomy-loop.test.ts
+++ b/tests/unit/config/autonomy-loop.test.ts
@@ -930,12 +930,14 @@ describe('the sweep that runs when the checks come in', () => {
 // shards from 30 unrelated follow-up pushes after the label landed --
 // `synchronize` was already in the list, `labeled` was not. Mirrors the same
 // fix already proven for `auto-assign-next.yml`'s READY TO MERGE marker
-// above.
+// above. `labeled` fires the same on a draft PR and its check run attaches
+// to the head SHA, so no separate `ready_for_review` type is needed to cover
+// a label applied before a PR goes ready.
 describe('ci.yml re-evaluates full-ci/build-check when the label lands', () => {
-  it('includes labeled and ready_for_review alongside the defaults', () => {
+  it('includes labeled alongside the defaults', () => {
     const ci = workflow('ci.yml');
     const types = /pull_request:[\s\S]*?types:\s*\[([^\]]+)\]/.exec(ci)?.[1] ?? '';
-    for (const type of ['opened', 'synchronize', 'reopened', 'labeled', 'ready_for_review']) {
+    for (const type of ['opened', 'synchronize', 'reopened', 'labeled']) {
       expect(types, `ci.yml's pull_request trigger is missing \`${type}\``).toContain(type);
     }
   });


### PR DESCRIPTION
## Summary

- `ci.yml`'s `pull_request` trigger fired a full second CI run when a draft PR went `ready_for_review`, even with no new commits.
- That type existed to close the PR #615/#616 class of bug: `full-ci`/`build-check` labels applied via API after `opened` don't re-evaluate the label-gated jobs unless a later `pull_request` event fires.
- `labeled` (already in the trigger list) closes that gap on its own: it fires regardless of the PR's draft state, and its check run attaches to the head SHA — so a label applied while a PR is still draft is already covered by the time it goes ready. `ready_for_review` was redundant on top of it.
- Dropped `ready_for_review` from `ci.yml`'s `pull_request.types` and updated the comment. Updated the matching pinned assertion in `tests/unit/config/autonomy-loop.test.ts`.

## Test plan

- [x] `npx vitest run tests/unit/config/autonomy-loop.test.ts` — 176 passed
- [x] `npx tsc --noEmit --project scripts/tsconfig.json` — clean
- [x] `npm run validate:context` — clean
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — parses
- [ ] CI on this PR itself (no code touched, so `test`/`typecheck`/`scenario-command` should run and pass; `ready_for_review` won't re-trigger a run when this PR comes out of draft, by design of this change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoRYYs5nd54pHKPkMn4pQj)_