### PR TITLE
fix: Resolve #698 — safety score's crisis floor survives delayed event resolution in interaction mode

### DIFF
--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -40,7 +40,7 @@ import { updateArrest } from '../../core/campaign/CriminalArrest.js';
 import { updateRevolt } from '../../core/campaign/WorkerRevolt.js';
 import { checkLevelComplete } from '../../core/campaign/LevelTransition.js';
 import { snapshotStats } from '../../core/campaign/SuccessTracker.js';
-import { updateScores, type ScoreInputs } from '../../core/scores/ScoreManager.js';
+import { updateScores, reassertFloorIfCrisisActive, type ScoreInputs } from '../../core/scores/ScoreManager.js';
 import { CONTRACT_REFRESH_INTERVAL } from '../../core/config/balance.js';
 import { BASE_TICK_MS } from '../../core/engine/GameLoop.js';
 import {
@@ -168,15 +168,17 @@ export function tickCommand(
 
     // 7. Score updates — decay + building/morale/vibration effects
     const avgMorale = computeAverageMorale(state.employees.employees);
+    const recentAccidents = state.damage.accidents.filter(a => a.tick >= state.tickCount - 10).length;
     const scoreInputs: ScoreInputs = {
       buildings: state.buildings,
       avgMorale,
-      recentAccidents: state.damage.accidents.filter(a => a.tick >= state.tickCount - 10).length,
+      recentAccidents,
       hasSafetyEquipment: state.buildings.buildings.some(b => b.type === 'management_office'),
       maxRecentVibration: 0,
       employeeCount: state.employees.employees.length,
     };
     updateScores(state.scores, scoreInputs);
+    reassertFloorIfCrisisActive(state.scores, recentAccidents);
 
     // 8. Employee needs — drain gauges, update morale, check collapse
     for (const emp of state.employees.employees) {

--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -181,20 +181,26 @@ export function tickCommand(
     // #698: recentAccidents (above) is windowed to the last 10 ticks, which
     // is right for the sfDelta hit but wrong for deciding whether the
     // post-death safety floor is still active — interaction-mode tick drift
-    // means a positive `safety` delta from an unrelated resolved event (an
-    // EventResolver.applyConsequence write, which bypasses this floor
-    // entirely) can land 36+ ticks after the accident that set the floor,
-    // well outside that window. crisisActiveCount is unbounded in time
-    // instead: a death keeps the floor engaged for as long as no deliberate
-    // recovery (see the 'choose' case above / DamageState.
-    // lastSafetyRecoveryTick) has resolved since, and a later death re-arms
-    // it even after a recovery.
+    // means a resolved consequence tagged `resolvesDeathCrisis` can land
+    // 36+ ticks after the accident that set the floor, well outside that
+    // window. crisisActiveCount is unbounded in time instead: a death keeps
+    // the floor engaged for as long as no deliberate recovery (see the
+    // 'choose' case above / DamageState.lastSafetyRecoveryTick) has resolved
+    // since, and a later death re-arms it even after a recovery.
     const lastDeathTick = state.damage.accidents.reduce(
       (max, a) => (a.type === 'death' && a.tick > max ? a.tick : max), -1,
     );
+    // `== null` (not `===`) deliberately treats a legacy save's missing
+    // lastSafetyRecoveryTick (serialized before #698 added the field —
+    // deserializes as `undefined`, not `null`) the same as "no recovery has
+    // ever happened" — same safe-defaulting precedent as GameState.ts's
+    // `revoltDisabled` field. No SAVE_VERSION bump/migration needed: the
+    // field already defaults to the correct "crisis still active" reading
+    // for a pre-existing save with deathCount > 0, which is what closes the
+    // gap this fix targets rather than reopening it for old saves.
     const recoveryTick = state.damage.lastSafetyRecoveryTick;
     const crisisActiveCount =
-      state.damage.deathCount > 0 && (recoveryTick === null || recoveryTick < lastDeathTick) ? 1 : 0;
+      state.damage.deathCount > 0 && (recoveryTick == null || recoveryTick < lastDeathTick) ? 1 : 0;
     reassertFloorIfCrisisActive(state.scores, crisisActiveCount);
 
     // 8. Employee needs — drain gauges, update morale, check collapse
@@ -563,15 +569,17 @@ export function eventCommand(
       if (result.corruptionChange !== 0) {
         state.corruption.level += result.corruptionChange;
       }
-      // #698: a chosen consequence that both raises `safety` and costs cash
-      // is the only "deliberate recovery" signal the current event data
-      // carries (LawsuitEvents1.ts's settle_death_suit/memorial_fund/
-      // plea_deal/etc. are all shaped this way — see DamageState.
-      // lastSafetyRecoveryTick's own doc comment). Record it so tickCommand's
-      // post-death floor reassertion doesn't re-pin `safety` back to 0 on the
-      // very next tick and silently erase the recovery the player just paid for.
-      const safetyGain = result.scoreChanges['safety'];
-      if (safetyGain !== undefined && safetyGain > 0 && result.cashChange < 0) {
+      // #698: stamp lastSafetyRecoveryTick only for a consequence explicitly
+      // tagged `resolvesDeathCrisis` (EventConsequence's own doc comment) —
+      // NOT inferred from a positive safety delta paired with a cash cost.
+      // That shape is common to many unrelated options (OSHA fines, weather
+      // payouts, bribes) that aren't gated on deathCount at all; stamping on
+      // any of those would wrongly lift the post-death floor for a payout
+      // that has nothing to do with the death. Only options tagged in the
+      // event data itself (e.g. LawsuitEvents1.ts's settle_death_suit/
+      // memorial_fund/plea_deal) count as the deliberate, paid-for
+      // resolution tickCommand's floor reassertion is waiting for.
+      if (result.resolvesDeathCrisis) {
         state.damage.lastSafetyRecoveryTick = state.tickCount;
       }
       // Resume the game after resolving the event (tick pauses on event)

--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -178,7 +178,24 @@ export function tickCommand(
       employeeCount: state.employees.employees.length,
     };
     updateScores(state.scores, scoreInputs);
-    reassertFloorIfCrisisActive(state.scores, recentAccidents);
+    // #698: recentAccidents (above) is windowed to the last 10 ticks, which
+    // is right for the sfDelta hit but wrong for deciding whether the
+    // post-death safety floor is still active — interaction-mode tick drift
+    // means a positive `safety` delta from an unrelated resolved event (an
+    // EventResolver.applyConsequence write, which bypasses this floor
+    // entirely) can land 36+ ticks after the accident that set the floor,
+    // well outside that window. crisisActiveCount is unbounded in time
+    // instead: a death keeps the floor engaged for as long as no deliberate
+    // recovery (see the 'choose' case above / DamageState.
+    // lastSafetyRecoveryTick) has resolved since, and a later death re-arms
+    // it even after a recovery.
+    const lastDeathTick = state.damage.accidents.reduce(
+      (max, a) => (a.type === 'death' && a.tick > max ? a.tick : max), -1,
+    );
+    const recoveryTick = state.damage.lastSafetyRecoveryTick;
+    const crisisActiveCount =
+      state.damage.deathCount > 0 && (recoveryTick === null || recoveryTick < lastDeathTick) ? 1 : 0;
+    reassertFloorIfCrisisActive(state.scores, crisisActiveCount);
 
     // 8. Employee needs — drain gauges, update morale, check collapse
     for (const emp of state.employees.employees) {
@@ -545,6 +562,17 @@ export function eventCommand(
       }
       if (result.corruptionChange !== 0) {
         state.corruption.level += result.corruptionChange;
+      }
+      // #698: a chosen consequence that both raises `safety` and costs cash
+      // is the only "deliberate recovery" signal the current event data
+      // carries (LawsuitEvents1.ts's settle_death_suit/memorial_fund/
+      // plea_deal/etc. are all shaped this way — see DamageState.
+      // lastSafetyRecoveryTick's own doc comment). Record it so tickCommand's
+      // post-death floor reassertion doesn't re-pin `safety` back to 0 on the
+      // very next tick and silently erase the recovery the player just paid for.
+      const safetyGain = result.scoreChanges['safety'];
+      if (safetyGain !== undefined && safetyGain > 0 && result.cashChange < 0) {
+        state.damage.lastSafetyRecoveryTick = state.tickCount;
       }
       // Resume the game after resolving the event (tick pauses on event)
       state.isPaused = false;

--- a/src/core/entities/Damage.ts
+++ b/src/core/entities/Damage.ts
@@ -49,10 +49,22 @@ export interface DamageState {
   deathCount: number;
   /** Total number of blasts detonated in this session. */
   blastCount: number;
+  /**
+   * Tick of the most recent *deliberate* safety-recovery event consequence —
+   * a chosen ("event choose") outcome that both raises `safety` and costs
+   * cash, the only signal the current event data (LawsuitEvents1.ts's
+   * settle_death_suit/memorial_fund/plea_deal/etc.) carries for "the player
+   * paid to fix this" as opposed to an incidental score nudge. `null` until
+   * the first such resolution. Consumed by tickCommand (src/console/commands/
+   * events.ts) to decide whether the post-death safety floor (#698) is still
+   * active: a death after this tick re-arms it, a recovery after the last
+   * death lifts it. Time-unbounded by design — not reset or windowed by tick.
+   */
+  lastSafetyRecoveryTick: number | null;
 }
 
 export function createDamageState(): DamageState {
-  return { accidents: [], lawsuitPending: false, deathCount: 0, blastCount: 0 };
+  return { accidents: [], lawsuitPending: false, deathCount: 0, blastCount: 0, lastSafetyRecoveryTick: null };
 }
 
 // ── Processing ──

--- a/src/core/entities/Damage.ts
+++ b/src/core/entities/Damage.ts
@@ -50,12 +50,16 @@ export interface DamageState {
   /** Total number of blasts detonated in this session. */
   blastCount: number;
   /**
-   * Tick of the most recent *deliberate* safety-recovery event consequence —
-   * a chosen ("event choose") outcome that both raises `safety` and costs
-   * cash, the only signal the current event data (LawsuitEvents1.ts's
-   * settle_death_suit/memorial_fund/plea_deal/etc.) carries for "the player
-   * paid to fix this" as opposed to an incidental score nudge. `null` until
-   * the first such resolution. Consumed by tickCommand (src/console/commands/
+   * Tick of the most recent chosen ("event choose") consequence explicitly
+   * tagged `resolvesDeathCrisis` (EventConsequence's own doc comment,
+   * EventPool.ts) — e.g. LawsuitEvents1.ts's settle_death_suit/memorial_fund/
+   * plea_deal. Not inferred from delta shape (a positive `safety` change
+   * paired with a cash cost also matches many unrelated options — OSHA
+   * fines, weather payouts, bribes — that must NOT lift the floor). `null`
+   * until the first such resolution; a legacy save serialized before this
+   * field existed deserializes it as `undefined`, which tickCommand treats
+   * identically to `null` via `== null` (no migration needed — see that
+   * call site's own comment). Consumed by tickCommand (src/console/commands/
    * events.ts) to decide whether the post-death safety floor (#698) is still
    * active: a death after this tick re-arms it, a recovery after the last
    * death lifts it. Time-unbounded by design — not reset or windowed by tick.

--- a/src/core/events/EventBuilder.ts
+++ b/src/core/events/EventBuilder.ts
@@ -13,7 +13,8 @@ export function ev(
     canFire?: (ctx: EventContext) => boolean;
     options: Array<{ cashDelta?: number; scoreDelta?: Partial<Record<keyof ScoreState, number>>;
       corruptionDelta?: number; followUp?: string; effectTag?: string;
-      probability?: number; alt?: Omit<EventConsequence, 'probability' | 'altConsequence'>; }>;
+      probability?: number; alt?: Omit<EventConsequence, 'probability' | 'altConsequence'>;
+      resolvesDeathCrisis?: boolean; }>;
   },
 ): EventDef {
   return {
@@ -31,6 +32,7 @@ export function ev(
       if (o.effectTag !== undefined) c.effectTag = o.effectTag;
       if (o.probability !== undefined) c.probability = o.probability;
       if (o.alt !== undefined) c.altConsequence = o.alt;
+      if (o.resolvesDeathCrisis !== undefined) c.resolvesDeathCrisis = o.resolvesDeathCrisis;
       return c;
     }),
     weightCoeff: opts.weight,

--- a/src/core/events/EventPool.ts
+++ b/src/core/events/EventPool.ts
@@ -44,6 +44,17 @@ export interface EventConsequence {
   probability?: number;
   /** Alternative consequence if probability fails. */
   altConsequence?: EventConsequence;
+  /**
+   * Marks this option as the deliberate, paid-for resolution of an active
+   * death-safety crisis (#698) — choosing it is what lifts
+   * `reassertFloorIfCrisisActive`'s post-death safety floor, as opposed to
+   * any other option that merely happens to raise `safety` alongside a cash
+   * cost (a fine, a bribe, an unrelated settlement). Set only on options
+   * genuinely gated on `deathCount` and intended as that gate's payoff —
+   * see LawsuitEvents1.ts's `lawsuit_wrongful_death`/`lawsuit_criminal_negligence`.
+   * Never inferred from delta shape; must be explicit per option.
+   */
+  resolvesDeathCrisis?: boolean;
 }
 
 export interface EventDef {

--- a/src/core/events/EventResolver.ts
+++ b/src/core/events/EventResolver.ts
@@ -24,6 +24,8 @@ export interface ResolutionResult {
   scoreChanges: Partial<Record<keyof ScoreState, number>>;
   corruptionChange: number;
   followUpQueued: string | null;
+  /** True when the resolved (post-probability-roll) consequence is tagged `resolvesDeathCrisis` (#698) — see EventConsequence's own doc comment. */
+  resolvesDeathCrisis: boolean;
 }
 
 /**
@@ -182,5 +184,6 @@ function applyConsequence(
     scoreChanges,
     corruptionChange,
     followUpQueued,
+    resolvesDeathCrisis: c.resolvesDeathCrisis === true,
   };
 }

--- a/src/core/events/LawsuitEvents1.ts
+++ b/src/core/events/LawsuitEvents1.ts
@@ -9,9 +9,9 @@ export const LAWSUIT_EVENTS_1: EventDef[] = [
     weight: (s) => 1.5 + 2.0 * (1 - r.sf(s)),
     canFire: (ctx) => ctx.deathCount >= 1,
     options: [
-      { cashDelta: -200000, scoreDelta: { safety: 5 }, effectTag: 'settle_death_suit' },
+      { cashDelta: -200000, scoreDelta: { safety: 5 }, effectTag: 'settle_death_suit', resolvesDeathCrisis: true },
       { cashDelta: -50000, corruptionDelta: 25, effectTag: 'intimidate_family' },
-      { cashDelta: -120000, scoreDelta: { safety: 10, wellBeing: 5 }, effectTag: 'memorial_fund' },
+      { cashDelta: -120000, scoreDelta: { safety: 10, wellBeing: 5 }, effectTag: 'memorial_fund', resolvesDeathCrisis: true },
     ],
   }),
   // 2 — Workers' class action for unsafe conditions
@@ -50,7 +50,7 @@ export const LAWSUIT_EVENTS_1: EventDef[] = [
     weight: (s) => 2.5 + 3.0 * (1 - r.sf(s)),
     canFire: (ctx) => ctx.deathCount >= 3 || (ctx.lawsuitCount >= 5 && ctx.scores.safety < 20),
     options: [
-      { cashDelta: -300000, scoreDelta: { safety: 20 }, effectTag: 'plea_deal' },
+      { cashDelta: -300000, scoreDelta: { safety: 20 }, effectTag: 'plea_deal', resolvesDeathCrisis: true },
       { cashDelta: -50000, probability: 0.3,
         alt: { cashDelta: -500000, effectTag: 'found_guilty' } },
       { cashDelta: -100000, corruptionDelta: 40, effectTag: 'flee_jurisdiction' },

--- a/src/core/events/LawsuitEvents2.ts
+++ b/src/core/events/LawsuitEvents2.ts
@@ -189,7 +189,7 @@ export const LAWSUIT_EVENTS_2: EventDef[] = [
     weight: (s) => 0.2 + 0.3 * (1 - r.sf(s)),
     canFire: (ctx) => ctx.deathCount > 0,
     options: [
-      { cashDelta: -10000, scoreDelta: { safety: 10, wellBeing: 8 }, effectTag: 'memorial_shrine' },
+      { cashDelta: -10000, scoreDelta: { safety: 10, wellBeing: 8 }, effectTag: 'memorial_shrine', resolvesDeathCrisis: true },
       { cashDelta: -5000, scoreDelta: { safety: -3 }, effectTag: 'exorcist_hired' },
       { cashDelta: -30000, scoreDelta: { safety: 15, wellBeing: 12 }, effectTag: 'ghost_satisfaction',
         probability: 0.5, alt: { cashDelta: -30000, scoreDelta: { safety: 5 }, effectTag: 'ghost_unsatisfied' } },

--- a/src/core/events/UnionEvents1.ts
+++ b/src/core/events/UnionEvents1.ts
@@ -232,7 +232,7 @@ export const UNION_EVENTS_1: EventDef[] = [
     weight: (s) => 0.15 + 0.3 * (1 - r.sf(s)),
     canFire: (ctx) => ctx.deathCount > 0,
     options: [
-      { cashDelta: -30000, scoreDelta: { wellBeing: 15, safety: 10 }, effectTag: 'ghost_paid' },
+      { cashDelta: -30000, scoreDelta: { wellBeing: 15, safety: 10 }, effectTag: 'ghost_paid', resolvesDeathCrisis: true },
       { cashDelta: 0, scoreDelta: { safety: -15, wellBeing: -10 }, effectTag: 'ghost_angry' },
       { cashDelta: -5000, corruptionDelta: 8, scoreDelta: { wellBeing: 5 }, effectTag: 'ghost_exorcised' },
       { cashDelta: -50000, scoreDelta: { wellBeing: 20, safety: 15 }, effectTag: 'ghost_promoted',

--- a/src/core/scores/ScoreManager.ts
+++ b/src/core/scores/ScoreManager.ts
@@ -147,13 +147,13 @@ function applyDecay(value: number, rate: number): number {
 }
 
 /**
- * Re-pin `safety` to its floor (0) when an active "crisis" (recent
- * accidents) is still ongoing, even after some other code has nudged the
- * score off the floor. No-op once the crisis has ended — the score is left
+ * Re-pin `safety` to its floor (0) when an active "crisis" (an unresolved
+ * death) is still ongoing, even after some other code has nudged the score
+ * off the floor. No-op once the crisis has ended — the score is left
  * untouched, whatever value it holds.
  */
-export function reassertFloorIfCrisisActive(state: ScoreState, recentAccidents: number): void {
-  if (recentAccidents > 0) {
+export function reassertFloorIfCrisisActive(state: ScoreState, crisisActive: number): void {
+  if (crisisActive > 0) {
     state.safety = 0;
   }
 }

--- a/src/core/scores/ScoreManager.ts
+++ b/src/core/scores/ScoreManager.ts
@@ -146,4 +146,14 @@ function applyDecay(value: number, rate: number): number {
   return value;
 }
 
+/**
+ * Re-pin a score to its floor when an active "crisis" (recent accidents) is
+ * still ongoing, even after some other code has nudged the score off the
+ * floor. Precautionary fallback stub for #698 — unused unless the
+ * scenario-JSON fix branch proves insufficient.
+ */
+export function reassertFloorIfCrisisActive(_state: ScoreState, _recentAccidents: number): void {
+  // TODO: implement
+}
+
 export type { ScoreId };

--- a/src/core/scores/ScoreManager.ts
+++ b/src/core/scores/ScoreManager.ts
@@ -147,13 +147,15 @@ function applyDecay(value: number, rate: number): number {
 }
 
 /**
- * Re-pin a score to its floor when an active "crisis" (recent accidents) is
- * still ongoing, even after some other code has nudged the score off the
- * floor. Precautionary fallback stub for #698 — unused unless the
- * scenario-JSON fix branch proves insufficient.
+ * Re-pin `safety` to its floor (0) when an active "crisis" (recent
+ * accidents) is still ongoing, even after some other code has nudged the
+ * score off the floor. No-op once the crisis has ended — the score is left
+ * untouched, whatever value it holds.
  */
-export function reassertFloorIfCrisisActive(_state: ScoreState, _recentAccidents: number): void {
-  // TODO: implement
+export function reassertFloorIfCrisisActive(state: ScoreState, recentAccidents: number): void {
+  if (recentAccidents > 0) {
+    state.safety = 0;
+  }
 }
 
 export type { ScoreId };

--- a/tests/integration/events.integration.test.ts
+++ b/tests/integration/events.integration.test.ts
@@ -25,6 +25,7 @@ import { clearEvents } from '../../src/core/events/EventPool.js';
 import { createRunner } from '../../src/console/createRunner.js';
 import { parseCommand } from '../../src/console/ConsoleRunner.js';
 import { makeCampaignCtx } from './full-level/helpers.js';
+import type { DamageState } from '../../src/core/entities/Damage.js';
 import {
   MIN_EVENT_INTERVAL_TICKS,
   MIN_EVENT_INTERVAL_ACTIONS,
@@ -783,6 +784,115 @@ describe('Event system', () => {
 
       expect(ctx.state!.levelEnded).toBe(false);
       expect(ctx.state!.levelEndReason).toBeNull();
+    });
+  });
+
+  // ── 14. Crisis-floor wiring (#698) ──────────────────────────────────────────
+  // Exercises tickCommand's lastDeathTick/crisisActiveCount derivation and
+  // eventCommand's lastSafetyRecoveryTick stamping through the real command
+  // handlers — tests/unit/scores/ScoreManager.test.ts covers the pure
+  // reassertFloorIfCrisisActive(state, crisisActive) function in isolation;
+  // this covers the wiring around it that decides what crisisActive *is*.
+
+  describe('crisis-floor wiring (#698)', () => {
+    /** Record a fatal accident and bump deathCount — mirrors what
+     * processEmployeeHit (Damage.ts) does on a real fatal fragment hit,
+     * without needing a full blast pipeline. Does NOT touch scores.safety
+     * directly — the floor pin is left to tickCommand's own
+     * reassertFloorIfCrisisActive wiring, so the ticks below prove the real
+     * mechanism drives safety to 0, rather than asserting a hand-set value.
+     */
+    function recordDeath(ctx: GameContext): void {
+      const state = ctx.state!;
+      state.damage.accidents.push({
+        tick: state.tickCount,
+        type: 'death',
+        entityId: 999,
+        fragmentId: 1,
+        kineticEnergy: 5000,
+      });
+      state.damage.deathCount++;
+    }
+
+    it('untagged event resolution does not lift the post-death safety floor', () => {
+      recordDeath(ctx);
+      tickCommand(ctx, ['1'], {}); // drives safety to 0 via the crisis floor
+      expect(ctx.state!.scores.safety).toBe(0);
+
+      // lawsuit_osha_hardhats' option 0 (osha_full_overhaul) has a positive
+      // safety delta but carries no resolvesDeathCrisis tag.
+      const fireResult = eventCommand(ctx, ['fire', 'lawsuit_osha_hardhats'], {});
+      expect(fireResult.success).toBe(true);
+      const chooseResult = eventCommand(ctx, ['choose', '0'], {});
+      expect(chooseResult.success).toBe(true);
+      expect(chooseResult.output).toContain('osha_full_overhaul');
+      expect(ctx.state!.scores.safety).toBe(15);
+      expect(ctx.state!.damage.lastSafetyRecoveryTick).toBeNull();
+
+      tickCommand(ctx, ['1'], {});
+
+      expect(ctx.state!.scores.safety).toBe(0);
+    });
+
+    it('resolvesDeathCrisis-tagged event resolution lifts the floor and it stays lifted', () => {
+      recordDeath(ctx);
+      // Advance well past updateScores' own 10-tick recentAccidents window so
+      // the assertion below isolates the crisis-floor mechanism from that
+      // unrelated -5 safety penalty (recordDeath's accident would otherwise
+      // still be "recent" and mask the floor lifting with its own penalty).
+      tickCommand(ctx, ['15'], {});
+      expect(ctx.state!.scores.safety).toBe(0);
+
+      // Option 0 (settle_death_suit) is tagged resolvesDeathCrisis: true.
+      const fireResult = eventCommand(ctx, ['fire', 'lawsuit_wrongful_death'], {});
+      expect(fireResult.success).toBe(true);
+      const chooseResult = eventCommand(ctx, ['choose', '0'], {});
+      expect(chooseResult.success).toBe(true);
+      expect(chooseResult.output).toContain('settle_death_suit');
+      expect(ctx.state!.damage.lastSafetyRecoveryTick).toBe(ctx.state!.tickCount);
+
+      tickCommand(ctx, ['1'], {});
+
+      // The resolved +5 safety delta stands — not reset to 0.
+      expect(ctx.state!.scores.safety).toBeGreaterThan(0);
+    });
+
+    it('a second death re-arms the crisis after a recovery', () => {
+      recordDeath(ctx);
+      tickCommand(ctx, ['15'], {});
+      eventCommand(ctx, ['fire', 'lawsuit_wrongful_death'], {});
+      eventCommand(ctx, ['choose', '0'], {});
+      tickCommand(ctx, ['1'], {});
+      expect(ctx.state!.scores.safety).toBeGreaterThan(0); // recovered
+
+      // A second, later death re-arms the crisis regardless of the earlier
+      // recovery already recorded on lastSafetyRecoveryTick.
+      recordDeath(ctx);
+      tickCommand(ctx, ['1'], {});
+
+      expect(ctx.state!.scores.safety).toBe(0);
+
+      // Stays re-pinned on a subsequent tick too, not just the one right
+      // after the new death.
+      tickCommand(ctx, ['1'], {});
+      expect(ctx.state!.scores.safety).toBe(0);
+    });
+
+    it('treats a legacy save (lastSafetyRecoveryTick deserialized as undefined) as crisis-active', () => {
+      // A save serialized before #698 added the field deserializes it as
+      // `undefined` (key absent), not `null` — construct that shape directly
+      // rather than going through createDamageState(), which always sets it.
+      ctx.state!.damage = {
+        accidents: [{ tick: 0, type: 'death', entityId: 1, fragmentId: 1, kineticEnergy: 5000 }],
+        lawsuitPending: false,
+        deathCount: 1,
+        blastCount: 0,
+      } as unknown as DamageState;
+      expect(ctx.state!.damage.lastSafetyRecoveryTick).toBeUndefined();
+
+      tickCommand(ctx, ['1'], {});
+
+      expect(ctx.state!.scores.safety).toBe(0);
     });
   });
 });

--- a/tests/unit/scores/ScoreManager.test.ts
+++ b/tests/unit/scores/ScoreManager.test.ts
@@ -5,6 +5,7 @@ import {
   recordAccident,
   recordVibration,
   recordSafetyInvestment,
+  reassertFloorIfCrisisActive,
   type ScoreInputs,
 } from '../../../src/core/scores/ScoreManager.js';
 import {
@@ -78,5 +79,63 @@ describe('Score system', () => {
     // Drive safety high
     for (let i = 0; i < 30; i++) recordSafetyInvestment(state, 5000);
     expect(state.safety).toBe(100);
+  });
+});
+
+// #698: interaction mode's own tick trajectory can diverge from command
+// mode's after a fatal blast (different real-time timing means a positive
+// -safety lawsuit event, gated on deathCount>=1 for the rest of the level,
+// can resolve outside the 10-tick accident-protection window in one mode but
+// not the other). `EventResolver.applyConsequence`'s own unconditional
+// `Math.max(0, Math.min(100, ...))` clamp bypasses `applyDecay`'s floor pin
+// when that happens, permanently un-pinning `safety` from 0 in exactly one
+// mode and leaving the two modes' final `safety` value to disagree — command
+// mode observed pinned at exactly 0.0 through the rest of the run on this
+// seed, interaction mode observed drifting back up (18.60999999999997) once
+// an event nudged it off the floor at tick 291. `reassertFloorIfCrisisActive`
+// is meant to make that floor authoritative regardless of which external
+// code last touched `safety`, independent of the exact tick alignment.
+describe('reassertFloorIfCrisisActive', () => {
+  it('re-pins safety to 0 when a crisis (recent accidents) is still active, even after an external mutation raised it', () => {
+    const state = createScoreState();
+    state.safety = 0; // driven to the floor by the accident-tick decay
+    state.safety = 18.60999999999997; // e.g. EventResolver's own unconditional clamp nudged it up
+
+    reassertFloorIfCrisisActive(state, 4); // 4 accidents still within the crisis window
+
+    expect(state.safety).toBe(0);
+  });
+
+  it('leaves safety alone once the crisis has just expired (no recent accidents) — an external mutation stands', () => {
+    const state = createScoreState();
+    state.safety = 18.60999999999997; // e.g. a resolved lawsuit event's positive delta
+
+    reassertFloorIfCrisisActive(state, 0); // crisis window has closed
+
+    expect(state.safety).toBe(18.60999999999997);
+  });
+
+  it('is a no-op when there have never been any accidents — an event delta applies and stays untouched', () => {
+    const state = createScoreState();
+    state.safety = 62; // e.g. a positive political-favor event, no accident ever recorded
+
+    reassertFloorIfCrisisActive(state, 0);
+
+    expect(state.safety).toBe(62);
+  });
+
+  it('never touches the other three scores, even while a crisis is active', () => {
+    const state = createScoreState();
+    state.wellBeing = 30;
+    state.ecology = 70;
+    state.nuisance = 40;
+    state.safety = 12; // off the floor, crisis still active
+
+    reassertFloorIfCrisisActive(state, 2);
+
+    expect(state.safety).toBe(0);
+    expect(state.wellBeing).toBe(30);
+    expect(state.ecology).toBe(70);
+    expect(state.nuisance).toBe(40);
   });
 });


### PR DESCRIPTION
Closes #698

10546 tests — all passing (325 files, 10545 passed, 1 skipped)

## Summary

Interaction-mode CI failed deterministically on scenario `level1-win-efficient`: `safety` was asserted to reach exactly `0` but stalled at `18.60999999999997`. Root cause, confirmed by an actual diagnostic run comparing command mode vs interaction mode step-by-step (not guessed): the two modes drive slightly different absolute tick counts due to unavoidable floating-point nondeterminism between Node's V8 and headless Chromium's V8 (no wall-clock coupling in `src/core/` — confirmed by grep). That divergence let a lawsuit/political event resolve outside a too-narrow 10-tick "recent accident" window, and `EventResolver.ts`'s unconditional score-delta clamp un-floored `safety` with nothing to re-pin it.

Fix: `safety` now stays pinned at exactly `0` for as long as there has been a death (`deathCount > 0`) and no *deliberate* recovery action has resolved since — unbounded in time, not windowed, so it survives however far interaction-mode tick drift compounds. "Deliberate recovery" is a new typed `resolvesDeathCrisis?: boolean` field on `EventConsequence` (`src/core/events/EventPool.ts`), tagged on the 5 existing event options that already pair a cash cost with a death-gated positive `safety` delta (`settle_death_suit`, `memorial_fund`, `plea_deal` in `LawsuitEvents1.ts`; `memorial_shrine` in `LawsuitEvents2.ts`; `ghost_paid` in `UnionEvents1.ts`) — every other safety-raising event (OSHA fines, weather, politics, mafia) is untagged and correctly still gets re-pinned.

### Verification

- `static`: `npm run typecheck` — clean.
- `logic`: `npm run test` — 325 files, 10545 passed, 1 skipped, 0 failed.
- `scenario`: `level1-win-efficient` passes in command mode (already did; no regression) and, re-run directly against this branch, in **interaction mode** — the exact channel and scenario named in the issue. `safety: 0.0` at every asserted step (106–108), full 109-step run, no failure.
- `build`: `npm run build` — clean production build.
- Backend-only diff (`src/core/`, `src/console/`, `tests/`) — no renderer/UI touched, so the general visual-channel trigger doesn't apply on its own merits; the `full-ci` label is carried from the issue and covers the interaction-mode scenario suite in CI regardless.

## Decisions taken

Defaulted under `agentic-decision-autonomy`; none blocked this run.

- **What was open:** the issue posed two hypotheses — a scenario-timing fix vs. a core hazard/incident-scheduling fix — and left which layer to fix undetermined.
  **Chosen:** core-code fix (`ScoreManager.ts`/`events.ts`/`EventPool.ts`), not scenario-JSON.
  **Why:** a diagnostic run comparing command-mode and interaction-mode per-step state proved the two modes send byte-identical commands from bit-identical state through step 44, then diverge purely from engine-level float nondeterminism accumulating over ~150+ ticks of vehicle/pathing simulation — not a scenario-authoring mistake `dragTiles`/`waitUntil` edits could fix.
  **If reversed:** not applicable — the diagnostic ruled out the scenario-JSON branch on evidence, not preference.

- **What was open:** which event consequences count as "deliberate safety recovery" that's allowed to lift the death-crisis floor — this directly affects gameplay (which lawsuit/union payouts can raise `safety` after a death, and when).
  **Chosen:** an explicit typed tag (`resolvesDeathCrisis: true`) on exactly 5 options, hand-identified by their existing shape (`canFire` gated on `deathCount`, paired with a real cash cost and positive `safety` delta): `settle_death_suit`, `memorial_fund`, `plea_deal`, `memorial_shrine`, `ghost_paid`.
  **Why:** the codebase has no existing category/type field distinguishing a deliberate recovery consequence from an incidental one (`effectTag` is free-form narrative text, not a typed marker); two earlier attempts using an inferred heuristic (safety-delta-up + cash-delta-down) were reviewed and found to misclassify unrelated events (OSHA fines, weather, politics, mafia bribes) as recovery, silently un-flooring safety for events that have nothing to do with a death. An explicit allowlist is the narrowest correct signal available without adding new infrastructure.
  **If reversed:** add or remove `resolvesDeathCrisis: true` on the relevant option literal in `LawsuitEvents1.ts`/`LawsuitEvents2.ts`/`UnionEvents1.ts` (or any future event file) — no other call site changes. A future safety-raising event that should also count as recovery needs this tag added by hand; nothing infers it automatically.

- **What was open:** whether the new persisted `DamageState.lastSafetyRecoveryTick` field needs a formal save migration.
  **Chosen:** no `SAVE_VERSION` bump — treat a legacy save's `undefined` field the same as `null` via loose equality (`recoveryTick == null`), matching the precedent already documented for `GameState.ts`'s `revoltDisabled` exception.
  **Why:** the field safely defaults to "no recovery ever recorded," which is the correct interpretation for any save older than this fix — a formal migration would add a version bump for no behavioral gain over the safe default.
  **If reversed:** change the check to `=== null` and add a `migrateV<N>ToV<N+1>` step defaulting the field to `null`, following `SaveLoad.ts`'s existing migration pattern.

This run's second decision changes a gameplay default (which events can recover the `safety` score after a death) — filing a `decision-review` follow-up issue per the rule below.

READY TO MERGE
