### PR TITLE
fix: Resolve #650 — waitForTutorialStep timeout names pending event as cause

### DIFF
--- a/scripts/shared/interaction-executor.ts
+++ b/scripts/shared/interaction-executor.ts
@@ -661,6 +661,7 @@ export async function executeActionOnPage(
       // outer wall-clock safety net against a genuine hang, not the loop's
       // own pacing budget.
       let ticksUsed = 0;
+      let blockedTicks = 0;
       for (;;) {
         const st = await page.evaluate(() => {
           const run = (window as unknown as {
@@ -670,9 +671,19 @@ export async function executeActionOnPage(
           const fn = (window as unknown as {
             __tutorialState?: () => { active: boolean; stepId: string | null; stageTarget: string | null };
           }).__tutorialState;
-          return fn === undefined ? null : fn();
+          const tutorialState = fn === undefined ? null : fn();
+          const getState = (window as unknown as {
+            __gameState?: () => Record<string, unknown> | null;
+          }).__gameState;
+          const gs = getState === undefined ? null : getState();
+          return tutorialState === null ? null : {
+            ...tutorialState,
+            pendingEvent: gs ? Boolean(gs.pendingEvent) : false,
+          };
         });
         ticksUsed++;
+        const blockedThisTick = Boolean(st?.pendingEvent);
+        blockedTicks = blockedThisTick ? blockedTicks + 1 : 0;
         onProgress?.(
           `waitForTutorialStep on "${st?.stepId ?? 'none'}", live control ${st?.stageTarget ?? 'none'}, `
           + `want ${wanted.map(s => `"${s}"`).join(' or ')}, tick ${ticksUsed}/${maxTicks}`,
@@ -683,7 +694,8 @@ export async function executeActionOnPage(
         if (ticksUsed >= maxTicks || Date.now() > deadline) {
           throw new Error(
             `waitForTutorialStep: tutorial never reached ${wanted.map(s => `"${s}"`).join(' or ')}`
-            + ` — it is on "${st.stepId}", live control ${st.stageTarget ?? 'none'}, after ${ticksUsed} tick(s)`,
+            + ` — it is on "${st.stepId}", live control ${st.stageTarget ?? 'none'}, after ${ticksUsed} tick(s)`
+            + (blockedTicks > 0 ? `; blocked by a pending event for ${blockedTicks} tick(s)` : ''),
           );
         }
       }

--- a/tests/unit/scenario-interaction.test.ts
+++ b/tests/unit/scenario-interaction.test.ts
@@ -235,6 +235,72 @@ describe('executeActionOnPage — waitForTutorialStep (issue #601, #631)', () =>
       'waitForTutorialStep on "drill-plan", live control charge-tool, want "drill-plan", tick 2/400',
     ]);
   });
+
+  // Issue #650: a timeout caused by a pending event looks identical to an
+  // ordinary stall today — the thrown message names only the step it's
+  // stuck on, not that a dialog is blocking every tick's `tick 1`. These
+  // cases pin the new cause-naming behavior without touching the pre-#650
+  // cases above, which continue to prove the ordinary-timeout message is
+  // byte-for-byte unchanged when no event was ever pending.
+  it('names a pending event as the timeout cause when every tick was blocked by one', async () => {
+    const evaluate = vi.fn().mockResolvedValue({
+      active: true,
+      stepId: 'grid-select',
+      stageTarget: 'grid-tool',
+      pendingEvent: true,
+    });
+    const page = fakePage({ evaluate });
+    const step: ScenarioStepDef = { command: 'wait_for_tutorial_step step:drill-plan', role: 'setup' };
+    const action = { type: 'waitForTutorialStep' as const, stepId: 'drill-plan', maxTicks: 3, timeout: 30000 };
+
+    await expect(executeActionOnPage(page, action, step)).rejects.toThrow(
+      /tutorial never reached "drill-plan" — it is on "grid-select", live control grid-tool, after 3 tick\(s\); blocked by a pending event for 3 tick\(s\)/,
+    );
+    // Still exactly one page.evaluate() round trip per loop iteration — the
+    // pendingEvent read must fold into the existing call, not add a second.
+    expect(evaluate).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws today\'s exact message, with no pending-event suffix, when no tick was ever blocked', async () => {
+    const evaluate = vi.fn().mockResolvedValue({
+      active: true,
+      stepId: 'grid-select',
+      stageTarget: 'grid-tool',
+      pendingEvent: false,
+    });
+    const page = fakePage({ evaluate });
+    const step: ScenarioStepDef = { command: 'wait_for_tutorial_step step:drill-plan', role: 'setup' };
+    const action = { type: 'waitForTutorialStep' as const, stepId: 'drill-plan', maxTicks: 3, timeout: 30000 };
+
+    let thrown: Error | undefined;
+    try {
+      await executeActionOnPage(page, action, step);
+    } catch (err) {
+      thrown = err as Error;
+    }
+
+    expect(thrown).toBeDefined();
+    expect(thrown?.message).toBe(
+      'waitForTutorialStep: tutorial never reached "drill-plan"'
+      + ' — it is on "grid-select", live control grid-tool, after 3 tick(s)',
+    );
+    expect(thrown?.message).not.toContain('blocked by a pending event');
+  });
+
+  it('counts only the trailing consecutive run of blocked ticks, resetting on any clean tick', async () => {
+    const evaluate = vi.fn()
+      .mockResolvedValueOnce({ active: true, stepId: 'grid-select', stageTarget: 'grid-tool', pendingEvent: true })
+      .mockResolvedValueOnce({ active: true, stepId: 'grid-select', stageTarget: 'grid-tool', pendingEvent: true })
+      .mockResolvedValueOnce({ active: true, stepId: 'grid-select', stageTarget: 'grid-tool', pendingEvent: false })
+      .mockResolvedValueOnce({ active: true, stepId: 'grid-select', stageTarget: 'grid-tool', pendingEvent: true });
+    const page = fakePage({ evaluate });
+    const step: ScenarioStepDef = { command: 'wait_for_tutorial_step step:drill-plan', role: 'setup' };
+    const action = { type: 'waitForTutorialStep' as const, stepId: 'drill-plan', maxTicks: 4, timeout: 30000 };
+
+    await expect(executeActionOnPage(page, action, step)).rejects.toThrow(
+      /tutorial never reached "drill-plan" — it is on "grid-select", live control grid-tool, after 4 tick\(s\); blocked by a pending event for 1 tick\(s\)/,
+    );
+  });
 });
 
 describe('executeActionOnPage — ensurePanel (PR #616 review round, item 7)', () => {


### PR DESCRIPTION
Closes #650

## Summary

`waitForTutorialStep` (`scripts/shared/interaction-executor.ts`) loops `tick 1` until a tutorial step is reached, or times out. `tickCommand` deliberately refuses to advance while an event is pending, so every subsequent tick was a silent no-op — and the timeout message named only the tutorial symptom ("it is on Y"), never the actual cause (an unresolved event blocking every tick).

This PR adds a `blockedTicks` counter — consecutive ticks where `window.__gameState().pendingEvent` was true, reset to 0 on any unblocked tick — folded into the same single `page.evaluate()` call already made each iteration (no second round trip). When the loop times out with `blockedTicks > 0`, the existing message gains a suffix: `; blocked by a pending event for N tick(s)`. When no event was blocking, the message is byte-for-byte identical to today's.

No change to loop timing, `maxTicks`/`deadline` budgets, `onProgress` behavior, or the deliberate no-auto-resolve rule — this is diagnostic-message-only, per the issue's own stated default.

10078 tests passing (318 files), including 3 new/modified cases in `tests/unit/scenario-interaction.test.ts` covering: blocked-every-tick (cause suffix with correct count), no-event regression (message unchanged), and counter-reset-on-clean-tick (proves consecutive-only, not cumulative).

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run; none are gameplay/economy/player-facing (both are internal to the Puppeteer test-harness diagnostic, not shipped game code), so no `decision-review` follow-up issue opened.

- **What was open:** the issue's example throw wording (`waitForTutorialStep: blocked by a pending event for N tick(s) while waiting for "X"`) is marked "for example," and conflicts with the Test section's requirement that the no-event message stay byte-identical to today's.
  **Chosen:** append `; blocked by a pending event for N tick(s)` as a suffix to the *existing* message rather than replacing it.
  **Why:** keeps the still-true symptom info (current step, live control), makes the "unchanged when no event pending" test a trivial string-prefix check instead of two independently maintained formats.
  **If reversed:** change the `cause` template literal in the `waitForTutorialStep` throw; nothing else depends on its exact wording beyond the one new assertion.

- **What was open:** the issue names `__uiState()` as the source of the typed `pendingEvent` mirror; that field doesn't exist there — it exists on `window.__gameState()`, which is what the two cited precedent readers in the same file (`resolveEventIfPending`, `waitUntil`) actually call.
  **Chosen:** read `pendingEvent` off `window.__gameState()`, matching established precedent exactly.
  **Why:** the code, not the issue prose, is authoritative for where the field lives; "ask the game, not the DOM" is satisfied identically either way.
  **If reversed:** N/A — no field to move.

- **Confirmed, not reopened:** message-only fix, per the issue's own explicit default. No fail-fast / early-exit behavior added; loop timing and budgets are untouched.

## Verification

- `static`: `npx tsc --noEmit` — clean.
- `logic`: `npm run test` — 318 files, 10078 tests, all passing (includes `npx vitest run --coverage`, `tests/integration`, `tests/unit/scenario-defs.test.ts`).
- `scenario`: `npm run scenarios` — 131/131 scenario definitions passing (command mode).
- `build`: `vite build` — succeeds.
- `visual`: not required — message-only change to a test-harness diagnostic; no scenario reaches this failure path (per issue's own verification list). Change is confined to `scripts/shared/` (test harness), not `src/renderer/` or `src/ui/`.

Code review (5 parallel specialists — security, quality, i18n, duplication, semantic): all PASS. One non-blocking duplication suggestion noted (a shared `__pendingEvent` bridge in `src/main.ts` would remove a 3-way inline-cast repetition across `resolveEventIfPending`/`waitUntil`/`waitForTutorialStep`) — not applied, as it follows this file's own established per-`page.evaluate()`-callback convention (Puppeteer serializes each callback via `.toString()`, so no closing over a shared Node-side helper is possible) and is not required for correctness.

READY TO MERGE