### PR TITLE
fix: Resolve #652 — ensureStep names the Blast panel as cause instead of timing out

### DIFF
--- a/scripts/shared/interaction-executor.ts
+++ b/scripts/shared/interaction-executor.ts
@@ -425,6 +425,23 @@ export function checkStepActionAllowed(
  *   fires, instead of a bare "Step N timed out after Xms" (issue: PR #616
  *   review round, item 5 — richer timeout diagnostics).
  */
+// #bs-toolbar's own `data-panel` -> the panel element __uiState() reports
+// visibility for (main.ts's `panels` map). `settings` opens a modal, not a
+// toggle panel, and is deliberately absent here even though TOOLBAR_TARGET
+// carries it — that absence, not TOOLBAR_TARGET's own key set, is what makes
+// "settings" rejected in the `ensurePanel` case below. Module scope (not
+// case-local) so both `ensurePanel` and `ensureStep` can reference the same
+// map instead of hardcoding a panel element id a second time (#652).
+const PANEL_ELEMENT_ID: Partial<Record<keyof typeof TOOLBAR_TARGET, string>> = {
+  blast: 'bs-blast-panel',
+  contracts: 'bs-contract-panel',
+  ops: 'bs-operations-panel',
+  build: 'bs-build-panel',
+  vehicles: 'bs-vehicle-panel',
+  employees: 'bs-employee-panel',
+  survey: 'bs-survey-panel',
+};
+
 export async function executeActionOnPage(
   page: Page,
   action: InteractionStepAction,
@@ -831,23 +848,11 @@ export async function executeActionOnPage(
       break;
     }
     case 'ensurePanel': {
-      // #bs-toolbar's own `data-panel` -> the panel element __uiState()
-      // reports visibility for (main.ts's `panels` map). `settings` opens a
-      // modal, not a toggle panel, and is deliberately absent here even
-      // though TOOLBAR_TARGET carries it — that absence, not TOOLBAR_TARGET's
-      // own key set, is what makes "settings" rejected below. The click
-      // selector itself reuses TOOLBAR_TARGET (tutorialStepHelpers.ts, pure
-      // data — the tutorial's own highlight targets) rather than rebuilding
-      // the same `#bs-toolbar [data-panel="..."]` string by hand a second time.
-      const PANEL_ELEMENT_ID: Partial<Record<keyof typeof TOOLBAR_TARGET, string>> = {
-        blast: 'bs-blast-panel',
-        contracts: 'bs-contract-panel',
-        ops: 'bs-operations-panel',
-        build: 'bs-build-panel',
-        vehicles: 'bs-vehicle-panel',
-        employees: 'bs-employee-panel',
-        survey: 'bs-survey-panel',
-      };
+      // PANEL_ELEMENT_ID is module-scoped (see above) so `ensureStep` below
+      // can reuse it too. The click selector itself reuses TOOLBAR_TARGET
+      // (tutorialStepHelpers.ts, pure data — the tutorial's own highlight
+      // targets) rather than rebuilding the same
+      // `#bs-toolbar [data-panel="..."]` string by hand a second time.
       const panelKey = action.panel as keyof typeof TOOLBAR_TARGET;
       const panelId = PANEL_ELEMENT_ID[panelKey];
       const selector = TOOLBAR_TARGET[panelKey];
@@ -870,6 +875,9 @@ export async function executeActionOnPage(
       break;
     }
     case 'ensureStep': {
+      // TODO(#652): implementer adds a panel-visibility check here, before
+      // the activeBlastStep check below, using module-scoped
+      // PANEL_ELEMENT_ID['blast'] rather than a hardcoded 'bs-blast-panel'.
       const active = await page.evaluate(() => {
         const getUiState = (window as unknown as {
           __uiState?: () => { activeBlastStep: number } | null;

--- a/scripts/shared/interaction-executor.ts
+++ b/scripts/shared/interaction-executor.ts
@@ -442,6 +442,24 @@ const PANEL_ELEMENT_ID: Partial<Record<keyof typeof TOOLBAR_TARGET, string>> = {
   survey: 'bs-survey-panel',
 };
 
+/**
+ * Whether the panel element `panelId` (a `PANEL_ELEMENT_ID` value) is
+ * currently visible, read from the page's own `__uiState()` mirror rather
+ * than the DOM directly. Shared by `ensurePanel` (checking the panel it is
+ * about to toggle) and `ensureStep` (checking the Blast panel is open before
+ * touching its step tabs) so the same `page.evaluate` closure exists once
+ * (#652).
+ */
+async function isPanelVisible(page: Page, panelId: string): Promise<boolean> {
+  return page.evaluate((id: string) => {
+    const getUiState = (window as unknown as {
+      __uiState?: () => { panels: Record<string, { visible: boolean }> } | null;
+    }).__uiState;
+    const st = getUiState === undefined ? null : getUiState();
+    return st?.panels[id]?.visible ?? false;
+  }, panelId);
+}
+
 export async function executeActionOnPage(
   page: Page,
   action: InteractionStepAction,
@@ -860,13 +878,7 @@ export async function executeActionOnPage(
         throw new Error(`ensurePanel: unknown panel "${action.panel}" (not a toggle panel, or misspelled)`);
       }
 
-      const alreadyOpen = await page.evaluate((id: string) => {
-        const getUiState = (window as unknown as {
-          __uiState?: () => { panels: Record<string, { visible: boolean }> } | null;
-        }).__uiState;
-        const st = getUiState === undefined ? null : getUiState();
-        return st?.panels[id]?.visible ?? false;
-      }, panelId);
+      const alreadyOpen = await isPanelVisible(page, panelId);
 
       onProgress?.(`ensurePanel "${action.panel}" ${alreadyOpen ? 'already open' : 'opening'}`);
       if (!alreadyOpen) {
@@ -875,15 +887,8 @@ export async function executeActionOnPage(
       break;
     }
     case 'ensureStep': {
-      const blastPanelId = PANEL_ELEMENT_ID.blast as string;
-      const panelVisible = await page.evaluate((id: string) => {
-        const getUiState = (window as unknown as {
-          __uiState?: () => { panels: Record<string, { visible: boolean }> } | null;
-        }).__uiState;
-        const st = getUiState === undefined ? null : getUiState();
-        return st?.panels[id]?.visible ?? false;
-      }, blastPanelId);
-      if (!panelVisible) {
+      const blastPanelId = PANEL_ELEMENT_ID.blast;
+      if (blastPanelId === undefined || !(await isPanelVisible(page, blastPanelId))) {
         throw new Error(
           "ensureStep: the Blast panel is not open — call ensurePanel({ panel: 'blast' }) first",
         );

--- a/scripts/shared/interaction-executor.ts
+++ b/scripts/shared/interaction-executor.ts
@@ -875,9 +875,20 @@ export async function executeActionOnPage(
       break;
     }
     case 'ensureStep': {
-      // TODO(#652): implementer adds a panel-visibility check here, before
-      // the activeBlastStep check below, using module-scoped
-      // PANEL_ELEMENT_ID['blast'] rather than a hardcoded 'bs-blast-panel'.
+      const blastPanelId = PANEL_ELEMENT_ID.blast as string;
+      const panelVisible = await page.evaluate((id: string) => {
+        const getUiState = (window as unknown as {
+          __uiState?: () => { panels: Record<string, { visible: boolean }> } | null;
+        }).__uiState;
+        const st = getUiState === undefined ? null : getUiState();
+        return st?.panels[id]?.visible ?? false;
+      }, blastPanelId);
+      if (!panelVisible) {
+        throw new Error(
+          "ensureStep: the Blast panel is not open — call ensurePanel({ panel: 'blast' }) first",
+        );
+      }
+
       const active = await page.evaluate(() => {
         const getUiState = (window as unknown as {
           __uiState?: () => { activeBlastStep: number } | null;

--- a/tests/unit/scenario-interaction.test.ts
+++ b/tests/unit/scenario-interaction.test.ts
@@ -345,19 +345,25 @@ describe('executeActionOnPage — ensurePanel (PR #616 review round, item 7)', (
 
 describe('executeActionOnPage — ensureStep (PR #616 review round, item 7)', () => {
   it('does not click when __uiState().activeBlastStep already matches', async () => {
-    const evaluate = vi.fn().mockResolvedValueOnce(2);
+    // First resolved value stands for the panel-visibility read
+    // (__uiState().panels['bs-blast-panel'].visible === true); the second
+    // stands for the activeBlastStep read that follows it (#652).
+    const evaluate = vi.fn()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(2);
     const page = fakePage({ evaluate });
     const step: ScenarioStepDef = { command: 'charge hole:H1 explosive:boomite amount:5kg stemming:2m', role: 'setup' };
     const action = { type: 'ensureStep' as const, step: 2 as const };
 
     await executeActionOnPage(page, action, step);
 
-    expect(evaluate).toHaveBeenCalledTimes(1);
+    expect(evaluate).toHaveBeenCalledTimes(2);
     expect(page.click).not.toHaveBeenCalled();
   });
 
   it('clicks the step tab when __uiState().activeBlastStep does not match', async () => {
     const evaluate = vi.fn()
+      .mockResolvedValueOnce(true) // panel-visibility read: Blast panel open
       .mockResolvedValueOnce(3)
       .mockResolvedValueOnce(null); // waitUsableAndClick's own probe: usable now
     const page = fakePage({ evaluate });
@@ -367,6 +373,42 @@ describe('executeActionOnPage — ensureStep (PR #616 review round, item 7)', ()
     await executeActionOnPage(page, action, step);
 
     expect(page.click).toHaveBeenCalledWith('#bs-blast-panel [data-step="2"]');
+  });
+
+  // Issue #652: ensureStep clicks the tab selector without ever checking
+  // whether the Blast panel itself is open. With the panel closed, the tab
+  // is display:none and waitUsableAndClick times out with a generic "control
+  // not usable" message instead of naming the real cause. ensureStep must
+  // read __uiState().panels['bs-blast-panel'].visible (via the module-scope
+  // PANEL_ELEMENT_ID.blast) before its activeBlastStep check and reject with
+  // a message naming ensurePanel({ panel: 'blast' }) as the fix, never
+  // reaching the tab-click path.
+  it('rejects naming ensurePanel when the Blast panel is not open, without ever clicking', async () => {
+    const evaluate = vi.fn().mockResolvedValueOnce(false); // panel-visibility read: Blast panel closed
+    const page = fakePage({ evaluate });
+    const step: ScenarioStepDef = { command: 'charge hole:H1 explosive:boomite amount:5kg stemming:2m', role: 'setup' };
+    const action = { type: 'ensureStep' as const, step: 2 as const };
+
+    await expect(executeActionOnPage(page, action, step)).rejects.toThrow(
+      /ensureStep: the Blast panel is not open — call ensurePanel\(\{ panel: 'blast' \}\) first/,
+    );
+    expect(page.click).not.toHaveBeenCalled();
+  });
+
+  it('treats an undefined panels[\'bs-blast-panel\'] entry identically to visible: false', async () => {
+    // __uiState() itself resolves, but the panels map has no entry at all for
+    // the Blast panel id (e.g. before the panel has ever been mounted) —
+    // must reject the same as an explicit `visible: false`, not throw a
+    // different error or fall through to the tab-click path.
+    const evaluate = vi.fn().mockResolvedValueOnce(undefined);
+    const page = fakePage({ evaluate });
+    const step: ScenarioStepDef = { command: 'charge hole:H1 explosive:boomite amount:5kg stemming:2m', role: 'setup' };
+    const action = { type: 'ensureStep' as const, step: 2 as const };
+
+    await expect(executeActionOnPage(page, action, step)).rejects.toThrow(
+      /ensureStep: the Blast panel is not open — call ensurePanel\(\{ panel: 'blast' \}\) first/,
+    );
+    expect(page.click).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Closes #652

`ensureStep` (`scripts/shared/interaction-executor.ts`) now checks `__uiState().panels['bs-blast-panel'].visible` before its existing `activeBlastStep` check, and throws a named error — `ensureStep: the Blast panel is not open — call ensurePanel({ panel: 'blast' }) first` — instead of letting `waitUsableAndClick` time out against an invisible tab control.

- Extracted a shared `isPanelVisible(page, panelId)` helper (module scope) used by both `ensurePanel` and `ensureStep`, so the `__uiState()` read logic exists exactly once (a duplication finding raised in code review and fixed in a second implementer round).
- `PANEL_ELEMENT_ID` hoisted to module scope so `ensureStep` reuses the same `'blast' -> 'bs-blast-panel'` mapping `ensurePanel` already had, rather than a second hardcoded literal.
- `ensurePanel`'s own behavior is unchanged — verified by the full existing test suite passing unmodified.

10080 tests — all passing

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** the issue didn't state how `ensureStep` should behave if `panels['bs-blast-panel']` itself is `undefined` (panel never registered), as opposed to registered-and-hidden.
  **Chosen:** treat `undefined` identically to `visible: false` (`?? false` fallback, matching the shared `isPanelVisible` helper both cases now use).
  **Why:** convention in the surrounding code — `ensurePanel`'s own reader already used this exact fallback shape, which the issue explicitly pointed to as the pattern to follow. An unregistered panel is at least as wrong as a hidden one, never more permissive.
  **If reversed:** change the fallback inside `isPanelVisible`; both call sites pick it up.

- **What was open:** the issue didn't state check order — panel-visibility vs. the existing `activeBlastStep` read — within the same `ensureStep` case.
  **Chosen:** panel-visibility check runs first.
  **Why:** if the panel is closed, `activeBlastStep` is a meaningless signal in that state and checking it first would waste a round-trip before failing anyway; failing on the coarser precondition first matches the issue's own stated goal (a specific, actionable error) and the order `ensurePanel` already uses internally (visibility before the click attempt).
  **If reversed:** swap the two blocks in the `ensureStep` case body — no other file changes.

## Verification

- static: `npm run typecheck` clean (src/ + scripts/)
- logic: `npm run test` — 10080/10080 passing, including new/updated `ensureStep` cases in `tests/unit/scenario-interaction.test.ts`
- scenario/visual: not required per the issue's own verification section — no scenario currently calls `ensureStep` without a preceding `ensurePanel`, so there is no interaction-mode regression to catch. `full-ci` intentionally left off.
- build: `npm run build` succeeds

READY TO MERGE