### PR TITLE
fix: Resolve #722 — collapse duplicated interaction-action test blocks into table-driven loop

### DIFF
--- a/tests/unit/scenario-defs-validation/interaction-actions.test.ts
+++ b/tests/unit/scenario-defs-validation/interaction-actions.test.ts
@@ -47,31 +47,48 @@ interface ActionTypeCheck<T extends InteractionStepAction['type'] = InteractionS
   check: (action: Extract<InteractionStepAction, { type: T }>, stepIndex: number) => void;
 }
 
+/**
+ * Builds one `ACTION_TYPE_CHECKS` entry. `T` is inferred per call from the
+ * literal `actionType` argument passed in — the same narrowing a function
+ * call always gets — so `check`'s `action` parameter is the one variant
+ * named by `actionType` while the body is being written. The array literal
+ * below can't do this itself: with the element type fixed to `ActionTypeCheck`
+ * (defaulting `T` to the full union), each object-literal element is checked
+ * against that default shape rather than inferring a narrower `T`, so a bare
+ * literal entry loses the narrowing `forEachActionOfType` promises. The cast
+ * here confines the erasure back to `ActionTypeCheck['check']` to this one
+ * spot, mirroring `forEachActionOfType`'s own cast.
+ */
+function defineActionCheck<T extends InteractionStepAction['type']>(
+  actionType: T,
+  description: string,
+  check: (action: Extract<InteractionStepAction, { type: T }>, stepIndex: number) => void,
+): ActionTypeCheck {
+  return { actionType, description, check: check as ActionTypeCheck['check'] };
+}
+
 const ACTION_TYPE_CHECKS: ActionTypeCheck[] = [
-  {
-    actionType: 'click', description: 'click actions have x and y coordinates',
-    check: (a) => { expect(typeof a.x).toBe('number'); expect(typeof a.y).toBe('number'); },
-  },
-  {
-    actionType: 'type', description: 'type actions have selector and text',
-    check: (a) => {
-      expect(typeof a.selector).toBe('string');
-      expect(a.selector.length).toBeGreaterThan(0);
-      expect(typeof a.text).toBe('string');
-    },
-  },
-  {
-    actionType: 'wait', description: 'wait actions have durationMs',
-    check: (a) => { expect(typeof a.durationMs).toBe('number'); expect(a.durationMs).toBeGreaterThan(0); },
-  },
-  {
-    actionType: 'waitForSelector', description: 'waitForSelector actions have selector',
-    check: (a) => { expect(typeof a.selector).toBe('string'); expect(a.selector.length).toBeGreaterThan(0); },
-  },
-  {
-    actionType: 'waitForTutorialStep',
-    description: 'waitForTutorialStep actions name at least one step id',
-    check: (a, i) => {
+  defineActionCheck('click', 'click actions have x and y coordinates', (a) => {
+    expect(typeof a.x).toBe('number');
+    expect(typeof a.y).toBe('number');
+  }),
+  defineActionCheck('type', 'type actions have selector and text', (a) => {
+    expect(typeof a.selector).toBe('string');
+    expect(a.selector.length).toBeGreaterThan(0);
+    expect(typeof a.text).toBe('string');
+  }),
+  defineActionCheck('wait', 'wait actions have durationMs', (a) => {
+    expect(typeof a.durationMs).toBe('number');
+    expect(a.durationMs).toBeGreaterThan(0);
+  }),
+  defineActionCheck('waitForSelector', 'waitForSelector actions have selector', (a) => {
+    expect(typeof a.selector).toBe('string');
+    expect(a.selector.length).toBeGreaterThan(0);
+  }),
+  defineActionCheck(
+    'waitForTutorialStep',
+    'waitForTutorialStep actions name at least one step id',
+    (a, i) => {
       const ids = Array.isArray(a.stepId) ? a.stepId : [a.stepId];
       expect(ids.length, `step[${i}] stepId must not be empty`).toBeGreaterThan(0);
       for (const id of ids) {
@@ -79,24 +96,27 @@ const ACTION_TYPE_CHECKS: ActionTypeCheck[] = [
         expect(id.length, `step[${i}] stepId entries must be non-empty`).toBeGreaterThan(0);
       }
     },
-  },
-  {
-    actionType: 'viewport', description: 'viewport actions have width and height',
-    check: (a) => { expect(typeof a.width).toBe('number'); expect(typeof a.height).toBe('number'); },
-  },
-  {
-    actionType: 'wheel', description: 'wheel actions have deltaX and deltaY',
-    check: (a) => { expect(typeof a.deltaX).toBe('number'); expect(typeof a.deltaY).toBe('number'); },
-  },
-  {
-    actionType: 'command',
-    description: 'command actions within interaction arrays have a command field',
-    check: (a) => { expect(typeof a.command).toBe('string'); expect(a.command.length).toBeGreaterThan(0); },
-  },
-  {
-    actionType: 'waitUntil',
-    description: 'waitUntil actions have field, equals, maxTicks, and timeoutMs',
-    check: (a) => {
+  ),
+  defineActionCheck('viewport', 'viewport actions have width and height', (a) => {
+    expect(typeof a.width).toBe('number');
+    expect(typeof a.height).toBe('number');
+  }),
+  defineActionCheck('wheel', 'wheel actions have deltaX and deltaY', (a) => {
+    expect(typeof a.deltaX).toBe('number');
+    expect(typeof a.deltaY).toBe('number');
+  }),
+  defineActionCheck(
+    'command',
+    'command actions within interaction arrays have a command field',
+    (a) => {
+      expect(typeof a.command).toBe('string');
+      expect(a.command.length).toBeGreaterThan(0);
+    },
+  ),
+  defineActionCheck(
+    'waitUntil',
+    'waitUntil actions have field, equals, maxTicks, and timeoutMs',
+    (a) => {
       expect(typeof a.field).toBe('string');
       expect(a.field.length).toBeGreaterThan(0);
       expect(a.equals).not.toBeUndefined();
@@ -105,16 +125,13 @@ const ACTION_TYPE_CHECKS: ActionTypeCheck[] = [
       expect(Number.isInteger(a.timeoutMs)).toBe(true);
       expect(a.timeoutMs).toBeGreaterThan(0);
     },
-  },
-  {
-    actionType: 'cameraFocus', description: 'cameraFocus actions have x, z, and distance',
-    check: (a) => {
-      expect(typeof a.x).toBe('number');
-      expect(typeof a.z).toBe('number');
-      expect(typeof a.distance).toBe('number');
-      expect(a.distance).toBeGreaterThan(0);
-    },
-  },
+  ),
+  defineActionCheck('cameraFocus', 'cameraFocus actions have x, z, and distance', (a) => {
+    expect(typeof a.x).toBe('number');
+    expect(typeof a.z).toBe('number');
+    expect(typeof a.distance).toBe('number');
+    expect(a.distance).toBeGreaterThan(0);
+  }),
 ];
 
 describe('Dual-play scenario steps — data-driven validation', () => {

--- a/tests/unit/scenario-defs-validation/interaction-actions.test.ts
+++ b/tests/unit/scenario-defs-validation/interaction-actions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { ScenarioStepDef } from '../../../scripts/shared/scenario-types.js';
+import type { InteractionStepAction, ScenarioDef, ScenarioStepDef } from '../../../scripts/shared/scenario-types.js';
 import { loadScenarioDef, SCENARIO_DIR } from '../../../scripts/shared/scenario-utils.js';
 import { ALL_SCENARIO_NAMES, KNOWN_INTERACTION_ACTION_TYPES } from './fixtures.js';
 
@@ -14,8 +14,114 @@ import { ALL_SCENARIO_NAMES, KNOWN_INTERACTION_ACTION_TYPES } from './fixtures.j
 // types are added to scenarios in the future.
 // ──────────────────────────────────────────────
 
+/**
+ * Shared scaffold behind the per-action-type checks below (issue #722): skip
+ * plain-string steps, skip steps with no `interaction` array, then run
+ * `check` against every action in the array matching `actionType`.
+ * `Extract<InteractionStepAction, { type: T }>` narrows the union to the one
+ * variant `actionType` names; TypeScript can't carry that narrowing through a
+ * runtime-supplied literal on its own, so the cast is confined to this one
+ * helper rather than repeated at each call site.
+ */
+function forEachActionOfType<T extends InteractionStepAction['type']>(
+  scenario: ScenarioDef,
+  actionType: T,
+  check: (action: Extract<InteractionStepAction, { type: T }>, stepIndex: number) => void,
+): void {
+  for (let i = 0; i < scenario.steps.length; i++) {
+    const step = scenario.steps[i];
+    if (typeof step === 'string') continue;
+    const stepObj = step as ScenarioStepDef;
+    if (!stepObj.interaction) continue;
+    for (const action of stepObj.interaction) {
+      if (action.type === actionType) {
+        check(action as Extract<InteractionStepAction, { type: T }>, i);
+      }
+    }
+  }
+}
+
+interface ActionTypeCheck<T extends InteractionStepAction['type'] = InteractionStepAction['type']> {
+  actionType: T;
+  description: string;
+  check: (action: Extract<InteractionStepAction, { type: T }>, stepIndex: number) => void;
+}
+
+const ACTION_TYPE_CHECKS: ActionTypeCheck[] = [
+  {
+    actionType: 'click', description: 'click actions have x and y coordinates',
+    check: (a) => { expect(typeof a.x).toBe('number'); expect(typeof a.y).toBe('number'); },
+  },
+  {
+    actionType: 'type', description: 'type actions have selector and text',
+    check: (a) => {
+      expect(typeof a.selector).toBe('string');
+      expect(a.selector.length).toBeGreaterThan(0);
+      expect(typeof a.text).toBe('string');
+    },
+  },
+  {
+    actionType: 'wait', description: 'wait actions have durationMs',
+    check: (a) => { expect(typeof a.durationMs).toBe('number'); expect(a.durationMs).toBeGreaterThan(0); },
+  },
+  {
+    actionType: 'waitForSelector', description: 'waitForSelector actions have selector',
+    check: (a) => { expect(typeof a.selector).toBe('string'); expect(a.selector.length).toBeGreaterThan(0); },
+  },
+  {
+    actionType: 'waitForTutorialStep',
+    description: 'waitForTutorialStep actions name at least one step id',
+    check: (a, i) => {
+      const ids = Array.isArray(a.stepId) ? a.stepId : [a.stepId];
+      expect(ids.length, `step[${i}] stepId must not be empty`).toBeGreaterThan(0);
+      for (const id of ids) {
+        expect(typeof id, `step[${i}] stepId entries must be strings`).toBe('string');
+        expect(id.length, `step[${i}] stepId entries must be non-empty`).toBeGreaterThan(0);
+      }
+    },
+  },
+  {
+    actionType: 'viewport', description: 'viewport actions have width and height',
+    check: (a) => { expect(typeof a.width).toBe('number'); expect(typeof a.height).toBe('number'); },
+  },
+  {
+    actionType: 'wheel', description: 'wheel actions have deltaX and deltaY',
+    check: (a) => { expect(typeof a.deltaX).toBe('number'); expect(typeof a.deltaY).toBe('number'); },
+  },
+  {
+    actionType: 'command',
+    description: 'command actions within interaction arrays have a command field',
+    check: (a) => { expect(typeof a.command).toBe('string'); expect(a.command.length).toBeGreaterThan(0); },
+  },
+  {
+    actionType: 'waitUntil',
+    description: 'waitUntil actions have field, equals, maxTicks, and timeoutMs',
+    check: (a) => {
+      expect(typeof a.field).toBe('string');
+      expect(a.field.length).toBeGreaterThan(0);
+      expect(a.equals).not.toBeUndefined();
+      expect(Number.isInteger(a.maxTicks)).toBe(true);
+      expect(a.maxTicks).toBeGreaterThan(0);
+      expect(Number.isInteger(a.timeoutMs)).toBe(true);
+      expect(a.timeoutMs).toBeGreaterThan(0);
+    },
+  },
+  {
+    actionType: 'cameraFocus', description: 'cameraFocus actions have x, z, and distance',
+    check: (a) => {
+      expect(typeof a.x).toBe('number');
+      expect(typeof a.z).toBe('number');
+      expect(typeof a.distance).toBe('number');
+      expect(a.distance).toBeGreaterThan(0);
+    },
+  },
+];
+
 describe('Dual-play scenario steps — data-driven validation', () => {
   for (const name of ALL_SCENARIO_NAMES) {
+    // Not table-driven: no type filter — scans every action of every step and
+    // throws (rather than skips) on a plain-string step, unlike the shared
+    // scaffold below.
     it(`${name} — all interaction action types are in the known set`, () => {
       const scenario = loadScenarioDef(name, SCENARIO_DIR);
       for (let i = 0; i < scenario.steps.length; i++) {
@@ -34,160 +140,16 @@ describe('Dual-play scenario steps — data-driven validation', () => {
       }
     });
 
-    it(`${name} — click actions have x and y coordinates`, () => {
-      const scenario = loadScenarioDef(name, SCENARIO_DIR);
-      for (let i = 0; i < scenario.steps.length; i++) {
-        const step = scenario.steps[i];
-        if (typeof step === 'string') continue;
-        const stepObj = step as ScenarioStepDef;
-        if (!stepObj.interaction) continue;
-        for (const action of stepObj.interaction) {
-          if (action.type === 'click') {
-            expect(typeof action.x).toBe('number');
-            expect(typeof action.y).toBe('number');
-          }
-        }
-      }
-    });
+    for (const entry of ACTION_TYPE_CHECKS) {
+      it(`${name} — ${entry.description}`, () => {
+        const scenario = loadScenarioDef(name, SCENARIO_DIR);
+        forEachActionOfType(scenario, entry.actionType, entry.check);
+      });
+    }
 
-    it(`${name} — type actions have selector and text`, () => {
-      const scenario = loadScenarioDef(name, SCENARIO_DIR);
-      for (let i = 0; i < scenario.steps.length; i++) {
-        const step = scenario.steps[i];
-        if (typeof step === 'string') continue;
-        const stepObj = step as ScenarioStepDef;
-        if (!stepObj.interaction) continue;
-        for (const action of stepObj.interaction) {
-          if (action.type === 'type') {
-            expect(typeof action.selector).toBe('string');
-            expect(action.selector.length).toBeGreaterThan(0);
-            expect(typeof action.text).toBe('string');
-          }
-        }
-      }
-    });
-
-    it(`${name} — wait actions have durationMs`, () => {
-      const scenario = loadScenarioDef(name, SCENARIO_DIR);
-      for (let i = 0; i < scenario.steps.length; i++) {
-        const step = scenario.steps[i];
-        if (typeof step === 'string') continue;
-        const stepObj = step as ScenarioStepDef;
-        if (!stepObj.interaction) continue;
-        for (const action of stepObj.interaction) {
-          if (action.type === 'wait') {
-            expect(typeof action.durationMs).toBe('number');
-            expect(action.durationMs).toBeGreaterThan(0);
-          }
-        }
-      }
-    });
-
-    it(`${name} — waitForSelector actions have selector`, () => {
-      const scenario = loadScenarioDef(name, SCENARIO_DIR);
-      for (let i = 0; i < scenario.steps.length; i++) {
-        const step = scenario.steps[i];
-        if (typeof step === 'string') continue;
-        const stepObj = step as ScenarioStepDef;
-        if (!stepObj.interaction) continue;
-        for (const action of stepObj.interaction) {
-          if (action.type === 'waitForSelector') {
-            expect(typeof action.selector).toBe('string');
-            expect(action.selector.length).toBeGreaterThan(0);
-          }
-        }
-      }
-    });
-
-    it(`${name} — waitForTutorialStep actions name at least one step id`, () => {
-      const scenario = loadScenarioDef(name, SCENARIO_DIR);
-      for (let i = 0; i < scenario.steps.length; i++) {
-        const step = scenario.steps[i];
-        if (typeof step === 'string') continue;
-        const stepObj = step as ScenarioStepDef;
-        if (!stepObj.interaction) continue;
-        for (const action of stepObj.interaction) {
-          if (action.type === 'waitForTutorialStep') {
-            const ids = Array.isArray(action.stepId) ? action.stepId : [action.stepId];
-            expect(ids.length, `step[${i}] stepId must not be empty`).toBeGreaterThan(0);
-            for (const id of ids) {
-              expect(typeof id, `step[${i}] stepId entries must be strings`).toBe('string');
-              expect(id.length, `step[${i}] stepId entries must be non-empty`).toBeGreaterThan(0);
-            }
-          }
-        }
-      }
-    });
-
-    it(`${name} — viewport actions have width and height`, () => {
-      const scenario = loadScenarioDef(name, SCENARIO_DIR);
-      for (let i = 0; i < scenario.steps.length; i++) {
-        const step = scenario.steps[i];
-        if (typeof step === 'string') continue;
-        const stepObj = step as ScenarioStepDef;
-        if (!stepObj.interaction) continue;
-        for (const action of stepObj.interaction) {
-          if (action.type === 'viewport') {
-            expect(typeof action.width).toBe('number');
-            expect(typeof action.height).toBe('number');
-          }
-        }
-      }
-    });
-
-    it(`${name} — wheel actions have deltaX and deltaY`, () => {
-      const scenario = loadScenarioDef(name, SCENARIO_DIR);
-      for (let i = 0; i < scenario.steps.length; i++) {
-        const step = scenario.steps[i];
-        if (typeof step === 'string') continue;
-        const stepObj = step as ScenarioStepDef;
-        if (!stepObj.interaction) continue;
-        for (const action of stepObj.interaction) {
-          if (action.type === 'wheel') {
-            expect(typeof action.deltaX).toBe('number');
-            expect(typeof action.deltaY).toBe('number');
-          }
-        }
-      }
-    });
-
-    it(`${name} — command actions within interaction arrays have a command field`, () => {
-      const scenario = loadScenarioDef(name, SCENARIO_DIR);
-      for (let i = 0; i < scenario.steps.length; i++) {
-        const step = scenario.steps[i];
-        if (typeof step === 'string') continue;
-        const stepObj = step as ScenarioStepDef;
-        if (!stepObj.interaction) continue;
-        for (const action of stepObj.interaction) {
-          if (action.type === 'command') {
-            expect(typeof action.command).toBe('string');
-            expect(action.command.length).toBeGreaterThan(0);
-          }
-        }
-      }
-    });
-
-    it(`${name} — waitUntil actions have field, equals, maxTicks, and timeoutMs`, () => {
-      const scenario = loadScenarioDef(name, SCENARIO_DIR);
-      for (let i = 0; i < scenario.steps.length; i++) {
-        const step = scenario.steps[i];
-        if (typeof step === 'string') continue;
-        const stepObj = step as ScenarioStepDef;
-        if (!stepObj.interaction) continue;
-        for (const action of stepObj.interaction) {
-          if (action.type === 'waitUntil') {
-            expect(typeof action.field).toBe('string');
-            expect(action.field.length).toBeGreaterThan(0);
-            expect(action.equals).not.toBeUndefined();
-            expect(Number.isInteger(action.maxTicks)).toBe(true);
-            expect(action.maxTicks).toBeGreaterThan(0);
-            expect(Number.isInteger(action.timeoutMs)).toBe(true);
-            expect(action.timeoutMs).toBeGreaterThan(0);
-          }
-        }
-      }
-    });
-
+    // Not table-driven: spans two action types (waitUntil, resolveEventIfPending)
+    // and computes one value per step rather than per action, unlike the
+    // shared scaffold above.
     it(`${name} — outer step timeout covers every inner waitUntil/resolveEventIfPending timeoutMs`, () => {
       // Regression for PR #616's headline bug: interaction-executor.ts and
       // the step runner race a step's own outer `timeout` (seconds,
@@ -210,24 +172,6 @@ describe('Dual-play scenario steps — data-driven validation', () => {
           } else if (action.type === 'resolveEventIfPending') {
             const innerMs = action.timeoutMs ?? 30000;
             expect(innerMs).toBeLessThanOrEqual(outerMs);
-          }
-        }
-      }
-    });
-
-    it(`${name} — cameraFocus actions have x, z, and distance`, () => {
-      const scenario = loadScenarioDef(name, SCENARIO_DIR);
-      for (let i = 0; i < scenario.steps.length; i++) {
-        const step = scenario.steps[i];
-        if (typeof step === 'string') continue;
-        const stepObj = step as ScenarioStepDef;
-        if (!stepObj.interaction) continue;
-        for (const action of stepObj.interaction) {
-          if (action.type === 'cameraFocus') {
-            expect(typeof action.x).toBe('number');
-            expect(typeof action.z).toBe('number');
-            expect(typeof action.distance).toBe('number');
-            expect(action.distance).toBeGreaterThan(0);
           }
         }
       }


### PR DESCRIPTION
Closes #722

10603 tests — all passing (1 pre-existing skip, unrelated)

## Summary

- Collapsed 10 of 12 near-identical per-action-type `it()` blocks in `tests/unit/scenario-defs-validation/interaction-actions.test.ts` into a table-driven `ACTION_TYPE_CHECKS` array + shared `forEachActionOfType<T>()` helper, eliminating the ~49% intra-file duplication jscpd flagged (now ~2.55% duplicated lines / ~4.65% duplicated tokens).
- Two structurally distinct blocks were deliberately left hand-written, each with a one-line comment explaining why: `all interaction action types are in the known set` (no type filter, throws instead of skips) and `outer step timeout covers every inner waitUntil/resolveEventIfPending timeoutMs` (spans two action types, computes one value per step rather than per action).
- Every original test title preserved verbatim — 110 scenarios × 12 tests = 1320, unchanged before/after (diffed the full sorted title list). No assertion logic changed; each `check` callback's assertions were copied out of their original inline bodies unmodified.
- File: 236 → 198 lines.
- No `src/` changes — pure test-file refactor.
- A code-review round caught a real defect in the first draft: building `ACTION_TYPE_CHECKS` as bare object literals in an explicitly-typed `ActionTypeCheck[]` array loses TypeScript's per-element generic narrowing (every `check` body actually typed against the full ~30-member `InteractionStepAction` union, not its own variant — invisible to `npm run typecheck` only because `tsconfig.json` excludes `tests/`). Fixed by wrapping each entry in a `defineActionCheck<T>()` factory so `T` is inferred per call the ordinary way; re-reviewed and confirmed by all 5 reviewers.

## Decisions taken

Defaulted under `agentic-decision-autonomy`:

- **What was open:** the issue names `tests/unit/scenario-defs-interaction-actions.test.ts`, a path that no longer exists — a later reorg after #703/#720 moved this content into a subdirectory.
  **Chosen:** targeted the actual current file, `tests/unit/scenario-defs-validation/interaction-actions.test.ts`, confirmed via `git log --follow` and matching the issue's stated 236-line count exactly.
  **Why:** `git log --follow` is the narrowest source that resolves a renamed file unambiguously; the line-count match rules out picking the wrong file.
  **If reversed:** n/a — factual correction, not a tunable.

- **What was open:** the issue says "13" per-action-type blocks; the file has 12, and 2 of those don't share the 10-way scaffold shape the other 10 do.
  **Chosen:** collapsed only the 10 structurally uniform single-type blocks into the table; left the other 2 hand-written with comments.
  **Why:** the issue's own edge-case guidance anticipates action types needing "unique logic ... without losing precision" — forcing a no-filter/throwing check and a two-type per-step check into a single-type-per-entry table would either lose that distinction or bloat every entry's shape for two callers' worth of generality.
  **If reversed:** nothing to reverse — this is the correct shape.

- **What was open:** this is a pure test-file refactor with no separate `src/` implementation, so the standard TDD branch-isolation cycle (implementer blind to tests on a separate `pipeline/impl-*` branch) has no natural mapping — the test file itself is the entire deliverable.
  **Chosen:** did the refactor directly on `pipeline/tests-722-32633840012`, then built `pipeline/feature-722-32633840012` from its HEAD. No `pipeline/impl-722-32633840012` branch was created.
  **Why:** branch isolation exists to prove an implementer satisfies tests it never saw; there is no separate production code here for an implementer to be blind to. Correctness was instead verified by diffing the full before/after test-title list and running the suite.
  **If reversed:** re-run through the standard `agentic-pipeline-tdd` skeleton/impl split if a future change to this file does introduce a genuine src/test split.

## Verification

- **static** (`npm run typecheck`): PASS, 0 errors
- **logic** (`npm run test`): PASS, 331 test files, 10603 tests passed, 1 skipped (pre-existing, unrelated)
- **build** (`npm run build`): PASS, no regression
- **scenario/visual**: not applicable — no `src/`, gameplay, console, or renderer/UI changes
- `npx jscpd tests/unit/scenario-defs-validation/interaction-actions.test.ts`: 48.71% → 2.55% duplicated lines, ~48.7% → 4.65% duplicated tokens — well below the issue's "materially lower" bar
- 5-way parallel code review (security, quality, i18n, duplication, semantic): all PASS after the type-narrowing fix

READY TO MERGE
