### PR TITLE
feat: Resolve #679 — scenario command-runner drift-report mode

### DIFF
--- a/scripts/run-all-scenarios.ts
+++ b/scripts/run-all-scenarios.ts
@@ -10,6 +10,15 @@
  *
  * Default mode: command (pure Node.js, no browser, ~24s for all 99).
  * Interaction mode: shared Puppeteer browser, ~2-3min for all 99.
+ *
+ * --report-drift (command mode only, issue #679): a step whose only
+ * failures are equals/changedBy mismatches no longer marks the step (or its
+ * scenario) as failed — it runs to completion instead, and every such
+ * mismatch is collected into a drift report (stdout + drift-report.json)
+ * rather than aborting the run. Directional goals (increased/decreased)
+ * still fail the run as before. This means a run under --report-drift can
+ * exit 0 while its drift report is non-empty — that's the point: it's a
+ * run-to-completion report, not a pass/fail gate.
  */
 
 import { readdirSync, mkdirSync, writeFileSync } from 'fs';
@@ -18,8 +27,7 @@ import type { ScenarioStepDef } from './shared/scenario-types.js';
 import {
   createGameEngine,
   runScenario,
-  formatDriftReport,
-  writeDriftReportFile,
+  emitDriftReport,
   type ScenarioResult,
   type DriftRecord,
 } from './shared/command-runner.js';
@@ -305,10 +313,7 @@ async function main(): Promise<void> {
 
   if (reportDrift && mode === 'command') {
     const driftRecords: DriftRecord[] = results.flatMap(r => r.driftRecords ?? []);
-    console.log(`\n${formatDriftReport(driftRecords)}`);
-    const driftPath = resolve(SCREENSHOT_DIR, 'drift-report.json');
-    writeDriftReportFile(driftRecords, driftPath);
-    console.log(`Drift report written to ${driftPath}`);
+    emitDriftReport(driftRecords, resolve(SCREENSHOT_DIR, 'drift-report.json'));
   }
 
   // Summary

--- a/scripts/run-all-scenarios.ts
+++ b/scripts/run-all-scenarios.ts
@@ -18,7 +18,10 @@ import type { ScenarioStepDef } from './shared/scenario-types.js';
 import {
   createGameEngine,
   runScenario,
+  formatDriftReport,
+  writeDriftReportFile,
   type ScenarioResult,
+  type DriftRecord,
 } from './shared/command-runner.js';
 import {
   formatStepIndex,
@@ -67,6 +70,7 @@ function parseArgs(): ParsedArgs {
   let mode = 'command';
   let port = DEV_SERVER_PORT;
   let shard: ShardSpec | undefined;
+  let reportDrift = false;
   const scenarios: string[] = [];
 
   for (let i = 0; i < args.length; i++) {
@@ -79,12 +83,14 @@ function parseArgs(): ParsedArgs {
     } else if (args[i] === '--shard' && args[i + 1]) {
       shard = parseShardArg(args[i + 1]!);
       i++;
+    } else if (args[i] === '--report-drift') {
+      reportDrift = true;
     } else if (args[i]) {
       scenarios.push(args[i]!);
     }
   }
 
-  return { mode, scenarios, port, ...(shard ? { shard } : {}), reportDrift: false };
+  return { mode, scenarios, port, ...(shard ? { shard } : {}), reportDrift };
 }
 
 /**
@@ -251,7 +257,7 @@ async function runBatchInteraction(
 }
 
 async function main(): Promise<void> {
-  const { mode, scenarios: filterScenarios, port, shard } = parseArgs();
+  const { mode, scenarios: filterScenarios, port, shard, reportDrift } = parseArgs();
 
   const scenarioFiles = readdirSync(SCENARIO_DIR)
     .filter(f => f.endsWith('.json'))
@@ -282,7 +288,7 @@ async function main(): Promise<void> {
       const name = names[i];
       try {
         const steps = loadScenarioDef(name!, SCENARIO_DIR).steps;
-        const result = runScenario(engine, name!, steps, SCREENSHOT_DIR);
+        const result = runScenario(engine, name!, steps, SCREENSHOT_DIR, reportDrift);
         results.push(result);
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -295,6 +301,14 @@ async function main(): Promise<void> {
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
       console.log(`  Progress: ${i + 1}/${names.length} (${passed} passed, ${failed} failed) [${elapsed}s]`);
     }
+  }
+
+  if (reportDrift && mode === 'command') {
+    const driftRecords: DriftRecord[] = results.flatMap(r => r.driftRecords ?? []);
+    console.log(`\n${formatDriftReport(driftRecords)}`);
+    const driftPath = resolve(SCREENSHOT_DIR, 'drift-report.json');
+    writeDriftReportFile(driftRecords, driftPath);
+    console.log(`Drift report written to ${driftPath}`);
   }
 
   // Summary

--- a/scripts/run-all-scenarios.ts
+++ b/scripts/run-all-scenarios.ts
@@ -48,6 +48,7 @@ interface ParsedArgs {
   scenarios: string[];
   port: number;
   shard?: ShardSpec;
+  reportDrift: boolean;
 }
 
 function parseShardArg(raw: string): ShardSpec {
@@ -83,7 +84,7 @@ function parseArgs(): ParsedArgs {
     }
   }
 
-  return { mode, scenarios, port, ...(shard ? { shard } : {}) };
+  return { mode, scenarios, port, ...(shard ? { shard } : {}), reportDrift: false };
 }
 
 /**

--- a/scripts/scenario-cli.ts
+++ b/scripts/scenario-cli.ts
@@ -48,6 +48,7 @@ export function parseArgs(): ParsedArgs {
   let viewport = { width: 1280, height: 720 };
   let mode = 'command'; // default mode
   let screenshots = false;
+  let reportDrift = false;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--scenario' && args[i + 1]) {
@@ -109,6 +110,8 @@ export function parseArgs(): ParsedArgs {
       i++;
     } else if (args[i] === '--screenshots') {
       screenshots = true;
+    } else if (args[i] === '--report-drift') {
+      reportDrift = true;
     }
   }
 
@@ -123,6 +126,6 @@ export function parseArgs(): ParsedArgs {
     viewport,
     mode,
     screenshots,
-    reportDrift: false,
+    reportDrift,
   };
 }

--- a/scripts/scenario-cli.ts
+++ b/scripts/scenario-cli.ts
@@ -23,6 +23,7 @@ export interface ParsedArgs {
   viewport: { width: number; height: number };
   mode: string;
   screenshots: boolean;
+  reportDrift: boolean;
 }
 
 function parseViewsArg(raw: string): ShotDef[] {
@@ -122,5 +123,6 @@ export function parseArgs(): ParsedArgs {
     viewport,
     mode,
     screenshots,
+    reportDrift: false,
   };
 }

--- a/scripts/scenario-test.ts
+++ b/scripts/scenario-test.ts
@@ -47,9 +47,8 @@ import type { ScenarioStepDef, StepResult } from './shared/scenario-types.js';
 import {
   createGameEngine,
   runSteps,
-  formatDriftReport,
-  writeDriftReportFile,
-  type DriftRecord,
+  toDriftRecords,
+  emitDriftReport,
   type GoalMismatch,
 } from './shared/command-runner.js';
 import {
@@ -137,13 +136,9 @@ if (mode === 'command') {
   runScenarioCommand(name, steps, reportDrift)
     .then(results => {
       if (reportDrift) {
-        const driftRecords: DriftRecord[] = results.flatMap(r =>
-          (r.driftMismatches ?? []).map(m => ({ ...m, scenario: name, step: r.step, command: r.command })),
-        );
-        console.log(`\n${formatDriftReport(driftRecords)}`);
+        const driftRecords = toDriftRecords(results, name);
         const driftPath = resolve(SCREENSHOT_DIR, `scenario-${name}-command`, 'drift-report.json');
-        writeDriftReportFile(driftRecords, driftPath);
-        console.log(`Drift report written to ${driftPath}`);
+        emitDriftReport(driftRecords, driftPath);
       }
       return results;
     })

--- a/scripts/scenario-test.ts
+++ b/scripts/scenario-test.ts
@@ -55,13 +55,13 @@ const SCREENSHOT_DIR = resolve(process.cwd(), 'screenshots');
 
 /** Run scenario in command mode (pure Node.js, no browser). */
 async function runScenarioCommand(
-  name: string, steps: ScenarioStepDef[],
+  name: string, steps: ScenarioStepDef[], reportDrift = false,
 ): Promise<StepResult[]> {
   const engine = createGameEngine();
   const outDir = resolve(SCREENSHOT_DIR, `scenario-${name}-command`);
 
   console.log(`\n--- Scenario: ${name} ---`);
-  const results = runSteps(engine, steps, outDir);
+  const results = runSteps(engine, steps, outDir, reportDrift);
 
   // Print per-step summary to stdout (matching expected CI output format)
   for (const r of results) {
@@ -88,7 +88,7 @@ async function runScenarioCommand(
 }
 
 // Main
-const { name, steps, shots, port, puppeteerPath, frames, intervalMs, viewport, mode, screenshots } = parseArgs();
+const { name, steps, shots, port, puppeteerPath, frames, intervalMs, viewport, mode, screenshots, reportDrift } = parseArgs();
 if (steps.length === 0) {
   console.error('No steps defined. Use --scenario <name> or --commands "cmd1; cmd2; ..."');
   process.exit(1);
@@ -126,7 +126,7 @@ function exitForResults(results: StepResult[]): never {
 }
 
 if (mode === 'command') {
-  runScenarioCommand(name, steps)
+  runScenarioCommand(name, steps, reportDrift)
     .then(exitForResults)
     .catch(err => {
       console.error('Scenario failed:', err);

--- a/scripts/scenario-test.ts
+++ b/scripts/scenario-test.ts
@@ -44,7 +44,14 @@
 
 import { resolve } from 'path';
 import type { ScenarioStepDef, StepResult } from './shared/scenario-types.js';
-import { createGameEngine, runSteps } from './shared/command-runner.js';
+import {
+  createGameEngine,
+  runSteps,
+  formatDriftReport,
+  writeDriftReportFile,
+  type DriftRecord,
+  type GoalMismatch,
+} from './shared/command-runner.js';
 import {
   formatStepIndex,
 } from './shared/scenario-utils.js';
@@ -56,7 +63,7 @@ const SCREENSHOT_DIR = resolve(process.cwd(), 'screenshots');
 /** Run scenario in command mode (pure Node.js, no browser). */
 async function runScenarioCommand(
   name: string, steps: ScenarioStepDef[], reportDrift = false,
-): Promise<StepResult[]> {
+): Promise<Array<StepResult & { driftMismatches?: GoalMismatch[] }>> {
   const engine = createGameEngine();
   const outDir = resolve(SCREENSHOT_DIR, `scenario-${name}-command`);
 
@@ -84,6 +91,7 @@ async function runScenarioCommand(
     screenshotPath: '',
     statePath: r.statePath,
     ...(r.error !== undefined ? { error: r.error } : {}),
+    ...(r.driftMismatches !== undefined ? { driftMismatches: r.driftMismatches } : {}),
   }));
 }
 
@@ -127,6 +135,18 @@ function exitForResults(results: StepResult[]): never {
 
 if (mode === 'command') {
   runScenarioCommand(name, steps, reportDrift)
+    .then(results => {
+      if (reportDrift) {
+        const driftRecords: DriftRecord[] = results.flatMap(r =>
+          (r.driftMismatches ?? []).map(m => ({ ...m, scenario: name, step: r.step, command: r.command })),
+        );
+        console.log(`\n${formatDriftReport(driftRecords)}`);
+        const driftPath = resolve(SCREENSHOT_DIR, `scenario-${name}-command`, 'drift-report.json');
+        writeDriftReportFile(driftRecords, driftPath);
+        console.log(`Drift report written to ${driftPath}`);
+      }
+      return results;
+    })
     .then(exitForResults)
     .catch(err => {
       console.error('Scenario failed:', err);

--- a/scripts/shared/command-runner.ts
+++ b/scripts/shared/command-runner.ts
@@ -14,7 +14,7 @@ import {
   buildScenarioReport,
   type ReportableStep,
 } from './scenario-utils.js';
-import { checkGoalAgainstState, checkCommandOutcome } from './scenario-goal.js';
+import { checkGoalAgainstState, checkCommandOutcome, type GoalMismatch } from './scenario-goal.js';
 
 /**
  * Command-mode side of the `waitUntil` action (issue #590): loop the
@@ -95,6 +95,37 @@ export interface ScenarioResult {
   failed: boolean;
   error?: string;
   reportPath?: string;
+  driftRecords?: DriftRecord[];
+}
+
+/**
+ * A single drift-report entry (issue #679): one `equals`/`changedBy`
+ * mismatch, located to the scenario/step/command that produced it.
+ */
+export interface DriftRecord extends GoalMismatch {
+  scenario: string;
+  step: number;
+  command: string;
+}
+
+/**
+ * Formats a batch of `DriftRecord`s into a human-readable report.
+ *
+ * TODO: implement — stub only during skeleton phase (#679).
+ */
+export function formatDriftReport(records: DriftRecord[]): string {
+  void records;
+  return '';
+}
+
+/**
+ * Writes a formatted drift report to `path`.
+ *
+ * TODO: implement — stub only during skeleton phase (#679).
+ */
+export function writeDriftReportFile(records: DriftRecord[], path: string): void {
+  void records;
+  void path;
 }
 
 export function createGameEngine(): RunnerWithContext {
@@ -105,7 +136,9 @@ export function runSteps(
   engine: RunnerWithContext,
   steps: ScenarioStepDef[],
   outDir: string,
-): StepResult[] {
+  reportDrift?: boolean,
+): Array<StepResult & { driftMismatches?: GoalMismatch[] }> {
+  void reportDrift;
   mkdirSync(outDir, { recursive: true });
   const { ctx } = engine;
   const results: StepResult[] = [];
@@ -137,8 +170,8 @@ export function runSteps(
       if (outcomeViolation !== null) throw new Error(outcomeViolation);
 
       if (step.expect) {
-        const violation = checkGoalAgainstState(step.expect, before, gameState);
-        if (violation !== null) throw new Error(`expect failed: ${violation}`);
+        const goalResult = checkGoalAgainstState(step.expect, before, gameState);
+        if (goalResult.violation !== null) throw new Error(`expect failed: ${goalResult.violation}`);
       }
     } catch (err: unknown) {
       error = err instanceof Error ? err.message : String(err);
@@ -178,6 +211,7 @@ export function runScenario(
   name: string,
   steps: ScenarioStepDef[],
   baseOutDir: string,
+  reportDrift?: boolean,
 ): ScenarioResult {
   const outDir = resolve(baseOutDir, `scenario-${name}-command`);
   const errors: string[] = [];
@@ -185,7 +219,7 @@ export function runScenario(
   console.log(`\n[${name}] Running ${steps.length} steps...`);
 
   try {
-    const results = runSteps(engine, steps, outDir);
+    const results = runSteps(engine, steps, outDir, reportDrift);
     const failedSteps = results.filter(r => r.error);
     for (const fs of failedSteps) {
       errors.push(`  Step ${fs.step} ("${fs.command}"): ${fs.error}`);

--- a/scripts/shared/command-runner.ts
+++ b/scripts/shared/command-runner.ts
@@ -3,7 +3,7 @@
 // Used by both scenario-test.ts (single scenario) and run-all-scenarios.ts (batch).
 
 import { mkdirSync, writeFileSync } from 'fs';
-import { resolve } from 'path';
+import { resolve, dirname } from 'path';
 import { createRunner, serializeGameState } from '../../src/console-api.js';
 import { runCommand } from '../../src/console/createRunner.js';
 import type { RunnerWithContext } from '../../src/console/createRunner.js';
@@ -15,6 +15,7 @@ import {
   type ReportableStep,
 } from './scenario-utils.js';
 import { checkGoalAgainstState, checkCommandOutcome, type GoalMismatch } from './scenario-goal.js';
+export type { GoalMismatch } from './scenario-goal.js';
 
 /**
  * Command-mode side of the `waitUntil` action (issue #590): loop the
@@ -109,23 +110,30 @@ export interface DriftRecord extends GoalMismatch {
 }
 
 /**
- * Formats a batch of `DriftRecord`s into a human-readable report.
- *
- * TODO: implement — stub only during skeleton phase (#679).
+ * Formats a batch of `DriftRecord`s into a human-readable report — one line
+ * per mismatch, naming the scenario, step, field, expected value, and
+ * actual value.
  */
 export function formatDriftReport(records: DriftRecord[]): string {
-  void records;
-  return '';
+  if (records.length === 0) {
+    return 'Drift report: no drift found — every equals/changedBy goal matched exactly.';
+  }
+  const lines = [`Drift report: ${records.length} mismatch(es) found:`];
+  for (const r of records) {
+    lines.push(
+      `scenario "${r.scenario}" step ${r.step}: ${r.field} expected ${JSON.stringify(r.expected)}, got ${JSON.stringify(r.actual)}`,
+    );
+  }
+  return lines.join('\n');
 }
 
 /**
- * Writes a formatted drift report to `path`.
- *
- * TODO: implement — stub only during skeleton phase (#679).
+ * Writes the raw drift records to `path` as JSON, creating the parent
+ * directory if it does not already exist.
  */
 export function writeDriftReportFile(records: DriftRecord[], path: string): void {
-  void records;
-  void path;
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(records, null, 2));
 }
 
 export function createGameEngine(): RunnerWithContext {
@@ -138,10 +146,9 @@ export function runSteps(
   outDir: string,
   reportDrift?: boolean,
 ): Array<StepResult & { driftMismatches?: GoalMismatch[] }> {
-  void reportDrift;
   mkdirSync(outDir, { recursive: true });
   const { ctx } = engine;
-  const results: StepResult[] = [];
+  const results: Array<StepResult & { driftMismatches?: GoalMismatch[] }> = [];
 
   for (let i = 0; i < steps.length; i++) {
     const step = steps[i]!;
@@ -155,6 +162,7 @@ export function runSteps(
     let error: string | undefined;
     let result: { success: boolean; output: string } = { success: false, output: '' };
     let gameState: Record<string, unknown> | null = null;
+    let driftMismatches: GoalMismatch[] | undefined;
 
     try {
       if (waitUntilAction) {
@@ -171,7 +179,12 @@ export function runSteps(
 
       if (step.expect) {
         const goalResult = checkGoalAgainstState(step.expect, before, gameState);
-        if (goalResult.violation !== null) throw new Error(`expect failed: ${goalResult.violation}`);
+        if (reportDrift && goalResult.mismatches.length > 0) {
+          driftMismatches = goalResult.mismatches;
+        }
+        if (goalResult.violation !== null && !(reportDrift && goalResult.onlyDriftViolations)) {
+          throw new Error(`expect failed: ${goalResult.violation}`);
+        }
       }
     } catch (err: unknown) {
       error = err instanceof Error ? err.message : String(err);
@@ -196,6 +209,7 @@ export function runSteps(
       gameState,
       statePath,
       ...(error !== undefined ? { error } : {}),
+      ...(driftMismatches !== undefined ? { driftMismatches } : {}),
     });
   }
 
@@ -230,7 +244,26 @@ export function runScenario(
     } else {
       console.log(`[${name}] OK — ${steps.length} steps`);
     }
-    return { name, totalSteps: steps.length, failed: failedSteps.length > 0, error: errors.join('\n'), reportPath: resolve(outDir, 'report.json') };
+
+    const driftRecords: DriftRecord[] = [];
+    if (reportDrift) {
+      for (const r of results) {
+        if (r.driftMismatches) {
+          for (const m of r.driftMismatches) {
+            driftRecords.push({ ...m, scenario: name, step: r.step, command: r.command });
+          }
+        }
+      }
+    }
+
+    return {
+      name,
+      totalSteps: steps.length,
+      failed: failedSteps.length > 0,
+      error: errors.join('\n'),
+      reportPath: resolve(outDir, 'report.json'),
+      ...(driftRecords.length > 0 ? { driftRecords } : {}),
+    };
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`[${name}] FAILED — ${msg}`);

--- a/scripts/shared/command-runner.ts
+++ b/scripts/shared/command-runner.ts
@@ -136,6 +136,40 @@ export function writeDriftReportFile(records: DriftRecord[], path: string): void
   writeFileSync(path, JSON.stringify(records, null, 2));
 }
 
+/**
+ * Turns a step's raw `driftMismatches` into `DriftRecord`s tagged with the
+ * scenario/step/command that produced them — the one aggregation both
+ * `runScenario` (below) and any caller holding its own per-step result array
+ * (`scenario-test.ts`, which needs those results for its own console
+ * printing and can't just delegate to `runScenario`) need to perform.
+ */
+export function toDriftRecords(
+  results: Array<{ step: number; command: string; driftMismatches?: GoalMismatch[] }>,
+  scenario: string,
+): DriftRecord[] {
+  const records: DriftRecord[] = [];
+  for (const r of results) {
+    if (r.driftMismatches) {
+      for (const m of r.driftMismatches) {
+        records.push({ ...m, scenario, step: r.step, command: r.command });
+      }
+    }
+  }
+  return records;
+}
+
+/**
+ * Prints the drift report to stdout, writes it to `path` as JSON, and logs
+ * the confirmation — the 4-statement sequence both CLI entry points
+ * (`run-all-scenarios.ts`, `scenario-test.ts`) run identically after a
+ * `--report-drift` batch, differing only in which directory `path` lands in.
+ */
+export function emitDriftReport(records: DriftRecord[], path: string): void {
+  console.log(`\n${formatDriftReport(records)}`);
+  writeDriftReportFile(records, path);
+  console.log(`Drift report written to ${path}`);
+}
+
 export function createGameEngine(): RunnerWithContext {
   return createRunner();
 }
@@ -182,7 +216,7 @@ export function runSteps(
         if (reportDrift && goalResult.mismatches.length > 0) {
           driftMismatches = goalResult.mismatches;
         }
-        if (goalResult.violation !== null && !(reportDrift && goalResult.onlyDriftViolations)) {
+        if (goalResult.violation !== null && !(reportDrift && goalResult.isDriftOnly)) {
           throw new Error(`expect failed: ${goalResult.violation}`);
         }
       }
@@ -245,16 +279,7 @@ export function runScenario(
       console.log(`[${name}] OK — ${steps.length} steps`);
     }
 
-    const driftRecords: DriftRecord[] = [];
-    if (reportDrift) {
-      for (const r of results) {
-        if (r.driftMismatches) {
-          for (const m of r.driftMismatches) {
-            driftRecords.push({ ...m, scenario: name, step: r.step, command: r.command });
-          }
-        }
-      }
-    }
+    const driftRecords: DriftRecord[] = reportDrift ? toDriftRecords(results, name) : [];
 
     return {
       name,

--- a/scripts/shared/scenario-goal.ts
+++ b/scripts/shared/scenario-goal.ts
@@ -41,23 +41,87 @@ export interface GoalCheckResult {
 /**
  * Checks `goal.equals`/`goal.increased`/`goal.decreased`/`goal.changedBy`
  * against `before`/`after` state dumps. Returns a violation message naming
- * the field and the mismatch, or `null` when everything holds.
+ * the field and the mismatch, or `null` when everything holds — identical
+ * text/semantics to the pre-#679 version (first violation found, in
+ * increased→decreased→equals→changedBy order).
+ *
+ * Additionally, for `equals`/`changedBy` goals, collects every mismatching
+ * field (not just the first) into `.mismatches` — the drift-report unit
+ * (issue #679). `increased`/`decreased` never contribute to `.mismatches`.
  * `usable`/`blocked`/`tutorialStep` are silently skipped — command mode has
  * no page to check them against, and that gap is filled by the same
  * scenario running in interaction mode.
- *
- * TODO: implement — stub only during skeleton phase (#679).
  */
 export function checkGoalAgainstState(
   goal: ScenarioStepGoal,
   before: Record<string, unknown>,
   after: Record<string, unknown> | null,
 ): GoalCheckResult {
-  // TODO: implement — stub only during skeleton phase (#679).
-  void goal;
-  void before;
-  void after;
-  throw new Error('not implemented');
+  let violation: string | null = null;
+  let violationIsDrift = false;
+  const mismatches: GoalMismatch[] = [];
+
+  if (goal.increased) {
+    for (const field of goal.increased) {
+      const wasRaw = before[field];
+      const nowRaw = after?.[field];
+      const was = typeof wasRaw === 'number' ? wasRaw : 0;
+      const now = typeof nowRaw === 'number' ? nowRaw : 0;
+      if (!(now > was) && violation === null) {
+        violation = `${field} should have increased but went ${was} → ${now}`;
+        violationIsDrift = false;
+      }
+    }
+  }
+
+  if (goal.decreased) {
+    for (const field of goal.decreased) {
+      const wasRaw = before[field];
+      const nowRaw = after?.[field];
+      const was = typeof wasRaw === 'number' ? wasRaw : 0;
+      const now = typeof nowRaw === 'number' ? nowRaw : 0;
+      if (!(now < was) && violation === null) {
+        violation = `${field} should have decreased but went ${was} → ${now}`;
+        violationIsDrift = false;
+      }
+    }
+  }
+
+  if (goal.equals) {
+    for (const [field, expected] of Object.entries(goal.equals)) {
+      const actual = after?.[field];
+      if (actual !== expected) {
+        mismatches.push({ field, goalType: 'equals', expected, actual });
+        if (violation === null) {
+          violation = `${field} should be ${JSON.stringify(expected)} but is ${JSON.stringify(actual)}`;
+          violationIsDrift = true;
+        }
+      }
+    }
+  }
+
+  if (goal.changedBy) {
+    for (const [field, expectedDelta] of Object.entries(goal.changedBy)) {
+      const wasRaw = before[field];
+      const nowRaw = after?.[field];
+      const was = typeof wasRaw === 'number' ? wasRaw : 0;
+      const now = typeof nowRaw === 'number' ? nowRaw : 0;
+      const actualDelta = now - was;
+      if (actualDelta !== expectedDelta) {
+        mismatches.push({ field, goalType: 'changedBy', expected: expectedDelta, actual: actualDelta });
+        if (violation === null) {
+          violation = `${field} should have changed by ${expectedDelta} but changed by ${actualDelta} (${was} → ${now})`;
+          violationIsDrift = true;
+        }
+      }
+    }
+  }
+
+  return {
+    violation,
+    mismatches,
+    onlyDriftViolations: violation !== null && violationIsDrift,
+  };
 }
 
 /**

--- a/scripts/shared/scenario-goal.ts
+++ b/scripts/shared/scenario-goal.ts
@@ -14,65 +14,50 @@
 import type { ScenarioStepGoal } from './scenario-types.js';
 
 /**
+ * A single `equals`/`changedBy` field mismatch — the drift-report unit
+ * (issue #679). Never produced for `increased`/`decreased`, which stay
+ * directional-only and out of scope for drift reporting.
+ */
+export interface GoalMismatch {
+  field: string;
+  goalType: 'equals' | 'changedBy';
+  expected: unknown;
+  /** For 'equals': the actual field value. For 'changedBy': the actual delta (after - before), not the absolute post-state value. */
+  actual: unknown;
+}
+
+/**
+ * Result of checking one step's goal against its before/after state dumps.
+ */
+export interface GoalCheckResult {
+  /** Same text/semantics as today's return value — first violation found, increased→decreased→equals→changedBy order. */
+  violation: string | null;
+  /** Every equals/changedBy field that mismatched, exhaustively (not just the first). Never contains increased/decreased failures. */
+  mismatches: GoalMismatch[];
+  /** True only when violation is non-null and every contributing failure is in `mismatches` — i.e. no increased/decreased goal also failed. */
+  onlyDriftViolations: boolean;
+}
+
+/**
  * Checks `goal.equals`/`goal.increased`/`goal.decreased`/`goal.changedBy`
  * against `before`/`after` state dumps. Returns a violation message naming
  * the field and the mismatch, or `null` when everything holds.
  * `usable`/`blocked`/`tutorialStep` are silently skipped — command mode has
  * no page to check them against, and that gap is filled by the same
  * scenario running in interaction mode.
+ *
+ * TODO: implement — stub only during skeleton phase (#679).
  */
 export function checkGoalAgainstState(
   goal: ScenarioStepGoal,
   before: Record<string, unknown>,
   after: Record<string, unknown> | null,
-): string | null {
-  if (goal.increased) {
-    for (const field of goal.increased) {
-      const wasRaw = before[field];
-      const nowRaw = after?.[field];
-      const was = typeof wasRaw === 'number' ? wasRaw : 0;
-      const now = typeof nowRaw === 'number' ? nowRaw : 0;
-      if (!(now > was)) {
-        return `${field} should have increased but went ${was} → ${now}`;
-      }
-    }
-  }
-
-  if (goal.decreased) {
-    for (const field of goal.decreased) {
-      const wasRaw = before[field];
-      const nowRaw = after?.[field];
-      const was = typeof wasRaw === 'number' ? wasRaw : 0;
-      const now = typeof nowRaw === 'number' ? nowRaw : 0;
-      if (!(now < was)) {
-        return `${field} should have decreased but went ${was} → ${now}`;
-      }
-    }
-  }
-
-  if (goal.equals) {
-    for (const [field, expected] of Object.entries(goal.equals)) {
-      const actual = after?.[field];
-      if (actual !== expected) {
-        return `${field} should be ${JSON.stringify(expected)} but is ${JSON.stringify(actual)}`;
-      }
-    }
-  }
-
-  if (goal.changedBy) {
-    for (const [field, expectedDelta] of Object.entries(goal.changedBy)) {
-      const wasRaw = before[field];
-      const nowRaw = after?.[field];
-      const was = typeof wasRaw === 'number' ? wasRaw : 0;
-      const now = typeof nowRaw === 'number' ? nowRaw : 0;
-      const actualDelta = now - was;
-      if (actualDelta !== expectedDelta) {
-        return `${field} should have changed by ${expectedDelta} but changed by ${actualDelta} (${was} → ${now})`;
-      }
-    }
-  }
-
-  return null;
+): GoalCheckResult {
+  // TODO: implement — stub only during skeleton phase (#679).
+  void goal;
+  void before;
+  void after;
+  throw new Error('not implemented');
 }
 
 /**

--- a/scripts/shared/scenario-goal.ts
+++ b/scripts/shared/scenario-goal.ts
@@ -35,7 +35,7 @@ export interface GoalCheckResult {
   /** Every equals/changedBy field that mismatched, exhaustively (not just the first). Never contains increased/decreased failures. */
   mismatches: GoalMismatch[];
   /** True only when violation is non-null and every contributing failure is in `mismatches` — i.e. no increased/decreased goal also failed. */
-  onlyDriftViolations: boolean;
+  isDriftOnly: boolean;
 }
 
 /**
@@ -120,7 +120,7 @@ export function checkGoalAgainstState(
   return {
     violation,
     mismatches,
-    onlyDriftViolations: violation !== null && violationIsDrift,
+    isDriftOnly: violation !== null && violationIsDrift,
   };
 }
 

--- a/tests/integration/scenario-expect.integration.test.ts
+++ b/tests/integration/scenario-expect.integration.test.ts
@@ -11,13 +11,19 @@
 import { describe, it, expect } from 'vitest';
 import { resolve } from 'path';
 import { tmpdir } from 'os';
-import { createGameEngine, runSteps } from '../../scripts/shared/command-runner.js';
+import { createGameEngine, runSteps, runScenario } from '../../scripts/shared/command-runner.js';
 import type { ScenarioStepDef } from '../../scripts/shared/scenario-types.js';
 
 function run(steps: ScenarioStepDef[]) {
   const engine = createGameEngine();
   const outDir = resolve(tmpdir(), `bs2026-scenario-expect-${Date.now()}-${Math.random().toString(36).slice(2)}`);
   return runSteps(engine, steps, outDir);
+}
+
+function runDrift(steps: ScenarioStepDef[]) {
+  const engine = createGameEngine();
+  const outDir = resolve(tmpdir(), `bs2026-scenario-expect-drift-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  return runSteps(engine, steps, outDir, true);
 }
 
 describe('command-mode runSteps checks a step\'s expect, not just whether the command threw', () => {
@@ -94,5 +100,87 @@ describe('command-mode runSteps checks a step\'s expect, not just whether the co
   it('a step with no expect at all is unaffected — pure "did it throw" as before', () => {
     const results = run([{ command: 'new_game seed:42' }]);
     expect(results[0]!.error).toBeUndefined();
+  });
+});
+
+// ──────────────────────────────────────────────
+// reportDrift mode (issue #679): runSteps(engine, steps, outDir, true) runs
+// every step to completion instead of stopping at the first equals/changedBy
+// mismatch, collecting the mismatches on the step's own result instead of
+// throwing. Directional (increased/decreased) goals are never suppressed.
+// ──────────────────────────────────────────────
+describe('runSteps with reportDrift=true', () => {
+  const mismatchedScenario: ScenarioStepDef[] = [
+    { command: 'new_game seed:42', expect: { equals: { cash: 1 } } },
+    { command: 'employee hire role:driller', expect: { increased: ['employeeCount'] } },
+  ];
+
+  it('does not set .error on a step whose expect.equals mismatches, and populates .driftMismatches instead', () => {
+    const results = runDrift(mismatchedScenario);
+    expect(results[0]!.error).toBeUndefined();
+    expect(results[0]!.driftMismatches).toBeDefined();
+    expect(results[0]!.driftMismatches!.length).toBeGreaterThan(0);
+    expect(results[0]!.driftMismatches![0]!.field).toBe('cash');
+    expect(results[0]!.driftMismatches![0]!.goalType).toBe('equals');
+  });
+
+  it('lets the scenario run to completion — the step after a drifted step still executes', () => {
+    const results = runDrift(mismatchedScenario);
+    // Second step ran for real against the post-first-step state (a hire genuinely happened).
+    expect(results).toHaveLength(2);
+    expect(results[1]!.error).toBeUndefined();
+    expect(results[1]!.commandOutput).not.toBe('');
+  });
+
+  it('the exact same scenario without reportDrift still fails normally (drift-on vs drift-off, side by side)', () => {
+    const results = run(mismatchedScenario);
+    expect(results[0]!.error).toMatch(/expect failed/);
+    expect(results[0]!.error).toMatch(/cash/);
+  });
+
+  it('a failed increased/decreased goal still sets .error even with reportDrift=true — directional goals are never suppressed', () => {
+    const results = runDrift([
+      { command: 'new_game seed:42' },
+      // `state` is a pure read — nothing increases.
+      { command: 'state', expect: { increased: ['employeeCount'] } },
+    ]);
+    expect(results[1]!.error).toMatch(/expect failed/);
+    expect(results[1]!.error).toMatch(/employeeCount/);
+  });
+
+  it('a scenario with zero mismatches under reportDrift=true leaves every step\'s .driftMismatches unset', () => {
+    const results = runDrift([
+      { command: 'new_game seed:42', expect: { equals: { cash: 50000, buildingCount: 0 } } },
+      { command: 'employee hire role:driller', expect: { increased: ['employeeCount'] } },
+    ]);
+    expect(results[0]!.driftMismatches ?? []).toEqual([]);
+    expect(results[1]!.driftMismatches ?? []).toEqual([]);
+  });
+});
+
+describe('runScenario with reportDrift=true (issue #679)', () => {
+  it('populates ScenarioResult.driftRecords with scenario/step/command plus the mismatch, when steps have mismatches', () => {
+    const engine = createGameEngine();
+    const outDir = resolve(tmpdir(), `bs2026-run-scenario-drift-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const steps: ScenarioStepDef[] = [
+      { command: 'new_game seed:42', expect: { equals: { cash: 1 } } },
+    ];
+    const result = runScenario(engine, 'drift-scenario', steps, outDir, true);
+    expect(result.driftRecords).toBeDefined();
+    const rec = result.driftRecords!.find(r => r.field === 'cash')!;
+    expect(rec).toBeDefined();
+    expect(rec.scenario).toBe('drift-scenario');
+    expect(rec.step).toBe(0);
+    expect(rec.command).toBe('new_game seed:42');
+  });
+
+  it('leaves driftRecords absent/empty when there are no mismatches', () => {
+    const engine = createGameEngine();
+    const outDir = resolve(tmpdir(), `bs2026-run-scenario-no-drift-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const steps: ScenarioStepDef[] = [
+      { command: 'new_game seed:42', expect: { equals: { cash: 50000, buildingCount: 0 } } },
+    ];
+    const result = runScenario(engine, 'clean-scenario', steps, outDir, true);
+    expect(result.driftRecords ?? []).toEqual([]);
   });
 });

--- a/tests/integration/scenario-expect.integration.test.ts
+++ b/tests/integration/scenario-expect.integration.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect } from 'vitest';
 import { resolve } from 'path';
 import { tmpdir } from 'os';
-import { createGameEngine, runSteps, runScenario } from '../../scripts/shared/command-runner.js';
+import { createGameEngine, runSteps } from '../../scripts/shared/command-runner.js';
 import type { ScenarioStepDef } from '../../scripts/shared/scenario-types.js';
 
 function run(steps: ScenarioStepDef[]) {
@@ -153,34 +153,12 @@ describe('runSteps with reportDrift=true', () => {
       { command: 'new_game seed:42', expect: { equals: { cash: 50000, buildingCount: 0 } } },
       { command: 'employee hire role:driller', expect: { increased: ['employeeCount'] } },
     ]);
-    expect(results[0]!.driftMismatches ?? []).toEqual([]);
-    expect(results[1]!.driftMismatches ?? []).toEqual([]);
+    expect(results[0]!.driftMismatches).toBeUndefined();
+    expect(results[1]!.driftMismatches).toBeUndefined();
   });
 });
 
-describe('runScenario with reportDrift=true (issue #679)', () => {
-  it('populates ScenarioResult.driftRecords with scenario/step/command plus the mismatch, when steps have mismatches', () => {
-    const engine = createGameEngine();
-    const outDir = resolve(tmpdir(), `bs2026-run-scenario-drift-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-    const steps: ScenarioStepDef[] = [
-      { command: 'new_game seed:42', expect: { equals: { cash: 1 } } },
-    ];
-    const result = runScenario(engine, 'drift-scenario', steps, outDir, true);
-    expect(result.driftRecords).toBeDefined();
-    const rec = result.driftRecords!.find(r => r.field === 'cash')!;
-    expect(rec).toBeDefined();
-    expect(rec.scenario).toBe('drift-scenario');
-    expect(rec.step).toBe(0);
-    expect(rec.command).toBe('new_game seed:42');
-  });
-
-  it('leaves driftRecords absent/empty when there are no mismatches', () => {
-    const engine = createGameEngine();
-    const outDir = resolve(tmpdir(), `bs2026-run-scenario-no-drift-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-    const steps: ScenarioStepDef[] = [
-      { command: 'new_game seed:42', expect: { equals: { cash: 50000, buildingCount: 0 } } },
-    ];
-    const result = runScenario(engine, 'clean-scenario', steps, outDir, true);
-    expect(result.driftRecords ?? []).toEqual([]);
-  });
-});
+// `runScenario`'s own `driftRecords` aggregation (scenario/step/command
+// plus the mismatch) is covered in tests/unit/command-runner.test.ts —
+// same function, same steps, same assertions as an earlier version of this
+// block; kept there only, matching that file's own stated scope.

--- a/tests/unit/command-runner.test.ts
+++ b/tests/unit/command-runner.test.ts
@@ -98,6 +98,6 @@ describe('runScenario — driftRecords (issue #679)', () => {
     ];
     const result = runScenario(engine, 'no-drift-test-scenario', steps, outDir, true);
 
-    expect(result.driftRecords ?? []).toEqual([]);
+    expect(result.driftRecords).toBeUndefined();
   });
 });

--- a/tests/unit/command-runner.test.ts
+++ b/tests/unit/command-runner.test.ts
@@ -1,0 +1,103 @@
+// BlastSimulator2026 — command-runner.ts unit coverage
+//
+// Covers the drift-report unit itself (issue #679): formatDriftReport,
+// writeDriftReportFile, and runScenario's own driftRecords population.
+// runSteps's wiring into a real game engine (drift suppresses .error,
+// scenario runs to completion) is covered in
+// tests/integration/scenario-expect.integration.test.ts — this file is the
+// pure/IO-adjacent half.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, mkdtempSync } from 'fs';
+import { resolve } from 'path';
+import { tmpdir } from 'os';
+import {
+  formatDriftReport,
+  writeDriftReportFile,
+  createGameEngine,
+  runScenario,
+  type DriftRecord,
+} from '../../scripts/shared/command-runner.js';
+import type { ScenarioStepDef } from '../../scripts/shared/scenario-types.js';
+
+const SAMPLE_RECORDS: DriftRecord[] = [
+  {
+    scenario: 'blast-basic',
+    step: 2,
+    command: 'blast',
+    field: 'cash',
+    goalType: 'equals',
+    expected: 70000,
+    actual: 80000,
+  },
+  {
+    scenario: 'blast-basic',
+    step: 4,
+    command: 'employee hire role:driller',
+    field: 'employeeCount',
+    goalType: 'changedBy',
+    expected: 1,
+    actual: 2,
+  },
+];
+
+describe('formatDriftReport', () => {
+  it('produces a string containing scenario, step, field, expected, and actual for each record', () => {
+    const report = formatDriftReport(SAMPLE_RECORDS);
+    for (const rec of SAMPLE_RECORDS) {
+      expect(report).toContain(rec.scenario);
+      expect(report).toContain(String(rec.step));
+      expect(report).toContain(rec.field);
+      expect(report).toContain(String(rec.expected));
+      expect(report).toContain(String(rec.actual));
+    }
+  });
+
+  it('returns an empty-ish report (no crash, no leftover field text) for an empty record list', () => {
+    const report = formatDriftReport([]);
+    expect(typeof report).toBe('string');
+    expect(report).not.toContain('undefined');
+  });
+});
+
+describe('writeDriftReportFile', () => {
+  it('writes valid JSON parseable back into the same records', () => {
+    const dir = mkdtempSync(resolve(tmpdir(), 'bs2026-drift-report-'));
+    const path = resolve(dir, 'drift-report.json');
+    writeDriftReportFile(SAMPLE_RECORDS, path);
+    const parsed = JSON.parse(readFileSync(path, 'utf-8'));
+    expect(parsed).toEqual(SAMPLE_RECORDS);
+  });
+});
+
+describe('runScenario — driftRecords (issue #679)', () => {
+  it('populates ScenarioResult.driftRecords with scenario/step/command plus the GoalMismatch fields when reportDrift finds mismatches', () => {
+    const engine = createGameEngine();
+    const outDir = resolve(tmpdir(), `bs2026-run-scenario-drift-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const steps: ScenarioStepDef[] = [
+      { command: 'new_game seed:42', expect: { equals: { cash: 1 } } },
+    ];
+    const result = runScenario(engine, 'drift-test-scenario', steps, outDir, true);
+
+    expect(result.driftRecords).toBeDefined();
+    expect(result.driftRecords!.length).toBeGreaterThan(0);
+    const rec = result.driftRecords!.find(r => r.field === 'cash')!;
+    expect(rec).toBeDefined();
+    expect(rec.scenario).toBe('drift-test-scenario');
+    expect(rec.step).toBe(0);
+    expect(rec.command).toBe('new_game seed:42');
+    expect(rec.goalType).toBe('equals');
+    expect(rec.expected).toBe(1);
+  });
+
+  it('leaves driftRecords absent/empty when there are no mismatches', () => {
+    const engine = createGameEngine();
+    const outDir = resolve(tmpdir(), `bs2026-run-scenario-no-drift-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const steps: ScenarioStepDef[] = [
+      { command: 'new_game seed:42', expect: { equals: { cash: 50000, buildingCount: 0 } } },
+    ];
+    const result = runScenario(engine, 'no-drift-test-scenario', steps, outDir, true);
+
+    expect(result.driftRecords ?? []).toEqual([]);
+  });
+});

--- a/tests/unit/scenario-goal.test.ts
+++ b/tests/unit/scenario-goal.test.ts
@@ -15,7 +15,7 @@ describe('checkGoalAgainstState — equals', () => {
       { equals: { cash: 70000, buildingCount: 1 } },
       {},
       { cash: 70000, buildingCount: 1 },
-    );
+    ).violation;
     expect(violation).toBeNull();
   });
 
@@ -24,19 +24,19 @@ describe('checkGoalAgainstState — equals', () => {
       { equals: { cash: 70000 } },
       {},
       { cash: 80000 },
-    );
+    ).violation;
     expect(violation).toContain('cash');
     expect(violation).toContain('70000');
     expect(violation).toContain('80000');
   });
 
   it('fails when the after state is null (step produced no state dump)', () => {
-    const violation = checkGoalAgainstState({ equals: { cash: 70000 } }, {}, null);
+    const violation = checkGoalAgainstState({ equals: { cash: 70000 } }, {}, null).violation;
     expect(violation).toContain('cash');
   });
 
   it('distinguishes missing field from a genuine mismatch — undefined does not satisfy "equals 0"', () => {
-    const violation = checkGoalAgainstState({ equals: { holeCount: 0 } }, {}, {});
+    const violation = checkGoalAgainstState({ equals: { holeCount: 0 } }, {}, {}).violation;
     expect(violation).toContain('holeCount');
   });
 });
@@ -47,7 +47,7 @@ describe('checkGoalAgainstState — increased', () => {
       { increased: ['employeeCount'] },
       { employeeCount: 0 },
       { employeeCount: 1 },
-    );
+    ).violation;
     expect(violation).toBeNull();
   });
 
@@ -56,7 +56,7 @@ describe('checkGoalAgainstState — increased', () => {
       { increased: ['employeeCount'] },
       { employeeCount: 1 },
       { employeeCount: 1 },
-    );
+    ).violation;
     expect(violation).toContain('employeeCount');
     expect(violation).toContain('1 → 1');
   });
@@ -66,7 +66,7 @@ describe('checkGoalAgainstState — increased', () => {
       { increased: ['cash'] },
       { cash: 100 },
       { cash: 50 },
-    );
+    ).violation;
     expect(violation).toContain('cash');
   });
 
@@ -75,7 +75,7 @@ describe('checkGoalAgainstState — increased', () => {
       { increased: ['newField'] },
       {},
       { newField: 5 },
-    );
+    ).violation;
     expect(violation).toBeNull();
   });
 });
@@ -86,7 +86,7 @@ describe('checkGoalAgainstState — changedBy', () => {
       { changedBy: { cash: -1000 } },
       { cash: 50000 },
       { cash: 49000 },
-    );
+    ).violation;
     expect(violation).toBeNull();
   });
 
@@ -95,7 +95,7 @@ describe('checkGoalAgainstState — changedBy', () => {
       { changedBy: { cash: -1000 } },
       { cash: 50000 },
       { cash: 49500 },
-    );
+    ).violation;
     expect(violation).toContain('cash');
     expect(violation).toContain('-1000');
     expect(violation).toContain('-500');
@@ -107,7 +107,7 @@ describe('checkGoalAgainstState — changedBy', () => {
       { changedBy: { nuisance: -30 } },
       { nuisance: 80 },
       { nuisance: 50 },
-    );
+    ).violation;
     expect(violation).toBeNull();
   });
 
@@ -116,7 +116,7 @@ describe('checkGoalAgainstState — changedBy', () => {
       { changedBy: { holeCount: 3 } },
       { holeCount: 2 },
       { holeCount: 5 },
-    );
+    ).violation;
     expect(violation).toBeNull();
   });
 
@@ -125,12 +125,12 @@ describe('checkGoalAgainstState — changedBy', () => {
       { changedBy: { newField: 5 } },
       {},
       { newField: 5 },
-    );
+    ).violation;
     expect(violation).toBeNull();
   });
 
   it('fails when the after state is null (step produced no state dump)', () => {
-    const violation = checkGoalAgainstState({ changedBy: { cash: -1000 } }, { cash: 50000 }, null);
+    const violation = checkGoalAgainstState({ changedBy: { cash: -1000 } }, { cash: 50000 }, null).violation;
     expect(violation).toContain('cash');
   });
 
@@ -139,7 +139,7 @@ describe('checkGoalAgainstState — changedBy', () => {
       { changedBy: { cash: -1000 } },
       { cash: 50000 },
       { cash: 50000 },
-    );
+    ).violation;
     expect(violation).toContain('changed by 0');
   });
 });
@@ -150,7 +150,7 @@ describe('checkGoalAgainstState — decreased', () => {
       { decreased: ['nuisance'] },
       { nuisance: 50 },
       { nuisance: 20 },
-    );
+    ).violation;
     expect(violation).toBeNull();
   });
 
@@ -159,7 +159,7 @@ describe('checkGoalAgainstState — decreased', () => {
       { decreased: ['nuisance'] },
       { nuisance: 50 },
       { nuisance: 50 },
-    );
+    ).violation;
     expect(violation).toContain('nuisance');
     expect(violation).toContain('50 → 50');
   });
@@ -169,7 +169,7 @@ describe('checkGoalAgainstState — decreased', () => {
       { decreased: ['ecology'] },
       { ecology: 20 },
       { ecology: 40 },
-    );
+    ).violation;
     expect(violation).toContain('ecology');
   });
 
@@ -178,7 +178,7 @@ describe('checkGoalAgainstState — decreased', () => {
       { decreased: ['newField'] },
       { newField: 5 },
       {},
-    );
+    ).violation;
     expect(violation).toBeNull();
   });
 });
@@ -189,7 +189,7 @@ describe('checkGoalAgainstState — combined and empty goals', () => {
       { increased: ['cash'], equals: { buildingCount: 1 } },
       { cash: 100 },
       { cash: 100, buildingCount: 1 },
-    );
+    ).violation;
     expect(violation).toContain('cash');
   });
 
@@ -198,7 +198,7 @@ describe('checkGoalAgainstState — combined and empty goals', () => {
       { decreased: ['nuisance'], equals: { buildingCount: 1 } },
       { nuisance: 50 },
       { nuisance: 50, buildingCount: 1 },
-    );
+    ).violation;
     expect(violation).toContain('nuisance');
   });
 
@@ -207,8 +207,124 @@ describe('checkGoalAgainstState — combined and empty goals', () => {
       { usable: '#bs-survey-run', note: 'checked only in interaction mode' },
       {},
       {},
-    );
+    ).violation;
     expect(violation).toBeNull();
+  });
+});
+
+// ──────────────────────────────────────────────
+// checkGoalAgainstState — drift-report fields (issue #679): `.mismatches`
+// and `.onlyDriftViolations`, exhaustive over equals/changedBy failures and
+// never populated by increased/decreased failures.
+// ──────────────────────────────────────────────
+describe('checkGoalAgainstState — mismatches (drift report, issue #679)', () => {
+  it('records one GoalMismatch for a mismatched equals goal, with the real post-state value as actual', () => {
+    const result = checkGoalAgainstState(
+      { equals: { cash: 70000 } },
+      {},
+      { cash: 80000 },
+    );
+    expect(result.mismatches).toEqual([
+      { field: 'cash', goalType: 'equals', expected: 70000, actual: 80000 },
+    ]);
+  });
+
+  it('records one GoalMismatch for a mismatched changedBy goal, with the observed delta as actual (not the absolute value)', () => {
+    const result = checkGoalAgainstState(
+      { changedBy: { cash: -1000 } },
+      { cash: 50000 },
+      { cash: 49500 },
+    );
+    expect(result.mismatches).toEqual([
+      { field: 'cash', goalType: 'changedBy', expected: -1000, actual: -500 },
+    ]);
+  });
+
+  it('is exhaustive: an equals goal with 3+ fields records every mismatching field, not just the first', () => {
+    const result = checkGoalAgainstState(
+      { equals: { cash: 70000, buildingCount: 1, employeeCount: 2 } },
+      {},
+      { cash: 80000, buildingCount: 1, employeeCount: 5 },
+    );
+    expect(result.mismatches).toHaveLength(2);
+    const fields = result.mismatches.map(m => m.field).sort();
+    expect(fields).toEqual(['cash', 'employeeCount']);
+    expect(result.mismatches).toContainEqual({ field: 'cash', goalType: 'equals', expected: 70000, actual: 80000 });
+    expect(result.mismatches).toContainEqual({ field: 'employeeCount', goalType: 'equals', expected: 2, actual: 5 });
+  });
+
+  it('never records a mismatch for a failed increased/decreased goal — mismatches stays empty', () => {
+    const result = checkGoalAgainstState(
+      { increased: ['employeeCount'] },
+      { employeeCount: 1 },
+      { employeeCount: 1 },
+    );
+    expect(result.violation).not.toBeNull();
+    expect(result.mismatches).toEqual([]);
+  });
+
+  it('onlyDriftViolations is true when the only failure is equals/changedBy', () => {
+    const result = checkGoalAgainstState(
+      { equals: { cash: 70000 } },
+      {},
+      { cash: 80000 },
+    );
+    expect(result.violation).not.toBeNull();
+    expect(result.onlyDriftViolations).toBe(true);
+  });
+
+  it('onlyDriftViolations is false when a directional goal also fails alongside an equals/changedBy mismatch', () => {
+    const result = checkGoalAgainstState(
+      { increased: ['employeeCount'], equals: { cash: 70000 } },
+      { employeeCount: 1, cash: 0 },
+      { employeeCount: 1, cash: 80000 },
+    );
+    expect(result.violation).not.toBeNull();
+    expect(result.onlyDriftViolations).toBe(false);
+  });
+
+  it('when nothing fails, violation is null (onlyDriftViolations is meaningless there, but must not be truthy)', () => {
+    const result = checkGoalAgainstState(
+      { increased: ['cash'], equals: { buildingCount: 1 } },
+      { cash: 100 },
+      { cash: 200, buildingCount: 1 },
+    );
+    expect(result.violation).toBeNull();
+    expect(result.onlyDriftViolations).toBeFalsy();
+  });
+
+  it('violation text and check ordering (increased → decreased → equals → changedBy) is unchanged from before drift-report support', () => {
+    // increased wins over a simultaneously-failing equals
+    const increasedFirst = checkGoalAgainstState(
+      { increased: ['cash'], equals: { buildingCount: 2 } },
+      { cash: 100 },
+      { cash: 100, buildingCount: 1 },
+    );
+    expect(increasedFirst.violation).toContain('cash');
+
+    // decreased wins over equals
+    const decreasedFirst = checkGoalAgainstState(
+      { decreased: ['nuisance'], equals: { buildingCount: 2 } },
+      { nuisance: 50 },
+      { nuisance: 50, buildingCount: 1 },
+    );
+    expect(decreasedFirst.violation).toContain('nuisance');
+
+    // equals wins over changedBy
+    const equalsFirst = checkGoalAgainstState(
+      { equals: { buildingCount: 2 }, changedBy: { cash: -1000 } },
+      { cash: 50000, buildingCount: 1 },
+      { cash: 50000, buildingCount: 1 },
+    );
+    expect(equalsFirst.violation).toContain('buildingCount');
+
+    // changedBy fires last, alone
+    const changedByOnly = checkGoalAgainstState(
+      { changedBy: { cash: -1000 } },
+      { cash: 50000 },
+      { cash: 50000 },
+    );
+    expect(changedByOnly.violation).toContain('changed by 0');
   });
 });
 

--- a/tests/unit/scenario-goal.test.ts
+++ b/tests/unit/scenario-goal.test.ts
@@ -214,7 +214,7 @@ describe('checkGoalAgainstState — combined and empty goals', () => {
 
 // ──────────────────────────────────────────────
 // checkGoalAgainstState — drift-report fields (issue #679): `.mismatches`
-// and `.onlyDriftViolations`, exhaustive over equals/changedBy failures and
+// and `.isDriftOnly`, exhaustive over equals/changedBy failures and
 // never populated by increased/decreased failures.
 // ──────────────────────────────────────────────
 describe('checkGoalAgainstState — mismatches (drift report, issue #679)', () => {
@@ -263,34 +263,34 @@ describe('checkGoalAgainstState — mismatches (drift report, issue #679)', () =
     expect(result.mismatches).toEqual([]);
   });
 
-  it('onlyDriftViolations is true when the only failure is equals/changedBy', () => {
+  it('isDriftOnly is true when the only failure is equals/changedBy', () => {
     const result = checkGoalAgainstState(
       { equals: { cash: 70000 } },
       {},
       { cash: 80000 },
     );
     expect(result.violation).not.toBeNull();
-    expect(result.onlyDriftViolations).toBe(true);
+    expect(result.isDriftOnly).toBe(true);
   });
 
-  it('onlyDriftViolations is false when a directional goal also fails alongside an equals/changedBy mismatch', () => {
+  it('isDriftOnly is false when a directional goal also fails alongside an equals/changedBy mismatch', () => {
     const result = checkGoalAgainstState(
       { increased: ['employeeCount'], equals: { cash: 70000 } },
       { employeeCount: 1, cash: 0 },
       { employeeCount: 1, cash: 80000 },
     );
     expect(result.violation).not.toBeNull();
-    expect(result.onlyDriftViolations).toBe(false);
+    expect(result.isDriftOnly).toBe(false);
   });
 
-  it('when nothing fails, violation is null (onlyDriftViolations is meaningless there, but must not be truthy)', () => {
+  it('when nothing fails, violation is null (isDriftOnly is meaningless there, but must not be truthy)', () => {
     const result = checkGoalAgainstState(
       { increased: ['cash'], equals: { buildingCount: 1 } },
       { cash: 100 },
       { cash: 200, buildingCount: 1 },
     );
     expect(result.violation).toBeNull();
-    expect(result.onlyDriftViolations).toBeFalsy();
+    expect(result.isDriftOnly).toBeFalsy();
   });
 
   it('violation text and check ordering (increased → decreased → equals → changedBy) is unchanged from before drift-report support', () => {


### PR DESCRIPTION
Closes #679

## Summary

Command-mode scenario runs gain an opt-in `--report-drift` flag (`scripts/run-all-scenarios.ts`, `scripts/scenario-test.ts`). Instead of stopping at the first failed `equals`/`changedBy` goal, a run under the flag continues every scenario to completion and collects every mismatched exact-value checkpoint — scenario, step, field, expected, actual — printing a human-readable report to stdout and writing a machine-readable `drift-report.json` alongside the existing scenario output layout. Directional goals (`increased`/`decreased`) and live-page goals (`usable`/`blocked`/`tutorialStep`) are never suppressed and never appear in the report — there's no expected number for them to drift from. With the flag unset, behavior (including exit code) is unchanged.

`checkGoalAgainstState` (`scripts/shared/scenario-goal.ts`) now returns `{ violation, mismatches, isDriftOnly }` instead of a bare `string | null`: `.violation` keeps the exact text/first-found-wins semantics of the pre-existing behavior, while `.mismatches` exhaustively lists every failing `equals`/`changedBy` field so the report doesn't stop at the first one. `runSteps`/`runScenario` (`scripts/shared/command-runner.ts`) thread an optional `reportDrift` parameter that, when true, records a drift-only mismatch instead of failing the step, and aggregate `DriftRecord`s onto `ScenarioResult`.

No file under `scripts/scenario-defs/` is touched by this tool under any flag.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run; none are material to gameplay, economy, or a player-facing default (this is dev/CI tooling under `scripts/`), so no `decision-review` follow-up issue was opened.

- **What was open:** the issue didn't name the CLI flag's spelling.
  **Chosen:** `--report-drift`, a boolean flag with no value, identical in `run-all-scenarios.ts` and `scenario-cli.ts`.
  **Why:** matches the issue's own vocabulary ("reporting mode", "drift") and the existing no-value boolean flag convention (`--screenshots`).
  **If reversed:** change the string literal at each `args[i] === '--report-drift'` check.

- **What was open:** where the machine-readable report file lands.
  **Chosen:** `screenshots/drift-report.json` for the whole-suite runner (sibling of every `scenario-*` output directory); `screenshots/scenario-{name}-command/drift-report.json` for the single-scenario runner, inside that scenario's own existing output directory.
  **Why:** "a downstream consumer should not have to parse a table" is satisfied by a purpose-built JSON array rather than repurposing the existing per-step `report.json` shape; keeps the change inside the files the issue names.
  **If reversed:** change the `resolve(...)` call sites in `run-all-scenarios.ts`/`scenario-test.ts`.

- **What was open:** whether a step with only an `equals`/`changedBy` mismatch still fails the run under the flag, and whether that changes the whole-suite exit code.
  **Chosen:** it does not fail (no `.error` set), and the whole-suite exit code stays 0 for a run whose only issues are drift mismatches; any other violation (directional goal, thrown exception) still fails the step and the run exactly as today, flag or not.
  **Why:** the issue frames this as an advisory reporting pass, not a new gate — gating stays with the exact-value checks `.claude/rules/scenario-defs.md` says must remain `equals`, re-verified against real numbers.
  **If reversed:** flip `isDriftOnly`'s computation in `checkGoalAgainstState`, or add an exit-code branch keyed on non-empty `driftRecords` in `run-all-scenarios.ts`.

- **What was open:** whether `--report-drift` does anything under `--mode interaction`.
  **Chosen:** no-op — parsed and stored, never consulted by interaction-mode's own goal checking.
  **Why:** the issue scopes this explicitly to "command-mode scenario runs"; live-page goals have no expected number to drift by definition.

- **What was open:** where the shared `DriftRecord`/`formatDriftReport`/`writeDriftReportFile`/`emitDriftReport`/`toDriftRecords` helpers live.
  **Chosen:** `scripts/shared/command-runner.ts` — already the shared module both CLI entry points import from, and one of the issue's four named files.
  **Why:** avoids a new file outside the issue's scope; keeps both entry points calling one shared aggregation/emission path (added during refactor to remove duplication reviewers flagged).

## Review & refactor

Five parallel specialist reviews ran clean (no critical/blocking findings): security PASS, quality PASS (1 warning + 3 suggestions), i18n PASS (CLI/dev-tooling output confirmed out of i18n scope), duplication (2 warnings), semantic PASS (contract verified correct line-by-line, including the `changedBy` delta-not-absolute semantics and `isDriftOnly` correctness under mixed directional+drift failures). The refactor step addressed every actionable finding: extracted `emitDriftReport`/`toDriftRecords` helpers to remove duplication between the two CLI entry points, documented the flag's pass/fail semantics change in `run-all-scenarios.ts`'s usage comment, renamed `onlyDriftViolations` → `isDriftOnly` to read as a predicate, removed duplicate test coverage of `runScenario`'s `driftRecords` between the unit and integration suites, and tightened two weak `?? [] / toEqual([])` assertions to `toBeUndefined()`.

## Verification

- **static** (`npm run typecheck`): PASS, clean.
- **logic** (`npm run test` / `npx vitest run`): PASS — 325 test files, 10525 passed, 1 pre-existing unrelated skip, 0 failed.
- **scenario, command mode, normal path** (`npx tsx scripts/run-all-scenarios.ts --mode command`): PASS — 131/131 scenarios, exit 0, unchanged from pre-PR behavior.
- **scenario, command mode, `--report-drift`** (real CLI invocation, e.g. `npx tsx scripts/scenario-test.ts --scenario sandbox-mode --mode command --report-drift`): PASS — scenario ran to completion, printed the drift report ("no drift found" on a clean scenario), wrote a valid `drift-report.json`.
- **build** (`npm run build`): PASS — this issue touches no build config, run as an extra regression check.
- Confirmed `git status --porcelain scripts/scenario-defs/` is empty after every run above — the tool never modifies scenario definitions, under any flag.
- **visual**: not applicable — this change is confined to `scripts/` dev/CI tooling; nothing under `src/renderer/`, `src/ui/`, or any player-facing flow is touched. `full-ci`/interaction-mode label not applied — no scenario's browser-driven click path exercises this tooling change (the tooling drives the scenarios, it isn't reachable from within one).

READY TO MERGE
