### PR TITLE
fix: Resolve #620 — training completion floors qual.xp at new level threshold

### DIFF
--- a/src/core/entities/EmployeeTraining.ts
+++ b/src/core/entities/EmployeeTraining.ts
@@ -16,6 +16,7 @@ import {
   TRAINING_BASE_FEE,
   TRAINING_LEVEL_COST_MULTIPLIER,
   TRAINING_RELOCATION_OFFSET,
+  XP_THRESHOLDS,
 } from '../config/balance.js';
 
 export type ProficiencyLevel = 1 | 2 | 3 | 4 | 5;
@@ -231,6 +232,7 @@ export function tickTraining(
       isNew = false;
       level = Math.min(MAX_PROFICIENCY, existing.proficiencyLevel + 1) as ProficiencyLevel;
       existing.proficiencyLevel = level;
+      existing.xp = Math.max(existing.xp, XP_THRESHOLDS[level]);
     }
     // A better-qualified employee demands more pay.
     emp.salary = calculateSalary(emp);

--- a/tests/integration/skills.integration.test.ts
+++ b/tests/integration/skills.integration.test.ts
@@ -22,7 +22,7 @@ import { surveyCommand } from '../../src/console/commands/mining.js';
 import { tickEmployees } from '../../src/core/engine/GameLoop.js';
 import { computeTaskDuration } from '../../src/core/entities/EmployeeTaskDuration.js';
 import { Random } from '../../src/core/math/Random.js';
-import { SURVEY_DURATION_TICKS } from '../../src/core/config/balance.js';
+import { SURVEY_DURATION_TICKS, XP_THRESHOLDS } from '../../src/core/config/balance.js';
 
 // ── Shared helpers ──────────────────────────────────────────────────────────
 
@@ -557,6 +557,51 @@ describe('Tick-driven task/XP pipeline (dispatch + tick command, issue #406)', (
 // surveyors and three unclaimed survey targets at different distances, the
 // way a real scenario or player-facing flow would. Red until tickEmployees
 // is rewired onto ActionSelection.ts's cost-based selection (#549).
+
+// ── Issue #620: training must not cost xp progress ──────────────────────────
+//
+// gainXp derives proficiencyLevel from cumulative qual.xp against
+// XP_THRESHOLDS, so two employees landing on the same level should need the
+// same additional xp to reach the next one — regardless of whether they got
+// there via training or via task xp accumulation. Red until tickTraining
+// floors qual.xp at XP_THRESHOLDS[newLevel] instead of leaving it untouched.
+
+describe('training and natural xp accumulation land at equal xp for the same level (#620)', () => {
+  it('a trained employee and a naturally-progressed employee at the same level need equal additional xp', () => {
+    const ctx = makeCtx();
+
+    // Employee A: reaches blasting level 3 through training, starting from a
+    // partial level-2 xp balance.
+    const empAId = hireOne(ctx, 'blaster'); // holds blasting at level 1
+    assignSkill(ctx.state!.employees, empAId, 'blasting', 2);
+    const qualA = ctx.state!.employees.employees.find(e => e.id === empAId)!
+      .qualifications.find(q => q.category === 'blasting')!;
+    qualA.xp = 150; // partial progress toward the level-3 threshold (300)
+
+    const startA = startTraining(ctx.state!.employees, empAId, 1, 'blasting', 5, 500);
+    expect(startA.success).toBe(true);
+    for (let i = 0; i < 5; i++) tickTraining(ctx.state!.employees);
+    expect(qualA.proficiencyLevel).toBe(3);
+
+    // Employee B: reaches blasting level 3 purely through gainXp, starting
+    // from the identical partial level-2 xp balance and given exactly enough
+    // xp to cross the level-3 threshold (300).
+    const empBId = hireOne(ctx, 'blaster');
+    assignSkill(ctx.state!.employees, empBId, 'blasting', 2);
+    const qualB = ctx.state!.employees.employees.find(e => e.id === empBId)!
+      .qualifications.find(q => q.category === 'blasting')!;
+    qualB.xp = 150;
+
+    const gainResult = gainXp(ctx.state!.employees, empBId, 'blasting', XP_THRESHOLDS[3] - qualB.xp, ctx.emitter);
+    expect(gainResult).not.toBeNull();
+    expect(qualB.proficiencyLevel).toBe(3);
+
+    // Both landed on level 3 — they must need equal additional xp to reach
+    // level 4, i.e. carry equal xp.
+    expect(qualA.xp).toBe(qualB.xp);
+    expect(XP_THRESHOLDS[4] - qualA.xp).toBe(XP_THRESHOLDS[4] - qualB.xp);
+  });
+});
 
 describe('Cost-based per-employee dispatch — full tick pipeline (#549)', () => {
   it('pairs each surveyor with their own nearest survey target, never double-claims, and every target eventually resolves', () => {

--- a/tests/unit/entities/EmployeeSkills.test.ts
+++ b/tests/unit/entities/EmployeeSkills.test.ts
@@ -13,6 +13,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { Random } from '../../../src/core/math/Random.js';
+import { XP_THRESHOLDS } from '../../../src/core/config/balance.js';
 import {
   createEmployeeState,
   hireEmployee,
@@ -308,13 +309,25 @@ describe('tickTraining', () => {
     expect(emp().salary).toBe(calculateSalary(emp()));
   });
 
-  it('granted qualification has xp initialised to 0', () => {
+  it('promoted qualification has xp floored at the new level\'s threshold', () => {
+    // blasting is a promotion (the employee already holds it), not a fresh
+    // grant — training it must not leave xp at 0, which would under-credit a
+    // trained employee relative to one who reached the same level via work.
     startTraining(state, empId, 1, 'blasting' as SkillCategory, 1, 100);
     tickTraining(state);
 
     const quals: SkillQualification[] = (state.employees.find(e => e.id === empId) as any).qualifications;
     const blasting = quals.find((q: SkillQualification) => q.category === 'blasting')!;
-    expect(blasting.xp).toBe(0);
+    expect(blasting.xp).toBe(XP_THRESHOLDS[blasting.proficiencyLevel as 1 | 2 | 3 | 4 | 5]);
+  });
+
+  it('freshly granted qualification has xp initialised to 0', () => {
+    startTraining(state, empId, 1, 'geology' as SkillCategory, 1, 100);
+    tickTraining(state);
+
+    const quals: SkillQualification[] = (state.employees.find(e => e.id === empId) as any).qualifications;
+    const geology = quals.find((q: SkillQualification) => q.category === 'geology')!;
+    expect(geology.xp).toBe(0);
   });
 
   it('does not complete training early — qualification is absent while ticksRemaining > 0', () => {

--- a/tests/unit/entities/EmployeeTraining.test.ts
+++ b/tests/unit/entities/EmployeeTraining.test.ts
@@ -24,6 +24,7 @@ import {
   MAX_PROFICIENCY,
 } from '../../../src/core/entities/EmployeeTraining.js';
 import type { Building, BuildingType, BuildingTier } from '../../../src/core/entities/Building.js';
+import { XP_THRESHOLDS } from '../../../src/core/config/balance.js';
 
 const SEED = 42;
 
@@ -198,6 +199,74 @@ describe('licences no role is hired with', () => {
     }
 
     expect(planTraining(employee, 'geology', 3)).toBeNull();
+  });
+});
+
+// ── Completion floors xp at the new level's threshold (#620) ────────────────
+//
+// gainXp derives proficiencyLevel from cumulative qual.xp against
+// XP_THRESHOLDS. tickTraining's existing-qualification branch used to raise
+// proficiencyLevel directly without touching xp, so a trained employee held
+// xp: 0 at their new level while a naturally-progressed peer at the same
+// level already carried partial progress — training silently cost ~half a
+// level's worth of progress toward the next one.
+
+describe('tickTraining floors qual.xp at the new level threshold', () => {
+  it('training from level 2 to level 3 raises xp to at least the level-3 threshold', () => {
+    const { state, employee } = makeStateWithOne('driller'); // holds blasting at level 1
+    assignSkill(state, employee.id, 'blasting', 2);
+
+    const result = enrolInTraining(state, employee.id, school('blasting_academy'), 'blasting');
+    expect(result.success, result.error).toBe(true);
+    for (let i = 0; i < result.plan!.ticks; i++) tickTraining(state);
+
+    const qual = employee.qualifications.find(q => q.category === 'blasting')!;
+    expect(qual.proficiencyLevel).toBe(3);
+    expect(qual.xp).toBeGreaterThanOrEqual(XP_THRESHOLDS[3]);
+  });
+
+  it('never lowers xp that already exceeds the new level threshold before completion', () => {
+    const { state, employee } = makeStateWithOne('driller');
+    assignSkill(state, employee.id, 'blasting', 2);
+
+    const result = enrolInTraining(state, employee.id, school('blasting_academy'), 'blasting');
+    expect(result.success, result.error).toBe(true);
+
+    // The employee already carries more xp than the level-3 threshold (300)
+    // by the time the course completes — training must not claw it back down.
+    const qual = employee.qualifications.find(q => q.category === 'blasting')!;
+    qual.xp = 500;
+
+    for (let i = 0; i < result.plan!.ticks; i++) tickTraining(state);
+
+    expect(qual.proficiencyLevel).toBe(3);
+    expect(qual.xp).toBe(500);
+  });
+
+  it('a brand-new qualification from training still starts at level 1 with 0 xp', () => {
+    const { state, employee } = makeStateWithOne('driver'); // holds driving.truck only
+    expect(employee.qualifications.some(q => q.category === 'driving.excavator')).toBe(false);
+
+    const result = enrolInTraining(state, employee.id, school('driving_center'), 'driving.excavator');
+    expect(result.success, result.error).toBe(true);
+    for (let i = 0; i < result.plan!.ticks; i++) tickTraining(state);
+
+    const qual = employee.qualifications.find(q => q.category === 'driving.excavator')!;
+    expect(qual.proficiencyLevel).toBe(1);
+    expect(qual.xp).toBe(XP_THRESHOLDS[1]);
+  });
+
+  it('training from level 4 to level 5 (MAX_PROFICIENCY) floors xp at the level-5 threshold', () => {
+    const { state, employee } = makeStateWithOne('driller');
+    assignSkill(state, employee.id, 'blasting', 4);
+
+    const result = enrolInTraining(state, employee.id, school('blasting_academy'), 'blasting');
+    expect(result.success, result.error).toBe(true);
+    for (let i = 0; i < result.plan!.ticks; i++) tickTraining(state);
+
+    const qual = employee.qualifications.find(q => q.category === 'blasting')!;
+    expect(qual.proficiencyLevel).toBe(MAX_PROFICIENCY);
+    expect(qual.xp).toBeGreaterThanOrEqual(XP_THRESHOLDS[5]);
   });
 });
 


### PR DESCRIPTION
Closes #620

## Problem

Training completion (`EmployeeTraining.ts`, `tickTraining`) raised `proficiencyLevel` directly without touching `qual.xp`, while `gainXp` (`EmployeeGainXp.ts`) accumulates `xp` and derives level by comparing cumulative `xp` against cumulative `XP_THRESHOLDS`. A trained employee ended up at their new level with `xp: 0`, needing the full threshold from scratch to reach the next level — while a naturally-progressed peer at the same level already carried partial credit.

## Fix

In `tickTraining`'s existing-qualification (promotion) branch, after raising `proficiencyLevel`:

```ts
existing.xp = Math.max(existing.xp, XP_THRESHOLDS[level]);
```

`Math.max` guarantees training never lowers an employee's existing `xp` (e.g. if they'd already accumulated more than the new threshold through on-the-job work). The `isNew` (fresh qualification) branch is untouched — it already starts at `xp: 0`, which equals `XP_THRESHOLDS[1]`.

`gainXp`'s own semantics are unchanged, per the issue's explicit constraint.

## Tests

- `tests/unit/entities/EmployeeTraining.test.ts` — level 2→3 promotion floors xp at `XP_THRESHOLDS[3]`; xp already above threshold is not lowered; fresh-grant qualification still starts at `xp: 0`; level 4→5 (`MAX_PROFICIENCY`) boundary also floors correctly.
- `tests/integration/skills.integration.test.ts` — a trained employee and a naturally-progressed (`gainXp`) employee landing at the same proficiency level end with equal `xp`, i.e. equal remaining XP to the next level.
- `tests/unit/entities/EmployeeSkills.test.ts` — a pre-existing test ("granted qualification has xp initialised to 0") actually exercised the promotion branch (via a role's starting qualification), baking in the old buggy behavior. Split into two tests: one for the real fresh-grant case (unchanged assertion), one for the promotion case (now asserts the floor).

9884 tests — all passing.

## Verification

- `static`: `npx tsc --noEmit` — clean.
- `logic`: `npm run test` — 317 files, 9884 tests, all pass.
- `scenario`: `npm run scenarios` — 131/131 scenarios pass.
- `build`: `vite build` succeeds, no regressions.
- Backend-only change (`src/core/entities/EmployeeTraining.ts` + tests) — no renderer/UI/player-facing flow touched, so the `visual` channel and `full-ci` label do not apply.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run. No material gameplay/economy/player-facing default was made: the issue specified the exact fix (floor at the new level's cumulative threshold, never lower existing xp) and this PR implements it as stated.

READY TO MERGE