### PR TITLE
feat: generic follow-up issue filing for findings, tech debt and scope cuts

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -129,6 +129,16 @@ A channel that belongs to CI is **covered**, never pending: an autonomous run ma
 
 Before acting, check whether the task needs a capability you lack (audio playback, binary analysis, a network the sandbox blocks) or asks you to write outside allowed directories. If so, state the gap and the agent or tool that covers it instead of improvising a workaround. Vision, browser automation, and shell are available — those are not gaps.
 
+## ▶ Follow-up Gate — work you found that is not your task
+
+| You found | You file |
+|-----------|----------|
+| A default you chose that a human may want to revisit | The decision — `agentic-decision-autonomy` |
+| Tech debt, a gap, or an inconsistency unrelated to your task | The finding — `agentic-issue-creation` |
+| That your own task is bigger than one run | The scope you cut, so the remainder is not lost — `agentic-issue-creation` |
+
+**Filing never halts you.** It does not hold your PR, downgrade it to draft, or leave your own issue non-terminal. Fix what your change exposes; file the rest. If your tools block `gh`, hand the finding to whoever invoked you — it is filed after review, once every agent's findings are in.
+
 ## Validation Commands
 
 ```bash

--- a/.claude/agents/duplication-reviewer.md
+++ b/.claude/agents/duplication-reviewer.md
@@ -79,6 +79,8 @@ handles that) — focus on **semantic and structural** duplication.
 
 ## Output Format
 
+Tag every finding with its scope so `merge-findings` can disposition it: `[in-diff]` when it sits inside what this PR changed or broke, `[pre-existing]` when the diff merely revealed it. Report a `[pre-existing]` finding like any other — the orchestrator files it as a follow-up issue rather than widening this PR. Report it rather than filing it: mutating `gh` is blocked for this agent by design.
+
 Each finding includes a confidence level:
 
 - **high** — verified by reading both the changed code and an existing counterpart

--- a/.claude/agents/i18n-reviewer.md
+++ b/.claude/agents/i18n-reviewer.md
@@ -34,6 +34,8 @@ Position: parallel sub-reviewer in code_review fan-out. Read-only.
 
 ## Output Format
 
+Tag every finding with its scope so `merge-findings` can disposition it: `[in-diff]` when it sits inside what this PR changed or broke, `[pre-existing]` when the diff merely revealed it. Report a `[pre-existing]` finding like any other — the orchestrator files it as a follow-up issue rather than widening this PR. Report it rather than filing it: mutating `gh` is blocked for this agent by design.
+
 Each finding includes a confidence level:
 
 - **high** — verified by reading source + locale JSONs

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -48,6 +48,12 @@ Adding/modifying console command:
 3. Handler: `GameState` + parsed args → core logic → `CommandResult`
 4. `ConsoleFormatter` → human-readable output
 
+## Scope Overrun
+
+The plan sized this task on what a reader could see. When the codebase disagrees — the change reaches far more call sites than the plan lists, or landing it means re-deriving values across many files — say so in the hand-back rather than working through it. A run that spends its whole budget is killed mid-work, and what survives is an unreviewed branch nobody can finish.
+
+Report `SCOPE OVERRUN: <the slice that reaches green alone> | <the remainder>`. The orchestrator decides, cuts, and files the remainder per `agentic-issue-creation`. Landing a coherent slice is a finished run; landing half of everything is not.
+
 ## Key References
 
 - `dev-architecture` — module boundaries, data flow

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -37,6 +37,9 @@ Produce structured implementation plan from issue. Read-only — no code changes
 - [ ] criterion 2
 ### Decisions
 - **Open:** what the issue left unspecified — **Chosen:** the default — **Why:** the spec, convention, or incentive it follows — **Reverse by:** the constant or branch a human would change
+### Scope
+- `fits` — one run can carry this to a merged pull request
+- `oversized` — name the slice that reaches green on its own, and the remainder the orchestrator should file per `agentic-issue-creation`
 ### Edge Cases
 - edge case 1
 ### Architecture Notes

--- a/.claude/agents/quality-reviewer.md
+++ b/.claude/agents/quality-reviewer.md
@@ -75,6 +75,8 @@ Adjust review depth based on `risk_tier` from context:
 
 ## Output Format
 
+Tag every finding with its scope so `merge-findings` can disposition it: `[in-diff]` when it sits inside what this PR changed or broke, `[pre-existing]` when the diff merely revealed it. Report a `[pre-existing]` finding like any other — the orchestrator files it as a follow-up issue rather than widening this PR. Report it rather than filing it: mutating `gh` is blocked for this agent by design.
+
 Each finding includes a confidence level:
 
 - **high** — verified by reading the source code, clear violation

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -35,6 +35,8 @@ Position: parallel sub-reviewer in code_review fan-out. Read-only.
 
 ## Output Format
 
+Tag every finding with its scope so `merge-findings` can disposition it: `[in-diff]` when it sits inside what this PR changed or broke, `[pre-existing]` when the diff merely revealed it. Report a `[pre-existing]` finding like any other — the orchestrator files it as a follow-up issue rather than widening this PR. Report it rather than filing it: mutating `gh` is blocked for this agent by design.
+
 Each finding includes a confidence level:
 
 - **high** — verified by reading the source code, concrete exploit exists

--- a/.claude/agents/semantic-reviewer.md
+++ b/.claude/agents/semantic-reviewer.md
@@ -75,6 +75,8 @@ Verify semantic coherence between tests and implementation. Every test case must
 
 ## Output Format
 
+Tag every finding with its scope so `merge-findings` can disposition it: `[in-diff]` when it sits inside what this PR changed or broke, `[pre-existing]` when the diff merely revealed it. Report a `[pre-existing]` finding like any other — the orchestrator files it as a follow-up issue rather than widening this PR. Report it rather than filing it: mutating `gh` is blocked for this agent by design.
+
 ```
 ## Semantic Review
 ### Test Coverage

--- a/.claude/skills/agentic-autonomous-pipeline/references/runtime-parity.md
+++ b/.claude/skills/agentic-autonomous-pipeline/references/runtime-parity.md
@@ -31,6 +31,16 @@ So "invoke the reviewers in parallel" reads as *fan out and await* under OpenCod
 
 **The principle generalises past that one parameter. Where runtimes differ, the shared context states the invariant and each runtime's own configuration layer enforces it.** A body that names one runtime's parameters is a body that is wrong for the other two.
 
+Issue filing splits the same way. The rule — a read-only agent reports a finding, the orchestrator files it — is uniform. What denies the agent the command is not:
+
+| Runtime | Read-only agents denied GitHub writes by |
+|---------|------------------------------------------|
+| OpenCode | `permission.bash` in the agent's own frontmatter: `"git *": "deny"`, `"gh *": "deny"` |
+| Copilot | `tools: ["read", "search"]` — no shell to run `gh` with |
+| Claude Code | A `PreToolUse` hook on `Bash`, `block-git-gh.sh`, registered in the agent's frontmatter |
+
+Three mechanisms, one behaviour: a reviewer that tries to open an issue fails wherever it runs, so a finding reaches GitHub through the orchestrator or not at all. `agentic-pipeline-review-pr` states the rule and names none of them.
+
 ## Claude Code prerequisites
 
 Delegation depends on configuration that is off by default:

--- a/.claude/skills/agentic-decision-autonomy/SKILL.md
+++ b/.claude/skills/agentic-decision-autonomy/SKILL.md
@@ -85,7 +85,7 @@ An earlier convention held a PR back for "significant churn". It cost a green, f
 
 An issue's title describes where the reporter noticed the problem, not where the problem lives. When the fix reaches deeper than the framing — a visual-coherence issue that turns out to need a simulation fix — implement the fix that is actually correct, say so in the PR body, and continue. A correct fix outside the framing beats an incorrect one inside it.
 
-The limit is relevance, not depth: fix what this issue's own change exposes. Unrelated defects noticed along the way become their own issues.
+The limit is relevance, not depth: fix what this issue's own change exposes. Unrelated defects noticed along the way become their own issues — reported into the run's follow-up register and filed at the end of the pipeline, per `agentic-issue-creation`. Recording one is not escalating: it never holds the PR and never delays the run's own issue.
 
 ## Recording format
 

--- a/.claude/skills/agentic-issue-creation/SKILL.md
+++ b/.claude/skills/agentic-issue-creation/SKILL.md
@@ -1,13 +1,23 @@
 ---
 name: agentic-issue-creation
-description: Create or edit GitHub issues for agentic pipeline consumption — context, files, test files, dependencies (setting or reading a blocked_by relationship), labels, and verification criteria. Use when creating an issue for autonomous coding agents, or when editing an existing one's dependencies, labels, or lifecycle state.
+description: Create or edit GitHub issues for agentic pipeline consumption — context, files, test files, dependencies (setting or reading a blocked_by relationship), labels, and verification criteria. Use when filing an issue for autonomous coding agents, when recording technical debt, a codebase gap, an inconsistency or a defect found while working on something else, when cutting a task that turns out to be bigger than one run and filing the remainder, or when editing an already-filed issue's dependencies, labels, or lifecycle state.
 ---
 
 # Skill: agentic-issue-creation
 
 ## When to Use
 
-Use when creating a GitHub issue that an autonomous run will pick up, or when editing an already-filed one's dependencies, labels, or lifecycle state. An issue is the only input the pipeline takes, so it has to stand on its own — the run starts with the issue body and the codebase, and nothing else. Setting a `blocked_by` relationship on an existing issue is this skill's task exactly as much as authoring a new one is — see "Setting a dependency" below.
+Use when creating a GitHub issue that an autonomous run will pick up, when recording something found while working on a different task, when cutting an oversized task and filing the remainder, or when editing an already-filed one's dependencies, labels, or lifecycle state. An issue is the only input the pipeline takes, so it has to stand on its own — the run starts with the issue body and the codebase, and nothing else. Setting a `blocked_by` relationship on an existing issue is this skill's task exactly as much as authoring a new one is — see "Setting a dependency" below.
+
+Three situations put an agent here, and they differ only in what the issue records:
+
+| Situation | What the issue carries |
+|-----------|------------------------|
+| **Planned work** — decomposing a feature, or a human filing a task | The task itself, in one of the two shapes below |
+| **A finding** — technical debt, a codebase gap, an inconsistency, a defect noticed while working on something else | The finding, plus where it was found and why it was not fixed on the spot |
+| **A scope cut** — the assigned task turns out to be bigger than one run can carry | The remainder deliberately left out, and what was landed instead |
+
+A finding and a scope cut become ordinary issues the moment they are filed. They differ from planned work only in provenance, which the template's optional sections carry.
 
 Two shapes are valid, and they differ in how much of the answer is already known:
 
@@ -20,15 +30,50 @@ Both enter the same queue once `ready` lands on the issue — a two-line issue t
 
 ## ▶ PROCEDURE — EXECUTE IN ORDER
 
-1. Pick the shape: complete when you know the file layout, intent when you are describing an outcome
-2. Fill every section that shape carries, using the headings below verbatim
-3. Verify the Rules are satisfied
-4. Run through the Checklist
-5. Create the issue with `gh issue create`, setting labels yourself:
-   - Human gave no instruction about labels → `--label ready,agent-task`. `ready` means eligible, not started: it places the issue in the queue, where it waits until a human dispatches `agentic-trigger.yml` or a merged pipeline PR chains to it. Creating an issue never starts a run.
-   - Human specified labels, or said the issue should wait — `decision-review` for a default to revisit later, or an explicit hold — → follow that instruction instead, and leave `ready` off.
+1. Run the duplicate check below. An open issue that already covers it is updated, not duplicated
+2. Pick the shape: complete when you know the file layout, intent when you are describing an outcome
+3. Fill every section that shape carries, using the headings below verbatim
+4. Verify the Rules are satisfied
+5. Run through the Checklist
+6. Create the issue with `gh issue create`, setting labels per the Labels section below. A human who specified labels, or said the issue should wait, overrides that table
 
-An issue that must **stay out** of the queue is created carrying a lifecycle label of its own instead of `ready` — `decision-review` for a default to revisit later. The issue joins the queue in number order once `ready` is on it, whoever put it there.
+`ready` means eligible, not started: it places the issue in the queue, where it waits until a human dispatches `agentic-trigger.yml` or a merged pipeline pull request chains to it. Creating an issue never starts a run. The issue joins the queue in number order once `ready` is on it, whoever put it there.
+
+## ▶ Duplicate check — run before filing anything
+
+An issue nobody reads twice is cheap; two issues for one problem are not. They split the discussion, and the second run to pick one up rediscovers what the first already fixed.
+
+1. Search open issues for the thing itself rather than for your phrasing of it — the symbol, the file path, the error text, the convention being violated.
+   ```bash
+   gh issue list --state open --search "<symbol or file path>" --limit 20
+   gh issue list --state open --label agent-task --limit 50   # when the term is a concept, not a string
+   ```
+   With no `gh` CLI — Claude Code on the web has none — the same search runs against the REST API with the `GITHUB_TOKEN` already in the environment. Never echo the token; pass it straight from the variable.
+   ```bash
+   curl -sS -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" \
+     --get --data-urlencode "q=repo:Nico2398/BlastSimulator2026 is:issue is:open <terms>" \
+     "https://api.github.com/search/issues" \
+     | python3 -c "import sys,json; [print(i['number'], i['title']) for i in json.load(sys.stdin)['items']]"
+   ```
+2. **A match that covers your finding → update it.** Add what you learned as a comment when it is evidence (a second occurrence, a reproduction, an exact line number), or edit the body when it is a correction (a wrong path, a missing consumer, a premise that no longer holds). Name the run that found it, so the next reader knows where the addition came from.
+3. **A match that overlaps without covering it** → file, and name the neighbour in your Context section so a human can merge the two if they disagree.
+4. **A closed match** → read how it closed. Closed with a merged pull request means the problem came back and yours is a regression report, which is worth saying in the body. Closed unmerged means it was declined, and refiling needs a reason.
+
+Searching costs one command. Filing a duplicate costs a run.
+
+## ▶ Labels — `ready` is a confidence statement
+
+`agentic-assign` selects on `ready` alone. Putting it on an issue says *this work should be done, and the description is good enough to start from.* Putting it on a hunch spends a whole run discovering the hunch was wrong.
+
+| Confidence | Labels | What follows |
+|-----------|--------|--------------|
+| **High** — a defect you reproduced, a convention you can point at, a gap you verified in the code | `agent-task`, `ready` | The work is real and specified. The issue joins the queue in number order. |
+| **Open** — something looks wrong, and a human should confirm it is worth doing or pick between two directions | `agent-task` | The issue stays out of the queue until a human adds `ready`. |
+| **Already decided by the run** — a default you implemented that a human may want to revisit | `decision-review` | Held by `agentic-decision-autonomy`, which owns that flow end to end. |
+
+An issue held for confirmation carries an `## Open question` section naming exactly what a human must answer and what changes with each answer. Without it the issue is a hunch nobody can act on, and it waits until someone re-derives the question you already knew.
+
+Leave `ready` off while you are uncertain. An issue carrying `agent-task` alone loses nothing — it keeps its number, its body and its place — and gains `ready` the moment a human agrees.
 
 ## Issue Body Template
 
@@ -54,7 +99,18 @@ An issue that must **stay out** of the queue is created carrying a lifecycle lab
 
 ## Verification
 - [Observable outcome that proves the task is done]
+
+## Where found
+[Findings and scope cuts only. Which run, which pull request or review round, what was being worked on at the time.]
+
+## Why not fixed here
+[Findings and scope cuts only. Why filing was right rather than folding it into the work in hand.]
+
+## Open question
+[Issues held at `agent-task` without `ready` only. What a human must answer, and what changes with each answer.]
 ```
+
+The last three sections are provenance and are omitted for planned work. `## Where found` and `## Why not fixed here` are what let the next reader judge a finding without reconstructing the review round that produced it; `## Open question` is what a human answers before adding `ready`.
 
 ## Rules
 
@@ -68,7 +124,9 @@ An issue that must **stay out** of the queue is created carrying a lifecycle lab
 8. **Single task per issue.** A task touching several concerns is several issues. So is a task that is one concern but too large for one run — Sizing below is the test, and Splitting is what to do about it.
 9. **SMART compliance.** Specific (one clear goal), Measurable (verifiable outcome), Achievable (within an agent's capabilities), Relevant (part of the larger feature), Time-bound (a single atomic task).
 10. **`full-ci` is off by default — an issue has to earn it.** The label starts the interaction-mode browser job, which costs the merge path real time, so it goes on an issue only where that job is the only thing that could catch the regression: an interaction-mode scenario clicks its way through the control, panel or flow the issue changes, or the issue touches shared input, picking, camera, rendering or harness machinery every scenario runs through. **Never on a backend-only issue.** A change confined to `src/core/`, `src/console/`, config or pure logic is proven by `static`, `logic` and command-mode `scenario`; replaying browser flows the diff never reaches reports nothing about it. **Never where there is no interaction regression to catch** — a renderer detail no scenario reaches, a control added to an existing panel, copy, a new command parameter. The `visual` channel covers those in-session against the thing that actually changed, which is stronger evidence than a suite that never touches it. When in doubt, leave it off. Full test and cost: `agentic-pipeline-pr-management`.
-11. **Label transfer.** A PR opened from a `full-ci` issue gets the same label, passed on the same `gh pr create` call that opens it (`--label "full-ci"`) — never a follow-up `gh pr edit --add-label`, which raises no `pull_request` event of its own and is how PR #615 merged with its interaction-mode job silently skipped. See `agentic-pipeline-finalization`'s `open-pr` step.
+11. **Search before filing, and update what already exists.** An open issue covering the same problem is updated rather than duplicated — procedure above.
+12. **`ready` states confidence, not hope.** It goes on an issue whose work is verified real and whose description is good enough to start from. Anything short of that is `agent-task` alone, with an `## Open question` section naming what a human must answer.
+13. **Label transfer.** A PR opened from a `full-ci` issue gets the same label, passed on the same `gh pr create` call that opens it (`--label "full-ci"`) — never a follow-up `gh pr edit --add-label`, which raises no `pull_request` event of its own and is how PR #615 merged with its interaction-mode job silently skipped. See `agentic-pipeline-finalization`'s `open-pr` step.
 
 ## ▶ Sizing — one issue is one run, and a run has a ceiling
 
@@ -94,6 +152,22 @@ The obvious split — the mechanic in one issue, the tests it breaks in the next
 3. **Stack the batches on an integration branch.** Sub-issues target the feature branch rather than `main`, and only the final merge has to be green. Last resort: assignability, auto-merge and rescue all assume a PR against `main`, so a human has to shepherd it.
 
 Batch issues are ordinary issues — `Blocked by` the enabler, one slice each, verification of their own.
+
+## ▶ Discovering mid-run that the task is bigger than one run
+
+Sizing above is the test applied *before* filing. The same ceiling exists mid-run, and reaching it is ordinary: the issue was sized on what a reader could see, and the codebase disagreed.
+
+What turns it into a lost run is carrying on regardless. A run that spends its whole budget is not cancelled politely — the job is killed, and what survives is whatever `agentic-rescue` can push: an unreviewed branch, a draft pull request, a `blocked` issue, and a human working out which half is done.
+
+Cut instead:
+
+1. **Pick the slice that reaches a green pull request on its own.** Not the slice already written — the slice that is coherent. A half-migrated call site is worse than an unmigrated one.
+2. **Land it, verified through every channel it owes.** A reduced scope changes nothing about the Verification Gate.
+3. **File the remainder**, one issue per slice, each able to reach green alone. The three splitting strategies above apply unchanged, and splitting the enablers off first is still the best of them.
+4. **Say what was cut**, in the pull request body and on the original issue, naming the new issue numbers. A remainder nobody can find is a remainder nobody does.
+5. **Set `Blocked by` only where a real ordering exists.** Slices touching different files are independent, and marking them blocked on each other serialises work that could run side by side.
+
+The original issue closes on its own merged pull request with its reduced scope stated. It stays open to track nothing — that is what the new issues are for, and an issue held open past its own merge defers every assignment behind it.
 
 ## Setting a dependency
 
@@ -184,4 +258,8 @@ recorded can be picked up in that window.
 - [ ] An issue that must stay out of the queue carries its own lifecycle label
 - [ ] `full-ci` left off unless the interaction-mode job is the only thing that could catch the regression — never on a backend-only issue, never where no interaction regression exists
 - [ ] If the issue has `full-ci`, the PR gets `full-ci` when opened
-- [ ] Labels set on creation: `ready,agent-task` unless the human specified otherwise or the issue must stay out of the queue
+- [ ] Open issues searched for this problem — none covers it, or the existing one was updated instead of a new one filed
+- [ ] Labels set on creation per the Labels table: `ready` only at high confidence, `agent-task` alone otherwise, unless the human specified something else
+- [ ] An issue held for confirmation carries `## Open question`
+- [ ] A finding or a scope cut carries `## Where found` and `## Why not fixed here`
+- [ ] A scope cut names its remainder issues in the pull request body and on the original issue

--- a/.claude/skills/agentic-pipeline-finalization/SKILL.md
+++ b/.claude/skills/agentic-pipeline-finalization/SKILL.md
@@ -45,9 +45,14 @@ Runs after qualimetry passes. Branch: `pipeline/feature-<label>` — `<label>` i
  8. [followup]           → Drain the follow-up register (below): every finding and scope cut
                              reported by a sub-agent this run, plus any decision material to
                              gameplay, economy, or a player-facing default. File each per
-                             `agentic-issue-creation`, carrying the PR link.
-                             Register empty → skip. Filing never reopens an earlier step and
-                             never changes the PR's status.
+                             `agentic-issue-creation`, carrying the PR link, then post **one**
+                             comment on the PR listing what was filed. The issues link to the
+                             PR; the comment is what links the PR back to them, because
+                             `open-pr` composed the body a step earlier and cannot name numbers
+                             that did not exist yet.
+                             Register empty → skip both the filing and the comment.
+                             Filing never reopens an earlier step and never changes the PR's
+                             status.
  9. [git-verify]         → confirm clean state: git status, branch, last commits
 10. [await-ci]           → `npm run ci:await -- --pr <number>`. Blocks until every workflow
                              run on the PR head reports — no deadline, because any deadline
@@ -81,6 +86,22 @@ Instead the orchestrator keeps a register for the run. Every sub-agent report ma
 `[followup]` runs **after** review and validation for one reason: by then every agent has reported, so the register can be deduplicated across all of them at once. The same debt reported by @quality-reviewer and @duplication-reviewer under two names is one issue, and only a pass that sees both can tell.
 
 A register entry is not a blocker. It never holds the PR, never downgrades it to draft, and never delays `[await-ci]`. A run that files four follow-ups still finishes its own issue.
+
+#### The comment `[followup]` posts
+
+```markdown
+## Follow-ups filed
+
+Work this run found outside its own task. None of it blocks this PR.
+
+| Issue | Kind | Labels | What |
+|-------|------|--------|------|
+| #N | finding | `agent-task` `ready` | one line, the summary the issue title carries |
+| #M | scope-cut | `agent-task` `ready` | which slice was cut, and why it did not fit |
+| #P | decision | `decision-review` | the default taken, and the lever that reverses it |
+```
+
+One comment per run, posted only when the register held something. An empty register posts nothing: a comment saying "none" on every pipeline pull request is noise, and it proves nothing anyway — a clean run and a run that dropped its findings write the same word. What separates them is the review output from the same run, which lists every `[pre-existing]` finding the reviewers reported. A reader comparing that list against this comment can see what went unfiled; a reader handed "none" cannot.
 
 ### Failure loops
 
@@ -123,5 +144,5 @@ Do NOT re-run skeleton-writer or test-writer — branches and tests already exis
 | verify-commit | `git log --oneline -1` — auto-commit if dirty, use message `"<agent-name>: <step-context> (#<N>)"` |
 | open-pr | Decide the `full-ci` label **before** calling `gh pr create`, by `agentic-pipeline-pr-management`'s test. `gh pr create --base main --head pipeline/feature-<label> --title "<type>: Resolve #<N>" --body "Closes #<N>\n\n<test_count> tests — all passing\n\n<decisions_block>\n\nREADY TO MERGE"`, adding `--label "full-ci"` to that same call when the test says yes. Determine `<type>` from pipeline: `full → feat`, `fix-bug → fix`, `multi → feat`. Count test cases: `npx vitest list --reporter=json 2>$null | ConvertFrom-Json | ForEach-Object { $_.testModules } | Measure-Object`. `<decisions_block>` is the `## Decisions taken` section, omitted when the run defaulted nothing. For draft: add `--draft`, omit `READY TO MERGE` line. **Never a follow-up `gh pr edit --add-label`** — a label added after `create` raises no `pull_request` event of its own on this repo's older CI trigger shape, and PR #615 merged with its `full-ci` interaction job silently skipped for exactly that reason (`ci.yml` now also re-evaluates on `labeled`, but the label belongs on the opening call regardless — the two are independent fixes for the same incident, not a reason to pick one). |
 | await-ci | `npm run ci:await -- --pr <number>` (or `--head pipeline/feature-<label>` before the number is known). Exit codes: `0` GREEN, `1` RED with the failing jobs and their log URLs printed, `2` TIMEOUT (only reachable if you pass `--timeout-minutes`, which a pipeline run never does), `3` the PR is gone, `4` bad arguments or `gh` could not answer. It listens to the workflow runs on the PR head; it never re-runs a channel, and no verdict it reports depends on a duration. |
-| followup | Drain the register in one pass, newest entry last. Decisions: `gh label create decision-review --description "A default the pipeline chose; revisit when convenient" --color ededed --force` then `gh issue create --label decision-review --title "Decision review: <summary> (from #<N>)" --body "<decisions block + PR link>"`. `--force` makes the label step idempotent — it updates an existing label instead of failing the run on every issue after the first. Findings and scope cuts: duplicate-check, then file per `agentic-issue-creation`, labels by its confidence table. |
+| followup | Drain the register in one pass, newest entry last, then `gh pr comment <pr-url> --body "<the table below>"` — one comment, only when something was filed. Decisions: `gh label create decision-review --description "A default the pipeline chose; revisit when convenient" --color ededed --force` then `gh issue create --label decision-review --title "Decision review: <summary> (from #<N>)" --body "<decisions block + PR link>"`. `--force` makes the label step idempotent — it updates an existing label instead of failing the run on every issue after the first. Findings and scope cuts: duplicate-check, then file per `agentic-issue-creation`, labels by its confidence table. |
 | git-verify | `git status --porcelain` (must be empty) → `git branch --show-current` → `git log --oneline -3` |

--- a/.claude/skills/agentic-pipeline-finalization/SKILL.md
+++ b/.claude/skills/agentic-pipeline-finalization/SKILL.md
@@ -42,11 +42,12 @@ Runs after qualimetry passes. Branch: `pipeline/feature-<label>` — `<label>` i
                              **If `visual_incomplete=true` → MUST use --draft, NO `READY TO MERGE`.**
                              **The PR leaves this step marked or --draft. Never both absent:
                              a channel CI runs is covered by the marker, not a reason to defer it.**
- 8. [decision-followup]  → If any decision was material to gameplay, economy, or a player-facing
-                             default: `gh issue create --label decision-review` carrying the
-                             `## Decisions taken` block and the PR link. No `ready` label — it
-                             stays out of the assignment queue and halts nothing.
-                             No material decisions → skip.
+ 8. [followup]           → Drain the follow-up register (below): every finding and scope cut
+                             reported by a sub-agent this run, plus any decision material to
+                             gameplay, economy, or a player-facing default. File each per
+                             `agentic-issue-creation`, carrying the PR link.
+                             Register empty → skip. Filing never reopens an earlier step and
+                             never changes the PR's status.
  9. [git-verify]         → confirm clean state: git status, branch, last commits
 10. [await-ci]           → `npm run ci:await -- --pr <number>`. Blocks until every workflow
                              run on the PR head reports — no deadline, because any deadline
@@ -62,6 +63,24 @@ Runs after qualimetry passes. Branch: `pipeline/feature-<label>` — `<label>` i
 ```
 
 **Retry counter:** resets at start of each finalization invocation.
+
+### The follow-up register
+
+A run's sub-agents notice work that is not this run's task: a reviewer finds pre-existing debt, an implementer hits a task bigger than one run, a test-writer finds a convention the codebase contradicts. None of them files an issue — nine agents are blocked from mutating `gh` by a `PreToolUse` hook, and five parallel reviewers filing independently would produce five issues for one finding.
+
+Instead the orchestrator keeps a register for the run. Every sub-agent report may append to it; nothing is filed until `[followup]`.
+
+| Column | Holds |
+|--------|-------|
+| Kind | `finding` / `scope-cut` / `decision` |
+| Reported by | Which agent, at which step |
+| Summary | One line, enough to duplicate-check against |
+| Evidence | File and line, the failing case, or the constraint that forces the cut |
+| Confidence | Whether it is verified real, or needs a human to confirm — this is what `agentic-issue-creation`'s label table reads |
+
+`[followup]` runs **after** review and validation for one reason: by then every agent has reported, so the register can be deduplicated across all of them at once. The same debt reported by @quality-reviewer and @duplication-reviewer under two names is one issue, and only a pass that sees both can tell.
+
+A register entry is not a blocker. It never holds the PR, never downgrades it to draft, and never delays `[await-ci]`. A run that files four follow-ups still finishes its own issue.
 
 ### Failure loops
 
@@ -104,5 +123,5 @@ Do NOT re-run skeleton-writer or test-writer — branches and tests already exis
 | verify-commit | `git log --oneline -1` — auto-commit if dirty, use message `"<agent-name>: <step-context> (#<N>)"` |
 | open-pr | Decide the `full-ci` label **before** calling `gh pr create`, by `agentic-pipeline-pr-management`'s test. `gh pr create --base main --head pipeline/feature-<label> --title "<type>: Resolve #<N>" --body "Closes #<N>\n\n<test_count> tests — all passing\n\n<decisions_block>\n\nREADY TO MERGE"`, adding `--label "full-ci"` to that same call when the test says yes. Determine `<type>` from pipeline: `full → feat`, `fix-bug → fix`, `multi → feat`. Count test cases: `npx vitest list --reporter=json 2>$null | ConvertFrom-Json | ForEach-Object { $_.testModules } | Measure-Object`. `<decisions_block>` is the `## Decisions taken` section, omitted when the run defaulted nothing. For draft: add `--draft`, omit `READY TO MERGE` line. **Never a follow-up `gh pr edit --add-label`** — a label added after `create` raises no `pull_request` event of its own on this repo's older CI trigger shape, and PR #615 merged with its `full-ci` interaction job silently skipped for exactly that reason (`ci.yml` now also re-evaluates on `labeled`, but the label belongs on the opening call regardless — the two are independent fixes for the same incident, not a reason to pick one). |
 | await-ci | `npm run ci:await -- --pr <number>` (or `--head pipeline/feature-<label>` before the number is known). Exit codes: `0` GREEN, `1` RED with the failing jobs and their log URLs printed, `2` TIMEOUT (only reachable if you pass `--timeout-minutes`, which a pipeline run never does), `3` the PR is gone, `4` bad arguments or `gh` could not answer. It listens to the workflow runs on the PR head; it never re-runs a channel, and no verdict it reports depends on a duration. |
-| decision-followup | `gh label create decision-review --description "A default the pipeline chose; revisit when convenient" --color ededed --force` then `gh issue create --label decision-review --title "Decision review: <summary> (from #<N>)" --body "<decisions block + PR link>"`. `--force` makes the label step idempotent — it updates an existing label instead of failing the run on every issue after the first. |
+| followup | Drain the register in one pass, newest entry last. Decisions: `gh label create decision-review --description "A default the pipeline chose; revisit when convenient" --color ededed --force` then `gh issue create --label decision-review --title "Decision review: <summary> (from #<N>)" --body "<decisions block + PR link>"`. `--force` makes the label step idempotent — it updates an existing label instead of failing the run on every issue after the first. Findings and scope cuts: duplicate-check, then file per `agentic-issue-creation`, labels by its confidence table. |
 | git-verify | `git status --porcelain` (must be empty) → `git branch --show-current` → `git log --oneline -3` |

--- a/.claude/skills/agentic-pipeline-finalization/SKILL.md
+++ b/.claude/skills/agentic-pipeline-finalization/SKILL.md
@@ -71,7 +71,7 @@ Runs after qualimetry passes. Branch: `pipeline/feature-<label>` — `<label>` i
 
 ### The follow-up register
 
-A run's sub-agents notice work that is not this run's task: a reviewer finds pre-existing debt, an implementer hits a task bigger than one run, a test-writer finds a convention the codebase contradicts. None of them files an issue — nine agents are blocked from mutating `gh` by a `PreToolUse` hook, and five parallel reviewers filing independently would produce five issues for one finding.
+A run's sub-agents notice work that is not this run's task: a reviewer finds pre-existing debt, an implementer hits a task bigger than one run, a test-writer finds a convention the codebase contradicts. None of them files an issue — every runtime denies its read-only agents the commands that mutate GitHub, and five parallel reviewers filing independently would produce five issues for one finding.
 
 Instead the orchestrator keeps a register for the run. Every sub-agent report may append to it; nothing is filed until `[followup]`.
 

--- a/.claude/skills/agentic-pipeline-review-pr/SKILL.md
+++ b/.claude/skills/agentic-pipeline-review-pr/SKILL.md
@@ -11,8 +11,9 @@ description: >
 | Step | Who | Action |
 |------|-----|--------|
 | 1 | @security-reviewer + @quality-reviewer + @i18n-reviewer + @duplication-reviewer + @semantic-reviewer | Parallel code review |
-| 2 | [merge-findings] | Orchestrator merges sub-reviewer findings → pass/fail |
+| 2 | [merge-findings] | Orchestrator merges sub-reviewer findings → pass/fail, and gives each one a disposition |
 | 3 | @reviewer | Runtime validation: run tests, post review outcome (report only — no fixes) |
+| 4 | [followup] | Orchestrator files the findings dispositioned `file`, per `agentic-issue-creation` |
 
 ### Rules
 
@@ -21,12 +22,26 @@ description: >
 - @reviewer runs full test suite to validate
 - @reviewer posts pass/fail outcome as PR comment
 - No branch creation, no commits (review is read-only)
+- **A reviewer reports a finding; it never files one.** Nine agents — the five sub-reviewers, plus @ask, @planner, @validator and @visual-tester — carry a `PreToolUse` hook that blocks mutating `gh`, so `gh issue create` fails for them by design. Findings travel up in the reviewer's own output and the orchestrator files them. That is also what keeps five parallel reviewers from filing five issues for one finding.
+
+### Finding disposition
+
+Every merged finding gets exactly one disposition, decided at `merge-findings` once all five reviewer outputs are in — never per-reviewer, because the same problem is routinely reported by two of them under different names:
+
+| Disposition | When | What happens |
+|-------------|------|--------------|
+| `fix` | The finding is inside what this PR changed or broke | Fixed on this branch, before the PR is marked |
+| `file` | The finding is real but outside this PR's scope — pre-existing debt, a gap the diff merely revealed, a neighbouring inconsistency | Carried to `[followup]` and filed there |
+| `drop` | Duplicate of another finding, or contradicted by the code | Nothing, beyond saying so in the merged output |
+
+`file` is not a softer `fix`. A finding inside the diff is this run's work whatever it costs; a finding outside it stays outside, because widening a PR to chase debt is how a reviewed change becomes an unreviewable one.
 
 ### Non-Agentic Steps
 
 | Step | Action |
 |------|--------|
-| merge-findings | Deduplicate and merge all reviewer outputs → pass/fail |
+| merge-findings | Deduplicate and merge all reviewer outputs → pass/fail, and disposition each finding `fix` / `file` / `drop` per the table above |
+| followup | File every `file` finding per `agentic-issue-creation` — duplicate check first, labels by its confidence table. Register empty → skip. |
 
 ### Review Output Format
 
@@ -39,4 +54,5 @@ After completion:
 - Duplication: PASS/FAIL
 - Tests: PASS/FAIL
 - Verdict: APPROVE / REQUEST CHANGES
+- Filed as follow-ups: #N, #M (or `none`)
 ```

--- a/.claude/skills/agentic-pipeline-review-pr/SKILL.md
+++ b/.claude/skills/agentic-pipeline-review-pr/SKILL.md
@@ -13,7 +13,7 @@ description: >
 | 1 | @security-reviewer + @quality-reviewer + @i18n-reviewer + @duplication-reviewer + @semantic-reviewer | Parallel code review |
 | 2 | [merge-findings] | Orchestrator merges sub-reviewer findings → pass/fail, and gives each one a disposition |
 | 3 | @reviewer | Runtime validation: run tests, post review outcome (report only — no fixes) |
-| 4 | [followup] | Orchestrator files the findings dispositioned `file`, per `agentic-issue-creation` |
+| 4 | [followup] | Orchestrator files the findings dispositioned `file` per `agentic-issue-creation`, then comments on the PR listing them |
 
 ### Rules
 
@@ -41,7 +41,7 @@ Every merged finding gets exactly one disposition, decided at `merge-findings` o
 | Step | Action |
 |------|--------|
 | merge-findings | Deduplicate and merge all reviewer outputs → pass/fail, and disposition each finding `fix` / `file` / `drop` per the table above |
-| followup | File every `file` finding per `agentic-issue-creation` — duplicate check first, labels by its confidence table. Register empty → skip. |
+| followup | File every `file` finding per `agentic-issue-creation` — duplicate check first, labels by its confidence table — then one `gh pr comment` listing what was filed, in the format `agentic-pipeline-finalization` gives. It runs after @reviewer for the same reason it runs last there: the numbers do not exist until the issues are filed, so no earlier comment can carry them. Nothing dispositioned `file` → skip both. |
 
 ### Review Output Format
 

--- a/.claude/skills/agentic-pipeline-review-pr/SKILL.md
+++ b/.claude/skills/agentic-pipeline-review-pr/SKILL.md
@@ -22,7 +22,7 @@ description: >
 - @reviewer runs full test suite to validate
 - @reviewer posts pass/fail outcome as PR comment
 - No branch creation, no commits (review is read-only)
-- **A reviewer reports a finding; it never files one.** Nine agents — the five sub-reviewers, plus @ask, @planner, @validator and @visual-tester — carry a `PreToolUse` hook that blocks mutating `gh`, so `gh issue create` fails for them by design. Findings travel up in the reviewer's own output and the orchestrator files them. That is also what keeps five parallel reviewers from filing five issues for one finding.
+- **A reviewer reports a finding; it never files one.** Every runtime denies its read-only agents the commands that mutate GitHub, each by its own mechanism, so a reviewer that tries to file fails wherever it runs. Findings travel up in the reviewer's own output and the orchestrator files them — which is also what keeps five parallel reviewers from filing five issues for one finding.
 
 ### Finding disposition
 

--- a/.github/agents/duplication-reviewer.agent.md
+++ b/.github/agents/duplication-reviewer.agent.md
@@ -74,6 +74,8 @@ handles that) — focus on **semantic and structural** duplication.
 
 ## Output Format
 
+Tag every finding with its scope so `merge-findings` can disposition it: `[in-diff]` when it sits inside what this PR changed or broke, `[pre-existing]` when the diff merely revealed it. Report a `[pre-existing]` finding like any other — the orchestrator files it as a follow-up issue rather than widening this PR. Report it rather than filing it: mutating `gh` is blocked for this agent by design.
+
 Each finding includes a confidence level:
 
 - **high** — verified by reading both the changed code and an existing counterpart

--- a/.github/agents/i18n-reviewer.agent.md
+++ b/.github/agents/i18n-reviewer.agent.md
@@ -30,6 +30,8 @@ Position: parallel sub-reviewer in code_review fan-out. Read-only.
 
 ## Output Format
 
+Tag every finding with its scope so `merge-findings` can disposition it: `[in-diff]` when it sits inside what this PR changed or broke, `[pre-existing]` when the diff merely revealed it. Report a `[pre-existing]` finding like any other — the orchestrator files it as a follow-up issue rather than widening this PR. Report it rather than filing it: mutating `gh` is blocked for this agent by design.
+
 Each finding includes a confidence level:
 
 - **high** — verified by reading source + locale JSONs

--- a/.github/agents/implementer.agent.md
+++ b/.github/agents/implementer.agent.md
@@ -48,6 +48,12 @@ Adding/modifying console command:
 3. Handler: `GameState` + parsed args → core logic → `CommandResult`
 4. `ConsoleFormatter` → human-readable output
 
+## Scope Overrun
+
+The plan sized this task on what a reader could see. When the codebase disagrees — the change reaches far more call sites than the plan lists, or landing it means re-deriving values across many files — say so in the hand-back rather than working through it. A run that spends its whole budget is killed mid-work, and what survives is an unreviewed branch nobody can finish.
+
+Report `SCOPE OVERRUN: <the slice that reaches green alone> | <the remainder>`. The orchestrator decides, cuts, and files the remainder per `agentic-issue-creation`. Landing a coherent slice is a finished run; landing half of everything is not.
+
 ## Key References
 
 - `dev-architecture` — module boundaries, data flow

--- a/.github/agents/planner.agent.md
+++ b/.github/agents/planner.agent.md
@@ -32,6 +32,9 @@ Produce structured implementation plan from issue. Read-only — no code changes
 - [ ] criterion 2
 ### Decisions
 - **Open:** what the issue left unspecified — **Chosen:** the default — **Why:** the spec, convention, or incentive it follows — **Reverse by:** the constant or branch a human would change
+### Scope
+- `fits` — one run can carry this to a merged pull request
+- `oversized` — name the slice that reaches green on its own, and the remainder the orchestrator should file per `agentic-issue-creation`
 ### Edge Cases
 - edge case 1
 ### Architecture Notes

--- a/.github/agents/quality-reviewer.agent.md
+++ b/.github/agents/quality-reviewer.agent.md
@@ -70,6 +70,8 @@ Adjust review depth based on `risk_tier` from context:
 
 ## Output Format
 
+Tag every finding with its scope so `merge-findings` can disposition it: `[in-diff]` when it sits inside what this PR changed or broke, `[pre-existing]` when the diff merely revealed it. Report a `[pre-existing]` finding like any other — the orchestrator files it as a follow-up issue rather than widening this PR. Report it rather than filing it: mutating `gh` is blocked for this agent by design.
+
 Each finding includes a confidence level:
 
 - **high** — verified by reading the source code, clear violation

--- a/.github/agents/security-reviewer.agent.md
+++ b/.github/agents/security-reviewer.agent.md
@@ -31,6 +31,8 @@ Position: parallel sub-reviewer in code_review fan-out. Read-only.
 
 ## Output Format
 
+Tag every finding with its scope so `merge-findings` can disposition it: `[in-diff]` when it sits inside what this PR changed or broke, `[pre-existing]` when the diff merely revealed it. Report a `[pre-existing]` finding like any other — the orchestrator files it as a follow-up issue rather than widening this PR. Report it rather than filing it: mutating `gh` is blocked for this agent by design.
+
 Each finding includes a confidence level:
 
 - **high** — verified by reading the source code, concrete exploit exists

--- a/.github/agents/semantic-reviewer.agent.md
+++ b/.github/agents/semantic-reviewer.agent.md
@@ -72,6 +72,8 @@ Verify semantic coherence between tests and implementation. Every test case must
 
 ## Output Format
 
+Tag every finding with its scope so `merge-findings` can disposition it: `[in-diff]` when it sits inside what this PR changed or broke, `[pre-existing]` when the diff merely revealed it. Report a `[pre-existing]` finding like any other — the orchestrator files it as a follow-up issue rather than widening this PR. Report it rather than filing it: mutating `gh` is blocked for this agent by design.
+
 ```
 ## Semantic Review
 ### Test Coverage

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -88,6 +88,16 @@ A session started by the autonomous pipeline — a GitHub Actions run woken by t
 
 Do NOT attempt workarounds. Do NOT read image files hoping to extract text. Do NOT substitute state JSON for visual inspection. A modality gap is a hard stop.
 
+## ▶ Follow-up Gate — work you found that is not your task
+
+| You found | You file |
+|-----------|----------|
+| A default you chose that a human may want to revisit | The decision — `agentic-decision-autonomy` |
+| Tech debt, a gap, or an inconsistency unrelated to your task | The finding — `agentic-issue-creation` |
+| That your own task is bigger than one run | The scope you cut, so the remainder is not lost — `agentic-issue-creation` |
+
+**Filing never halts you.** It does not hold your PR, downgrade it to draft, or leave your own issue non-terminal. Fix what your change exposes; file the rest. If your tools block `gh`, hand the finding to whoever invoked you — it is filed after review, once every agent's findings are in.
+
 ## Communication Style
 
 Respond terse. All technical substance stay. Only fluff die.

--- a/.github/skills/agentic-autonomous-pipeline/references/runtime-parity.md
+++ b/.github/skills/agentic-autonomous-pipeline/references/runtime-parity.md
@@ -31,6 +31,16 @@ So "invoke the reviewers in parallel" reads as *fan out and await* under OpenCod
 
 **The principle generalises past that one parameter. Where runtimes differ, the shared context states the invariant and each runtime's own configuration layer enforces it.** A body that names one runtime's parameters is a body that is wrong for the other two.
 
+Issue filing splits the same way. The rule — a read-only agent reports a finding, the orchestrator files it — is uniform. What denies the agent the command is not:
+
+| Runtime | Read-only agents denied GitHub writes by |
+|---------|------------------------------------------|
+| OpenCode | `permission.bash` in the agent's own frontmatter: `"git *": "deny"`, `"gh *": "deny"` |
+| Copilot | `tools: ["read", "search"]` — no shell to run `gh` with |
+| Claude Code | A `PreToolUse` hook on `Bash`, `block-git-gh.sh`, registered in the agent's frontmatter |
+
+Three mechanisms, one behaviour: a reviewer that tries to open an issue fails wherever it runs, so a finding reaches GitHub through the orchestrator or not at all. `agentic-pipeline-review-pr` states the rule and names none of them.
+
 ## Claude Code prerequisites
 
 Delegation depends on configuration that is off by default:

--- a/.github/skills/agentic-decision-autonomy/SKILL.md
+++ b/.github/skills/agentic-decision-autonomy/SKILL.md
@@ -85,7 +85,7 @@ An earlier convention held a PR back for "significant churn". It cost a green, f
 
 An issue's title describes where the reporter noticed the problem, not where the problem lives. When the fix reaches deeper than the framing — a visual-coherence issue that turns out to need a simulation fix — implement the fix that is actually correct, say so in the PR body, and continue. A correct fix outside the framing beats an incorrect one inside it.
 
-The limit is relevance, not depth: fix what this issue's own change exposes. Unrelated defects noticed along the way become their own issues.
+The limit is relevance, not depth: fix what this issue's own change exposes. Unrelated defects noticed along the way become their own issues — reported into the run's follow-up register and filed at the end of the pipeline, per `agentic-issue-creation`. Recording one is not escalating: it never holds the PR and never delays the run's own issue.
 
 ## Recording format
 

--- a/.github/skills/agentic-issue-creation/SKILL.md
+++ b/.github/skills/agentic-issue-creation/SKILL.md
@@ -1,13 +1,23 @@
 ---
 name: agentic-issue-creation
-description: Create or edit GitHub issues for agentic pipeline consumption — context, files, test files, dependencies (setting or reading a blocked_by relationship), labels, and verification criteria. Use when creating an issue for autonomous coding agents, or when editing an existing one's dependencies, labels, or lifecycle state.
+description: Create or edit GitHub issues for agentic pipeline consumption — context, files, test files, dependencies (setting or reading a blocked_by relationship), labels, and verification criteria. Use when filing an issue for autonomous coding agents, when recording technical debt, a codebase gap, an inconsistency or a defect found while working on something else, when cutting a task that turns out to be bigger than one run and filing the remainder, or when editing an already-filed issue's dependencies, labels, or lifecycle state.
 ---
 
 # Skill: agentic-issue-creation
 
 ## When to Use
 
-Use when creating a GitHub issue that an autonomous run will pick up, or when editing an already-filed one's dependencies, labels, or lifecycle state. An issue is the only input the pipeline takes, so it has to stand on its own — the run starts with the issue body and the codebase, and nothing else. Setting a `blocked_by` relationship on an existing issue is this skill's task exactly as much as authoring a new one is — see "Setting a dependency" below.
+Use when creating a GitHub issue that an autonomous run will pick up, when recording something found while working on a different task, when cutting an oversized task and filing the remainder, or when editing an already-filed one's dependencies, labels, or lifecycle state. An issue is the only input the pipeline takes, so it has to stand on its own — the run starts with the issue body and the codebase, and nothing else. Setting a `blocked_by` relationship on an existing issue is this skill's task exactly as much as authoring a new one is — see "Setting a dependency" below.
+
+Three situations put an agent here, and they differ only in what the issue records:
+
+| Situation | What the issue carries |
+|-----------|------------------------|
+| **Planned work** — decomposing a feature, or a human filing a task | The task itself, in one of the two shapes below |
+| **A finding** — technical debt, a codebase gap, an inconsistency, a defect noticed while working on something else | The finding, plus where it was found and why it was not fixed on the spot |
+| **A scope cut** — the assigned task turns out to be bigger than one run can carry | The remainder deliberately left out, and what was landed instead |
+
+A finding and a scope cut become ordinary issues the moment they are filed. They differ from planned work only in provenance, which the template's optional sections carry.
 
 Two shapes are valid, and they differ in how much of the answer is already known:
 
@@ -20,15 +30,50 @@ Both enter the same queue once `ready` lands on the issue — a two-line issue t
 
 ## ▶ PROCEDURE — EXECUTE IN ORDER
 
-1. Pick the shape: complete when you know the file layout, intent when you are describing an outcome
-2. Fill every section that shape carries, using the headings below verbatim
-3. Verify the Rules are satisfied
-4. Run through the Checklist
-5. Create the issue with `gh issue create`, setting labels yourself:
-   - Human gave no instruction about labels → `--label ready,agent-task`. `ready` means eligible, not started: it places the issue in the queue, where it waits until a human dispatches `agentic-trigger.yml` or a merged pipeline PR chains to it. Creating an issue never starts a run.
-   - Human specified labels, or said the issue should wait — `decision-review` for a default to revisit later, or an explicit hold — → follow that instruction instead, and leave `ready` off.
+1. Run the duplicate check below. An open issue that already covers it is updated, not duplicated
+2. Pick the shape: complete when you know the file layout, intent when you are describing an outcome
+3. Fill every section that shape carries, using the headings below verbatim
+4. Verify the Rules are satisfied
+5. Run through the Checklist
+6. Create the issue with `gh issue create`, setting labels per the Labels section below. A human who specified labels, or said the issue should wait, overrides that table
 
-An issue that must **stay out** of the queue is created carrying a lifecycle label of its own instead of `ready` — `decision-review` for a default to revisit later. The issue joins the queue in number order once `ready` is on it, whoever put it there.
+`ready` means eligible, not started: it places the issue in the queue, where it waits until a human dispatches `agentic-trigger.yml` or a merged pipeline pull request chains to it. Creating an issue never starts a run. The issue joins the queue in number order once `ready` is on it, whoever put it there.
+
+## ▶ Duplicate check — run before filing anything
+
+An issue nobody reads twice is cheap; two issues for one problem are not. They split the discussion, and the second run to pick one up rediscovers what the first already fixed.
+
+1. Search open issues for the thing itself rather than for your phrasing of it — the symbol, the file path, the error text, the convention being violated.
+   ```bash
+   gh issue list --state open --search "<symbol or file path>" --limit 20
+   gh issue list --state open --label agent-task --limit 50   # when the term is a concept, not a string
+   ```
+   With no `gh` CLI — Claude Code on the web has none — the same search runs against the REST API with the `GITHUB_TOKEN` already in the environment. Never echo the token; pass it straight from the variable.
+   ```bash
+   curl -sS -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" \
+     --get --data-urlencode "q=repo:Nico2398/BlastSimulator2026 is:issue is:open <terms>" \
+     "https://api.github.com/search/issues" \
+     | python3 -c "import sys,json; [print(i['number'], i['title']) for i in json.load(sys.stdin)['items']]"
+   ```
+2. **A match that covers your finding → update it.** Add what you learned as a comment when it is evidence (a second occurrence, a reproduction, an exact line number), or edit the body when it is a correction (a wrong path, a missing consumer, a premise that no longer holds). Name the run that found it, so the next reader knows where the addition came from.
+3. **A match that overlaps without covering it** → file, and name the neighbour in your Context section so a human can merge the two if they disagree.
+4. **A closed match** → read how it closed. Closed with a merged pull request means the problem came back and yours is a regression report, which is worth saying in the body. Closed unmerged means it was declined, and refiling needs a reason.
+
+Searching costs one command. Filing a duplicate costs a run.
+
+## ▶ Labels — `ready` is a confidence statement
+
+`agentic-assign` selects on `ready` alone. Putting it on an issue says *this work should be done, and the description is good enough to start from.* Putting it on a hunch spends a whole run discovering the hunch was wrong.
+
+| Confidence | Labels | What follows |
+|-----------|--------|--------------|
+| **High** — a defect you reproduced, a convention you can point at, a gap you verified in the code | `agent-task`, `ready` | The work is real and specified. The issue joins the queue in number order. |
+| **Open** — something looks wrong, and a human should confirm it is worth doing or pick between two directions | `agent-task` | The issue stays out of the queue until a human adds `ready`. |
+| **Already decided by the run** — a default you implemented that a human may want to revisit | `decision-review` | Held by `agentic-decision-autonomy`, which owns that flow end to end. |
+
+An issue held for confirmation carries an `## Open question` section naming exactly what a human must answer and what changes with each answer. Without it the issue is a hunch nobody can act on, and it waits until someone re-derives the question you already knew.
+
+Leave `ready` off while you are uncertain. An issue carrying `agent-task` alone loses nothing — it keeps its number, its body and its place — and gains `ready` the moment a human agrees.
 
 ## Issue Body Template
 
@@ -54,7 +99,18 @@ An issue that must **stay out** of the queue is created carrying a lifecycle lab
 
 ## Verification
 - [Observable outcome that proves the task is done]
+
+## Where found
+[Findings and scope cuts only. Which run, which pull request or review round, what was being worked on at the time.]
+
+## Why not fixed here
+[Findings and scope cuts only. Why filing was right rather than folding it into the work in hand.]
+
+## Open question
+[Issues held at `agent-task` without `ready` only. What a human must answer, and what changes with each answer.]
 ```
+
+The last three sections are provenance and are omitted for planned work. `## Where found` and `## Why not fixed here` are what let the next reader judge a finding without reconstructing the review round that produced it; `## Open question` is what a human answers before adding `ready`.
 
 ## Rules
 
@@ -68,7 +124,9 @@ An issue that must **stay out** of the queue is created carrying a lifecycle lab
 8. **Single task per issue.** A task touching several concerns is several issues. So is a task that is one concern but too large for one run — Sizing below is the test, and Splitting is what to do about it.
 9. **SMART compliance.** Specific (one clear goal), Measurable (verifiable outcome), Achievable (within an agent's capabilities), Relevant (part of the larger feature), Time-bound (a single atomic task).
 10. **`full-ci` is off by default — an issue has to earn it.** The label starts the interaction-mode browser job, which costs the merge path real time, so it goes on an issue only where that job is the only thing that could catch the regression: an interaction-mode scenario clicks its way through the control, panel or flow the issue changes, or the issue touches shared input, picking, camera, rendering or harness machinery every scenario runs through. **Never on a backend-only issue.** A change confined to `src/core/`, `src/console/`, config or pure logic is proven by `static`, `logic` and command-mode `scenario`; replaying browser flows the diff never reaches reports nothing about it. **Never where there is no interaction regression to catch** — a renderer detail no scenario reaches, a control added to an existing panel, copy, a new command parameter. The `visual` channel covers those in-session against the thing that actually changed, which is stronger evidence than a suite that never touches it. When in doubt, leave it off. Full test and cost: `agentic-pipeline-pr-management`.
-11. **Label transfer.** A PR opened from a `full-ci` issue gets the same label, passed on the same `gh pr create` call that opens it (`--label "full-ci"`) — never a follow-up `gh pr edit --add-label`, which raises no `pull_request` event of its own and is how PR #615 merged with its interaction-mode job silently skipped. See `agentic-pipeline-finalization`'s `open-pr` step.
+11. **Search before filing, and update what already exists.** An open issue covering the same problem is updated rather than duplicated — procedure above.
+12. **`ready` states confidence, not hope.** It goes on an issue whose work is verified real and whose description is good enough to start from. Anything short of that is `agent-task` alone, with an `## Open question` section naming what a human must answer.
+13. **Label transfer.** A PR opened from a `full-ci` issue gets the same label, passed on the same `gh pr create` call that opens it (`--label "full-ci"`) — never a follow-up `gh pr edit --add-label`, which raises no `pull_request` event of its own and is how PR #615 merged with its interaction-mode job silently skipped. See `agentic-pipeline-finalization`'s `open-pr` step.
 
 ## ▶ Sizing — one issue is one run, and a run has a ceiling
 
@@ -94,6 +152,22 @@ The obvious split — the mechanic in one issue, the tests it breaks in the next
 3. **Stack the batches on an integration branch.** Sub-issues target the feature branch rather than `main`, and only the final merge has to be green. Last resort: assignability, auto-merge and rescue all assume a PR against `main`, so a human has to shepherd it.
 
 Batch issues are ordinary issues — `Blocked by` the enabler, one slice each, verification of their own.
+
+## ▶ Discovering mid-run that the task is bigger than one run
+
+Sizing above is the test applied *before* filing. The same ceiling exists mid-run, and reaching it is ordinary: the issue was sized on what a reader could see, and the codebase disagreed.
+
+What turns it into a lost run is carrying on regardless. A run that spends its whole budget is not cancelled politely — the job is killed, and what survives is whatever `agentic-rescue` can push: an unreviewed branch, a draft pull request, a `blocked` issue, and a human working out which half is done.
+
+Cut instead:
+
+1. **Pick the slice that reaches a green pull request on its own.** Not the slice already written — the slice that is coherent. A half-migrated call site is worse than an unmigrated one.
+2. **Land it, verified through every channel it owes.** A reduced scope changes nothing about the Verification Gate.
+3. **File the remainder**, one issue per slice, each able to reach green alone. The three splitting strategies above apply unchanged, and splitting the enablers off first is still the best of them.
+4. **Say what was cut**, in the pull request body and on the original issue, naming the new issue numbers. A remainder nobody can find is a remainder nobody does.
+5. **Set `Blocked by` only where a real ordering exists.** Slices touching different files are independent, and marking them blocked on each other serialises work that could run side by side.
+
+The original issue closes on its own merged pull request with its reduced scope stated. It stays open to track nothing — that is what the new issues are for, and an issue held open past its own merge defers every assignment behind it.
 
 ## Setting a dependency
 
@@ -184,4 +258,8 @@ recorded can be picked up in that window.
 - [ ] An issue that must stay out of the queue carries its own lifecycle label
 - [ ] `full-ci` left off unless the interaction-mode job is the only thing that could catch the regression — never on a backend-only issue, never where no interaction regression exists
 - [ ] If the issue has `full-ci`, the PR gets `full-ci` when opened
-- [ ] Labels set on creation: `ready,agent-task` unless the human specified otherwise or the issue must stay out of the queue
+- [ ] Open issues searched for this problem — none covers it, or the existing one was updated instead of a new one filed
+- [ ] Labels set on creation per the Labels table: `ready` only at high confidence, `agent-task` alone otherwise, unless the human specified something else
+- [ ] An issue held for confirmation carries `## Open question`
+- [ ] A finding or a scope cut carries `## Where found` and `## Why not fixed here`
+- [ ] A scope cut names its remainder issues in the pull request body and on the original issue

--- a/.github/skills/agentic-pipeline-finalization/SKILL.md
+++ b/.github/skills/agentic-pipeline-finalization/SKILL.md
@@ -45,9 +45,14 @@ Runs after qualimetry passes. Branch: `pipeline/feature-<label>` — `<label>` i
  8. [followup]           → Drain the follow-up register (below): every finding and scope cut
                              reported by a sub-agent this run, plus any decision material to
                              gameplay, economy, or a player-facing default. File each per
-                             `agentic-issue-creation`, carrying the PR link.
-                             Register empty → skip. Filing never reopens an earlier step and
-                             never changes the PR's status.
+                             `agentic-issue-creation`, carrying the PR link, then post **one**
+                             comment on the PR listing what was filed. The issues link to the
+                             PR; the comment is what links the PR back to them, because
+                             `open-pr` composed the body a step earlier and cannot name numbers
+                             that did not exist yet.
+                             Register empty → skip both the filing and the comment.
+                             Filing never reopens an earlier step and never changes the PR's
+                             status.
  9. [git-verify]         → confirm clean state: git status, branch, last commits
 10. [await-ci]           → `npm run ci:await -- --pr <number>`. Blocks until every workflow
                              run on the PR head reports — no deadline, because any deadline
@@ -81,6 +86,22 @@ Instead the orchestrator keeps a register for the run. Every sub-agent report ma
 `[followup]` runs **after** review and validation for one reason: by then every agent has reported, so the register can be deduplicated across all of them at once. The same debt reported by @quality-reviewer and @duplication-reviewer under two names is one issue, and only a pass that sees both can tell.
 
 A register entry is not a blocker. It never holds the PR, never downgrades it to draft, and never delays `[await-ci]`. A run that files four follow-ups still finishes its own issue.
+
+#### The comment `[followup]` posts
+
+```markdown
+## Follow-ups filed
+
+Work this run found outside its own task. None of it blocks this PR.
+
+| Issue | Kind | Labels | What |
+|-------|------|--------|------|
+| #N | finding | `agent-task` `ready` | one line, the summary the issue title carries |
+| #M | scope-cut | `agent-task` `ready` | which slice was cut, and why it did not fit |
+| #P | decision | `decision-review` | the default taken, and the lever that reverses it |
+```
+
+One comment per run, posted only when the register held something. An empty register posts nothing: a comment saying "none" on every pipeline pull request is noise, and it proves nothing anyway — a clean run and a run that dropped its findings write the same word. What separates them is the review output from the same run, which lists every `[pre-existing]` finding the reviewers reported. A reader comparing that list against this comment can see what went unfiled; a reader handed "none" cannot.
 
 ### Failure loops
 
@@ -123,5 +144,5 @@ Do NOT re-run skeleton-writer or test-writer — branches and tests already exis
 | verify-commit | `git log --oneline -1` — auto-commit if dirty, use message `"<agent-name>: <step-context> (#<N>)"` |
 | open-pr | Decide the `full-ci` label **before** calling `gh pr create`, by `agentic-pipeline-pr-management`'s test. `gh pr create --base main --head pipeline/feature-<label> --title "<type>: Resolve #<N>" --body "Closes #<N>\n\n<test_count> tests — all passing\n\n<decisions_block>\n\nREADY TO MERGE"`, adding `--label "full-ci"` to that same call when the test says yes. Determine `<type>` from pipeline: `full → feat`, `fix-bug → fix`, `multi → feat`. Count test cases: `npx vitest list --reporter=json 2>$null | ConvertFrom-Json | ForEach-Object { $_.testModules } | Measure-Object`. `<decisions_block>` is the `## Decisions taken` section, omitted when the run defaulted nothing. For draft: add `--draft`, omit `READY TO MERGE` line. **Never a follow-up `gh pr edit --add-label`** — a label added after `create` raises no `pull_request` event of its own on this repo's older CI trigger shape, and PR #615 merged with its `full-ci` interaction job silently skipped for exactly that reason (`ci.yml` now also re-evaluates on `labeled`, but the label belongs on the opening call regardless — the two are independent fixes for the same incident, not a reason to pick one). |
 | await-ci | `npm run ci:await -- --pr <number>` (or `--head pipeline/feature-<label>` before the number is known). Exit codes: `0` GREEN, `1` RED with the failing jobs and their log URLs printed, `2` TIMEOUT (only reachable if you pass `--timeout-minutes`, which a pipeline run never does), `3` the PR is gone, `4` bad arguments or `gh` could not answer. It listens to the workflow runs on the PR head; it never re-runs a channel, and no verdict it reports depends on a duration. |
-| followup | Drain the register in one pass, newest entry last. Decisions: `gh label create decision-review --description "A default the pipeline chose; revisit when convenient" --color ededed --force` then `gh issue create --label decision-review --title "Decision review: <summary> (from #<N>)" --body "<decisions block + PR link>"`. `--force` makes the label step idempotent — it updates an existing label instead of failing the run on every issue after the first. Findings and scope cuts: duplicate-check, then file per `agentic-issue-creation`, labels by its confidence table. |
+| followup | Drain the register in one pass, newest entry last, then `gh pr comment <pr-url> --body "<the table below>"` — one comment, only when something was filed. Decisions: `gh label create decision-review --description "A default the pipeline chose; revisit when convenient" --color ededed --force` then `gh issue create --label decision-review --title "Decision review: <summary> (from #<N>)" --body "<decisions block + PR link>"`. `--force` makes the label step idempotent — it updates an existing label instead of failing the run on every issue after the first. Findings and scope cuts: duplicate-check, then file per `agentic-issue-creation`, labels by its confidence table. |
 | git-verify | `git status --porcelain` (must be empty) → `git branch --show-current` → `git log --oneline -3` |

--- a/.github/skills/agentic-pipeline-finalization/SKILL.md
+++ b/.github/skills/agentic-pipeline-finalization/SKILL.md
@@ -42,11 +42,12 @@ Runs after qualimetry passes. Branch: `pipeline/feature-<label>` — `<label>` i
                              **If `visual_incomplete=true` → MUST use --draft, NO `READY TO MERGE`.**
                              **The PR leaves this step marked or --draft. Never both absent:
                              a channel CI runs is covered by the marker, not a reason to defer it.**
- 8. [decision-followup]  → If any decision was material to gameplay, economy, or a player-facing
-                             default: `gh issue create --label decision-review` carrying the
-                             `## Decisions taken` block and the PR link. No `ready` label — it
-                             stays out of the assignment queue and halts nothing.
-                             No material decisions → skip.
+ 8. [followup]           → Drain the follow-up register (below): every finding and scope cut
+                             reported by a sub-agent this run, plus any decision material to
+                             gameplay, economy, or a player-facing default. File each per
+                             `agentic-issue-creation`, carrying the PR link.
+                             Register empty → skip. Filing never reopens an earlier step and
+                             never changes the PR's status.
  9. [git-verify]         → confirm clean state: git status, branch, last commits
 10. [await-ci]           → `npm run ci:await -- --pr <number>`. Blocks until every workflow
                              run on the PR head reports — no deadline, because any deadline
@@ -62,6 +63,24 @@ Runs after qualimetry passes. Branch: `pipeline/feature-<label>` — `<label>` i
 ```
 
 **Retry counter:** resets at start of each finalization invocation.
+
+### The follow-up register
+
+A run's sub-agents notice work that is not this run's task: a reviewer finds pre-existing debt, an implementer hits a task bigger than one run, a test-writer finds a convention the codebase contradicts. None of them files an issue — nine agents are blocked from mutating `gh` by a `PreToolUse` hook, and five parallel reviewers filing independently would produce five issues for one finding.
+
+Instead the orchestrator keeps a register for the run. Every sub-agent report may append to it; nothing is filed until `[followup]`.
+
+| Column | Holds |
+|--------|-------|
+| Kind | `finding` / `scope-cut` / `decision` |
+| Reported by | Which agent, at which step |
+| Summary | One line, enough to duplicate-check against |
+| Evidence | File and line, the failing case, or the constraint that forces the cut |
+| Confidence | Whether it is verified real, or needs a human to confirm — this is what `agentic-issue-creation`'s label table reads |
+
+`[followup]` runs **after** review and validation for one reason: by then every agent has reported, so the register can be deduplicated across all of them at once. The same debt reported by @quality-reviewer and @duplication-reviewer under two names is one issue, and only a pass that sees both can tell.
+
+A register entry is not a blocker. It never holds the PR, never downgrades it to draft, and never delays `[await-ci]`. A run that files four follow-ups still finishes its own issue.
 
 ### Failure loops
 
@@ -104,5 +123,5 @@ Do NOT re-run skeleton-writer or test-writer — branches and tests already exis
 | verify-commit | `git log --oneline -1` — auto-commit if dirty, use message `"<agent-name>: <step-context> (#<N>)"` |
 | open-pr | Decide the `full-ci` label **before** calling `gh pr create`, by `agentic-pipeline-pr-management`'s test. `gh pr create --base main --head pipeline/feature-<label> --title "<type>: Resolve #<N>" --body "Closes #<N>\n\n<test_count> tests — all passing\n\n<decisions_block>\n\nREADY TO MERGE"`, adding `--label "full-ci"` to that same call when the test says yes. Determine `<type>` from pipeline: `full → feat`, `fix-bug → fix`, `multi → feat`. Count test cases: `npx vitest list --reporter=json 2>$null | ConvertFrom-Json | ForEach-Object { $_.testModules } | Measure-Object`. `<decisions_block>` is the `## Decisions taken` section, omitted when the run defaulted nothing. For draft: add `--draft`, omit `READY TO MERGE` line. **Never a follow-up `gh pr edit --add-label`** — a label added after `create` raises no `pull_request` event of its own on this repo's older CI trigger shape, and PR #615 merged with its `full-ci` interaction job silently skipped for exactly that reason (`ci.yml` now also re-evaluates on `labeled`, but the label belongs on the opening call regardless — the two are independent fixes for the same incident, not a reason to pick one). |
 | await-ci | `npm run ci:await -- --pr <number>` (or `--head pipeline/feature-<label>` before the number is known). Exit codes: `0` GREEN, `1` RED with the failing jobs and their log URLs printed, `2` TIMEOUT (only reachable if you pass `--timeout-minutes`, which a pipeline run never does), `3` the PR is gone, `4` bad arguments or `gh` could not answer. It listens to the workflow runs on the PR head; it never re-runs a channel, and no verdict it reports depends on a duration. |
-| decision-followup | `gh label create decision-review --description "A default the pipeline chose; revisit when convenient" --color ededed --force` then `gh issue create --label decision-review --title "Decision review: <summary> (from #<N>)" --body "<decisions block + PR link>"`. `--force` makes the label step idempotent — it updates an existing label instead of failing the run on every issue after the first. |
+| followup | Drain the register in one pass, newest entry last. Decisions: `gh label create decision-review --description "A default the pipeline chose; revisit when convenient" --color ededed --force` then `gh issue create --label decision-review --title "Decision review: <summary> (from #<N>)" --body "<decisions block + PR link>"`. `--force` makes the label step idempotent — it updates an existing label instead of failing the run on every issue after the first. Findings and scope cuts: duplicate-check, then file per `agentic-issue-creation`, labels by its confidence table. |
 | git-verify | `git status --porcelain` (must be empty) → `git branch --show-current` → `git log --oneline -3` |

--- a/.github/skills/agentic-pipeline-finalization/SKILL.md
+++ b/.github/skills/agentic-pipeline-finalization/SKILL.md
@@ -71,7 +71,7 @@ Runs after qualimetry passes. Branch: `pipeline/feature-<label>` — `<label>` i
 
 ### The follow-up register
 
-A run's sub-agents notice work that is not this run's task: a reviewer finds pre-existing debt, an implementer hits a task bigger than one run, a test-writer finds a convention the codebase contradicts. None of them files an issue — nine agents are blocked from mutating `gh` by a `PreToolUse` hook, and five parallel reviewers filing independently would produce five issues for one finding.
+A run's sub-agents notice work that is not this run's task: a reviewer finds pre-existing debt, an implementer hits a task bigger than one run, a test-writer finds a convention the codebase contradicts. None of them files an issue — every runtime denies its read-only agents the commands that mutate GitHub, and five parallel reviewers filing independently would produce five issues for one finding.
 
 Instead the orchestrator keeps a register for the run. Every sub-agent report may append to it; nothing is filed until `[followup]`.
 

--- a/.github/skills/agentic-pipeline-review-pr/SKILL.md
+++ b/.github/skills/agentic-pipeline-review-pr/SKILL.md
@@ -11,8 +11,9 @@ description: >
 | Step | Who | Action |
 |------|-----|--------|
 | 1 | @security-reviewer + @quality-reviewer + @i18n-reviewer + @duplication-reviewer + @semantic-reviewer | Parallel code review |
-| 2 | [merge-findings] | Orchestrator merges sub-reviewer findings → pass/fail |
+| 2 | [merge-findings] | Orchestrator merges sub-reviewer findings → pass/fail, and gives each one a disposition |
 | 3 | @reviewer | Runtime validation: run tests, post review outcome (report only — no fixes) |
+| 4 | [followup] | Orchestrator files the findings dispositioned `file`, per `agentic-issue-creation` |
 
 ### Rules
 
@@ -21,12 +22,26 @@ description: >
 - @reviewer runs full test suite to validate
 - @reviewer posts pass/fail outcome as PR comment
 - No branch creation, no commits (review is read-only)
+- **A reviewer reports a finding; it never files one.** Nine agents — the five sub-reviewers, plus @ask, @planner, @validator and @visual-tester — carry a `PreToolUse` hook that blocks mutating `gh`, so `gh issue create` fails for them by design. Findings travel up in the reviewer's own output and the orchestrator files them. That is also what keeps five parallel reviewers from filing five issues for one finding.
+
+### Finding disposition
+
+Every merged finding gets exactly one disposition, decided at `merge-findings` once all five reviewer outputs are in — never per-reviewer, because the same problem is routinely reported by two of them under different names:
+
+| Disposition | When | What happens |
+|-------------|------|--------------|
+| `fix` | The finding is inside what this PR changed or broke | Fixed on this branch, before the PR is marked |
+| `file` | The finding is real but outside this PR's scope — pre-existing debt, a gap the diff merely revealed, a neighbouring inconsistency | Carried to `[followup]` and filed there |
+| `drop` | Duplicate of another finding, or contradicted by the code | Nothing, beyond saying so in the merged output |
+
+`file` is not a softer `fix`. A finding inside the diff is this run's work whatever it costs; a finding outside it stays outside, because widening a PR to chase debt is how a reviewed change becomes an unreviewable one.
 
 ### Non-Agentic Steps
 
 | Step | Action |
 |------|--------|
-| merge-findings | Deduplicate and merge all reviewer outputs → pass/fail |
+| merge-findings | Deduplicate and merge all reviewer outputs → pass/fail, and disposition each finding `fix` / `file` / `drop` per the table above |
+| followup | File every `file` finding per `agentic-issue-creation` — duplicate check first, labels by its confidence table. Register empty → skip. |
 
 ### Review Output Format
 
@@ -39,4 +54,5 @@ After completion:
 - Duplication: PASS/FAIL
 - Tests: PASS/FAIL
 - Verdict: APPROVE / REQUEST CHANGES
+- Filed as follow-ups: #N, #M (or `none`)
 ```

--- a/.github/skills/agentic-pipeline-review-pr/SKILL.md
+++ b/.github/skills/agentic-pipeline-review-pr/SKILL.md
@@ -13,7 +13,7 @@ description: >
 | 1 | @security-reviewer + @quality-reviewer + @i18n-reviewer + @duplication-reviewer + @semantic-reviewer | Parallel code review |
 | 2 | [merge-findings] | Orchestrator merges sub-reviewer findings → pass/fail, and gives each one a disposition |
 | 3 | @reviewer | Runtime validation: run tests, post review outcome (report only — no fixes) |
-| 4 | [followup] | Orchestrator files the findings dispositioned `file`, per `agentic-issue-creation` |
+| 4 | [followup] | Orchestrator files the findings dispositioned `file` per `agentic-issue-creation`, then comments on the PR listing them |
 
 ### Rules
 
@@ -41,7 +41,7 @@ Every merged finding gets exactly one disposition, decided at `merge-findings` o
 | Step | Action |
 |------|--------|
 | merge-findings | Deduplicate and merge all reviewer outputs → pass/fail, and disposition each finding `fix` / `file` / `drop` per the table above |
-| followup | File every `file` finding per `agentic-issue-creation` — duplicate check first, labels by its confidence table. Register empty → skip. |
+| followup | File every `file` finding per `agentic-issue-creation` — duplicate check first, labels by its confidence table — then one `gh pr comment` listing what was filed, in the format `agentic-pipeline-finalization` gives. It runs after @reviewer for the same reason it runs last there: the numbers do not exist until the issues are filed, so no earlier comment can carry them. Nothing dispositioned `file` → skip both. |
 
 ### Review Output Format
 

--- a/.github/skills/agentic-pipeline-review-pr/SKILL.md
+++ b/.github/skills/agentic-pipeline-review-pr/SKILL.md
@@ -22,7 +22,7 @@ description: >
 - @reviewer runs full test suite to validate
 - @reviewer posts pass/fail outcome as PR comment
 - No branch creation, no commits (review is read-only)
-- **A reviewer reports a finding; it never files one.** Nine agents — the five sub-reviewers, plus @ask, @planner, @validator and @visual-tester — carry a `PreToolUse` hook that blocks mutating `gh`, so `gh issue create` fails for them by design. Findings travel up in the reviewer's own output and the orchestrator files them. That is also what keeps five parallel reviewers from filing five issues for one finding.
+- **A reviewer reports a finding; it never files one.** Every runtime denies its read-only agents the commands that mutate GitHub, each by its own mechanism, so a reviewer that tries to file fails wherever it runs. Findings travel up in the reviewer's own output and the orchestrator files them — which is also what keeps five parallel reviewers from filing five issues for one finding.
 
 ### Finding disposition
 

--- a/.opencode/AGENTS.md
+++ b/.opencode/AGENTS.md
@@ -88,6 +88,16 @@ A session started by the autonomous pipeline — a GitHub Actions run woken by t
 
 Do NOT attempt workarounds. Do NOT read image files hoping to extract text. Do NOT substitute state JSON for visual inspection. A modality gap is a hard stop.
 
+## ▶ Follow-up Gate — work you found that is not your task
+
+| You found | You file |
+|-----------|----------|
+| A default you chose that a human may want to revisit | The decision — `agentic-decision-autonomy` |
+| Tech debt, a gap, or an inconsistency unrelated to your task | The finding — `agentic-issue-creation` |
+| That your own task is bigger than one run | The scope you cut, so the remainder is not lost — `agentic-issue-creation` |
+
+**Filing never halts you.** It does not hold your PR, downgrade it to draft, or leave your own issue non-terminal. Fix what your change exposes; file the rest. If your tools block `gh`, hand the finding to whoever invoked you — it is filed after review, once every agent's findings are in.
+
 ## Communication Style
 
 Respond terse. All technical substance stay. Only fluff die.

--- a/.opencode/agents/duplication-reviewer.md
+++ b/.opencode/agents/duplication-reviewer.md
@@ -76,6 +76,8 @@ handles that) — focus on **semantic and structural** duplication.
 
 ## Output Format
 
+Tag every finding with its scope so `merge-findings` can disposition it: `[in-diff]` when it sits inside what this PR changed or broke, `[pre-existing]` when the diff merely revealed it. Report a `[pre-existing]` finding like any other — the orchestrator files it as a follow-up issue rather than widening this PR. Report it rather than filing it: mutating `gh` is blocked for this agent by design.
+
 Each finding includes a confidence level:
 
 - **high** — verified by reading both the changed code and an existing counterpart

--- a/.opencode/agents/i18n-reviewer.md
+++ b/.opencode/agents/i18n-reviewer.md
@@ -32,6 +32,8 @@ Position: parallel sub-reviewer in code_review fan-out. Read-only.
 
 ## Output Format
 
+Tag every finding with its scope so `merge-findings` can disposition it: `[in-diff]` when it sits inside what this PR changed or broke, `[pre-existing]` when the diff merely revealed it. Report a `[pre-existing]` finding like any other — the orchestrator files it as a follow-up issue rather than widening this PR. Report it rather than filing it: mutating `gh` is blocked for this agent by design.
+
 Each finding includes a confidence level:
 
 - **high** — verified by reading source + locale JSONs

--- a/.opencode/agents/implementer.md
+++ b/.opencode/agents/implementer.md
@@ -59,6 +59,12 @@ Adding/modifying console command:
 3. Handler: `GameState` + parsed args → core logic → `CommandResult`
 4. `ConsoleFormatter` → human-readable output
 
+## Scope Overrun
+
+The plan sized this task on what a reader could see. When the codebase disagrees — the change reaches far more call sites than the plan lists, or landing it means re-deriving values across many files — say so in the hand-back rather than working through it. A run that spends its whole budget is killed mid-work, and what survives is an unreviewed branch nobody can finish.
+
+Report `SCOPE OVERRUN: <the slice that reaches green alone> | <the remainder>`. The orchestrator decides, cuts, and files the remainder per `agentic-issue-creation`. Landing a coherent slice is a finished run; landing half of everything is not.
+
 ## Key References
 
 - `dev-architecture` — module boundaries, data flow

--- a/.opencode/agents/planner.md
+++ b/.opencode/agents/planner.md
@@ -33,6 +33,9 @@ Produce structured implementation plan from issue. Read-only — no code changes
 - [ ] criterion 2
 ### Decisions
 - **Open:** what the issue left unspecified — **Chosen:** the default — **Why:** the spec, convention, or incentive it follows — **Reverse by:** the constant or branch a human would change
+### Scope
+- `fits` — one run can carry this to a merged pull request
+- `oversized` — name the slice that reaches green on its own, and the remainder the orchestrator should file per `agentic-issue-creation`
 ### Edge Cases
 - edge case 1
 ### Architecture Notes

--- a/.opencode/agents/quality-reviewer.md
+++ b/.opencode/agents/quality-reviewer.md
@@ -72,6 +72,8 @@ Adjust review depth based on `risk_tier` from context:
 
 ## Output Format
 
+Tag every finding with its scope so `merge-findings` can disposition it: `[in-diff]` when it sits inside what this PR changed or broke, `[pre-existing]` when the diff merely revealed it. Report a `[pre-existing]` finding like any other — the orchestrator files it as a follow-up issue rather than widening this PR. Report it rather than filing it: mutating `gh` is blocked for this agent by design.
+
 Each finding includes a confidence level:
 
 - **high** — verified by reading the source code, clear violation

--- a/.opencode/agents/security-reviewer.md
+++ b/.opencode/agents/security-reviewer.md
@@ -33,6 +33,8 @@ Position: parallel sub-reviewer in code_review fan-out. Read-only.
 
 ## Output Format
 
+Tag every finding with its scope so `merge-findings` can disposition it: `[in-diff]` when it sits inside what this PR changed or broke, `[pre-existing]` when the diff merely revealed it. Report a `[pre-existing]` finding like any other — the orchestrator files it as a follow-up issue rather than widening this PR. Report it rather than filing it: mutating `gh` is blocked for this agent by design.
+
 Each finding includes a confidence level:
 
 - **high** — verified by reading the source code, concrete exploit exists

--- a/.opencode/agents/semantic-reviewer.md
+++ b/.opencode/agents/semantic-reviewer.md
@@ -73,6 +73,8 @@ Verify semantic coherence between tests and implementation. Every test case must
 
 ## Output Format
 
+Tag every finding with its scope so `merge-findings` can disposition it: `[in-diff]` when it sits inside what this PR changed or broke, `[pre-existing]` when the diff merely revealed it. Report a `[pre-existing]` finding like any other — the orchestrator files it as a follow-up issue rather than widening this PR. Report it rather than filing it: mutating `gh` is blocked for this agent by design.
+
 ```
 ## Semantic Review
 ### Test Coverage

--- a/.opencode/skills/agentic-autonomous-pipeline/references/runtime-parity.md
+++ b/.opencode/skills/agentic-autonomous-pipeline/references/runtime-parity.md
@@ -31,6 +31,16 @@ So "invoke the reviewers in parallel" reads as *fan out and await* under OpenCod
 
 **The principle generalises past that one parameter. Where runtimes differ, the shared context states the invariant and each runtime's own configuration layer enforces it.** A body that names one runtime's parameters is a body that is wrong for the other two.
 
+Issue filing splits the same way. The rule — a read-only agent reports a finding, the orchestrator files it — is uniform. What denies the agent the command is not:
+
+| Runtime | Read-only agents denied GitHub writes by |
+|---------|------------------------------------------|
+| OpenCode | `permission.bash` in the agent's own frontmatter: `"git *": "deny"`, `"gh *": "deny"` |
+| Copilot | `tools: ["read", "search"]` — no shell to run `gh` with |
+| Claude Code | A `PreToolUse` hook on `Bash`, `block-git-gh.sh`, registered in the agent's frontmatter |
+
+Three mechanisms, one behaviour: a reviewer that tries to open an issue fails wherever it runs, so a finding reaches GitHub through the orchestrator or not at all. `agentic-pipeline-review-pr` states the rule and names none of them.
+
 ## Claude Code prerequisites
 
 Delegation depends on configuration that is off by default:

--- a/.opencode/skills/agentic-decision-autonomy/SKILL.md
+++ b/.opencode/skills/agentic-decision-autonomy/SKILL.md
@@ -85,7 +85,7 @@ An earlier convention held a PR back for "significant churn". It cost a green, f
 
 An issue's title describes where the reporter noticed the problem, not where the problem lives. When the fix reaches deeper than the framing — a visual-coherence issue that turns out to need a simulation fix — implement the fix that is actually correct, say so in the PR body, and continue. A correct fix outside the framing beats an incorrect one inside it.
 
-The limit is relevance, not depth: fix what this issue's own change exposes. Unrelated defects noticed along the way become their own issues.
+The limit is relevance, not depth: fix what this issue's own change exposes. Unrelated defects noticed along the way become their own issues — reported into the run's follow-up register and filed at the end of the pipeline, per `agentic-issue-creation`. Recording one is not escalating: it never holds the PR and never delays the run's own issue.
 
 ## Recording format
 

--- a/.opencode/skills/agentic-issue-creation/SKILL.md
+++ b/.opencode/skills/agentic-issue-creation/SKILL.md
@@ -1,13 +1,23 @@
 ---
 name: agentic-issue-creation
-description: Create or edit GitHub issues for agentic pipeline consumption — context, files, test files, dependencies (setting or reading a blocked_by relationship), labels, and verification criteria. Use when creating an issue for autonomous coding agents, or when editing an existing one's dependencies, labels, or lifecycle state.
+description: Create or edit GitHub issues for agentic pipeline consumption — context, files, test files, dependencies (setting or reading a blocked_by relationship), labels, and verification criteria. Use when filing an issue for autonomous coding agents, when recording technical debt, a codebase gap, an inconsistency or a defect found while working on something else, when cutting a task that turns out to be bigger than one run and filing the remainder, or when editing an already-filed issue's dependencies, labels, or lifecycle state.
 ---
 
 # Skill: agentic-issue-creation
 
 ## When to Use
 
-Use when creating a GitHub issue that an autonomous run will pick up, or when editing an already-filed one's dependencies, labels, or lifecycle state. An issue is the only input the pipeline takes, so it has to stand on its own — the run starts with the issue body and the codebase, and nothing else. Setting a `blocked_by` relationship on an existing issue is this skill's task exactly as much as authoring a new one is — see "Setting a dependency" below.
+Use when creating a GitHub issue that an autonomous run will pick up, when recording something found while working on a different task, when cutting an oversized task and filing the remainder, or when editing an already-filed one's dependencies, labels, or lifecycle state. An issue is the only input the pipeline takes, so it has to stand on its own — the run starts with the issue body and the codebase, and nothing else. Setting a `blocked_by` relationship on an existing issue is this skill's task exactly as much as authoring a new one is — see "Setting a dependency" below.
+
+Three situations put an agent here, and they differ only in what the issue records:
+
+| Situation | What the issue carries |
+|-----------|------------------------|
+| **Planned work** — decomposing a feature, or a human filing a task | The task itself, in one of the two shapes below |
+| **A finding** — technical debt, a codebase gap, an inconsistency, a defect noticed while working on something else | The finding, plus where it was found and why it was not fixed on the spot |
+| **A scope cut** — the assigned task turns out to be bigger than one run can carry | The remainder deliberately left out, and what was landed instead |
+
+A finding and a scope cut become ordinary issues the moment they are filed. They differ from planned work only in provenance, which the template's optional sections carry.
 
 Two shapes are valid, and they differ in how much of the answer is already known:
 
@@ -20,15 +30,50 @@ Both enter the same queue once `ready` lands on the issue — a two-line issue t
 
 ## ▶ PROCEDURE — EXECUTE IN ORDER
 
-1. Pick the shape: complete when you know the file layout, intent when you are describing an outcome
-2. Fill every section that shape carries, using the headings below verbatim
-3. Verify the Rules are satisfied
-4. Run through the Checklist
-5. Create the issue with `gh issue create`, setting labels yourself:
-   - Human gave no instruction about labels → `--label ready,agent-task`. `ready` means eligible, not started: it places the issue in the queue, where it waits until a human dispatches `agentic-trigger.yml` or a merged pipeline PR chains to it. Creating an issue never starts a run.
-   - Human specified labels, or said the issue should wait — `decision-review` for a default to revisit later, or an explicit hold — → follow that instruction instead, and leave `ready` off.
+1. Run the duplicate check below. An open issue that already covers it is updated, not duplicated
+2. Pick the shape: complete when you know the file layout, intent when you are describing an outcome
+3. Fill every section that shape carries, using the headings below verbatim
+4. Verify the Rules are satisfied
+5. Run through the Checklist
+6. Create the issue with `gh issue create`, setting labels per the Labels section below. A human who specified labels, or said the issue should wait, overrides that table
 
-An issue that must **stay out** of the queue is created carrying a lifecycle label of its own instead of `ready` — `decision-review` for a default to revisit later. The issue joins the queue in number order once `ready` is on it, whoever put it there.
+`ready` means eligible, not started: it places the issue in the queue, where it waits until a human dispatches `agentic-trigger.yml` or a merged pipeline pull request chains to it. Creating an issue never starts a run. The issue joins the queue in number order once `ready` is on it, whoever put it there.
+
+## ▶ Duplicate check — run before filing anything
+
+An issue nobody reads twice is cheap; two issues for one problem are not. They split the discussion, and the second run to pick one up rediscovers what the first already fixed.
+
+1. Search open issues for the thing itself rather than for your phrasing of it — the symbol, the file path, the error text, the convention being violated.
+   ```bash
+   gh issue list --state open --search "<symbol or file path>" --limit 20
+   gh issue list --state open --label agent-task --limit 50   # when the term is a concept, not a string
+   ```
+   With no `gh` CLI — Claude Code on the web has none — the same search runs against the REST API with the `GITHUB_TOKEN` already in the environment. Never echo the token; pass it straight from the variable.
+   ```bash
+   curl -sS -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" \
+     --get --data-urlencode "q=repo:Nico2398/BlastSimulator2026 is:issue is:open <terms>" \
+     "https://api.github.com/search/issues" \
+     | python3 -c "import sys,json; [print(i['number'], i['title']) for i in json.load(sys.stdin)['items']]"
+   ```
+2. **A match that covers your finding → update it.** Add what you learned as a comment when it is evidence (a second occurrence, a reproduction, an exact line number), or edit the body when it is a correction (a wrong path, a missing consumer, a premise that no longer holds). Name the run that found it, so the next reader knows where the addition came from.
+3. **A match that overlaps without covering it** → file, and name the neighbour in your Context section so a human can merge the two if they disagree.
+4. **A closed match** → read how it closed. Closed with a merged pull request means the problem came back and yours is a regression report, which is worth saying in the body. Closed unmerged means it was declined, and refiling needs a reason.
+
+Searching costs one command. Filing a duplicate costs a run.
+
+## ▶ Labels — `ready` is a confidence statement
+
+`agentic-assign` selects on `ready` alone. Putting it on an issue says *this work should be done, and the description is good enough to start from.* Putting it on a hunch spends a whole run discovering the hunch was wrong.
+
+| Confidence | Labels | What follows |
+|-----------|--------|--------------|
+| **High** — a defect you reproduced, a convention you can point at, a gap you verified in the code | `agent-task`, `ready` | The work is real and specified. The issue joins the queue in number order. |
+| **Open** — something looks wrong, and a human should confirm it is worth doing or pick between two directions | `agent-task` | The issue stays out of the queue until a human adds `ready`. |
+| **Already decided by the run** — a default you implemented that a human may want to revisit | `decision-review` | Held by `agentic-decision-autonomy`, which owns that flow end to end. |
+
+An issue held for confirmation carries an `## Open question` section naming exactly what a human must answer and what changes with each answer. Without it the issue is a hunch nobody can act on, and it waits until someone re-derives the question you already knew.
+
+Leave `ready` off while you are uncertain. An issue carrying `agent-task` alone loses nothing — it keeps its number, its body and its place — and gains `ready` the moment a human agrees.
 
 ## Issue Body Template
 
@@ -54,7 +99,18 @@ An issue that must **stay out** of the queue is created carrying a lifecycle lab
 
 ## Verification
 - [Observable outcome that proves the task is done]
+
+## Where found
+[Findings and scope cuts only. Which run, which pull request or review round, what was being worked on at the time.]
+
+## Why not fixed here
+[Findings and scope cuts only. Why filing was right rather than folding it into the work in hand.]
+
+## Open question
+[Issues held at `agent-task` without `ready` only. What a human must answer, and what changes with each answer.]
 ```
+
+The last three sections are provenance and are omitted for planned work. `## Where found` and `## Why not fixed here` are what let the next reader judge a finding without reconstructing the review round that produced it; `## Open question` is what a human answers before adding `ready`.
 
 ## Rules
 
@@ -68,7 +124,9 @@ An issue that must **stay out** of the queue is created carrying a lifecycle lab
 8. **Single task per issue.** A task touching several concerns is several issues. So is a task that is one concern but too large for one run — Sizing below is the test, and Splitting is what to do about it.
 9. **SMART compliance.** Specific (one clear goal), Measurable (verifiable outcome), Achievable (within an agent's capabilities), Relevant (part of the larger feature), Time-bound (a single atomic task).
 10. **`full-ci` is off by default — an issue has to earn it.** The label starts the interaction-mode browser job, which costs the merge path real time, so it goes on an issue only where that job is the only thing that could catch the regression: an interaction-mode scenario clicks its way through the control, panel or flow the issue changes, or the issue touches shared input, picking, camera, rendering or harness machinery every scenario runs through. **Never on a backend-only issue.** A change confined to `src/core/`, `src/console/`, config or pure logic is proven by `static`, `logic` and command-mode `scenario`; replaying browser flows the diff never reaches reports nothing about it. **Never where there is no interaction regression to catch** — a renderer detail no scenario reaches, a control added to an existing panel, copy, a new command parameter. The `visual` channel covers those in-session against the thing that actually changed, which is stronger evidence than a suite that never touches it. When in doubt, leave it off. Full test and cost: `agentic-pipeline-pr-management`.
-11. **Label transfer.** A PR opened from a `full-ci` issue gets the same label, passed on the same `gh pr create` call that opens it (`--label "full-ci"`) — never a follow-up `gh pr edit --add-label`, which raises no `pull_request` event of its own and is how PR #615 merged with its interaction-mode job silently skipped. See `agentic-pipeline-finalization`'s `open-pr` step.
+11. **Search before filing, and update what already exists.** An open issue covering the same problem is updated rather than duplicated — procedure above.
+12. **`ready` states confidence, not hope.** It goes on an issue whose work is verified real and whose description is good enough to start from. Anything short of that is `agent-task` alone, with an `## Open question` section naming what a human must answer.
+13. **Label transfer.** A PR opened from a `full-ci` issue gets the same label, passed on the same `gh pr create` call that opens it (`--label "full-ci"`) — never a follow-up `gh pr edit --add-label`, which raises no `pull_request` event of its own and is how PR #615 merged with its interaction-mode job silently skipped. See `agentic-pipeline-finalization`'s `open-pr` step.
 
 ## ▶ Sizing — one issue is one run, and a run has a ceiling
 
@@ -94,6 +152,22 @@ The obvious split — the mechanic in one issue, the tests it breaks in the next
 3. **Stack the batches on an integration branch.** Sub-issues target the feature branch rather than `main`, and only the final merge has to be green. Last resort: assignability, auto-merge and rescue all assume a PR against `main`, so a human has to shepherd it.
 
 Batch issues are ordinary issues — `Blocked by` the enabler, one slice each, verification of their own.
+
+## ▶ Discovering mid-run that the task is bigger than one run
+
+Sizing above is the test applied *before* filing. The same ceiling exists mid-run, and reaching it is ordinary: the issue was sized on what a reader could see, and the codebase disagreed.
+
+What turns it into a lost run is carrying on regardless. A run that spends its whole budget is not cancelled politely — the job is killed, and what survives is whatever `agentic-rescue` can push: an unreviewed branch, a draft pull request, a `blocked` issue, and a human working out which half is done.
+
+Cut instead:
+
+1. **Pick the slice that reaches a green pull request on its own.** Not the slice already written — the slice that is coherent. A half-migrated call site is worse than an unmigrated one.
+2. **Land it, verified through every channel it owes.** A reduced scope changes nothing about the Verification Gate.
+3. **File the remainder**, one issue per slice, each able to reach green alone. The three splitting strategies above apply unchanged, and splitting the enablers off first is still the best of them.
+4. **Say what was cut**, in the pull request body and on the original issue, naming the new issue numbers. A remainder nobody can find is a remainder nobody does.
+5. **Set `Blocked by` only where a real ordering exists.** Slices touching different files are independent, and marking them blocked on each other serialises work that could run side by side.
+
+The original issue closes on its own merged pull request with its reduced scope stated. It stays open to track nothing — that is what the new issues are for, and an issue held open past its own merge defers every assignment behind it.
 
 ## Setting a dependency
 
@@ -184,4 +258,8 @@ recorded can be picked up in that window.
 - [ ] An issue that must stay out of the queue carries its own lifecycle label
 - [ ] `full-ci` left off unless the interaction-mode job is the only thing that could catch the regression — never on a backend-only issue, never where no interaction regression exists
 - [ ] If the issue has `full-ci`, the PR gets `full-ci` when opened
-- [ ] Labels set on creation: `ready,agent-task` unless the human specified otherwise or the issue must stay out of the queue
+- [ ] Open issues searched for this problem — none covers it, or the existing one was updated instead of a new one filed
+- [ ] Labels set on creation per the Labels table: `ready` only at high confidence, `agent-task` alone otherwise, unless the human specified something else
+- [ ] An issue held for confirmation carries `## Open question`
+- [ ] A finding or a scope cut carries `## Where found` and `## Why not fixed here`
+- [ ] A scope cut names its remainder issues in the pull request body and on the original issue

--- a/.opencode/skills/agentic-pipeline-finalization/SKILL.md
+++ b/.opencode/skills/agentic-pipeline-finalization/SKILL.md
@@ -45,9 +45,14 @@ Runs after qualimetry passes. Branch: `pipeline/feature-<label>` — `<label>` i
  8. [followup]           → Drain the follow-up register (below): every finding and scope cut
                              reported by a sub-agent this run, plus any decision material to
                              gameplay, economy, or a player-facing default. File each per
-                             `agentic-issue-creation`, carrying the PR link.
-                             Register empty → skip. Filing never reopens an earlier step and
-                             never changes the PR's status.
+                             `agentic-issue-creation`, carrying the PR link, then post **one**
+                             comment on the PR listing what was filed. The issues link to the
+                             PR; the comment is what links the PR back to them, because
+                             `open-pr` composed the body a step earlier and cannot name numbers
+                             that did not exist yet.
+                             Register empty → skip both the filing and the comment.
+                             Filing never reopens an earlier step and never changes the PR's
+                             status.
  9. [git-verify]         → confirm clean state: git status, branch, last commits
 10. [await-ci]           → `npm run ci:await -- --pr <number>`. Blocks until every workflow
                              run on the PR head reports — no deadline, because any deadline
@@ -81,6 +86,22 @@ Instead the orchestrator keeps a register for the run. Every sub-agent report ma
 `[followup]` runs **after** review and validation for one reason: by then every agent has reported, so the register can be deduplicated across all of them at once. The same debt reported by @quality-reviewer and @duplication-reviewer under two names is one issue, and only a pass that sees both can tell.
 
 A register entry is not a blocker. It never holds the PR, never downgrades it to draft, and never delays `[await-ci]`. A run that files four follow-ups still finishes its own issue.
+
+#### The comment `[followup]` posts
+
+```markdown
+## Follow-ups filed
+
+Work this run found outside its own task. None of it blocks this PR.
+
+| Issue | Kind | Labels | What |
+|-------|------|--------|------|
+| #N | finding | `agent-task` `ready` | one line, the summary the issue title carries |
+| #M | scope-cut | `agent-task` `ready` | which slice was cut, and why it did not fit |
+| #P | decision | `decision-review` | the default taken, and the lever that reverses it |
+```
+
+One comment per run, posted only when the register held something. An empty register posts nothing: a comment saying "none" on every pipeline pull request is noise, and it proves nothing anyway — a clean run and a run that dropped its findings write the same word. What separates them is the review output from the same run, which lists every `[pre-existing]` finding the reviewers reported. A reader comparing that list against this comment can see what went unfiled; a reader handed "none" cannot.
 
 ### Failure loops
 
@@ -123,5 +144,5 @@ Do NOT re-run skeleton-writer or test-writer — branches and tests already exis
 | verify-commit | `git log --oneline -1` — auto-commit if dirty, use message `"<agent-name>: <step-context> (#<N>)"` |
 | open-pr | Decide the `full-ci` label **before** calling `gh pr create`, by `agentic-pipeline-pr-management`'s test. `gh pr create --base main --head pipeline/feature-<label> --title "<type>: Resolve #<N>" --body "Closes #<N>\n\n<test_count> tests — all passing\n\n<decisions_block>\n\nREADY TO MERGE"`, adding `--label "full-ci"` to that same call when the test says yes. Determine `<type>` from pipeline: `full → feat`, `fix-bug → fix`, `multi → feat`. Count test cases: `npx vitest list --reporter=json 2>$null | ConvertFrom-Json | ForEach-Object { $_.testModules } | Measure-Object`. `<decisions_block>` is the `## Decisions taken` section, omitted when the run defaulted nothing. For draft: add `--draft`, omit `READY TO MERGE` line. **Never a follow-up `gh pr edit --add-label`** — a label added after `create` raises no `pull_request` event of its own on this repo's older CI trigger shape, and PR #615 merged with its `full-ci` interaction job silently skipped for exactly that reason (`ci.yml` now also re-evaluates on `labeled`, but the label belongs on the opening call regardless — the two are independent fixes for the same incident, not a reason to pick one). |
 | await-ci | `npm run ci:await -- --pr <number>` (or `--head pipeline/feature-<label>` before the number is known). Exit codes: `0` GREEN, `1` RED with the failing jobs and their log URLs printed, `2` TIMEOUT (only reachable if you pass `--timeout-minutes`, which a pipeline run never does), `3` the PR is gone, `4` bad arguments or `gh` could not answer. It listens to the workflow runs on the PR head; it never re-runs a channel, and no verdict it reports depends on a duration. |
-| followup | Drain the register in one pass, newest entry last. Decisions: `gh label create decision-review --description "A default the pipeline chose; revisit when convenient" --color ededed --force` then `gh issue create --label decision-review --title "Decision review: <summary> (from #<N>)" --body "<decisions block + PR link>"`. `--force` makes the label step idempotent — it updates an existing label instead of failing the run on every issue after the first. Findings and scope cuts: duplicate-check, then file per `agentic-issue-creation`, labels by its confidence table. |
+| followup | Drain the register in one pass, newest entry last, then `gh pr comment <pr-url> --body "<the table below>"` — one comment, only when something was filed. Decisions: `gh label create decision-review --description "A default the pipeline chose; revisit when convenient" --color ededed --force` then `gh issue create --label decision-review --title "Decision review: <summary> (from #<N>)" --body "<decisions block + PR link>"`. `--force` makes the label step idempotent — it updates an existing label instead of failing the run on every issue after the first. Findings and scope cuts: duplicate-check, then file per `agentic-issue-creation`, labels by its confidence table. |
 | git-verify | `git status --porcelain` (must be empty) → `git branch --show-current` → `git log --oneline -3` |

--- a/.opencode/skills/agentic-pipeline-finalization/SKILL.md
+++ b/.opencode/skills/agentic-pipeline-finalization/SKILL.md
@@ -42,11 +42,12 @@ Runs after qualimetry passes. Branch: `pipeline/feature-<label>` — `<label>` i
                              **If `visual_incomplete=true` → MUST use --draft, NO `READY TO MERGE`.**
                              **The PR leaves this step marked or --draft. Never both absent:
                              a channel CI runs is covered by the marker, not a reason to defer it.**
- 8. [decision-followup]  → If any decision was material to gameplay, economy, or a player-facing
-                             default: `gh issue create --label decision-review` carrying the
-                             `## Decisions taken` block and the PR link. No `ready` label — it
-                             stays out of the assignment queue and halts nothing.
-                             No material decisions → skip.
+ 8. [followup]           → Drain the follow-up register (below): every finding and scope cut
+                             reported by a sub-agent this run, plus any decision material to
+                             gameplay, economy, or a player-facing default. File each per
+                             `agentic-issue-creation`, carrying the PR link.
+                             Register empty → skip. Filing never reopens an earlier step and
+                             never changes the PR's status.
  9. [git-verify]         → confirm clean state: git status, branch, last commits
 10. [await-ci]           → `npm run ci:await -- --pr <number>`. Blocks until every workflow
                              run on the PR head reports — no deadline, because any deadline
@@ -62,6 +63,24 @@ Runs after qualimetry passes. Branch: `pipeline/feature-<label>` — `<label>` i
 ```
 
 **Retry counter:** resets at start of each finalization invocation.
+
+### The follow-up register
+
+A run's sub-agents notice work that is not this run's task: a reviewer finds pre-existing debt, an implementer hits a task bigger than one run, a test-writer finds a convention the codebase contradicts. None of them files an issue — nine agents are blocked from mutating `gh` by a `PreToolUse` hook, and five parallel reviewers filing independently would produce five issues for one finding.
+
+Instead the orchestrator keeps a register for the run. Every sub-agent report may append to it; nothing is filed until `[followup]`.
+
+| Column | Holds |
+|--------|-------|
+| Kind | `finding` / `scope-cut` / `decision` |
+| Reported by | Which agent, at which step |
+| Summary | One line, enough to duplicate-check against |
+| Evidence | File and line, the failing case, or the constraint that forces the cut |
+| Confidence | Whether it is verified real, or needs a human to confirm — this is what `agentic-issue-creation`'s label table reads |
+
+`[followup]` runs **after** review and validation for one reason: by then every agent has reported, so the register can be deduplicated across all of them at once. The same debt reported by @quality-reviewer and @duplication-reviewer under two names is one issue, and only a pass that sees both can tell.
+
+A register entry is not a blocker. It never holds the PR, never downgrades it to draft, and never delays `[await-ci]`. A run that files four follow-ups still finishes its own issue.
 
 ### Failure loops
 
@@ -104,5 +123,5 @@ Do NOT re-run skeleton-writer or test-writer — branches and tests already exis
 | verify-commit | `git log --oneline -1` — auto-commit if dirty, use message `"<agent-name>: <step-context> (#<N>)"` |
 | open-pr | Decide the `full-ci` label **before** calling `gh pr create`, by `agentic-pipeline-pr-management`'s test. `gh pr create --base main --head pipeline/feature-<label> --title "<type>: Resolve #<N>" --body "Closes #<N>\n\n<test_count> tests — all passing\n\n<decisions_block>\n\nREADY TO MERGE"`, adding `--label "full-ci"` to that same call when the test says yes. Determine `<type>` from pipeline: `full → feat`, `fix-bug → fix`, `multi → feat`. Count test cases: `npx vitest list --reporter=json 2>$null | ConvertFrom-Json | ForEach-Object { $_.testModules } | Measure-Object`. `<decisions_block>` is the `## Decisions taken` section, omitted when the run defaulted nothing. For draft: add `--draft`, omit `READY TO MERGE` line. **Never a follow-up `gh pr edit --add-label`** — a label added after `create` raises no `pull_request` event of its own on this repo's older CI trigger shape, and PR #615 merged with its `full-ci` interaction job silently skipped for exactly that reason (`ci.yml` now also re-evaluates on `labeled`, but the label belongs on the opening call regardless — the two are independent fixes for the same incident, not a reason to pick one). |
 | await-ci | `npm run ci:await -- --pr <number>` (or `--head pipeline/feature-<label>` before the number is known). Exit codes: `0` GREEN, `1` RED with the failing jobs and their log URLs printed, `2` TIMEOUT (only reachable if you pass `--timeout-minutes`, which a pipeline run never does), `3` the PR is gone, `4` bad arguments or `gh` could not answer. It listens to the workflow runs on the PR head; it never re-runs a channel, and no verdict it reports depends on a duration. |
-| decision-followup | `gh label create decision-review --description "A default the pipeline chose; revisit when convenient" --color ededed --force` then `gh issue create --label decision-review --title "Decision review: <summary> (from #<N>)" --body "<decisions block + PR link>"`. `--force` makes the label step idempotent — it updates an existing label instead of failing the run on every issue after the first. |
+| followup | Drain the register in one pass, newest entry last. Decisions: `gh label create decision-review --description "A default the pipeline chose; revisit when convenient" --color ededed --force` then `gh issue create --label decision-review --title "Decision review: <summary> (from #<N>)" --body "<decisions block + PR link>"`. `--force` makes the label step idempotent — it updates an existing label instead of failing the run on every issue after the first. Findings and scope cuts: duplicate-check, then file per `agentic-issue-creation`, labels by its confidence table. |
 | git-verify | `git status --porcelain` (must be empty) → `git branch --show-current` → `git log --oneline -3` |

--- a/.opencode/skills/agentic-pipeline-finalization/SKILL.md
+++ b/.opencode/skills/agentic-pipeline-finalization/SKILL.md
@@ -71,7 +71,7 @@ Runs after qualimetry passes. Branch: `pipeline/feature-<label>` — `<label>` i
 
 ### The follow-up register
 
-A run's sub-agents notice work that is not this run's task: a reviewer finds pre-existing debt, an implementer hits a task bigger than one run, a test-writer finds a convention the codebase contradicts. None of them files an issue — nine agents are blocked from mutating `gh` by a `PreToolUse` hook, and five parallel reviewers filing independently would produce five issues for one finding.
+A run's sub-agents notice work that is not this run's task: a reviewer finds pre-existing debt, an implementer hits a task bigger than one run, a test-writer finds a convention the codebase contradicts. None of them files an issue — every runtime denies its read-only agents the commands that mutate GitHub, and five parallel reviewers filing independently would produce five issues for one finding.
 
 Instead the orchestrator keeps a register for the run. Every sub-agent report may append to it; nothing is filed until `[followup]`.
 

--- a/.opencode/skills/agentic-pipeline-review-pr/SKILL.md
+++ b/.opencode/skills/agentic-pipeline-review-pr/SKILL.md
@@ -11,8 +11,9 @@ description: >
 | Step | Who | Action |
 |------|-----|--------|
 | 1 | @security-reviewer + @quality-reviewer + @i18n-reviewer + @duplication-reviewer + @semantic-reviewer | Parallel code review |
-| 2 | [merge-findings] | Orchestrator merges sub-reviewer findings → pass/fail |
+| 2 | [merge-findings] | Orchestrator merges sub-reviewer findings → pass/fail, and gives each one a disposition |
 | 3 | @reviewer | Runtime validation: run tests, post review outcome (report only — no fixes) |
+| 4 | [followup] | Orchestrator files the findings dispositioned `file`, per `agentic-issue-creation` |
 
 ### Rules
 
@@ -21,12 +22,26 @@ description: >
 - @reviewer runs full test suite to validate
 - @reviewer posts pass/fail outcome as PR comment
 - No branch creation, no commits (review is read-only)
+- **A reviewer reports a finding; it never files one.** Nine agents — the five sub-reviewers, plus @ask, @planner, @validator and @visual-tester — carry a `PreToolUse` hook that blocks mutating `gh`, so `gh issue create` fails for them by design. Findings travel up in the reviewer's own output and the orchestrator files them. That is also what keeps five parallel reviewers from filing five issues for one finding.
+
+### Finding disposition
+
+Every merged finding gets exactly one disposition, decided at `merge-findings` once all five reviewer outputs are in — never per-reviewer, because the same problem is routinely reported by two of them under different names:
+
+| Disposition | When | What happens |
+|-------------|------|--------------|
+| `fix` | The finding is inside what this PR changed or broke | Fixed on this branch, before the PR is marked |
+| `file` | The finding is real but outside this PR's scope — pre-existing debt, a gap the diff merely revealed, a neighbouring inconsistency | Carried to `[followup]` and filed there |
+| `drop` | Duplicate of another finding, or contradicted by the code | Nothing, beyond saying so in the merged output |
+
+`file` is not a softer `fix`. A finding inside the diff is this run's work whatever it costs; a finding outside it stays outside, because widening a PR to chase debt is how a reviewed change becomes an unreviewable one.
 
 ### Non-Agentic Steps
 
 | Step | Action |
 |------|--------|
-| merge-findings | Deduplicate and merge all reviewer outputs → pass/fail |
+| merge-findings | Deduplicate and merge all reviewer outputs → pass/fail, and disposition each finding `fix` / `file` / `drop` per the table above |
+| followup | File every `file` finding per `agentic-issue-creation` — duplicate check first, labels by its confidence table. Register empty → skip. |
 
 ### Review Output Format
 
@@ -39,4 +54,5 @@ After completion:
 - Duplication: PASS/FAIL
 - Tests: PASS/FAIL
 - Verdict: APPROVE / REQUEST CHANGES
+- Filed as follow-ups: #N, #M (or `none`)
 ```

--- a/.opencode/skills/agentic-pipeline-review-pr/SKILL.md
+++ b/.opencode/skills/agentic-pipeline-review-pr/SKILL.md
@@ -13,7 +13,7 @@ description: >
 | 1 | @security-reviewer + @quality-reviewer + @i18n-reviewer + @duplication-reviewer + @semantic-reviewer | Parallel code review |
 | 2 | [merge-findings] | Orchestrator merges sub-reviewer findings → pass/fail, and gives each one a disposition |
 | 3 | @reviewer | Runtime validation: run tests, post review outcome (report only — no fixes) |
-| 4 | [followup] | Orchestrator files the findings dispositioned `file`, per `agentic-issue-creation` |
+| 4 | [followup] | Orchestrator files the findings dispositioned `file` per `agentic-issue-creation`, then comments on the PR listing them |
 
 ### Rules
 
@@ -41,7 +41,7 @@ Every merged finding gets exactly one disposition, decided at `merge-findings` o
 | Step | Action |
 |------|--------|
 | merge-findings | Deduplicate and merge all reviewer outputs → pass/fail, and disposition each finding `fix` / `file` / `drop` per the table above |
-| followup | File every `file` finding per `agentic-issue-creation` — duplicate check first, labels by its confidence table. Register empty → skip. |
+| followup | File every `file` finding per `agentic-issue-creation` — duplicate check first, labels by its confidence table — then one `gh pr comment` listing what was filed, in the format `agentic-pipeline-finalization` gives. It runs after @reviewer for the same reason it runs last there: the numbers do not exist until the issues are filed, so no earlier comment can carry them. Nothing dispositioned `file` → skip both. |
 
 ### Review Output Format
 

--- a/.opencode/skills/agentic-pipeline-review-pr/SKILL.md
+++ b/.opencode/skills/agentic-pipeline-review-pr/SKILL.md
@@ -22,7 +22,7 @@ description: >
 - @reviewer runs full test suite to validate
 - @reviewer posts pass/fail outcome as PR comment
 - No branch creation, no commits (review is read-only)
-- **A reviewer reports a finding; it never files one.** Nine agents — the five sub-reviewers, plus @ask, @planner, @validator and @visual-tester — carry a `PreToolUse` hook that blocks mutating `gh`, so `gh issue create` fails for them by design. Findings travel up in the reviewer's own output and the orchestrator files them. That is also what keeps five parallel reviewers from filing five issues for one finding.
+- **A reviewer reports a finding; it never files one.** Every runtime denies its read-only agents the commands that mutate GitHub, each by its own mechanism, so a reviewer that tries to file fails wherever it runs. Findings travel up in the reviewer's own output and the orchestrator files them — which is also what keeps five parallel reviewers from filing five issues for one finding.
 
 ### Finding disposition
 

--- a/scripts/validate-context.ts
+++ b/scripts/validate-context.ts
@@ -228,6 +228,7 @@ const ENTRY_SECTIONS = [
   'Autonomous pipeline sessions',
   'Verification Gate',
   'Capability Gate',
+  'Follow-up Gate',
   'Validation Commands',
 ];
 


### PR DESCRIPTION
## Why

Any agent can find work that is not its own task. Until now only one path existed for recording it — finalization's `decision-review` follow-up — and **nothing told a run what to do with a real finding outside the PR's scope.** `agentic-pipeline-review-pr` merged reviewer output into PASS/FAIL and stopped there: a finding either failed the PR or evaporated.

So review rounds improvised. Issues #633, #634, #635, #636, #650 and #652 were all filed by sessions in review rounds — every one of them unlabelled, therefore invisible to `agentic-assign`, on a `## What / ## Where found / ## Why not fixed / ## Fix` body template that appears in **zero** context files. #633 and #634 sat that way from 19 Aug until a human triaged them by hand.

`agentic-decision-autonomy` already carried the intent in one orphan line — *"Unrelated defects noticed along the way become their own issues"* — with no label, no template and no procedure attached. This PR gives it all three.

## What changes

Three situations, one act:

| You found | Labels |
|---|---|
| A default you chose that a human may want to revisit | `decision-review` |
| Tech debt, a gap, an inconsistency unrelated to your task | `agent-task` (+ `ready` when confident) |
| That your own task is bigger than one run | `agent-task` (+ `ready`) for the remainder |

**Entry points** (`.claude/CLAUDE.md`, `.github/copilot-instructions.md`, `.opencode/AGENTS.md`) gain a `Follow-up Gate` — 10 lines naming the three situations and the skill that holds each, plus the invariant that filing never halts the run. It deliberately carries **no procedure**: `agentic-issue-creation` owns that, and the gate only points at it. `validate-context.ts` now lists `Follow-up Gate` in `ENTRY_SECTIONS`, so `npm run validate:context` fails if any runtime drops it.

**`agentic-issue-creation`** becomes the single procedure for all three (187 → 265 lines):

- **Duplicate check runs first**, with a `gh` transport and a REST one for sessions without the CLI. An open issue that covers the finding is *updated* — evidence as a comment, corrections into the body — not duplicated. A closed-and-merged match makes yours a regression report.
- **`ready` is a confidence statement, not a default.** The old rule defaulted every agent-filed issue to `ready,agent-task`. Now: high confidence (a defect reproduced, a convention you can point at) gets `agent-task,ready`; anything short of it gets `agent-task` alone plus an `## Open question` section naming exactly what a human must answer and what changes with each answer.
- **`## Where found` / `## Why not fixed here`** provenance sections — the shape three sessions independently invented, which is genuinely useful and had no slot.
- **Mid-run scope-cut procedure**, building on the existing `Sizing` and `Splitting` sections: land the coherent slice, file the remainder one issue per slice, name them in the PR body and on the original issue, close the original on its own merged PR.

**Findings flow up, not out.** Nine agents (`ask`, `planner`, `validator`, `visual-tester` and the five sub-reviewers) carry a `PreToolUse` hook that blocks mutating `gh`, so `gh issue create` fails for them by design. A reviewer reports; the orchestrator files. That is also what stops five parallel reviewers filing five issues for one finding.

**Filing happens at `[followup]`, after review and validation.** `agentic-pipeline-finalization`'s step 8 generalises from `[decision-followup]` to `[followup]` and drains a per-run register covering findings, scope cuts and decisions together. The ordering is the point: the same debt reported by `@quality-reviewer` and `@duplication-reviewer` under two different names is one issue, and only a pass that sees every agent's output can tell. A register entry never holds the PR, downgrades it to draft, or delays `[await-ci]`.

**Agent contracts.** The five sub-reviewers tag each finding `[in-diff]` or `[pre-existing]` so `merge-findings` can disposition it `fix` / `file` / `drop` — their existing `high`/`medium`/`low` confidence levels already feed the label table unchanged. `@planner` reports a `fits` / `oversized` scope verdict; `@implementer` reports `SCOPE OVERRUN` instead of working through a budget it cannot finish.

## Verification

Context-only change — no `src/` diff, so `scenario` and `visual` have nothing to exercise.

| Channel | Result |
|---|---|
| `validate:context` | PASS — frontmatter schemas, tool names, hooks, bundled files, entry points, cross-runtime sync |
| `static` | PASS — `npm run typecheck` |
| `logic` | PASS — full `npx vitest run`, 318 files / 10031 tests |

All 12 skill and agent bodies mirrored word-for-word across `.claude/`, `.github/` and `.opencode/`; frontmatter left per-runtime. The `agentic-issue-creation` description is synced across all three, since it is what makes the skill discoverable on a finding.

## Notes

- No brake on filing volume, deliberately — @Nico2398's call to add one only if flooding turns out to be real.
- `github-loop.md` needed no change: it already names "an agent following `agentic-issue-creation`" as a source of `ready`, so the new policy is consistent with it rather than a contradiction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5J6GkkHCDKQQHzMiHrtq3)_