### PR TITLE
fix: replenish a completed rest for its full duration, not one tick (#700)

### DIFF
--- a/scripts/scenario-defs/needs-collapse-visual.json
+++ b/scripts/scenario-defs/needs-collapse-visual.json
@@ -1,6 +1,6 @@
 {
   "name": "needs-collapse-visual",
-  "description": "Visual check of collapse state: dispatch an employee to work so need gauges drain at the working rate and no rest can be claimed, drive fatigue below the collapse threshold (≤5), verify the employee is flagged COLLAPSING in state and rendered with the collapsing row style, then build living_quarters and advance ticks to confirm rest recovery and a return to normal task dispatch",
+  "description": "Visual check of collapse state: dispatch an employee to work so need gauges drain at the working rate and no rest can be claimed, drive fatigue below the collapse threshold (\u22645), verify the employee is flagged COLLAPSING in state and rendered with the collapsing row style, then build living_quarters and advance ticks to confirm rest recovery and a return to normal task dispatch",
   "steps": [
     {
       "command": "new_game seed:42 cash:100000",
@@ -118,7 +118,7 @@
           "command": "employee dispatch 2 x:34 z:32"
         }
       ],
-      "description": "#680 follow-up: Stan (id 2, blaster), like Walt, must be genuinely, continuously busy for his own later collapse checkpoint to stay reachable — autoInsertNeedTasks now auto-routes ANY fully idle employee (with or without a living_quarters anywhere on the map) into a same-tick, zero-distance, zero-drain ground-rest the instant a gauge dips under its warning threshold, so an employee left idle the whole file can no longer collapse at all (direct probe, GameLoop.ts). A busy employee's queued rest stays unclaimed instead, so genuine neglect (no idle window, no living_quarters yet) still bites. Repeated ahead of each tick block below to keep him continuously dispatched the same way Walt is, right up to the collapse checkpoint (#593's note, below, on why it's specifically Stan's crossing).",
+      "description": "#680 follow-up: Stan (id 2, blaster), like Walt, must be genuinely, continuously busy for his own later collapse checkpoint to stay reachable \u2014 autoInsertNeedTasks now auto-routes ANY fully idle employee (with or without a living_quarters anywhere on the map) into a same-tick, zero-distance, zero-drain ground-rest the instant a gauge dips under its warning threshold, so an employee left idle the whole file can no longer collapse at all (direct probe, GameLoop.ts). A busy employee's queued rest stays unclaimed instead, so genuine neglect (no idle window, no living_quarters yet) still bites. Repeated ahead of each tick block below to keep him continuously dispatched the same way Walt is, right up to the collapse checkpoint (#593's note, below, on why it's specifically Stan's crossing).",
       "role": "bootstrap",
       "expect": {
         "equals": {
@@ -171,7 +171,7 @@
           "command": "employee dispatch 2 x:34 z:32"
         }
       ],
-      "description": "See the first Stan dispatch above — keeps him continuously busy across this handoff too.",
+      "description": "See the first Stan dispatch above \u2014 keeps him continuously busy across this handoff too.",
       "role": "bootstrap",
       "expect": {
         "equals": {
@@ -254,7 +254,7 @@
           "command": "employee dispatch 2 x:34 z:32"
         }
       ],
-      "description": "See the first Stan dispatch above — keeps him continuously busy across this handoff too.",
+      "description": "See the first Stan dispatch above \u2014 keeps him continuously busy across this handoff too.",
       "role": "bootstrap",
       "expect": {
         "equals": {
@@ -317,7 +317,7 @@
           "command": "employee dispatch 2 x:34 z:32"
         }
       ],
-      "description": "See the first Stan dispatch above — keeps him continuously busy across this handoff too.",
+      "description": "See the first Stan dispatch above \u2014 keeps him continuously busy across this handoff too.",
       "role": "bootstrap",
       "expect": {
         "equals": {
@@ -338,7 +338,7 @@
         "equals": {
           "collapsedCount": 0
         },
-        "note": "still recovered, no new collapse — Stan is kept continuously dispatched (working-rate drain) rather than idling, same as Walt, and stays above the collapse threshold through this batch"
+        "note": "still recovered, no new collapse \u2014 Stan is kept continuously dispatched (working-rate drain) rather than idling, same as Walt, and stays above the collapse threshold through this batch"
       }
     },
     {
@@ -418,7 +418,7 @@
           "command": "employee dispatch 2 x:34 z:32"
         }
       ],
-      "description": "See the first Stan dispatch above — keeps him continuously busy right up to this checkpoint.",
+      "description": "See the first Stan dispatch above \u2014 keeps him continuously busy right up to this checkpoint.",
       "role": "bootstrap",
       "expect": {
         "equals": {
@@ -427,51 +427,19 @@
       }
     },
     {
-      "command": "tick 20",
+      "command": "tick 5",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 20"
+          "command": "tick 5"
         }
       ],
       "role": "setup",
       "expect": {
         "equals": {
           "collapsedCount": 0
-        },
-        "note": "#680 follow-up (supersedes the old #593 note): the collapse-recovery equivalent for Stan is real, but no longer through idle drain plus LQ proximity, and no longer lands inside this particular batch. #680's resting=0 drain fix means autoInsertNeedTasks now saves ANY idle employee the same tick their gauge dips under warning (self-targeted, zero-distance ground-rest, holds flat for the rest's whole duration), with or without a living_quarters anywhere on the map, so a purely idle Stan could no longer collapse at all (direct probe, GameLoop.ts). He is now kept continuously dispatched instead (see the bootstrap steps above), which drains at the faster working rate uninterrupted by any auto-claimed rest — a queued rest for a busy employee stays unclaimed — so tickCollapse's own unconditional threshold check still fires for real, unrelieved neglect; it just fires two steps later than the old idle-drain timing did (see the tick 30 step below) — re-derived from a real run, not assumed."
+        }
       }
-    },
-    {
-      "command": "event choose 0",
-      "interaction": [
-        {
-          "type": "resolveEventIfPending"
-        }
-      ],
-      "description": "Resolved through the event dialog's own buttons. Decides whether an event is pending from authoritative game state, not from whether the modal has rendered -- a DOM-only probe silently missed events on a no-GPU runner where a frame costs ~6s, leaving them pending so later ticks halted and the run diverged while still passing command mode.",
-      "role": "player",
-      "commandOutcome": "either"
-    },
-    {
-      "command": "employee list",
-      "interaction": [
-        {
-          "type": "command",
-          "command": "employee list"
-        }
-      ],
-      "role": "observe"
-    },
-    {
-      "command": "needs",
-      "interaction": [
-        {
-          "type": "command",
-          "command": "needs"
-        }
-      ],
-      "role": "observe"
     },
     {
       "command": "employee dispatch 2 x:34 z:32",
@@ -481,15 +449,113 @@
           "command": "employee dispatch 2 x:34 z:32"
         }
       ],
-      "description": "See the first Stan dispatch above — keeps him continuously busy across this final handoff too.",
-      "role": "bootstrap"
+      "description": "See the first Stan dispatch above -- keeps him continuously busy right up to this checkpoint.",
+      "role": "bootstrap",
+      "expect": {
+        "equals": {
+          "collapsedCount": 0
+        }
+      }
     },
     {
-      "command": "tick 30",
+      "command": "tick 5",
       "interaction": [
         {
           "type": "command",
-          "command": "tick 30"
+          "command": "tick 5"
+        }
+      ],
+      "role": "setup",
+      "expect": {
+        "equals": {
+          "collapsedCount": 0
+        }
+      }
+    },
+    {
+      "command": "employee dispatch 2 x:34 z:32",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "employee dispatch 2 x:34 z:32"
+        }
+      ],
+      "description": "See the first Stan dispatch above -- keeps him continuously busy right up to this checkpoint.",
+      "role": "bootstrap",
+      "expect": {
+        "equals": {
+          "collapsedCount": 0
+        }
+      }
+    },
+    {
+      "command": "tick 5",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 5"
+        }
+      ],
+      "role": "setup",
+      "expect": {
+        "equals": {
+          "collapsedCount": 0
+        }
+      }
+    },
+    {
+      "command": "employee dispatch 2 x:34 z:32",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "employee dispatch 2 x:34 z:32"
+        }
+      ],
+      "description": "See the first Stan dispatch above -- keeps him continuously busy right up to this checkpoint.",
+      "role": "bootstrap",
+      "expect": {
+        "equals": {
+          "collapsedCount": 0
+        }
+      }
+    },
+    {
+      "command": "tick 5",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 5"
+        }
+      ],
+      "role": "setup",
+      "expect": {
+        "equals": {
+          "collapsedCount": 0
+        }
+      }
+    },
+    {
+      "command": "employee dispatch 2 x:34 z:32",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "employee dispatch 2 x:34 z:32"
+        }
+      ],
+      "description": "See the first Stan dispatch above -- keeps him continuously busy right up to this checkpoint.",
+      "role": "bootstrap",
+      "expect": {
+        "equals": {
+          "collapsedCount": 0
+        }
+      }
+    },
+    {
+      "command": "tick 10",
+      "interaction": [
+        {
+          "type": "command",
+          "command": "tick 10"
         }
       ],
       "role": "setup",
@@ -498,7 +564,7 @@
           "collapsedCount": 1,
           "buildingCount": 1
         },
-        "note": "genuine collapse lands here: Stan, kept continuously dispatched (working-rate drain, no idle window for an auto-claimed rest to save him), crosses his collapse threshold partway through this batch (a real run logs 'NEED: employee_collapsed' at cumulative tick 207) — re-derived from that real run, not assumed. This is the collapsing-row visual checkpoint (see 'collapse-state' shot) — it no longer coincides with the old idle-drain-plus-LQ-proximity timing (#593), it lands two batches later under continuous forced work instead."
+        "note": "#700 follow-up: replenishment now applies its rate for a rest's own full duration, so a completed rest recovers much more than before -- keeping Stan continuously re-dispatched every 5 ticks (rather than the old single 20/30-tick gaps) closes the idle window an auto-claimed rest could otherwise slip into and recover him. Under this tighter cadence he still crosses the collapse threshold from continuous working-rate drain with no rest ever claimed (a real run confirms 'NEED: employee_collapsed' fires within this final batch). This is the collapsing-row visual checkpoint (see 'collapse-state' shot)."
       }
     },
     {

--- a/scripts/scenario-defs/needs-proactive-queue-visual.json
+++ b/scripts/scenario-defs/needs-proactive-queue-visual.json
@@ -115,7 +115,7 @@
     },
     {
       "command": "build living_quarters at:15,15",
-      "description": "Placed away from the (10,10) dispatch target (#437) — building on top of the employee's own tile made that cell permanently NavGrid-blocked with the employee still standing on it, so every later rest/collapse routing failed to path out and the employee got stuck COLLAPSING at 0/0/0 needs forever instead of demonstrating the queued-rest recovery this scenario is about.",
+      "description": "Placed away from the (10,10) dispatch target (#437) \u2014 building on top of the employee's own tile made that cell permanently NavGrid-blocked with the employee still standing on it, so every later rest/collapse routing failed to path out and the employee got stuck COLLAPSING at 0/0/0 needs forever instead of demonstrating the queued-rest recovery this scenario is about.",
       "interaction": [
         {
           "type": "clickSelector",
@@ -228,16 +228,14 @@
       "role": "setup",
       "expect": {
         "decreased": [
-          "cash"
-        ],
-        "increased": [
+          "cash",
           "minFatigue"
         ],
         "equals": {
           "pendingActionCount": 0,
           "collapsedCount": 0
         },
-        "note": "Recalibrated for #680 (tri-state 'working'/'idle'/'resting' need-drain classification): with a rest now correctly drained at 0 while actually resting (previously idle-rate the whole time it was in progress), the auto-inserted rest queued by the tick-80 checkpoint's dip claims, completes, and recovers fatigue within this batch instead of merely slowing its decline -- minFatigue rises 29.8->31.8 rather than continuing to fall, and pendingActionCount is back to 0 (the rest that was pending is claimed, not a fresh one queued) instead of the old calibration's re-dip. collapsedCount stays 0, well above the collapse floor. tickCollapse/collapsedCount is exercised directly (and correctly) by needs-collapse-visual instead."
+        "note": "#700: the tick-80/tick-120 checkpoints' rest cycle now applies its replenish rate for the rest's own full duration (not once), so fatigue recovered comfortably above the 25 warning threshold (50.9 at tick 120) instead of barely clearing it -- no second rest cycle triggers in this window, so fatigue simply continues its natural working decline (50.9 -> 38.9) instead of the old calibration's own partial re-recovery. pendingActionCount stays 0 (nothing queued, the crew is genuinely resting-free right now) and collapsedCount stays 0."
       }
     },
     {
@@ -286,10 +284,10 @@
           "minFatigue"
         ],
         "equals": {
-          "pendingActionCount": 0,
+          "pendingActionCount": 1,
           "collapsedCount": 0
         },
-        "note": "Recalibrated for #680 (see the earlier 'tick 20' step's note for root cause): the previous step's rest cycle already claimed and completed, so no rest is pending here -- Walt is back to natural fatigue decline while idle, nowhere near collapse. This batch is interrupted early by an unrelated random event (union_heated_seats) at cumulative tick 145, only 5 of the requested 30 ticks run -- not enough for a fresh dip below the warning threshold to queue another rest, so pendingActionCount stays 0 instead of the old calibration's re-dip."
+        "note": "#700: with the stronger, correctly-scaled replenishment above, fatigue's natural working decline reaches the 25 warning threshold a few ticks later than the old calibration did, landing inside this batch instead of the next one -- a proactive rest is queued (pendingActionCount 1, confirmed via direct trace) but not yet claimed/completed by the point this random-event interruption cuts the batch short at 5 of 30 requested ticks. collapsedCount stays 0, well above the collapse floor."
       }
     },
     {

--- a/scripts/scenario-defs/needs-replenishment-visual.json
+++ b/scripts/scenario-defs/needs-replenishment-visual.json
@@ -1,6 +1,6 @@
 {
   "name": "needs-replenishment-visual",
-  "description": "Visual check of building replenishment rates. Finding #26 (same root cause as Finding #11's collapse-recovery.json): a direct engine trace shows fatigue does NOT sustainably recover after living_quarters T1 is built — tickNeedGauges keeps draining the gauge at the idle rate throughout an active rest cycle, so each rest's completion burst (~+8) is mostly offset by the drain accrued during its own duration, leaving the employee oscillating near the collapse floor (0-8) indefinitely rather than climbing back to a healthy baseline. Assertions describe this real, verified behavior rather than the originally-intended \"restores gauge values over time\" claim.",
+  "description": "Visual check of building replenishment rates. Finding #26 (fixed by #700): completeRestForEmployee used to apply BUILDING_REPLENISH_RATES exactly once per rest regardless of how many ticks the rest actually spent, despite the rate's own \"per-tick\" doc comment -- a rest's completion burst (~+8 for a tier-1 fatigue rest) was smaller than the idle/working drain the same employee accrued getting to and from the building, so fatigue oscillated near the collapse floor indefinitely instead of climbing back to a healthy baseline. #700 scales the burst by the rest's own NEED_REST_DURATIONS[needKey] (matching the rate's per-tick contract), so a completed rest now genuinely restores the gauge -- the behaviour this file originally set out to prove.",
   "steps": [
     {
       "command": "new_game seed:42",
@@ -181,7 +181,7 @@
           "cash",
           "minFatigue"
         ],
-        "note": "still above the fatigue warning threshold (~25) at this point — no rest cycle has started yet"
+        "note": "still above the fatigue warning threshold (~25) at this point \u2014 no rest cycle has started yet"
       }
     },
     {
@@ -219,7 +219,7 @@
           "cash",
           "minFatigue"
         ],
-        "note": "Finding #26: fatigue has now crossed its warning threshold and auto-rest cycles have begun (confirmed via direct trace), but each rest's completion burst is mostly offset by the idle drain accrued during the rest itself — net still decreasing, not recovering"
+        "note": "Finding #26: fatigue has now crossed its warning threshold and auto-rest cycles have begun (confirmed via direct trace), but each rest's completion burst is mostly offset by the idle drain accrued during the rest itself \u2014 net still decreasing, not recovering"
       }
     },
     {
@@ -253,11 +253,13 @@
       ],
       "role": "setup",
       "expect": {
-        "decreased": [
-          "cash",
+        "increased": [
           "minFatigue"
         ],
-        "note": "Finding #26: by 210 total ticks, fatigue is still oscillating near the collapse floor rather than having genuinely recovered — this file's original claim that replenishment \"restores gauge values over time\" does not hold within this tick budget; same root cause as Finding #11's collapse-recovery.json"
+        "decreased": [
+          "cash"
+        ],
+        "note": "#700: the rest cycle active by this point now applies its replenish rate for the rest's own full duration, not once -- minFatigue climbs from the collapse floor instead of merely holding near it (confirmed live: 30.05 -> 72.15 over this window)."
       }
     },
     {

--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -986,7 +986,24 @@ function completeRestForEmployee(state: GameState, emp: Employee, needKey: NeedK
   const building = findNearestLivingQuarters(state, emp.x, emp.z);
   if (building) {
     const def = getBuildingDef(building.type, building.tier);
-    replenishNeed(emp, needKey, building.tier, def.capacity);
+    // BUILDING_REPLENISH_RATES is a per-tick rate (its own doc comment, and
+    // Employee.test.ts's "per-tick fill rate" framing), but this call site
+    // used to apply it exactly once regardless of how many ticks the rest
+    // actually spent — one tick's worth of gain for the whole visit. Against
+    // any real travel distance to and from the building, that one tick is
+    // smaller than what the round trip alone costs in drain, so an employee
+    // whose work site isn't adjacent to their living_quarters nets negative
+    // every cycle: collapse, rest, walk back barely recovered, collapse
+    // again before finishing (or even starting) the next task — confirmed
+    // live, a solo driller stuck oscillating at ~0-10 fatigue for 5000+
+    // ticks with a tier-1 living_quarters two tiles from the drill grid,
+    // never landing a single hole (#700). Scaling by the rest's own
+    // NEED_REST_DURATIONS[needKey] — the same constant that sets how many
+    // ticks the visit takes — applies the full rate for the full stay,
+    // matching the "per-tick" contract the rate was already documented as.
+    for (let i = 0; i < NEED_REST_DURATIONS[needKey]; i++) {
+      replenishNeed(emp, needKey, building.tier, def.capacity);
+    }
   } else {
     // No building services this need — the employee rests where they stand.
     // That keeps them on their feet but never fully satisfies them: the gauge

--- a/tests/unit/engine/GameLoop.test.ts
+++ b/tests/unit/engine/GameLoop.test.ts
@@ -3889,7 +3889,7 @@ describe('processShiftCycle — under an applied policy (#678)', () => {
       const { employee } = hireEmployee(state.employees, 'driller', rng);
       employee.activeActionId = 1100;
       employee.ticksWorked = SHIFT_DURATIONS_TICKS.shift_8h - 1; // fires this call
-      employee.fatigue = 50;
+      employee.fatigue = 10;
 
       processShiftCycle(state, []); // fires forced rest via the applied policy
       resolveArrival(state); // promotes pendingRestDuration/NeedKey -> restTicksRemaining/restNeedKey
@@ -3906,8 +3906,15 @@ describe('processShiftCycle — under an applied policy (#678)', () => {
     const tier1 = runToCompletion(1);
     const tier2 = runToCompletion(2);
 
-    expect(tier1.fatigueAfter - 50).toBe(BUILDING_REPLENISH_RATES.fatigue[1]);
-    expect(tier2.fatigueAfter - 50).toBe(BUILDING_REPLENISH_RATES.fatigue[2]);
+    // The rate applies for the rest's own full duration (#700 fix) — a single
+    // tick's worth used to net negative against any real travel to and from
+    // the building, so this now matches BUILDING_REPLENISH_RATES's own
+    // "per-tick" doc comment instead of a flat one-shot bonus. Starting well
+    // below the ceiling (10) so tier 1's smaller total (8 × 8 ticks = 64)
+    // stays under 100 while tier 2's larger one (14 × 8 = 112) saturates —
+    // still two distinct, tier-differentiated outcomes.
+    expect(tier1.fatigueAfter).toBe(Math.min(100, 10 + BUILDING_REPLENISH_RATES.fatigue[1] * NEED_REST_DURATIONS.fatigue));
+    expect(tier2.fatigueAfter).toBe(Math.min(100, 10 + BUILDING_REPLENISH_RATES.fatigue[2] * NEED_REST_DURATIONS.fatigue));
     expect(tier1.fatigueAfter).not.toBe(tier2.fatigueAfter);
     expect(tier1.activeActionId).toBeNull();
     expect(tier2.activeActionId).toBeNull();


### PR DESCRIPTION
Closes #700

## What was wrong

`completeRestForEmployee` (`src/core/engine/GameLoop.ts`) applied `BUILDING_REPLENISH_RATES[need][tier]` exactly **once** per completed rest, regardless of how many ticks the rest actually spent — despite the rate's own doc comment and `Employee.test.ts`'s framing both describing it as a **per-tick** rate. A tier-1 fatigue rest's completion burst (+8) was routinely smaller than the drain the same employee accrued walking to and from the building, so any employee whose work site required real travel could net negative every cycle: collapse → rest → walk back barely recovered → collapse again, forever.

## How #700 was actually diagnosed

#700 was originally filed suspecting a missing vehicle-redispatch mechanism (a driver never reboarding a released vehicle). A full instrumented trace (raw engine, tick-by-tick) disproved that: the vehicle reboards correctly every single cycle. The real signature was different — a solo driller permanently stuck oscillating at 0–10 fatigue, never landing a single hole over 5000+ ticks, because each rest gave back only a sliver of what the round trip cost. Moving the employee's `living_quarters` progressively closer to the work site only shrank the gap, never closed it — confirming this was a replenishment-formula defect, not a distance/pathing one.

## The fix

Scale the replenish burst by the rest's own `NEED_REST_DURATIONS[needKey]` — the same constant that already sets how many ticks the visit takes — so the full rate applies for the full stay, matching the rate's documented per-tick contract. `replenishNeed` itself is untouched (still a single flat-rate primitive, its own unit tests pass unchanged); only its caller now invokes it the right number of times.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** three existing scenario files encoded the old broken behavior as their expected outcome; one (`needs-replenishment-visual.json`) even carried a prior investigation ("Finding #26") that concluded replenishment "does not hold within this tick budget" rather than diagnosing the actual formula bug.
  **Chosen:** update their assertions to the corrected trajectory, re-derived empirically from real runs, and tighten `needs-collapse-visual.json`'s redispatch cadence (5-tick chunks instead of 20/30-tick gaps) so a genuinely continuously-busy employee still collapses under the now much stronger recovery available to anyone who *does* get a moment's rest.
  **Why:** the old assertions described a bug, not intended behavior — matching them would have re-encoded the defect as spec.
  **If reversed:** the three scenario JSON diffs are independent of the engine fix; reverting `GameLoop.ts`'s loop back to a single call reproduces the old numbers these files used to assert.

## Verification channels run

- `static` (`npm run typecheck`): PASS.
- `logic` (`npm run test`): PASS — 325 files, 10531 passed / 1 skipped (pre-existing) / 0 failed.
- `scenario` (`npm run scenarios`, command mode, all 131 files): PASS — 131/131, including `tutorial-steps-visual`/`tutorial-interactive`.
- `visual`: not required — this change is confined to `src/core/engine/GameLoop.ts` and scenario JSON; nothing in `src/renderer/` or `src/ui/` changed.

READY TO MERGE


---
_Generated by [Claude Code](https://claude.ai/code/session_019hfE42vyuxaoTUAHfroPGs)_