### PR TITLE
fix: Resolve #675 — assignSkill refuses a dead employee, matching sibling guards

### DIFF
--- a/src/console/commands/employees.ts
+++ b/src/console/commands/employees.ts
@@ -130,6 +130,7 @@ export function employeeCommand(
 
       const emp = state.employees.employees.find(e => e.id === id);
       if (!emp) return { success: false, output: `Employee #${id} not found.` };
+      if (!emp.alive) return { success: false, output: `Employee #${id} is dead and cannot be assigned a skill.` };
 
       assignSkill(state.employees, id, skillRaw as SkillCategory, level as 1 | 2 | 3 | 4 | 5);
       return { success: true, output: `Employee #${id} assigned skill: ${skillRaw} (level ${level}).` };

--- a/src/core/entities/Employee.ts
+++ b/src/core/entities/Employee.ts
@@ -394,7 +394,7 @@ export function assignSkill(
   level: 1 | 2 | 3 | 4 | 5,
 ): boolean {
   const emp = state.employees.find(e => e.id === employeeId);
-  if (!emp) return false;
+  if (!emp || !emp.alive) return false;
 
   const idx = emp.qualifications.findIndex(q => q.category === category);
   const qual: SkillQualification = { category, proficiencyLevel: level, xp: 0 };

--- a/tests/integration/employee-commands.test.ts
+++ b/tests/integration/employee-commands.test.ts
@@ -6,6 +6,7 @@ import { employeeCommand, needsCommand } from '../../src/console/commands/entiti
 import { setPolicyCommand } from '../../src/console/commands/policy.js';
 import { drillPlanCommand, type MiningContext } from '../../src/console/commands/mining.js';
 import { EventEmitter } from '../../src/core/state/EventEmitter.js';
+import { killEmployee } from '../../src/core/entities/Employee.js';
 
 // ── Shared helpers ──────────────────────────────────────────────────────────
 
@@ -162,6 +163,33 @@ describe('Console — employee assign_skill', () => {
       );
       expect(result.success, `category "${category}" should be accepted`).toBe(true);
     }
+  });
+
+  // ── #675: assign_skill against a dead employee ────────────────────────────
+
+  it('refuses to assign a skill to a dead employee', () => {
+    killEmployee(ctx.state!.employees, empId);
+
+    const result = employeeCommand(
+      ctx,
+      ['assign_skill', String(empId)],
+      { skill: 'blasting', level: '3' },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.output).toBe(`Employee #${empId} is dead and cannot be assigned a skill.`);
+  });
+
+  it('does not append a qualification when the refused call targets a dead employee', () => {
+    const emp = ctx.state!.employees.employees.find(e => e.id === empId)!;
+    const before = emp.qualifications.length;
+
+    killEmployee(ctx.state!.employees, empId);
+    // 'geology' is not the blaster's starting qualification, so a missing
+    // guard would grow the array rather than merely overwrite a value.
+    employeeCommand(ctx, ['assign_skill', String(empId)], { skill: 'geology', level: '3' });
+
+    expect(emp.qualifications.length).toBe(before);
   });
 });
 

--- a/tests/unit/entities/EmployeeSkills.test.ts
+++ b/tests/unit/entities/EmployeeSkills.test.ts
@@ -17,6 +17,7 @@ import { XP_THRESHOLDS } from '../../../src/core/config/balance.js';
 import {
   createEmployeeState,
   hireEmployee,
+  killEmployee,
   type EmployeeState,
   // ── New exports (CH1.4 — not yet implemented in Employee.ts) ────────────────
   assignSkill,
@@ -133,6 +134,28 @@ describe('assignSkill', () => {
     const before = state.employees.length;
     assignSkill(state, 9999, 'geology' as SkillCategory, 1);
     expect(state.employees.length).toBe(before);
+  });
+
+  // ── #675: assignSkill against a dead employee ──────────────────────────────
+
+  it('returns false when the employee is not alive', () => {
+    expect(killEmployee(state, empId)).toBe(true);
+
+    const ok = assignSkill(state, empId, 'blasting' as SkillCategory, 1);
+    expect(ok).toBe(false);
+  });
+
+  it('does not modify qualifications when the employee is not alive', () => {
+    const emp = state.employees.find(e => e.id === empId)!;
+    const before = JSON.parse(JSON.stringify(emp.qualifications));
+
+    killEmployee(state, empId);
+    // 'geology' is not the driller's starting qualification — a category the
+    // employee doesn't already hold, so a missing guard would append a new
+    // entry rather than silently no-op on an unchanged value.
+    assignSkill(state, empId, 'geology' as SkillCategory, 3);
+
+    expect(emp.qualifications).toEqual(before);
   });
 });
 


### PR DESCRIPTION
Closes #675

`assignSkill()` in `src/core/entities/Employee.ts` was the only mutation function in its neighborhood that did not check `employee.alive` before acting — `giveRaise()`, `enrolInTraining()`, and `canAssignDriver()` all already refuse cleanly on a dead employee. This let a dead employee still be granted a qualification/licence, and the console command `employee assign_skill` reported a false `success: true` confirmation for an action with no meaningful effect.

## Changes

- `src/core/entities/Employee.ts` — `assignSkill()`'s guard changes from `if (!emp) return false;` to `if (!emp || !emp.alive) return false;`, matching `giveRaise`'s existing guard style in the same file exactly.
- `src/console/commands/employees.ts` — the `'assign_skill'` case now returns `{ success: false, output: 'Employee #${id} is dead and cannot be assigned a skill.' }` when the target is dead, inserted between the existing not-found check and the mutation call, instead of the previous unconditional success confirmation.
- Unit tests added to `tests/unit/entities/EmployeeSkills.test.ts`: `assignSkill` returns `false` against a dead employee, and leaves `qualifications` unchanged.
- Integration tests added to `tests/integration/employee-commands.test.ts`: the console command refuses a dead employee id with the exact message, and does not append a qualification.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** the issue specified the console command should return `{ success: false, output: ... }` "naming the reason" but did not give exact wording.
  **Chosen:** `Employee #${id} is dead and cannot be assigned a skill.`
  **Why:** matches the local convention already in the same `switch` — the sibling `dispatch` case uses `Employee #${id} is injured and cannot be dispatched.` / `... is in training and cannot be dispatched.`, same `Employee #${id} is <state> and cannot be <verb>.` shape. "Dead" matches the roster's own `DEAD` status label used elsewhere in the same file.
  **If reversed:** change the string literal on that one line; the test asserting it verbatim would need updating too, no other call site depends on the exact text.

## Verification

- `static` — `npm run typecheck`: clean, exit 0.
- `logic` — `npm run test`: 322 files, 10461 passed, 1 skipped, exit 0.
- `scenario` — `npm run scenarios`: 131/131 passed.
- `build` — production build: 284 modules, exit 0.
- Code review: security, quality, i18n, duplication, semantic reviewers — all PASS.

Backend-only change (`src/core/`, `src/console/`) — no `full-ci` label, per the issue's own conventions: no renderer/UI file touched, no interaction-mode scenario applies.

READY TO MERGE