### PR TITLE
feat: Resolve #621 — extend XP award routing to a rule function returning a list

### DIFF
--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -11,7 +11,7 @@ import { tickEventSystem, type FiredEvent } from '../events/EventSystem.js';
 import { detectTrafficJam } from '../events/EventEngine.js';
 import { checkCollapse, gainXp, type NeedKey, type Employee, type SkillCategory } from '../entities/Employee.js';
 import { replenishNeed } from '../entities/EmployeeNeeds.js';
-import { computeXpPerTick } from '../entities/EmployeeXpRules.js';
+import { computeTaskXpAwards } from '../entities/EmployeeXpRules.js';
 import type { EventEmitter } from '../state/EventEmitter.js';
 import { addExpense } from '../economy/Finance.js';
 import { tickVehicle, tickVehicleTaskState, tickEmployeeMovement, type EmployeeMovementResult } from './EntityMovementTick.js';
@@ -1134,15 +1134,16 @@ export function tickTaskProgress(state: GameState, emp: Employee, emitter?: Even
 
   emp.taskTicksRemaining -= 1;
 
-  const skill = emp.activeTaskSkill;
+  const action = state.pendingActions.find(a => a.id === emp.activeActionId);
+  const awards = action ? computeTaskXpAwards(emp, action) : [];
+
+  let skill: SkillCategory | null = null;
   let leveledUp = false;
   let levelUpLevels: { oldLevel: 1 | 2 | 3 | 4 | 5; newLevel: 1 | 2 | 3 | 4 | 5 } | null = null;
 
-  if (skill !== null) {
-    const qual = emp.qualifications.find(q => q.category === skill);
-    const currentLevel = qual?.proficiencyLevel ?? 1;
-    const xpPerTick = computeXpPerTick(currentLevel);
-    const xpResult = gainXp(state.employees, emp.id, skill, xpPerTick, emitter);
+  for (const award of awards) {
+    skill = award.category;
+    const xpResult = gainXp(state.employees, emp.id, award.category, award.amount, emitter);
     if (xpResult) {
       leveledUp = xpResult.leveledUp;
       if (xpResult.leveledUp) {

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -1135,15 +1135,18 @@ export function tickTaskProgress(state: GameState, emp: Employee, emitter?: Even
   emp.taskTicksRemaining -= 1;
 
   const action = state.pendingActions.find(a => a.id === emp.activeActionId);
-  const awards = action ? computeTaskXpAwards(emp, action) : [];
+  const xpAwards = action ? computeTaskXpAwards(emp, action) : [];
 
   let skill: SkillCategory | null = null;
   let leveledUp = false;
   let levelUpLevels: { oldLevel: 1 | 2 | 3 | 4 | 5; newLevel: 1 | 2 | 3 | 4 | 5 } | null = null;
 
-  for (const award of awards) {
-    skill = award.category;
-    const xpResult = gainXp(state.employees, emp.id, award.category, award.amount, emitter);
+  // computeTaskXpAwards returns 0 or 1 awards today (0 when the action carries
+  // no skill); looping keeps this call site correct if it ever grants XP in
+  // more than one category for the same tick.
+  for (const xpAward of xpAwards) {
+    skill = xpAward.category;
+    const xpResult = gainXp(state.employees, emp.id, xpAward.category, xpAward.amount, emitter);
     if (xpResult) {
       leveledUp = xpResult.leveledUp;
       if (xpResult.leveledUp) {

--- a/src/core/entities/EmployeeXpRules.ts
+++ b/src/core/entities/EmployeeXpRules.ts
@@ -29,7 +29,10 @@ export interface XpAward {
  * in that category (default 1 if unqualified).
  */
 export function computeTaskXpAwards(employee: Employee, action: PendingAction): XpAward[] {
-  void employee;
-  void action;
-  throw new Error('not implemented');
+  if (action.requiredSkill === null) return [];
+
+  const qual = employee.qualifications.find(q => q.category === action.requiredSkill);
+  const level = qual?.proficiencyLevel ?? 1;
+
+  return [{ category: action.requiredSkill, amount: computeXpPerTick(level) }];
 }

--- a/src/core/entities/EmployeeXpRules.ts
+++ b/src/core/entities/EmployeeXpRules.ts
@@ -1,6 +1,8 @@
 // BlastSimulator2026 — XP-per-tick award rules for employee skill proficiency.
 
 import { XP_PER_TICK_BASE, XP_PER_TICK_LEVEL_SCALE } from '../config/balance.js';
+import type { Employee, SkillCategory } from './Employee.js';
+import type { PendingAction } from '../state/GameState.js';
 
 /**
  * Compute the XP awarded per tick for an employee working at the given
@@ -10,4 +12,24 @@ import { XP_PER_TICK_BASE, XP_PER_TICK_LEVEL_SCALE } from '../config/balance.js'
  */
 export function computeXpPerTick(proficiencyLevel: 1 | 2 | 3 | 4 | 5): number {
   return XP_PER_TICK_BASE + Math.floor(proficiencyLevel * XP_PER_TICK_LEVEL_SCALE);
+}
+
+/** One skill-category/amount XP grant for a single tick of work. */
+export interface XpAward {
+  category: SkillCategory;
+  amount: number;
+}
+
+/**
+ * Compute the XP award(s) `employee` earns for one tick of work on `action`.
+ * Pure — no state mutation, no side effects.
+ * Returns [] when action.requiredSkill is null.
+ * Otherwise returns exactly one award: { category: action.requiredSkill, amount }
+ * where amount = computeXpPerTick(level), level = employee's current proficiency
+ * in that category (default 1 if unqualified).
+ */
+export function computeTaskXpAwards(employee: Employee, action: PendingAction): XpAward[] {
+  void employee;
+  void action;
+  throw new Error('not implemented');
 }

--- a/tests/unit/engine/GameLoop.test.ts
+++ b/tests/unit/engine/GameLoop.test.ts
@@ -46,6 +46,7 @@ import { placeBuilding } from '../../../src/core/entities/Building.js';
 import {
   hireEmployee, assignSkill, checkCollapse, getNeedMultiplier, computeTaskDuration,
 } from '../../../src/core/entities/Employee.js';
+import { computeXpPerTick } from '../../../src/core/entities/EmployeeXpRules.js';
 import type { NeedKey } from '../../../src/core/entities/Employee.js';
 import type { PendingAction, PlannedRamp, RampSegmentTracker } from '../../../src/core/state/GameState.js';
 import { purchaseVehicle, ROLE_LICENCE_REQUIRED } from '../../../src/core/entities/Vehicle.js';
@@ -1724,6 +1725,169 @@ describe('tickTaskProgress — per-tick countdown, incremental XP, and completio
     tickTaskProgress(state, employee);
 
     expect(qual().xp).toBe(3); // level 5 -> XP_PER_TICK_BASE + floor(5 * 0.5) = 3
+  });
+});
+
+// ── tickTaskProgress via computeTaskXpAwards (issue #621) ────────────────────
+//
+// tickTaskProgress is expected to stop reading emp.activeTaskSkill directly
+// and instead look up the PendingAction via
+// state.pendingActions.find(a => a.id === emp.activeActionId) and call
+// computeTaskXpAwards(emp, action), looping over the returned awards. These
+// tests exercise that path's observable behaviour end-to-end through
+// tickTaskProgress — they do not call computeTaskXpAwards directly (see
+// EmployeeXpRules.test.ts for that).
+describe('tickTaskProgress — XP awards via computeTaskXpAwards rule function (issue #621)', () => {
+  const SEED = 42;
+
+  /** Dispatch a task of `type`/`requiredSkill` to `employeeId` and let tickEmployees claim + seed it. */
+  function dispatchAndClaimTyped(
+    state: GameState,
+    employeeId: number,
+    actionId: number,
+    type: PendingAction['type'],
+    requiredSkill: PendingAction['requiredSkill'],
+  ): void {
+    state.pendingActions.push({
+      id: actionId, type, requiredSkill, requiredVehicleRole: null,
+      targetX: 0, targetZ: 0, targetY: 0, payload: {}, targetEmployeeId: employeeId,
+      status: 'queued', holderId: null,
+    });
+    tickEmployees(state);
+    resolveArrival(state);
+  }
+
+  it('a drill_hole task grants blasting XP equal to computeXpPerTick at the employee\'s current level', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'blaster', rng); // 'blasting' level 1
+    dispatchAndClaimTyped(state, employee.id, 1, 'drill_hole', 'blasting');
+
+    const qual = () => employee.qualifications.find(q => q.category === 'blasting')!;
+    expect(qual().xp).toBe(0);
+
+    const progress = tickTaskProgress(state, employee);
+
+    expect(qual().xp).toBe(computeXpPerTick(1));
+    expect(progress?.skill).toBe('blasting');
+  });
+
+  it('a drill_hole task at a higher proficiency level grants the scaled amount', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'blaster', rng);
+    assignSkill(state.employees, employee.id, 'blasting', 4);
+    dispatchAndClaimTyped(state, employee.id, 1, 'drill_hole', 'blasting');
+
+    const qual = () => employee.qualifications.find(q => q.category === 'blasting')!;
+
+    tickTaskProgress(state, employee);
+
+    expect(qual().xp).toBe(computeXpPerTick(4));
+  });
+
+  it('a survey task grants geology XP equal to computeXpPerTick at the employee\'s current level', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'surveyor', rng); // 'geology' level 1
+    dispatchAndClaimTyped(state, employee.id, 2, 'survey', 'geology');
+
+    const qual = () => employee.qualifications.find(q => q.category === 'geology')!;
+    expect(qual().xp).toBe(0);
+
+    const progress = tickTaskProgress(state, employee);
+
+    expect(qual().xp).toBe(computeXpPerTick(1));
+    expect(progress?.skill).toBe('geology');
+  });
+
+  it('a survey task at a higher proficiency level grants the scaled amount', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'surveyor', rng);
+    assignSkill(state.employees, employee.id, 'geology', 3);
+    dispatchAndClaimTyped(state, employee.id, 2, 'survey', 'geology');
+
+    const qual = () => employee.qualifications.find(q => q.category === 'geology')!;
+
+    tickTaskProgress(state, employee);
+
+    expect(qual().xp).toBe(computeXpPerTick(3));
+  });
+
+  it('a drill_hole tick crossing the level-2 threshold returns leveledUp:true with correct oldLevel/newLevel', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'blaster', rng);
+    // Position XP just short of the level-2 threshold so this single tick's
+    // award (computeXpPerTick(1) = 1) crosses it.
+    employee.qualifications.find(q => q.category === 'blasting')!.xp = XP_THRESHOLDS[2] - 1;
+    dispatchAndClaimTyped(state, employee.id, 1, 'drill_hole', 'blasting');
+
+    const progress = tickTaskProgress(state, employee);
+
+    expect(progress?.leveledUp).toBe(true);
+    expect(progress?.oldLevel).toBe(1);
+    expect(progress?.newLevel).toBe(2);
+  });
+
+  it('a survey tick crossing the level-2 threshold returns leveledUp:true with correct oldLevel/newLevel', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'surveyor', rng);
+    employee.qualifications.find(q => q.category === 'geology')!.xp = XP_THRESHOLDS[2] - 1;
+    dispatchAndClaimTyped(state, employee.id, 2, 'survey', 'geology');
+
+    const progress = tickTaskProgress(state, employee);
+
+    expect(progress?.leveledUp).toBe(true);
+    expect(progress?.oldLevel).toBe(1);
+    expect(progress?.newLevel).toBe(2);
+  });
+
+  it('a tick that does not cross a threshold returns leveledUp:false with no oldLevel/newLevel keys', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'blaster', rng); // fresh, xp 0, far from threshold
+    dispatchAndClaimTyped(state, employee.id, 1, 'drill_hole', 'blasting');
+
+    const progress = tickTaskProgress(state, employee);
+
+    expect(progress?.leveledUp).toBe(false);
+    expect(progress).not.toHaveProperty('oldLevel');
+    expect(progress).not.toHaveProperty('newLevel');
+  });
+
+  // Real haul_debris/fragment_debris actions (HaulDispatch.ts:24-32) set
+  // requiredSkill: null the same way, but they're claimed through a
+  // haul/fragment-specific eligibility check (isHaulOrFragmentActionClaimable)
+  // this synthetic fixture doesn't satisfy — 'general_work' is the same
+  // null-skill shape (matches the tickEmployees describe block's own
+  // makeAction default above) without that extra machinery.
+  it("the result's skill field is null for a task whose action has requiredSkill: null, and grants no XP to any qualification", () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'blaster', rng);
+    const qualsBefore = JSON.parse(JSON.stringify(employee.qualifications));
+
+    dispatchAndClaimTyped(state, employee.id, 1, 'general_work', null);
+    const progress = tickTaskProgress(state, employee);
+
+    expect(progress?.skill).toBeNull();
+    expect(employee.qualifications).toEqual(qualsBefore);
+  });
+
+  it('a second requiredSkill: null task also grants no XP and reports skill:null (not a one-off)', () => {
+    const state = createGame({ seed: SEED });
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state.employees, 'surveyor', rng);
+    const qualsBefore = JSON.parse(JSON.stringify(employee.qualifications));
+
+    dispatchAndClaimTyped(state, employee.id, 1, 'general_work', null);
+    const progress = tickTaskProgress(state, employee);
+
+    expect(progress?.skill).toBeNull();
+    expect(employee.qualifications).toEqual(qualsBefore);
   });
 });
 

--- a/tests/unit/entities/EmployeeXpRules.test.ts
+++ b/tests/unit/entities/EmployeeXpRules.test.ts
@@ -9,8 +9,11 @@
 //   level 1 -> 1, level 2 -> 2, level 3 -> 2, level 4 -> 3, level 5 -> 3
 
 import { describe, it, expect } from 'vitest';
-import { computeXpPerTick } from '../../../src/core/entities/EmployeeXpRules.js';
+import { computeXpPerTick, computeTaskXpAwards } from '../../../src/core/entities/EmployeeXpRules.js';
 import { XP_PER_TICK_BASE, XP_PER_TICK_LEVEL_SCALE } from '../../../src/core/config/balance.js';
+import { createEmployeeState, hireEmployee, assignSkill, type Employee } from '../../../src/core/entities/Employee.js';
+import { Random } from '../../../src/core/math/Random.js';
+import type { PendingAction } from '../../../src/core/state/GameState.js';
 
 describe('computeXpPerTick', () => {
   it('returns 1 XP for proficiency level 1 (Rookie, minimum boundary)', () => {
@@ -57,5 +60,147 @@ describe('computeXpPerTick', () => {
       const award = computeXpPerTick(level);
       expect(Number.isInteger(award)).toBe(true);
     }
+  });
+});
+
+// ── computeTaskXpAwards (issue #621) ─────────────────────────────────────
+//
+// Replaces tickTaskProgress's direct single-skill `gainXp` call with a pure
+// rule function returning a list of awards, so future multi-skill task types
+// can award more than one category per tick without touching GameLoop.ts.
+
+describe('computeTaskXpAwards', () => {
+  const SEED = 42;
+
+  function makeAction(overrides: Partial<PendingAction> & { requiredSkill: PendingAction['requiredSkill'] }): PendingAction {
+    return {
+      id: 1,
+      type: 'general_work',
+      requiredVehicleRole: null,
+      targetX: 0, targetZ: 0, targetY: 0,
+      payload: {},
+      targetEmployeeId: null,
+      status: 'in_progress',
+      holderId: null,
+      ...overrides,
+    };
+  }
+
+  function makeEmployee(role: 'driller' | 'blaster' | 'driver' | 'surveyor' | 'manager' = 'blaster'): Employee {
+    const state = createEmployeeState();
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state, role, rng);
+    return employee;
+  }
+
+  it('drill_hole-shaped action (requiredSkill: blasting) returns exactly one award at Rookie level', () => {
+    const employee = makeEmployee('blaster'); // starts with 'blasting' level 1
+    const action = makeAction({ type: 'drill_hole', requiredSkill: 'blasting' });
+
+    const awards = computeTaskXpAwards(employee, action);
+
+    expect(awards).toEqual([{ category: 'blasting', amount: computeXpPerTick(1) }]);
+  });
+
+  it('drill_hole-shaped action scales the award via computeXpPerTick as proficiency rises (not hardcoded)', () => {
+    const state = createEmployeeState();
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state, 'blaster', rng);
+    assignSkill(state, employee.id, 'blasting', 4);
+    const action = makeAction({ type: 'drill_hole', requiredSkill: 'blasting' });
+
+    const awards = computeTaskXpAwards(employee, action);
+
+    expect(awards).toEqual([{ category: 'blasting', amount: computeXpPerTick(4) }]);
+    // Regression guard: level 1 and level 4 must not produce the same amount,
+    // or this assertion would pass even with a hardcoded constant.
+    expect(computeXpPerTick(4)).not.toBe(computeXpPerTick(1));
+  });
+
+  it('drill_hole-shaped action at Master (level 5) uses the level-5 rate', () => {
+    const state = createEmployeeState();
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state, 'blaster', rng);
+    assignSkill(state, employee.id, 'blasting', 5);
+    const action = makeAction({ type: 'drill_hole', requiredSkill: 'blasting' });
+
+    const awards = computeTaskXpAwards(employee, action);
+
+    expect(awards).toEqual([{ category: 'blasting', amount: computeXpPerTick(5) }]);
+  });
+
+  it('survey-shaped action (requiredSkill: geology) returns exactly one award', () => {
+    const employee = makeEmployee('surveyor'); // starts with 'geology' level 1
+    const action = makeAction({ type: 'survey', requiredSkill: 'geology' });
+
+    const awards = computeTaskXpAwards(employee, action);
+
+    expect(awards).toEqual([{ category: 'geology', amount: computeXpPerTick(1) }]);
+  });
+
+  it('survey-shaped action scales via computeXpPerTick at a higher geology level', () => {
+    const state = createEmployeeState();
+    const rng = new Random(SEED);
+    const { employee } = hireEmployee(state, 'surveyor', rng);
+    assignSkill(state, employee.id, 'geology', 3);
+    const action = makeAction({ type: 'survey', requiredSkill: 'geology' });
+
+    const awards = computeTaskXpAwards(employee, action);
+
+    expect(awards).toEqual([{ category: 'geology', amount: computeXpPerTick(3) }]);
+  });
+
+  it('action with requiredSkill: null (e.g. haul_debris/fragment_debris) returns an empty array', () => {
+    const employee = makeEmployee('driver');
+    const action = makeAction({ type: 'haul_debris', requiredSkill: null });
+
+    expect(computeTaskXpAwards(employee, action)).toEqual([]);
+  });
+
+  it('action with requiredSkill: null returns an empty array regardless of employee qualifications', () => {
+    const employee = makeEmployee('blaster');
+    const action = makeAction({ type: 'fragment_debris', requiredSkill: null });
+
+    expect(computeTaskXpAwards(employee, action)).toEqual([]);
+  });
+
+  it('employee with no qualification at all in the required category defaults level to 1', () => {
+    const employee = makeEmployee('driver'); // only has 'driving.truck', not 'geology'
+    expect(employee.qualifications.some(q => q.category === 'geology')).toBe(false);
+    const action = makeAction({ type: 'survey', requiredSkill: 'geology' });
+
+    const awards = computeTaskXpAwards(employee, action);
+
+    expect(awards).toEqual([{ category: 'geology', amount: computeXpPerTick(1) }]);
+  });
+
+  it('does not mutate the employee object passed in', () => {
+    const employee = makeEmployee('blaster');
+    const before = JSON.parse(JSON.stringify(employee));
+    const action = makeAction({ type: 'drill_hole', requiredSkill: 'blasting' });
+
+    computeTaskXpAwards(employee, action);
+
+    expect(JSON.parse(JSON.stringify(employee))).toEqual(before);
+  });
+
+  it('does not mutate the action object passed in', () => {
+    const employee = makeEmployee('blaster');
+    const action = makeAction({ type: 'drill_hole', requiredSkill: 'blasting' });
+    const before = JSON.parse(JSON.stringify(action));
+
+    computeTaskXpAwards(employee, action);
+
+    expect(JSON.parse(JSON.stringify(action))).toEqual(before);
+  });
+
+  it('is pure — calling it twice with the same inputs returns equal results', () => {
+    const employee = makeEmployee('surveyor');
+    const action = makeAction({ type: 'survey', requiredSkill: 'geology' });
+
+    const first = computeTaskXpAwards(employee, action);
+    const second = computeTaskXpAwards(employee, action);
+
+    expect(second).toEqual(first);
   });
 });


### PR DESCRIPTION
Closes #621

## Summary

Replaces the single-skill XP award in `tickTaskProgress` (`src/core/engine/GameLoop.ts`) with a pure rule function, `computeTaskXpAwards`, added to `src/core/entities/EmployeeXpRules.ts`. It returns the list of XP awards (`{ category, amount }`) an action grants for one tick, computed via #619's `computeXpPerTick` rate function. `tickTaskProgress` now loops over that list and applies each award via `gainXp`, instead of reading `emp.activeTaskSkill` directly.

Behavior is unchanged for every action type dispatched today: `drill_hole` still grants exactly one `blasting` award, `survey` still grants exactly one `geology` award, and an action with `requiredSkill: null` still grants nothing — proven byte-identical by new `GameLoop.test.ts` assertions built the same way the pre-change formula was. `emp.activeTaskSkill` itself is untouched; it still seeds from `action.requiredSkill` at claim time and still serves task-duration and UI consumers.

This is the extension point #622 needs: adding a second skill to an action (e.g. `drill_hole` also rewarding a `drill_rig` licence category) will require changing only `computeTaskXpAwards`'s return list, with no change to `tickTaskProgress`'s loop.

10057/10057 tests passing (318 files), including 20 new tests across `tests/unit/entities/EmployeeXpRules.test.ts` and `tests/unit/engine/GameLoop.test.ts`.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run. All are implementation-detail defaults, not material to gameplay/economy/player-facing behavior, so no `decision-review` follow-up issue was opened.

- **What was open:** what type represents "the action being worked" as `computeTaskXpAwards`'s second argument.
  **Chosen:** `PendingAction` (`src/core/state/GameState.ts`), looked up in `tickTaskProgress` via `state.pendingActions.find(a => a.id === emp.activeActionId)`.
  **Why:** matches the sibling function `computeActionWorkTicks(state, employee, action: PendingAction)` in `ActionSelection.ts`; `activeActionId` is guaranteed present in `state.pendingActions` for the whole span `tickTaskProgress` runs.
  **If reversed:** change the lookup expression and the second parameter's type in `computeTaskXpAwards`.

- **What was open:** behavior when the `PendingAction` lookup by `activeActionId` fails.
  **Chosen:** treat it as no award this tick (`action ? computeTaskXpAwards(emp, action) : []`) rather than throwing.
  **Why:** genuinely unreachable under current claim/promote/complete invariants; a defensive no-op is safer than a thrown error taking down the tick loop.
  **If reversed:** replace the ternary with an assertion/throw if this invariant is ever intentionally broken.

- **What was open:** how to report a level-up on `TaskProgressResult` once more than one award can occur (relevant to #622).
  **Chosen:** do not extend `TaskProgressResult` in this issue; loop over awards (length 0 or 1 today) and let the last award processed win for `skill`/`oldLevel`/`newLevel`/`leveledUp`.
  **Why:** the issue scopes extending `TaskProgressResult` to only when multiple simultaneous level-ups genuinely cannot be reported through it — not yet true, since this issue's rule function returns at most one entry.
  **If reversed:** when #622 adds a second concurrent award, change `TaskProgressResult` to carry an array of level-up records and change the loop from overwrite to push.

## Verification

- static: `npm run typecheck` — clean, 0 errors.
- logic: `npm run test` — 10057/10057 passed (318 files).
- scenario: `npm run scenarios` — 131/131 passed, command mode.
- build: `npm run build` — succeeded, pre-existing chunk-size warning only, unrelated to this change.
- visual: not applicable — change confined to `src/core/entities/EmployeeXpRules.ts` and `src/core/engine/GameLoop.ts`, no `src/renderer/` or `src/ui/` touched.

Code review: security, quality, i18n, duplication, semantic reviewers all PASS, no critical/warning findings. Runtime validator: APPROVE, full suite green.

READY TO MERGE