### PR TITLE
Gate automatic Claude Code review behind a repository variable

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,6 +17,7 @@ jobs:
     # owner's PAT, so they carry the same author login as hand-written PRs.
     # The head branch prefix is the only reliable distinguisher.
     if: >-
+      vars.CLAUDE_REVIEW_ENABLED != 'false' &&
       !startsWith(github.head_ref, 'pipeline/') &&
       !startsWith(github.head_ref, 'claude/') &&
       !startsWith(github.head_ref, 'opencode/') &&

--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ The pipeline runs under Claude Code or OpenCode. One repository variable decides
 | `AGENTIC_AUTO_ASSIGN_ENABLED` | `true` / anything else | Whether a finished issue chains to the next `ready` one |
 | `AGENTIC_AUTO_MERGE_ENABLED` | `true` / anything else | Whether a PR whose body carries `READY TO MERGE` gets GitHub native auto-merge |
 | `AGENTIC_STALL_MINUTES` | minutes, default `240` | How long an issue may stay `in-progress` without a linked PR before the watchdog marks it `blocked` |
+| `CLAUDE_REVIEW_ENABLED` | `false` / anything else, default enabled | Whether opening or marking a hand-written PR ready-for-review triggers the automatic Claude Code review |
 
 Set them under **Settings → Secrets and variables → Actions → Variables**. Switching agent is a one-value change; nothing else moves.
 


### PR DESCRIPTION
## Summary
- Add `vars.CLAUDE_REVIEW_ENABLED != 'false'` to the `if:` guard on `claude-review` in `.github/workflows/claude-code-review.yml`, so the automatic Claude Code review on human-made PRs (opened / ready-for-review) can be disabled repo-wide via a repository variable.
- Defaults to enabled when the variable is unset, matching the `AGENTIC_CI_FIX_ENABLED` convention (`!= 'false'` rather than `== 'true'`).
- Document `CLAUDE_REVIEW_ENABLED` in the README's repository-variables table.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-code-review.yml'))"` — YAML parses
- [x] `npx vitest run tests/unit/config/autonomy-loop.test.ts tests/unit/config/pipeline-run-integrity.test.ts` — 207 tests pass, no regressions


---
_Generated by [Claude Code](https://claude.ai/code/session_01LVTMbiz91qny3cDSLNyqmg)_