### PR TITLE
fix: Resolve #684 — legacy forced shift rest orphans the interrupted action

### DIFF
--- a/src/core/engine/GameLoop.ts
+++ b/src/core/engine/GameLoop.ts
@@ -1357,6 +1357,14 @@ function forceShiftRestIfNeeded(
   if (emp.activeActionId === null) return;
   if (emp.ticksWorked < WORK_DURATION_TICKS) return;
 
+  // Release the action this employee was actively working back to the pool
+  // before handing activeActionId to the rest action below — mirrors
+  // tickCollapse's and forceShiftRestIfNeededByPolicy's own interruptActiveAction
+  // call for the identical reason (#684): without this, overwriting
+  // activeActionId directly orphans the interrupted action permanently.
+  const priorActionId = emp.activeActionId;
+  interruptActiveAction(state, emp, priorActionId);
+
   // Find nearest living_quarters for target coordinates
   const building = findNearestLivingQuarters(state, emp.x, emp.z);
   let targetX = emp.x;

--- a/tests/unit/engine/GameLoop.test.ts
+++ b/tests/unit/engine/GameLoop.test.ts
@@ -3533,6 +3533,64 @@ describe('processShiftCycle (7.9)', () => {
 
     expect(events).toContain('employee:shift_change');
   });
+
+  // ── Interrupted work is released for reclaim, not orphaned (#684) ─────────
+
+  // forceShiftRestIfNeeded (the legacy, no-policy path exercised throughout
+  // this suite — state.sitePolicy.revision stays 0, the default for every
+  // fixture above) overwrites employee.activeActionId with the new rest
+  // action's id directly, without ever releasing the action it replaces —
+  // unlike its sibling forceShiftRestIfNeededByPolicy (#678, see the suite
+  // below) and tickCollapse, both of which call interruptActiveAction first.
+  // The interrupted action's record stays 'assigned' (or whatever in-flight
+  // status it had)/holderId === employee.id forever: never completed (the
+  // employee is resting, not ticking it) and never reclaimed (open-pool
+  // dispatch only matches 'queued' actions), so the employee goes idle
+  // permanently once the forced rest ends. This test fails on the old code
+  // (action stays held by the employee, activeActionId overwritten with no
+  // trace of it) and passes on the fix (action released to 'queued'/
+  // holderId: null, its remaining duration preserved for whoever reclaims it
+  // next).
+  it('releases the interrupted active action back to the pool instead of orphaning it (#684)', () => {
+    const state = createGame({ seed: SEED });
+    state.buildings.unlockedTiers.living_quarters = 3;
+    const rng = new Random(SEED);
+    expect(state.sitePolicy.revision).toBe(0); // no set_policy — the legacy path
+
+    const { employee } = hireEmployee(state.employees, 'driller', rng);
+    const interrupted: PendingAction = {
+      id: 950,
+      type: 'general_work',
+      requiredSkill: null,
+      requiredVehicleRole: null,
+      targetX: 5, targetZ: 5, targetY: 0,
+      payload: { note: 'drilling' },
+      targetEmployeeId: null,
+      status: 'in_progress',
+      holderId: employee.id,
+    };
+    state.pendingActions.push(interrupted);
+    employee.activeActionId = interrupted.id;
+    employee.taskTicksRemaining = 4; // work already in progress, not merely claimed
+    employee.ticksWorked = WORK_DURATION_TICKS - 1; // fires this call
+
+    placeBuilding(state.buildings, 'living_quarters', 0, 0, 100, 100, 2);
+
+    processShiftCycle(state, []);
+
+    // Released back to the pool — 'queued', unheld — not left 'assigned'/
+    // held by an employee who is now resting and will never tick it again.
+    const released = state.pendingActions.find(a => a.id === interrupted.id)!;
+    expect(released.status).toBe('queued');
+    expect(released.holderId).toBeNull();
+    // Remaining work is preserved on the action itself so whoever reclaims
+    // it resumes instead of restarting from scratch.
+    expect(released.payload['durationTicks']).toBe(4);
+    // The employee's activeActionId now points at the new rest action, not
+    // the interrupted one and not null.
+    expect(employee.activeActionId).not.toBe(interrupted.id);
+    expect(employee.activeActionId).not.toBeNull();
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #684

## Summary

`forceShiftRestIfNeeded` (`src/core/engine/GameLoop.ts`) forced an employee into shift rest by overwriting `emp.activeActionId` directly, without releasing the action being displaced. That action stayed `status: 'assigned'`, `holderId: <employee>` forever — never completed (employee is resting) and never reclaimed by open-pool dispatch (which only matches `'queued'` actions). Once rest ended the employee had nothing to do and the work item was gone.

This is the same defect class fixed in #678 for the policy-aware sibling `forceShiftRestIfNeededByPolicy`, and already avoided by `tickCollapse` — both call `interruptActiveAction` to release the interrupted action before reassigning the employee's active action. `forceShiftRestIfNeeded` (the legacy, no-policy path, which fires whenever `state.sitePolicy.revision === 0` — the default for any site that never calls `set_policy`) was the one path still missing it.

## Fix

Added the same two-line release call already used by the two sibling call sites, right after the `ticksWorked < WORK_DURATION_TICKS` guard (where `emp.activeActionId` is guaranteed non-null) and before the function reassigns it to the new rest action:

```ts
const priorActionId = emp.activeActionId;
interruptActiveAction(state, emp, priorActionId);
```

`interruptActiveAction` already exists and is already imported in this file (`./TaskDispatch.js`) — no new helper, no new abstraction, per the issue's explicit instruction to follow the existing pattern rather than invent a third shape.

`forceShiftRestIfNeededByPolicy` and `tickCollapse` are untouched (confirmed via `git diff` — the change is a single hunk, entirely inside `forceShiftRestIfNeeded`), preserving #678's byte-for-byte-unchanged requirement for the no-policy path through the policy-aware function.

## Tests

Regression test added in `tests/unit/engine/GameLoop.test.ts`, mirroring #678's own regression test but on the legacy no-policy path: employee mid-task, tier-2+ `living_quarters`, no `set_policy` ever called (`state.sitePolicy.revision === 0`), employee reaches `WORK_DURATION_TICKS`. Asserts the interrupted action becomes `'queued'`/`holderId: null` with ticks preserved, and that `employee.activeActionId` moves off the interrupted action. Confirmed failing against pre-fix code (`expected 'in_progress' to be 'queued'`), passing after the fix.

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** the issue's test requirement suggested a `drill_hole` or "comparable vehicle-gated task" for the interrupted action; #678's own regression test used a synthetic `general_work` action instead.
  **Chosen:** mirror #678's test shape exactly (`general_work`, synthetic payload).
  **Why:** consistency with the sibling #678 fix's test convention in the same file and describe-block neighborhood; `interruptActiveAction`'s vehicle-reservation-release branch is generic and already covered by `tickCollapse`'s own tests, so it doesn't need re-exercising per call site.
  **If reversed:** add an additional integration test using a real `drill_hole` + vehicle reservation in `tests/integration/needs.integration.test.ts`; no call site moves.

## Verification

- `static` — `npx tsc --noEmit`: PASS, 0 errors
- `logic` — `npx vitest run`: PASS, 331 test files, 10593 tests passed, 1 skipped, 0 failed
- `scenario` — `npm run scenarios`: PASS, 132/132 scenarios passed
- `visual` — not owed: pure `src/core/` simulation-logic change, no renderer/UI/console surface touched, no player-facing flow altered
- 5 parallel code reviewers (security, quality, i18n, duplication, semantic): all PASS. Two non-blocking suggestions surfaced (pre-existing `GameLoop.ts` file-size note; a test-duplication suggestion between this PR's new test and #678's, explicitly flagged non-blocking by its own reviewer) — neither actioned, neither warrants a follow-up issue.

READY TO MERGE