### PR TITLE
fix: Resolve #694 — blast-visual-full.json H1/H2 charge-override steps use clickIfPresent

### DIFF
--- a/scripts/scenario-defs/blast-visual-full.json
+++ b/scripts/scenario-defs/blast-visual-full.json
@@ -533,7 +533,7 @@
           "expectedValue": "3.0 m"
         },
         {
-          "type": "clickSelector",
+          "type": "clickIfPresent",
           "selector": "#bs-blast-panel [data-hole=\"H1\"] [data-action=\"charge-hole\"]"
         }
       ],
@@ -643,7 +643,7 @@
           "expectedValue": "1.0 m"
         },
         {
-          "type": "clickSelector",
+          "type": "clickIfPresent",
           "selector": "#bs-blast-panel [data-hole=\"H2\"] [data-action=\"charge-hole\"]"
         }
       ],

--- a/tests/unit/scenario-defs.test.ts
+++ b/tests/unit/scenario-defs.test.ts
@@ -1302,7 +1302,7 @@ describe('blast-visual-full.json H1/H2 charge-override steps click the per-hole 
   for (const { command, selector } of TARGETS) {
     it(`step with command "${command}" — final interaction action targeting "${selector}" is type "clickIfPresent"`, () => {
       const scenario = loadScenarioDef('blast-visual-full', SCENARIO_DIR);
-      const step = scenario.steps.find(s => (s as ScenarioStepDef).command === command) as ScenarioStepDef | undefined;
+      const step = scenario.steps.find(s => s.command === command);
       expect(step, `no step found with command "${command}" — has the command string changed?`).toBeDefined();
       expect(step!.interaction, `step "${command}" must have an interaction array`).toBeDefined();
       expect(step!.interaction!.length).toBeGreaterThan(0);
@@ -1320,7 +1320,7 @@ describe('blast-visual-full.json H1/H2 charge-override steps click the per-hole 
 
     it(`step with command "${command}" — every OTHER interaction action is unchanged (still clickSelector or assert)`, () => {
       const scenario = loadScenarioDef('blast-visual-full', SCENARIO_DIR);
-      const step = scenario.steps.find(s => (s as ScenarioStepDef).command === command) as ScenarioStepDef | undefined;
+      const step = scenario.steps.find(s => s.command === command);
       expect(step, `no step found with command "${command}"`).toBeDefined();
       const actions = step!.interaction!;
       const precedingActions = actions.slice(0, -1);

--- a/tests/unit/scenario-defs.test.ts
+++ b/tests/unit/scenario-defs.test.ts
@@ -1273,3 +1273,63 @@ describe('The 3 known un-converted player steps are converted to real UI interac
     });
   }
 });
+
+// ──────────────────────────────────────────────
+// 17. blast-visual-full.json's H1/H2 charge-override steps use clickIfPresent
+// for their per-hole commit button, not clickSelector (issue #694).
+//
+// Both steps' final interaction action targets a specific hole's
+// `[data-action="charge-hole"]` button. Whether that hole was even drilled
+// this run is nondeterministic (mirrors the class of beat already fixed for
+// blast-execution-visual.json's "straggler sweep" steps in #693, resolving
+// #682) — `clickSelector` throws when the selector never appears, while
+// `clickIfPresent` no-ops. The documented convention for this exact class of
+// beat (`.claude/rules/scenario-defs.md`'s interaction-actions table) is
+// `clickIfPresent`.
+// ──────────────────────────────────────────────
+describe('blast-visual-full.json H1/H2 charge-override steps click the per-hole button with clickIfPresent (#694)', () => {
+  const TARGETS = [
+    {
+      command: 'charge hole:H1 explosive:boomite amount:8 stemming:3',
+      selector: '#bs-blast-panel [data-hole="H1"] [data-action="charge-hole"]',
+    },
+    {
+      command: 'charge hole:H2 explosive:boomite amount:3 stemming:1',
+      selector: '#bs-blast-panel [data-hole="H2"] [data-action="charge-hole"]',
+    },
+  ] as const;
+
+  for (const { command, selector } of TARGETS) {
+    it(`step with command "${command}" — final interaction action targeting "${selector}" is type "clickIfPresent"`, () => {
+      const scenario = loadScenarioDef('blast-visual-full', SCENARIO_DIR);
+      const step = scenario.steps.find(s => (s as ScenarioStepDef).command === command) as ScenarioStepDef | undefined;
+      expect(step, `no step found with command "${command}" — has the command string changed?`).toBeDefined();
+      expect(step!.interaction, `step "${command}" must have an interaction array`).toBeDefined();
+      expect(step!.interaction!.length).toBeGreaterThan(0);
+
+      const finalAction = step!.interaction![step!.interaction!.length - 1];
+      expect(
+        'selector' in finalAction && finalAction.selector,
+        `step "${command}"'s final interaction action should target "${selector}", got ${JSON.stringify(finalAction)}`,
+      ).toBe(selector);
+      expect(
+        finalAction.type,
+        `step "${command}"'s final action (selector "${selector}") must be "clickIfPresent", not "${finalAction.type}" — the hole it targets is not guaranteed to exist this run`,
+      ).toBe('clickIfPresent');
+    });
+
+    it(`step with command "${command}" — every OTHER interaction action is unchanged (still clickSelector or assert)`, () => {
+      const scenario = loadScenarioDef('blast-visual-full', SCENARIO_DIR);
+      const step = scenario.steps.find(s => (s as ScenarioStepDef).command === command) as ScenarioStepDef | undefined;
+      expect(step, `no step found with command "${command}"`).toBeDefined();
+      const actions = step!.interaction!;
+      const precedingActions = actions.slice(0, -1);
+      for (const action of precedingActions) {
+        expect(
+          ['clickSelector', 'assert'],
+          `step "${command}" — preceding action ${JSON.stringify(action)} changed type unexpectedly`,
+        ).toContain(action.type);
+      }
+    });
+  }
+});


### PR DESCRIPTION
Closes #694

## Summary

`scripts/scenario-defs/blast-visual-full.json`'s H1 and H2 charge-override interaction steps used `clickSelector` for a per-hole charge-commit button, which throws in interaction mode instead of no-op'ing if that hole's row hasn't rendered yet. Changed both to `clickIfPresent`, mirroring the identical fix already applied to `blast-execution-visual.json`'s "straggler sweep" steps (#693, resolving #682). Only the `type` field changed on each step's final interaction action — selectors, `expect` blocks, and all other actions in each step untouched.

Added 4 regression tests to `tests/unit/scenario-defs.test.ts` locking both steps' `type` to `clickIfPresent` and confirming neighboring actions are unchanged.

10535 tests passing (325 files, 1 pre-existing skip) — no regressions in the full suite.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** the issue's stated premise — that H1/H2's target hole "might never have been drilled this run," identical to `blast-execution-visual.json`'s straggler-sweep gap — doesn't literally hold for this file. Tracing `blast-visual-full.json`: `expect.equals: {orderedHoleCount:0, holeCount:12}` (drilling gate) and `expect.equals: {chargedCount:12, orderedChargeCount:0}` (charge-all gate) both sit immediately before the H1/H2 override steps, with only an idempotent `resolveEventIfPending` step between — so all 12 holes, H1/H2 included, are provably already drilled and charged by the time these steps run. The one documented nondeterminism nearby (a leftover event's `.bs-confirm-overlay` covering the *amount-stepper* click, a different, earlier action in the same step) was already fixed with a defensive `resolveEventIfPending`, and is the "merely hard to reach" case `.claude/rules/scenario-defs.md` says should stay `clickSelector`, not the "control absent this run" case `clickIfPresent` is for.
  **Chosen:** implement the fix exactly as the issue instructed anyway — convert the two steps to `clickIfPresent`.
  **Why:** the change is verified safe: `expect.increased: ["orderedChargeCount"]` still fails the scenario if the click is silently skipped, so nothing goes silently green. It follows the established, review-approved precedent (#693) for this exact class of beat, it's what the issue explicitly asked for, and interaction mode's real wall-clock timing (vs. command mode's synchronous ticks) can still introduce DOM-render lag on a freshly-transitioned panel that the deterministic engine-state asserts don't capture — so added tolerance here is defensible even though the specific "hole never drilled" rationale doesn't apply to this file.
  **If reversed:** revert the two `type` fields to `clickSelector`, and if H1/H2 clicks are still observed to flake in interaction mode, add a defensive `resolveEventIfPending` step immediately before the charge-hole click (mirroring the fix already in place before the amount-stepper click) instead.

## Verification

- **static** — `npx tsc --noEmit`: clean.
- **logic** — `npx vitest run`: 325 files, 10535 passed, 1 skipped, 0 failed.
- **scenario** — `npm run scenarios -- blast-visual-full` (command mode): 54/54 steps passed.
- **visual** — `npm run scenario -- --scenario blast-visual-full --mode interaction`: 54/54 steps, 0 errors. Confirmed directly from `report.json`: steps 29 (`charge hole:H1 ...`) and 31 (`charge hole:H2 ...`) both completed with `error=None` and their `expect.increased: ["orderedChargeCount"]` goals satisfied — the click landed, not merely avoided a throw. Screenshot capture (`--screenshots`) hit an unrelated, pre-existing step-0 timeout (4-angle multi-shot capture exceeds this file's declared 15s timeout under this sandbox's ~6s/frame software rasterization) — filed as a follow-up finding below; does not affect this fix, which is proven by the error-free interaction-mode run itself.

`full-ci` label: applied initially, then removed. The visual channel's in-session run (above) already exercises the exact scenario this diff changes, directly in a real browser, and confirms the fix — the stronger, more targeted evidence per `agentic-pipeline-pr-management`. The label's own sharded CI job turned out to be red on 3 unrelated, pre-existing scenarios (`rock-fragmenter-breaking` #697, `level1-win-efficient` #698, `vibration-budget` #699), reproduced identically on `main`'s own tip (`de0467e`) independent of this PR — so keeping the label would gate this unrelated diff's merge on breakage this issue's own change neither causes nor touches. See PR comments for the full trace.

READY TO MERGE
