### PR TITLE
fix: Resolve #654 — level2 contract guards keyed by type, not a probed id

### DIFF
--- a/scripts/scenario-defs/level2-playthrough-win.json
+++ b/scripts/scenario-defs/level2-playthrough-win.json
@@ -1576,9 +1576,9 @@
           "command": "contract deliver type:ore_sale amount:100"
         }
       ],
-      "description": "#554: selector-based, same reasoning as the accept step above. BLOCKED, same class as this file's other deliver guards: the ACTIVE card's DELIVER button is disabled because storage never holds anything -- nothing in this scenario ever hauls material in, and by now the mine has been bankrupt and running on a destroyed drill fleet for hundreds of ticks besides. `expect.blocked` proves the guard instead of faking a click no player could make.",
+      "description": "#654: deliver button for the active ore_sale contract is blocked because storage never holds anything -- nothing in this scenario ever hauls material in. Selector is now type-based (`data-contract-type=\"ore_sale\"`, first-DOM-match) instead of a hardcoded numeric id: it resolves in the same first-match order the preceding `contract deliver type:ore_sale` command already used, so it stays correct across upstream tick-count drift without re-probing an id.",
       "expect": {
-        "blocked": "#bs-contract-panel [data-contract-id=\"26\"] .bs-contract-deliver"
+        "blocked": "#bs-contract-panel [data-contract-type=\"ore_sale\"] .bs-contract-deliver"
       },
       "role": "guard"
     },
@@ -1613,9 +1613,9 @@
           "command": "contract deliver type:ore_sale amount:40"
         }
       ],
-      "description": "#554: selector-based, same reasoning as the earlier deliver step. BLOCKED, same class as this file's other deliver guards: the ACTIVE card's DELIVER button is disabled because storage never holds anything -- nothing in this scenario ever hauls material in, and by now the mine has been bankrupt and running on a destroyed drill fleet for hundreds of ticks besides. `expect.blocked` proves the guard instead of faking a click no player could make.",
+      "description": "#654: deliver button for the active ore_sale contract is blocked because storage never holds anything -- nothing in this scenario ever hauls material in. Selector is now type-based (`data-contract-type=\"ore_sale\"`, first-DOM-match) instead of a hardcoded numeric id: it resolves in the same first-match order the preceding `contract deliver type:ore_sale` command already used, so it stays correct across upstream tick-count drift without re-probing an id.",
       "expect": {
-        "blocked": "#bs-contract-panel [data-contract-id=\"26\"] .bs-contract-deliver"
+        "blocked": "#bs-contract-panel [data-contract-type=\"ore_sale\"] .bs-contract-deliver"
       },
       "role": "guard"
     },
@@ -2418,9 +2418,9 @@
           "command": "contract deliver type:ore_sale amount:100"
         }
       ],
-      "description": "#554: selector-based, same reasoning as the accept step above. BLOCKED, same class as this file's other deliver guards: the ACTIVE card's DELIVER button is disabled because storage never holds anything -- nothing in this scenario ever hauls material in, and by now the mine has been bankrupt and running on a destroyed drill fleet for hundreds of ticks besides. `expect.blocked` proves the guard instead of faking a click no player could make. #601-followup: id corrected 70 -> 71 -- #601's deterministic `waitUntil` harness fix shifts this file's exact tick counts, and the id this step's own selector needs to match is whatever `type:ore_sale` actually resolved to at the accept step just above at those new tick counts, not the literal id number the original #554 round happened to observe (a live, rotating pool, not a fixed catalog). Re-derived via a direct command-mode probe of this exact step (`contract accept type:ore_sale` -> \"Accepted contract #71: Deliver absurdium ore\"), not guessed.",
+      "description": "#654: deliver button for the active ore_sale contract is blocked because storage never holds anything -- nothing in this scenario ever hauls material in. Selector is now type-based (`data-contract-type=\"ore_sale\"`, first-DOM-match) instead of a hardcoded numeric id: it resolves in the same first-match order the preceding `contract deliver type:ore_sale` command already used, so it stays correct across upstream tick-count drift without re-probing an id.",
       "expect": {
-        "blocked": "#bs-contract-panel [data-contract-id=\"71\"] .bs-contract-deliver"
+        "blocked": "#bs-contract-panel [data-contract-type=\"ore_sale\"] .bs-contract-deliver"
       },
       "role": "guard"
     },
@@ -2992,9 +2992,9 @@
           "command": "contract deliver type:ore_sale amount:300"
         }
       ],
-      "description": "#554: selector-based, same reasoning as the accept step above. BLOCKED, same class as this file's other deliver guards: the ACTIVE card's DELIVER button is disabled because storage never holds anything -- nothing in this scenario ever hauls material in, and by now the mine has been bankrupt and running on a destroyed drill fleet for well over a thousand ticks besides. `expect.blocked` proves the guard instead of faking a click no player could make. #601-followup: id corrected 100 -> 101, same mechanism and re-derivation method as this file's earlier #71 guard (a direct command-mode probe of this exact step: `contract accept type:ore_sale` -> \"Accepted contract #101: Deliver sparkium ore\").",
+      "description": "#654: deliver button for the active ore_sale contract is blocked because storage never holds anything -- nothing in this scenario ever hauls material in. Selector is now type-based (`data-contract-type=\"ore_sale\"`, first-DOM-match) instead of a hardcoded numeric id: it resolves in the same first-match order the preceding `contract deliver type:ore_sale` command already used, so it stays correct across upstream tick-count drift without re-probing an id.",
       "expect": {
-        "blocked": "#bs-contract-panel [data-contract-id=\"101\"] .bs-contract-deliver"
+        "blocked": "#bs-contract-panel [data-contract-type=\"ore_sale\"] .bs-contract-deliver"
       },
       "role": "guard"
     },
@@ -3727,9 +3727,9 @@
           "command": "contract deliver type:ore_sale amount:350"
         }
       ],
-      "description": "BLOCKED, same class as this file's other deliver guards: the ACTIVE card's DELIVER button is disabled because storage never holds anything -- nothing in this scenario ever hauls material in, and by now the mine has been bankrupt and running on a destroyed drill fleet for well over a thousand ticks besides. `expect.blocked` proves the guard instead of faking a click no player could make. `usable` on goto-ops dropped -- covered by the same overlay as everything else. #601-followup: id corrected 115 -> 139, same mechanism and re-derivation method as this file's earlier #71/#101 guards (a direct command-mode probe of this exact step: `contract accept type:ore_sale` -> \"Accepted contract #139: Deliver blingite ore\").",
+      "description": "#654: deliver button for the active ore_sale contract is blocked because storage never holds anything -- nothing in this scenario ever hauls material in. `usable` on goto-ops dropped -- covered by the same overlay as everything else. Selector is now type-based (`data-contract-type=\"ore_sale\"`, first-DOM-match) instead of a hardcoded numeric id: it resolves in the same first-match order the preceding `contract deliver type:ore_sale` command already used, so it stays correct across upstream tick-count drift without re-probing an id.",
       "expect": {
-        "blocked": "#bs-contract-panel [data-contract-id=\"139\"] .bs-contract-deliver"
+        "blocked": "#bs-contract-panel [data-contract-type=\"ore_sale\"] .bs-contract-deliver"
       },
       "role": "guard"
     },

--- a/tests/unit/scenario-defs.test.ts
+++ b/tests/unit/scenario-defs.test.ts
@@ -392,6 +392,58 @@ describe('"contract" commands use type:/material:, not a numeric id (issue #597)
 });
 
 // ──────────────────────────────────────────────
+// 7c. No step's JSON (any field — selector, expect.blocked, expect.usable,
+// etc., not just command strings) contains a literal `data-contract-id="N"`
+// DOM selector (issue #654). The contract-offer pool rotates on
+// `CONTRACT_REFRESH_INTERVAL`, so an id baked straight into a guard selector
+// (e.g. `#bs-contract-panel [data-contract-id="26"] .bs-contract-deliver`)
+// pins to whatever the pool happened to resolve to at authoring time and
+// breaks the moment an upstream timing change shifts tick counts — the same
+// class of flake 7b already guards against for `contract` command strings,
+// widened here to catch the id showing up in ANY field of a step. This check
+// is field-name agnostic by design: it does not care which selector or
+// attribute the implementer uses to target a contract row, only that the
+// literal numeric id is gone.
+//
+// level1-win-efficient.json is exempted by name: it has its own pre-existing
+// literal `data-contract-id="N"` selectors that predate #654 and need a
+// separate migration. That migration is out of scope for #654 — this is a
+// deliberate, named skip, not a loophole.
+// ──────────────────────────────────────────────
+describe('No step contains a literal data-contract-id="N" DOM selector (issue #654)', () => {
+  // Matches the pattern in a step's raw field value (data-contract-id="26")
+  // as well as inside a JSON.stringify()'d string, where the CSS selector's
+  // own double quotes come out backslash-escaped (data-contract-id=\"26\").
+  const LITERAL_CONTRACT_ID = /data-contract-id=\\?"\d+\\?"/;
+
+  // Deliberate, named exemption — see comment above. Not part of #654's scope.
+  const EXEMPT_SCENARIOS = new Set(['level1-win-efficient']);
+
+  for (const name of ALL_SCENARIO_NAMES) {
+    if (EXEMPT_SCENARIOS.has(name)) {
+      it.skip(`${name} — exempted from data-contract-id lint (issue #654, separate follow-up)`, () => {});
+      continue;
+    }
+
+    it(`${name} — no step JSON contains a literal data-contract-id="N" selector`, () => {
+      const scenario = loadScenarioDef(name, SCENARIO_DIR);
+      const offenders: string[] = [];
+
+      for (let i = 0; i < scenario.steps.length; i++) {
+        const step = scenario.steps[i] as ScenarioStepDef;
+        const serialized = JSON.stringify(step);
+        const match = LITERAL_CONTRACT_ID.exec(serialized);
+        if (match) {
+          offenders.push(`step[${i}]: ${match[0]}`);
+        }
+      }
+
+      expect(offenders).toEqual([]);
+    });
+  }
+});
+
+// ──────────────────────────────────────────────
 // 8b. "vehicle buy" steps pass a valid VehicleRole
 // Regression: scripts/scenario-defs/vehicle-traffic.json used to pass
 // "hauler" as the role argument, which is not a member of VehicleRole

--- a/tests/unit/scenario-defs.test.ts
+++ b/tests/unit/scenario-defs.test.ts
@@ -392,38 +392,51 @@ describe('"contract" commands use type:/material:, not a numeric id (issue #597)
 });
 
 // ──────────────────────────────────────────────
-// 7c. No step's JSON (any field — selector, expect.blocked, expect.usable,
-// etc., not just command strings) contains a literal `data-contract-id="N"`
+// 7c. No step's FUNCTIONAL fields — the ones that actually drive DOM
+// targeting or command dispatch (`command`, `interaction[].command`,
+// `interaction[].selector` on any action that carries one, and
+// `expect.blocked`/`expect.usable`) — contain a literal `data-contract-id="N"`
 // DOM selector (issue #654). The contract-offer pool rotates on
 // `CONTRACT_REFRESH_INTERVAL`, so an id baked straight into a guard selector
 // (e.g. `#bs-contract-panel [data-contract-id="26"] .bs-contract-deliver`)
 // pins to whatever the pool happened to resolve to at authoring time and
 // breaks the moment an upstream timing change shifts tick counts — the same
 // class of flake 7b already guards against for `contract` command strings,
-// widened here to catch the id showing up in ANY field of a step. This check
-// is field-name agnostic by design: it does not care which selector or
-// attribute the implementer uses to target a contract row, only that the
-// literal numeric id is gone.
+// widened here to catch the id showing up in any functional field of a step.
+//
+// Deliberately scoped to those fields, NOT the whole `JSON.stringify(step)`
+// (post-review fix, issue #654): a step's free-text `description` narrates
+// its own authoring history in prose and can legitimately quote an old,
+// already-fixed selector (e.g. "...previously scoped to
+// `[data-contract-id=\"19\"] .bs-contract-accept`...") without that prose
+// being a live violation. Scanning the whole step produced a false positive
+// on level3-playthrough-win.json step 79, whose live `command`/`selector`/
+// `expect` fields are already migrated to `type:`/`data-contract-type`
+// selectors — only its description mentions the old id it moved away from.
 //
 // level1-win-efficient.json is exempted by name: it has its own pre-existing
-// literal `data-contract-id="N"` selectors that predate #654 and need a
-// separate migration. That migration is out of scope for #654 — this is a
-// deliberate, named skip, not a loophole.
-//
-// level3-playthrough-win.json is exempted the same way: pre-existing literal
-// id, out of scope for this issue — follow-up needed. Issue #654 names
-// exactly one file to fix (level2-playthrough-win.json), whose probe history
-// is specific to that file's own tick counts; level3's violation is real but
-// separate.
+// literal `data-contract-id="N"` selectors in real `selector`/`expect.blocked`
+// fields that predate #654 and need a separate migration. That migration is
+// out of scope for #654 — this is a deliberate, named skip, not a loophole.
 // ──────────────────────────────────────────────
 describe('No step contains a literal data-contract-id="N" DOM selector (issue #654)', () => {
-  // Matches the pattern in a step's raw field value (data-contract-id="26")
-  // as well as inside a JSON.stringify()'d string, where the CSS selector's
-  // own double quotes come out backslash-escaped (data-contract-id=\"26\").
-  const LITERAL_CONTRACT_ID = /data-contract-id=\\?"\d+\\?"/;
+  // Matches the pattern in a step's raw field value (data-contract-id="26").
+  const LITERAL_CONTRACT_ID = /data-contract-id="\d+"/;
 
-  // Deliberate, named exemptions — see comment above. Not part of #654's scope.
-  const EXEMPT_SCENARIOS = new Set(['level1-win-efficient', 'level3-playthrough-win']);
+  // Deliberate, named exemption — see comment above. Not part of #654's scope.
+  const EXEMPT_SCENARIOS = new Set(['level1-win-efficient']);
+
+  /** Every functional (DOM/command-dispatching) string field of a step, not free text like `description`. */
+  const functionalStrings = (step: ScenarioStepDef): string[] => {
+    const values: string[] = [step.command];
+    if (step.expect?.blocked !== undefined) values.push(step.expect.blocked);
+    if (step.expect?.usable !== undefined) values.push(step.expect.usable);
+    for (const action of step.interaction ?? []) {
+      if ('command' in action && typeof action.command === 'string') values.push(action.command);
+      if ('selector' in action && typeof action.selector === 'string') values.push(action.selector);
+    }
+    return values;
+  };
 
   for (const name of ALL_SCENARIO_NAMES) {
     if (EXEMPT_SCENARIOS.has(name)) {
@@ -431,16 +444,17 @@ describe('No step contains a literal data-contract-id="N" DOM selector (issue #6
       continue;
     }
 
-    it(`${name} — no step JSON contains a literal data-contract-id="N" selector`, () => {
+    it(`${name} — no step's functional fields contain a literal data-contract-id="N" selector`, () => {
       const scenario = loadScenarioDef(name, SCENARIO_DIR);
       const offenders: string[] = [];
 
       for (let i = 0; i < scenario.steps.length; i++) {
         const step = scenario.steps[i] as ScenarioStepDef;
-        const serialized = JSON.stringify(step);
-        const match = LITERAL_CONTRACT_ID.exec(serialized);
-        if (match) {
-          offenders.push(`step[${i}]: ${match[0]}`);
+        for (const value of functionalStrings(step)) {
+          const match = LITERAL_CONTRACT_ID.exec(value);
+          if (match) {
+            offenders.push(`step[${i}]: ${match[0]}`);
+          }
         }
       }
 

--- a/tests/unit/scenario-defs.test.ts
+++ b/tests/unit/scenario-defs.test.ts
@@ -409,6 +409,12 @@ describe('"contract" commands use type:/material:, not a numeric id (issue #597)
 // literal `data-contract-id="N"` selectors that predate #654 and need a
 // separate migration. That migration is out of scope for #654 — this is a
 // deliberate, named skip, not a loophole.
+//
+// level3-playthrough-win.json is exempted the same way: pre-existing literal
+// id, out of scope for this issue — follow-up needed. Issue #654 names
+// exactly one file to fix (level2-playthrough-win.json), whose probe history
+// is specific to that file's own tick counts; level3's violation is real but
+// separate.
 // ──────────────────────────────────────────────
 describe('No step contains a literal data-contract-id="N" DOM selector (issue #654)', () => {
   // Matches the pattern in a step's raw field value (data-contract-id="26")
@@ -416,8 +422,8 @@ describe('No step contains a literal data-contract-id="N" DOM selector (issue #6
   // own double quotes come out backslash-escaped (data-contract-id=\"26\").
   const LITERAL_CONTRACT_ID = /data-contract-id=\\?"\d+\\?"/;
 
-  // Deliberate, named exemption — see comment above. Not part of #654's scope.
-  const EXEMPT_SCENARIOS = new Set(['level1-win-efficient']);
+  // Deliberate, named exemptions — see comment above. Not part of #654's scope.
+  const EXEMPT_SCENARIOS = new Set(['level1-win-efficient', 'level3-playthrough-win']);
 
   for (const name of ALL_SCENARIO_NAMES) {
     if (EXEMPT_SCENARIOS.has(name)) {


### PR DESCRIPTION
Closes #654

## Summary

`scripts/scenario-defs/level2-playthrough-win.json` pinned 5 `expect.blocked` guard selectors to a literal `data-contract-id="N"`, even though each guard's preceding step accepts the contract by TYPE (`contract accept type:ore_sale`). The id is whatever the rotating offer pool resolved to that tick, so any upstream change shifting this file's tick counts silently breaks the guard — this file has needed hand re-probing three times already (#601, #626).

Changes:
- `scripts/scenario-defs/level2-playthrough-win.json` — all 5 guards converted to `#bs-contract-panel [data-contract-type="ore_sale"] .bs-contract-deliver`. Traced (by two independent reviewers, through `Contract.ts`'s `findContract` and `ContractsPanel.ts`'s card rendering) that `querySelector`'s first-DOM-match and the console command's first-array-match walk the same underlying array in the same order, so the selector and the preceding `contract deliver type:ore_sale` command always resolve to the same card — including at the one guard point (line ~1618) where two `ore_sale` contracts are simultaneously active. Descriptions rewritten to explain the new mechanism instead of recording a probed id.
- `tests/unit/scenario-defs.test.ts` — new "7c" check: scans every scenario-def step's functional fields (`command`, `expect.blocked`, `expect.usable`, `interaction[].command`/`.selector`) for a literal `data-contract-id="N"` and fails if found, so this class of fragility can't come back through the DOM side. One named exemption remains: `level1-win-efficient.json`, which has real pre-existing literal-id selectors out of this issue's scope.

131/131 scenarios pass command mode; `level2-playthrough-win` specifically: 192/192 steps OK, `deathCount`/`levelEndReason`/final `cash` assertions unchanged. Full unit/integration suite: 10189 passed, 1 skipped, 0 failed. Typecheck clean.

## Decisions taken

Defaulted under `agentic-decision-autonomy`:

- **What was open:** the issue's own verification list asks the new lint to catch a literal `data-contract-id="N"` "inside a step's selectors" repo-wide (extending #638/#635's convention), but a first pass scanning the whole stringified step (including free-text `description` fields) produced a false positive on `level3-playthrough-win.json` — its only match was inside prose narrating an already-completed historical fix, not a live selector.
  **Chosen:** scope the "7c" scan to the functional fields that actually drive DOM/command targeting (`command`, `expect.blocked`, `expect.usable`, `interaction[].command`/`.selector`), excluding `description`/`note`/free text. This removed the need for a `level3-playthrough-win` exemption entirely — it now passes for real, with zero violations in functional fields.
  **Why:** matching narrative text produces false positives that erode trust in the lint (exactly the "human re-probing" cost this issue exists to eliminate, just moved into acknowledging a fake violation) and mischaracterizes a clean file as needing follow-up work it doesn't need.
  **If reversed:** widen `functionalStrings()` in `tests/unit/scenario-defs.test.ts`'s "7c" block back to `JSON.stringify(step)`; re-add a `level3-playthrough-win` entry to the exemption set if that regresses.
- **What was open:** `level1-win-efficient.json` still has 6 live literal-id selectors, and the issue's verification list reads as if the lint should be repo-wide.
  **Chosen:** keep `level1-win-efficient.json` as a named, commented `it.skip` exemption rather than migrating it in this PR.
  **Why:** the issue's own Files section names only `level2-playthrough-win.json` as the file to modify; migrating level1's ids would require a live interaction-mode re-probe of a file this issue never asked to touch, real work outside its stated scope.
  **If reversed:** migrate `level1-win-efficient.json`'s selectors the same way as this PR (type/material-based), then delete its exemption entry.

Neither decision changes gameplay, economy, or a player-facing default — both are test-infrastructure scoping calls — so no `decision-review` follow-up issue was opened.

## Verification

- static: `npm run typecheck` — clean
- logic: `npm run test` — 10189 passed, 1 skipped, 0 failed (318 files)
- scenario (command mode): `npm run scenarios` — 131/131 passed, including `level2-playthrough-win` (192/192 steps, unchanged final assertions)
- scenario (interaction mode) — not run in this session; `level2-playthrough-win`'s 5 converted guards only get a real DOM/CSS `querySelector` exercise under a browser, which is exactly what proves the fix. Covered by the `full-ci` label below — CI's `Scenarios (interaction mode)` job reports on it.

READY TO MERGE
