### PR TITLE
fix: Resolve #725 — generalize scenario-def step timeout floor for --screenshots capture cost

### DIFF
--- a/scripts/bench-scenarios.ts
+++ b/scripts/bench-scenarios.ts
@@ -176,7 +176,10 @@ async function benchInteraction(names: string[], port: number, screenshots: bool
 
       for (let s = 0; s < steps.length; s++) {
         const step = steps[s]!;
-        const stepTimeout = effectiveStepTimeoutMs(step, DEFAULT_STEP_TIMEOUT);
+        const stepTimeout = effectiveStepTimeoutMs(step, DEFAULT_STEP_TIMEOUT, {
+          enabled: screenshots,
+          shotsCount: 0,
+        });
         // See scenario-interaction-runner.ts's own copy of this comment
         // (PR #616 review round, item 5).
         let lastProgress = 'no interaction action has started yet';

--- a/scripts/scenario-defs/blast-basic.json
+++ b/scripts/scenario-defs/blast-basic.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42 staffed:true",
-      "timeout": 10,
+      "timeout": 30,
       "interaction": [
         {
           "type": "command",

--- a/scripts/scenario-defs/blast-charge-sequence-visual.json
+++ b/scripts/scenario-defs/blast-charge-sequence-visual.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42 staffed:true",
-      "timeout": 10,
+      "timeout": 30,
       "description": "Staffed opening (#551): a driller with blasting + drill_rig licence, a blaster with a bare blasting licence (no vehicle — #554's charge_hole actions are on-foot, requiredVehicleRole: null), plus an unmanned drill_rig, are hired/purchased for free at game-open — #553's automatic drill dispatch needs both to ever land an ordered hole.",
       "interaction": [
         {

--- a/scripts/scenario-defs/blast-detonation-sequence-ui.json
+++ b/scripts/scenario-defs/blast-detonation-sequence-ui.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42 staffed:true",
-      "timeout": 10,
+      "timeout": 30,
       "description": "Staffed opening (#551): a driller with blasting + drill_rig licence, plus an unmanned drill_rig, are hired/purchased for free at game-open — #553's automatic drill dispatch needs both to ever land an ordered hole.",
       "interaction": [
         {

--- a/scripts/scenario-defs/blast-drill-plan-ui.json
+++ b/scripts/scenario-defs/blast-drill-plan-ui.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42 staffed:true",
-      "timeout": 10,
+      "timeout": 40,
       "description": "Staffed opening (#551): a driller with blasting + drill_rig licence, plus an unmanned drill_rig, are hired/purchased for free at game-open — exactly what #553's automatic drill dispatch needs.",
       "interaction": [
         {

--- a/scripts/scenario-defs/blast-drill-plan-visual.json
+++ b/scripts/scenario-defs/blast-drill-plan-visual.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42 staffed:true",
-      "timeout": 10,
+      "timeout": 40,
       "description": "Staffed opening (#551): a driller with blasting + drill_rig licence, plus an unmanned drill_rig, are hired/purchased for free at game-open — exactly what #553's automatic drill dispatch needs.",
       "interaction": [
         {

--- a/scripts/scenario-defs/blast-execution-effects.json
+++ b/scripts/scenario-defs/blast-execution-effects.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42 staffed:true",
-      "timeout": 10,
+      "timeout": 40,
       "description": "Staffed opening (#551): a driller with blasting + drill_rig licence, plus an unmanned drill_rig, are hired/purchased for free at game-open -- #553's automatic drill dispatch needs both to ever land an ordered hole.",
       "interaction": [
         {

--- a/scripts/scenario-defs/blast-execution-visual.json
+++ b/scripts/scenario-defs/blast-execution-visual.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42 cash:3000000",
-      "timeout": 15,
+      "timeout": 40,
       "interaction": [
         {
           "type": "command",
@@ -309,7 +309,7 @@
     },
     {
       "command": "blast",
-      "timeout": 30,
+      "timeout": 70,
       "frames": 6,
       "interval": 50,
       "interaction": [
@@ -704,7 +704,7 @@
     },
     {
       "command": "blast",
-      "timeout": 30,
+      "timeout": 70,
       "frames": 6,
       "interval": 50,
       "interaction": [
@@ -1170,7 +1170,7 @@
     },
     {
       "command": "blast",
-      "timeout": 30,
+      "timeout": 70,
       "frames": 6,
       "interval": 50,
       "interaction": [
@@ -2757,7 +2757,7 @@
     },
     {
       "command": "blast",
-      "timeout": 30,
+      "timeout": 80,
       "frames": 8,
       "interval": 50,
       "interaction": [
@@ -3055,7 +3055,7 @@
     },
     {
       "command": "blast",
-      "timeout": 30,
+      "timeout": 70,
       "frames": 6,
       "interval": 50,
       "description": "#560: this step's own default post-step screenshot (plus the 6 extra frames above) is the proof artifact for this cycle -- inspect it for a closed boundary/skirt wall around the crater at the site's true edge, no see-through gap to whatever lies beyond (59,59)-(61,61).",

--- a/scripts/scenario-defs/blast-preview-software-tiers.json
+++ b/scripts/scenario-defs/blast-preview-software-tiers.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42 cash:80000 staffed:true",
-      "timeout": 10,
+      "timeout": 20,
       "description": "Staffed opening (#551): a driller with blasting + drill_rig licence, plus an unmanned drill_rig, are hired/purchased for free at game-open -- #553's automatic drill dispatch needs both to ever land an ordered hole.",
       "interaction": [
         {

--- a/scripts/scenario-defs/blast-preview-tiers-visual.json
+++ b/scripts/scenario-defs/blast-preview-tiers-visual.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42 staffed:true cash:90000",
-      "timeout": 10,
+      "timeout": 30,
       "description": "Staffed opening (#551): a driller with blasting + drill_rig licence, plus an unmanned drill_rig, are hired/purchased for free at game-open -- #553's automatic drill dispatch needs both to ever land an ordered hole. cash:90000, up from the 50000 default (#554): charging is real work now, and the staffed roster's payroll/fuel upkeep during the extra ticks the charge order below takes to land left too little for the tier:4 software purchase further down this file (observed short by ~1400 at the default).",
       "interaction": [
         {

--- a/scripts/scenario-defs/blast-report-metrics.json
+++ b/scripts/scenario-defs/blast-report-metrics.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42 staffed:true",
-      "timeout": 10,
+      "timeout": 30,
       "description": "Staffed opening (#551): a driller with blasting + drill_rig licence, plus an unmanned drill_rig, are hired/purchased for free at game-open -- #553's automatic drill dispatch needs both to ever land an ordered hole.",
       "interaction": [
         {

--- a/scripts/scenario-defs/blast-report-visual.json
+++ b/scripts/scenario-defs/blast-report-visual.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42 staffed:true",
-      "timeout": 15,
+      "timeout": 20,
       "description": "Staffed opening (#551): a driller with blasting + drill_rig licence, plus an unmanned drill_rig, are hired/purchased for free at game-open -- #553's automatic drill dispatch needs both to ever land an ordered hole.",
       "interaction": [
         {
@@ -147,7 +147,7 @@
     },
     {
       "command": "blast",
-      "timeout": 30,
+      "timeout": 70,
       "frames": 6,
       "interval": 50,
       "interaction": [

--- a/scripts/scenario-defs/blast-voxel-fragmentation-visual.json
+++ b/scripts/scenario-defs/blast-voxel-fragmentation-visual.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42 staffed:true",
-      "timeout": 15,
+      "timeout": 30,
       "description": "Staffed opening (#551): a driller with blasting + drill_rig licence, plus an unmanned drill_rig, are hired/purchased for free at game-open — #553's automatic drill dispatch needs both to ever land an ordered hole.",
       "interaction": [
         {
@@ -153,7 +153,7 @@
     },
     {
       "command": "blast",
-      "timeout": 30,
+      "timeout": 70,
       "frames": 6,
       "interval": 50,
       "interaction": [

--- a/scripts/scenario-defs/blast-voxel-fragmentation.json
+++ b/scripts/scenario-defs/blast-voxel-fragmentation.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42 cash:400000 staffed:true",
-      "timeout": 10,
+      "timeout": 40,
       "description": "Staffed opening (#551): a driller with blasting + drill_rig licence, plus an unmanned drill_rig, are hired/purchased for free at game-open — #553's automatic drill dispatch needs both to ever land an ordered hole. Cash bumped to $400,000: this file's 16-hole grid is a heavier workload than most (a single driller/drill_rig lands roughly one hole every 15 ticks door-to-door at this tight spacing), and every hole must actually land before charging — a partially-drilled 4x4 pattern would corrupt the crater/island physics this file exists to visualize — so headroom matters more than usual (no income anywhere in this file).",
       "interaction": [
         {

--- a/scripts/scenario-defs/building-destruction-visual.json
+++ b/scripts/scenario-defs/building-destruction-visual.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42 staffed:true",
-      "timeout": 30,
+      "timeout": 70,
       "description": "Staffed opening (#551): a driller with blasting + drill_rig licence, plus an unmanned drill_rig, are hired/purchased for free at game-open — exactly what #553's automatic drill dispatch needs.",
       "interaction": [
         {
@@ -341,7 +341,7 @@
     },
     {
       "command": "blast",
-      "timeout": 30,
+      "timeout": 70,
       "frames": 6,
       "interval": 50,
       "interaction": [

--- a/scripts/scenario-defs/building-living-visual.json
+++ b/scripts/scenario-defs/building-living-visual.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42 cash:200000",
-      "timeout": 10,
+      "timeout": 40,
       "interaction": [
         {
           "type": "command",

--- a/scripts/scenario-defs/building-ramp-visual.json
+++ b/scripts/scenario-defs/building-ramp-visual.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42 staffed:true",
-      "timeout": 15,
+      "timeout": 20,
       "interaction": [
         {
           "type": "command",

--- a/scripts/scenario-defs/building-tier-system-visual.json
+++ b/scripts/scenario-defs/building-tier-system-visual.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42 cash:200000",
-      "timeout": 10,
+      "timeout": 40,
       "interaction": [
         {
           "type": "command",

--- a/scripts/scenario-defs/building-training-visual.json
+++ b/scripts/scenario-defs/building-training-visual.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42 cash:60000",
-      "timeout": 10,
+      "timeout": 30,
       "interaction": [
         {
           "type": "command",

--- a/scripts/scenario-defs/building-vehicle-depot-visual.json
+++ b/scripts/scenario-defs/building-vehicle-depot-visual.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42",
-      "timeout": 10,
+      "timeout": 30,
       "interaction": [
         {
           "type": "command",

--- a/scripts/scenario-defs/building-warehouse-visual.json
+++ b/scripts/scenario-defs/building-warehouse-visual.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42",
-      "timeout": 10,
+      "timeout": 30,
       "interaction": [
         {
           "type": "command",

--- a/scripts/scenario-defs/core-loop-visual.json
+++ b/scripts/scenario-defs/core-loop-visual.json
@@ -471,7 +471,7 @@
     },
     {
       "command": "blast",
-      "timeout": 30,
+      "timeout": 70,
       "frames": 6,
       "interval": 50,
       "description": "#554-followup (issue #586 CI): restored to a real click sequence (execute -> confirm -> report close), same reason as the steps above -- matches blast-basic.json's own execute flow.",

--- a/scripts/scenario-defs/landscape-continuity-visual.json
+++ b/scripts/scenario-defs/landscape-continuity-visual.json
@@ -331,6 +331,7 @@
     },
     {
       "command": "tick 50",
+      "timeout": 90,
       "description": "#553: drain the ordered plan — the staffed driller/drill_rig lands all 4 holes well inside this pad (sandbox-measured landing at tick 41).",
       "interaction": [
         {

--- a/scripts/scenario-defs/main-menu-visual.json
+++ b/scripts/scenario-defs/main-menu-visual.json
@@ -65,7 +65,7 @@
     },
     {
       "command": "new_game seed:42",
-      "timeout": 15,
+      "timeout": 40,
       "interaction": [
         {
           "type": "command",

--- a/scripts/scenario-defs/needs-drain-visual.json
+++ b/scripts/scenario-defs/needs-drain-visual.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42",
-      "timeout": 10,
+      "timeout": 20,
       "interaction": [
         {
           "type": "command",

--- a/scripts/scenario-defs/needs-gauges-visual.json
+++ b/scripts/scenario-defs/needs-gauges-visual.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42",
-      "timeout": 10,
+      "timeout": 30,
       "interaction": [
         {
           "type": "command",

--- a/scripts/scenario-defs/safety-projection-visual.json
+++ b/scripts/scenario-defs/safety-projection-visual.json
@@ -545,7 +545,7 @@
     },
     {
       "command": "blast",
-      "timeout": 30,
+      "timeout": 70,
       "frames": 6,
       "interval": 50,
       "interaction": [

--- a/scripts/scenario-defs/tutorial-interactive.json
+++ b/scripts/scenario-defs/tutorial-interactive.json
@@ -263,7 +263,7 @@
     },
     {
       "command": "set_policy mode:continuous",
-      "timeout": 15,
+      "timeout": 30,
       "description": "#681: set-early-policy complete -- the tutorial's new step 3a-ii. A living_quarters alone does not force anyone to rest: forceShiftRestIfNeededByPolicy (GameLoop.ts) only engages once state.sitePolicy.revision > 0, so this policy application is what actually makes the building above protect the crew through the grind that follows. Selects Continuous under Shift Mode first, then Apply -- shift_8h's own SHIFT_DURATIONS_TICKS (8) is shorter than a single drill_hole action, so applying it this early interrupted the queued vehicle-gated work below before it could finish (confirmed live pre-#700). Continuous still forces rest on hunger/fatigue (shouldForceRest checks that in every mode), just without the shift-length cap. The later set-policy step (unchanged) still teaches shift_8h once the grind is over.",
       "role": "player",
       "interaction": [

--- a/scripts/scenario-defs/tutorial-steps-visual.json
+++ b/scripts/scenario-defs/tutorial-steps-visual.json
@@ -21,7 +21,7 @@
   "steps": [
     {
       "command": "campaign start level:tutorial_pit cash:300176",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "command",
@@ -61,7 +61,7 @@
     },
     {
       "command": "time resume",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "command",
@@ -73,7 +73,7 @@
     },
     {
       "command": "time speed 2",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "awaitUsable",
@@ -100,7 +100,7 @@
     },
     {
       "command": "employee hire role:surveyor",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "clickSelector",
@@ -129,7 +129,7 @@
     },
     {
       "command": "employee assign_skill 1 skill:geology level:3",
-      "timeout": 15,
+      "timeout": 30,
       "description": "Test-only bootstrap, not a tutorial stage: hiring already grants Rookie geology (ROLE_STARTING_QUALIFICATION in Employee.ts), this only raises the level for tighter survey estimates. No role tag -- there is no UI control for this and none should exist; the player-facing way to raise a skill is `employee train` at a training building, which this scenario does not need.",
       "interaction": [
         {
@@ -202,7 +202,7 @@
     },
     {
       "command": "employee hire role:driller",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "clickSelector",
@@ -231,7 +231,7 @@
     },
     {
       "command": "employee assign_skill 2 skill:blasting level:3",
-      "timeout": 15,
+      "timeout": 30,
       "description": "Test-only bootstrap, not a tutorial stage -- see the geology assign_skill step above for why this stays an unmarked (legacy) command step in interaction mode too.",
       "interaction": [
         {
@@ -285,7 +285,7 @@
     },
     {
       "command": "set_policy mode:continuous",
-      "timeout": 15,
+      "timeout": 40,
       "interaction": [
         {
           "type": "clickSelector",
@@ -589,7 +589,7 @@
     },
     {
       "command": "drill_plan grid rows:3 cols:3 spacing:3 depth:6 start:20,20 diameter:0.089",
-      "timeout": 15,
+      "timeout": 40,
       "interaction": [
         {
           "type": "clickSelector",
@@ -852,7 +852,7 @@
     },
     {
       "command": "charge hole:* explosive:boomite amount:5 stemming:2",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "clickSelector",
@@ -912,7 +912,7 @@
     },
     {
       "command": "sequence auto delay_step:25",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "clickSelector",
@@ -934,7 +934,7 @@
     },
     {
       "command": "blast",
-      "timeout": 30,
+      "timeout": 40,
       "interaction": [
         {
           "type": "clickSelector",
@@ -986,7 +986,7 @@
     },
     {
       "command": "scores",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "command",
@@ -1050,7 +1050,7 @@
     },
     {
       "command": "employee hire role:manager",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "clickSelector",
@@ -1079,7 +1079,7 @@
     },
     {
       "command": "employee assign_skill 3 skill:management level:3",
-      "timeout": 15,
+      "timeout": 30,
       "description": "Test-only bootstrap, not a tutorial stage -- see the geology assign_skill step above.",
       "interaction": [
         {
@@ -1112,7 +1112,7 @@
     },
     {
       "command": "contract accept type:rubble_disposal",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "clickSelector",
@@ -1138,7 +1138,7 @@
     },
     {
       "command": "employee hire role:driver",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "clickSelector",
@@ -1167,7 +1167,7 @@
     },
     {
       "command": "employee assign_skill 4 skill:driving.truck level:3",
-      "timeout": 15,
+      "timeout": 30,
       "description": "Test-only bootstrap, not a tutorial stage -- see the geology assign_skill step above; kept for command mode, which needs it for the explicit `vehicle driver 1 4` below to succeed identically.",
       "interaction": [
         {
@@ -1179,7 +1179,7 @@
     },
     {
       "command": "vehicle buy debris_hauler",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "clickSelector",
@@ -1329,7 +1329,7 @@
     },
     {
       "command": "finances",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "command",
@@ -1340,7 +1340,7 @@
     },
     {
       "command": "build_ramp start:10,15 end:10,25",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "command",
@@ -1352,7 +1352,7 @@
     },
     {
       "command": "needs",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "command",
@@ -1363,7 +1363,7 @@
     },
     {
       "command": "set_policy mode:shift_8h",
-      "timeout": 15,
+      "timeout": 40,
       "interaction": [
         {
           "type": "waitForTutorialStep",
@@ -1409,7 +1409,7 @@
     },
     {
       "command": "campaign complete",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "command",
@@ -1431,7 +1431,7 @@
     },
     {
       "command": "tick 1",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "command",

--- a/scripts/scenario-defs/vehicle-3d-rendering-visual.json
+++ b/scripts/scenario-defs/vehicle-3d-rendering-visual.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "campaign start level:dusty_hollow cash:200000",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "command",
@@ -23,7 +23,7 @@
     },
     {
       "command": "vehicle buy debris_hauler",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "clickSelector",
@@ -51,7 +51,7 @@
     },
     {
       "command": "vehicle buy rock_digger",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "awaitUsable",
@@ -75,7 +75,7 @@
     },
     {
       "command": "vehicle buy drill_rig",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "awaitUsable",
@@ -99,7 +99,7 @@
     },
     {
       "command": "vehicle buy building_destroyer",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "awaitUsable",
@@ -123,7 +123,7 @@
     },
     {
       "command": "vehicle buy rock_fragmenter",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "awaitUsable",
@@ -147,7 +147,7 @@
     },
     {
       "command": "vehicle list",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "command",
@@ -158,7 +158,7 @@
     },
     {
       "command": "state full",
-      "timeout": 15,
+      "timeout": 30,
       "interaction": [
         {
           "type": "command",

--- a/scripts/scenario-defs/vehicle-purchase-tier-ui-visual.json
+++ b/scripts/scenario-defs/vehicle-purchase-tier-ui-visual.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "command": "new_game seed:42 cash:300000",
-      "timeout": 10,
+      "timeout": 30,
       "description": "Bumped cash from 100k to 300k: the file's 4 purchases (25k+50k+50k+140k=265k) overdraw command mode past 100k before the tier:2/tier:3 buys, which would leave those buy buttons disabled for a real click -- exactly what this file's own name (tier UI) needs to demonstrate.",
       "interaction": [
         {

--- a/scripts/scenario-interaction-runner.ts
+++ b/scripts/scenario-interaction-runner.ts
@@ -107,7 +107,10 @@ export async function runScenarioInteraction(
       // specific error; this covers the residual case where several actions'
       // combined time — none individually stalling — exceeds the outer budget.
       let lastProgress = 'no interaction action has started yet';
-      const stepTimeout = effectiveStepTimeoutMs(step, DEFAULT_STEP_TIMEOUT);
+      const stepTimeout = effectiveStepTimeoutMs(step, DEFAULT_STEP_TIMEOUT, {
+        enabled: enableScreenshots,
+        shotsCount: shots.length,
+      });
       const timeoutPromise = new Promise<void>((_, reject) =>
         setTimeout(() => {
           timedOut = true;

--- a/scripts/shared/scenario-utils.ts
+++ b/scripts/shared/scenario-utils.ts
@@ -139,6 +139,20 @@ const DEFAULT_INNER_TIMEOUT_MS: Partial<Record<InteractionStepAction['type'], nu
 };
 
 /**
+ * Capture-cost floor (ms) for interaction-mode `--screenshots`: the base
+ * step-end capture plus every inline `screenshot` action plus the scenario's
+ * own `shots` count plus `step.frames`, each at `SOFTWARE_RASTER_FRAME_COST_MS`
+ * under software rasterization (#725). Exported so
+ * `tests/unit/scenario-defs-validation/interaction-actions.test.ts`'s #725
+ * regression check calls the real formula instead of reimplementing it by
+ * hand, which would otherwise silently drift out of sync with this file.
+ */
+export function captureCostFloorMs(step: ScenarioStepDef, shotsCount: number): number {
+  const screenshotActionCount = (step.interaction ?? []).filter(a => a.type === 'screenshot').length;
+  return (1 + screenshotActionCount + shotsCount + (step.frames ?? 0)) * SOFTWARE_RASTER_FRAME_COST_MS;
+}
+
+/**
  * A step's own outer `timeout` (seconds) and an inner action's `timeoutMs`
  * (ms) are raced independently by `scenario-interaction-runner.ts` /
  * `run-all-scenarios.ts` / `bench-scenarios.ts`, each against a fresh
@@ -158,6 +172,13 @@ const DEFAULT_INNER_TIMEOUT_MS: Partial<Record<InteractionStepAction['type'], nu
  * value the runners actually race against; that test catches a scenario
  * file whose *declared* `timeout` reads as misleadingly low to a human
  * editing it, even though the runners themselves no longer act on it alone.
+ *
+ * @param capture When provided with `enabled: true`, the returned deadline is
+ * also raised to cover interaction-mode `--screenshots` capture cost — base
+ * capture plus inline `screenshot` actions plus `capture.shotsCount` plus
+ * `step.frames`, at `SOFTWARE_RASTER_FRAME_COST_MS` per unit, via
+ * `captureCostFloorMs` (#725). Omitted or `enabled: false` leaves the return
+ * value unchanged from the pre-#725 behavior.
  */
 export function effectiveStepTimeoutMs(
   step: ScenarioStepDef,
@@ -185,9 +206,5 @@ export function effectiveStepTimeoutMs(
 
   if (!capture?.enabled) return base;
 
-  const screenshotActionCount = (step.interaction ?? []).filter(a => a.type === 'screenshot').length;
-  const captureFloorMs =
-    (1 + screenshotActionCount + capture.shotsCount + (step.frames ?? 0)) * SOFTWARE_RASTER_FRAME_COST_MS;
-
-  return Math.max(base, captureFloorMs);
+  return Math.max(base, captureCostFloorMs(step, capture.shotsCount));
 }

--- a/scripts/shared/scenario-utils.ts
+++ b/scripts/shared/scenario-utils.ts
@@ -113,6 +113,15 @@ export function loadScenarioDef(name: string, dir?: string): ScenarioDef {
 const TIMEOUT_MARGIN_MS = 5000;
 
 /**
+ * Per-frame cost of screenshot/frame capture under software rasterization
+ * (no GPU), documented in `.claude/CLAUDE.md`. Used by `effectiveStepTimeoutMs`
+ * to raise a step's effective floor when `--screenshots` is active, so a step
+ * with a low declared `timeout` doesn't false-timeout purely from capture
+ * overhead the runners themselves impose.
+ */
+export const SOFTWARE_RASTER_FRAME_COST_MS = 6000;
+
+/**
  * Effective inner deadline when an action's own `timeoutMs` is absent. Must
  * match what each executor actually applies — `waitUntil` has none (the
  * field is required); `resolveEventIfPending` defaults to 30000
@@ -150,7 +159,15 @@ const DEFAULT_INNER_TIMEOUT_MS: Partial<Record<InteractionStepAction['type'], nu
  * file whose *declared* `timeout` reads as misleadingly low to a human
  * editing it, even though the runners themselves no longer act on it alone.
  */
-export function effectiveStepTimeoutMs(step: ScenarioStepDef, defaultOuterSeconds: number): number {
+export function effectiveStepTimeoutMs(
+  step: ScenarioStepDef,
+  defaultOuterSeconds: number,
+  capture?: { enabled: boolean; shotsCount: number },
+): number {
+  // TODO: implement — capture-cost floor. Skeleton phase only: signature
+  // extended, param accepted but not yet folded into the return value.
+  void capture;
+
   const declaredMs = (step.timeout ?? defaultOuterSeconds) * 1000;
 
   let maxInnerMs = 0;

--- a/scripts/shared/scenario-utils.ts
+++ b/scripts/shared/scenario-utils.ts
@@ -164,10 +164,6 @@ export function effectiveStepTimeoutMs(
   defaultOuterSeconds: number,
   capture?: { enabled: boolean; shotsCount: number },
 ): number {
-  // TODO: implement — capture-cost floor. Skeleton phase only: signature
-  // extended, param accepted but not yet folded into the return value.
-  void capture;
-
   const declaredMs = (step.timeout ?? defaultOuterSeconds) * 1000;
 
   let maxInnerMs = 0;
@@ -185,5 +181,13 @@ export function effectiveStepTimeoutMs(
     maxInnerMs = Math.max(maxInnerMs, explicit ?? fallback ?? 0);
   }
 
-  return maxInnerMs === 0 ? declaredMs : Math.max(declaredMs, maxInnerMs + TIMEOUT_MARGIN_MS);
+  const base = maxInnerMs === 0 ? declaredMs : Math.max(declaredMs, maxInnerMs + TIMEOUT_MARGIN_MS);
+
+  if (!capture?.enabled) return base;
+
+  const screenshotActionCount = (step.interaction ?? []).filter(a => a.type === 'screenshot').length;
+  const captureFloorMs =
+    (1 + screenshotActionCount + capture.shotsCount + (step.frames ?? 0)) * SOFTWARE_RASTER_FRAME_COST_MS;
+
+  return Math.max(base, captureFloorMs);
 }

--- a/tests/unit/scenario-defs-validation/interaction-actions.test.ts
+++ b/tests/unit/scenario-defs-validation/interaction-actions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { InteractionStepAction, ScenarioDef, ScenarioStepDef } from '../../../scripts/shared/scenario-types.js';
-import { loadScenarioDef, SCENARIO_DIR, SOFTWARE_RASTER_FRAME_COST_MS } from '../../../scripts/shared/scenario-utils.js';
+import { captureCostFloorMs, loadScenarioDef, SCENARIO_DIR } from '../../../scripts/shared/scenario-utils.js';
 import { ALL_SCENARIO_NAMES, KNOWN_INTERACTION_ACTION_TYPES } from './fixtures.js';
 
 // Dual-play scenario steps — interaction array validation (data-driven) —
@@ -211,8 +211,7 @@ describe('Dual-play scenario steps — data-driven validation', () => {
         const step = scenario.steps[i];
         if (typeof step === 'string') continue;
         const stepObj = step as ScenarioStepDef;
-        const screenshotActions = (stepObj.interaction ?? []).filter(a => a.type === 'screenshot').length;
-        const floorMs = (1 + screenshotActions + shotsCount + (stepObj.frames ?? 0)) * SOFTWARE_RASTER_FRAME_COST_MS;
+        const floorMs = captureCostFloorMs(stepObj, shotsCount);
         const declaredMs = (stepObj.timeout ?? 60) * 1000;
         expect(
           declaredMs,

--- a/tests/unit/scenario-defs-validation/interaction-actions.test.ts
+++ b/tests/unit/scenario-defs-validation/interaction-actions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { InteractionStepAction, ScenarioDef, ScenarioStepDef } from '../../../scripts/shared/scenario-types.js';
-import { loadScenarioDef, SCENARIO_DIR } from '../../../scripts/shared/scenario-utils.js';
+import { loadScenarioDef, SCENARIO_DIR, SOFTWARE_RASTER_FRAME_COST_MS } from '../../../scripts/shared/scenario-utils.js';
 import { ALL_SCENARIO_NAMES, KNOWN_INTERACTION_ACTION_TYPES } from './fixtures.js';
 
 // Dual-play scenario steps — interaction array validation (data-driven) —
@@ -191,6 +191,33 @@ describe('Dual-play scenario steps — data-driven validation', () => {
             expect(innerMs).toBeLessThanOrEqual(outerMs);
           }
         }
+      }
+    });
+
+    // Generalizes issue #704's narrow, single-file lock (blast-visual-full.json
+    // only) to every scenario file, per issue #725: in interaction mode with
+    // `--screenshots`, each step also pays a capture cost
+    // (SOFTWARE_RASTER_FRAME_COST_MS per frame, software rasterization, no
+    // GPU, #475) for 1 base capture, each inline `{type:'screenshot'}`
+    // interaction action, the scenario-level `shots.length` (orbit angles
+    // captured every step when the scenario declares `shots`), and
+    // `step.frames`. A step whose declared `timeout` sits below this floor
+    // false-timeouts the instant `--screenshots` is used, regardless of
+    // whether the step's own work would have finished in time.
+    it(`${name} — declared step timeout covers interaction-mode --screenshots capture-cost floor (#725)`, () => {
+      const scenario = loadScenarioDef(name, SCENARIO_DIR);
+      const shotsCount = scenario.shots?.length ?? 0;
+      for (let i = 0; i < scenario.steps.length; i++) {
+        const step = scenario.steps[i];
+        if (typeof step === 'string') continue;
+        const stepObj = step as ScenarioStepDef;
+        const screenshotActions = (stepObj.interaction ?? []).filter(a => a.type === 'screenshot').length;
+        const floorMs = (1 + screenshotActions + shotsCount + (stepObj.frames ?? 0)) * SOFTWARE_RASTER_FRAME_COST_MS;
+        const declaredMs = (stepObj.timeout ?? 60) * 1000;
+        expect(
+          declaredMs,
+          `step[${i}] "${stepObj.command}" declared timeout ${declaredMs}ms is below the --screenshots capture-cost floor ${floorMs}ms`,
+        ).toBeGreaterThanOrEqual(floorMs);
       }
     });
   }

--- a/tests/unit/scenario-defs-validation/issue-regressions.test.ts
+++ b/tests/unit/scenario-defs-validation/issue-regressions.test.ts
@@ -145,54 +145,9 @@ describe('blast-visual-full.json H1/H2 charge-override steps click the per-hole 
   }
 });
 
-// ──────────────────────────────────────────────
-// 18. blast-visual-full.json's step timeouts cover interaction-mode
-// --screenshots capture cost (issue #704).
-//
-// Step timeouts were set without accounting for interaction-mode
-// --screenshots capture cost (1 base render + 4 `shots` angles per step,
-// plus any per-step `frames`, each costing several seconds under software
-// rasterization with no GPU). This locks in that each step's timeout budget
-// actually covers its capture cost.
-//
-// See scripts/scenario-defs/blast-visual-full.json and its top-level
-// `shots` array (4 camera angles captured after every step).
-// ──────────────────────────────────────────────
-describe('blast-visual-full.json step timeouts cover screenshot capture cost (#704)', () => {
-  // Per-frame capture cost under software rasterization (no GPU). Not an
-  // exported named constant anywhere in source as of #704 — hardcoded here.
-  // .claude/CLAUDE.md states this cost twice with two different figures
-  // ("~6s/frame" in one section, "~6.4s/frame" in another, same #475 root
-  // cause); using the lower figure still leaves comfortable margin at both
-  // fixed timeouts.
-  const SOFTWARE_RASTER_FRAME_COST_MS = 6000;
-
-  const scenario = loadScenarioDef('blast-visual-full', SCENARIO_DIR);
-  const shotsCount = scenario.shots?.length ?? 0;
-
-  it('step 0 timeout covers base + shots capture cost under software rasterization', () => {
-    const step = scenario.steps.find(
-      (s): s is ScenarioStepDef => typeof s !== 'string' && s.command === 'new_game seed:42 cash:200000',
-    );
-    expect(step, 'expected step 0 to be "new_game seed:42 cash:200000"').toBeDefined();
-
-    // floor = (1 base capture + shots.length + step.frames) * per-frame cost
-    const floorMs = (1 + shotsCount + (step!.frames ?? 0)) * SOFTWARE_RASTER_FRAME_COST_MS;
-    const declaredMs = (step!.timeout ?? 60) * 1000;
-
-    expect(declaredMs).toBeGreaterThanOrEqual(floorMs);
-  });
-
-  it('step 36 (blast) timeout covers base + frames + shots capture cost', () => {
-    const blastStep = scenario.steps.find(
-      (s): s is ScenarioStepDef => typeof s !== 'string' && s.command === 'blast',
-    );
-    expect(blastStep, 'expected a step with command "blast" in blast-visual-full.json').toBeDefined();
-    const step = blastStep as ScenarioStepDef;
-
-    const floorMs = (1 + shotsCount + (step.frames ?? 0)) * SOFTWARE_RASTER_FRAME_COST_MS;
-    const declaredMs = (step.timeout ?? 60) * 1000;
-
-    expect(declaredMs).toBeGreaterThanOrEqual(floorMs);
-  });
-});
+// Issue #704's blast-visual-full.json-only capture-cost timeout lock was
+// generalized to every scenario file by issue #725 — see
+// `tests/unit/scenario-defs-validation/interaction-actions.test.ts`'s
+// "declared step timeout covers interaction-mode --screenshots capture-cost
+// floor (#725)" check, which covers blast-visual-full.json too (it is a
+// member of VISUAL_SCENARIO_NAMES ⊂ ALL_SCENARIO_NAMES).

--- a/tests/unit/scripts/shared/scenario-utils.test.ts
+++ b/tests/unit/scripts/shared/scenario-utils.test.ts
@@ -13,7 +13,7 @@
 // `timeoutMs` and no `timeout` of its own is correct by construction.
 
 import { describe, it, expect } from 'vitest';
-import { effectiveStepTimeoutMs } from '../../../../scripts/shared/scenario-utils.js';
+import { effectiveStepTimeoutMs, SOFTWARE_RASTER_FRAME_COST_MS } from '../../../../scripts/shared/scenario-utils.js';
 import type { ScenarioStepDef } from '../../../../scripts/shared/scenario-types.js';
 
 const DEFAULT_OUTER_SECONDS = 60;
@@ -99,4 +99,87 @@ describe('effectiveStepTimeoutMs', () => {
       expect(effectiveStepTimeoutMs(s, DEFAULT_OUTER_SECONDS)).toBe(6000 + 5000);
     },
   );
+});
+
+// ──────────────────────────────────────────────
+// #725 — capture-cost floor. In interaction mode with `--screenshots`, every
+// step also pays a per-frame capture cost (SOFTWARE_RASTER_FRAME_COST_MS,
+// software rasterization, no GPU, #475) for: 1 base capture, each inline
+// `{type:'screenshot'}` interaction action, the scenario-level `shots.length`
+// (orbit angles captured every step when the scenario declares `shots`), and
+// `step.frames`. #704 fixed this by hand for blast-visual-full.json alone;
+// #725 folds the same floor into effectiveStepTimeoutMs itself via a new
+// optional 3rd `capture` param, so every scenario file benefits structurally
+// instead of one file being patched by hand.
+// ──────────────────────────────────────────────
+describe('effectiveStepTimeoutMs — capture-cost floor (#725)', () => {
+  it('is a no-op when capture is omitted entirely (backward compatibility)', () => {
+    const s = step({ timeout: 10 });
+    const withoutCapture = effectiveStepTimeoutMs(s, DEFAULT_OUTER_SECONDS);
+    expect(withoutCapture).toBe(10000);
+  });
+
+  it('is a no-op when capture.enabled is false, regardless of shotsCount', () => {
+    const s = step({ timeout: 10 });
+    const omitted = effectiveStepTimeoutMs(s, DEFAULT_OUTER_SECONDS);
+    const disabledZero = effectiveStepTimeoutMs(s, DEFAULT_OUTER_SECONDS, { enabled: false, shotsCount: 0 });
+    const disabledMany = effectiveStepTimeoutMs(s, DEFAULT_OUTER_SECONDS, { enabled: false, shotsCount: 50 });
+    expect(disabledZero).toBe(omitted);
+    expect(disabledMany).toBe(omitted);
+    expect(disabledMany).toBe(10000);
+  });
+
+  it('raises a low declared timeout to the capture-cost floor when shots are captured (floor wins)', () => {
+    // base = 10000 (declared timeout, no interaction actions to derive past).
+    // floor = (1 base capture + 0 screenshot actions + 3 shots + 0 frames) * SOFTWARE_RASTER_FRAME_COST_MS.
+    const s = step({ timeout: 10 });
+    const result = effectiveStepTimeoutMs(s, DEFAULT_OUTER_SECONDS, { enabled: true, shotsCount: 3 });
+    const floorMs = (1 + 0 + 3 + 0) * SOFTWARE_RASTER_FRAME_COST_MS;
+    expect(floorMs).toBe(24000);
+    expect(result).toBe(floorMs);
+  });
+
+  it('keeps the declared/derived base when it already exceeds the capture-cost floor (base wins)', () => {
+    // base = 120000 (declared timeout). floor = (1 + 0 + 0 + 0) * 6000 = 6000, well under base.
+    const s = step({ timeout: 120 });
+    const result = effectiveStepTimeoutMs(s, DEFAULT_OUTER_SECONDS, { enabled: true, shotsCount: 0 });
+    const floorMs = (1 + 0 + 0 + 0) * SOFTWARE_RASTER_FRAME_COST_MS;
+    expect(floorMs).toBe(6000);
+    expect(result).toBe(120000);
+  });
+
+  it('folds step.frames into the capture-cost floor', () => {
+    // base = 10000 (declared timeout). floor = (1 + 0 + 0 + 5) * 6000 = 36000.
+    const s = step({ timeout: 10, frames: 5 });
+    const result = effectiveStepTimeoutMs(s, DEFAULT_OUTER_SECONDS, { enabled: true, shotsCount: 0 });
+    const floorMs = (1 + 0 + 0 + 5) * SOFTWARE_RASTER_FRAME_COST_MS;
+    expect(floorMs).toBe(36000);
+    expect(result).toBe(floorMs);
+  });
+
+  it('counts inline {type: "screenshot"} interaction actions into the capture-cost floor', () => {
+    // base = 10000 (declared timeout). floor = (1 + 2 + 0 + 0) * 6000 = 18000.
+    const s = step({
+      timeout: 10,
+      interaction: [{ type: 'screenshot' }, { type: 'screenshot' }],
+    });
+    const result = effectiveStepTimeoutMs(s, DEFAULT_OUTER_SECONDS, { enabled: true, shotsCount: 0 });
+    const floorMs = (1 + 2 + 0 + 0) * SOFTWARE_RASTER_FRAME_COST_MS;
+    expect(floorMs).toBe(18000);
+    expect(result).toBe(floorMs);
+  });
+
+  it('folds shotsCount + step.frames + inline screenshot actions together into one floor (combined shape)', () => {
+    // base = 10000 (declared timeout).
+    // floor = (1 base + 1 inline screenshot action + 2 shots + 3 frames) * 6000 = 42000.
+    const s = step({
+      timeout: 10,
+      frames: 3,
+      interaction: [{ type: 'screenshot' }],
+    });
+    const result = effectiveStepTimeoutMs(s, DEFAULT_OUTER_SECONDS, { enabled: true, shotsCount: 2 });
+    const floorMs = (1 + 1 + 2 + 3) * SOFTWARE_RASTER_FRAME_COST_MS;
+    expect(floorMs).toBe(42000);
+    expect(result).toBe(floorMs);
+  });
 });


### PR DESCRIPTION
Closes #725

## Summary

Issue #704 fixed `scripts/scenario-defs/blast-visual-full.json`'s step timeouts, which were too low to cover the multi-angle `shots` capture cost (~6s/frame under software rasterization, #475) in interaction mode with `--screenshots`. That fix was scoped to one file. This PR generalizes it:

- `scripts/shared/scenario-utils.ts`: `effectiveStepTimeoutMs` gains an optional 3rd parameter `capture?: { enabled: boolean; shotsCount: number }`. When provided and `enabled`, the returned deadline is raised to `Math.max(base, captureCostFloorMs(step, capture.shotsCount))`, where the new exported `captureCostFloorMs(step, shotsCount)` computes `(1 base capture + inline screenshot interaction actions + shotsCount + step.frames) × SOFTWARE_RASTER_FRAME_COST_MS (6000ms)`. Omitted or `enabled: false` is a pure no-op — byte-identical to pre-#725 behavior.
- Wired into `scripts/scenario-interaction-runner.ts` (`{ enabled: enableScreenshots, shotsCount: shots.length }`) and `scripts/bench-scenarios.ts` (`{ enabled: screenshots, shotsCount: 0 }`, no orbit-shots concept there). `scripts/run-all-scenarios.ts` is unchanged — batch/command mode never screenshots, so its existing 2-arg call already gets the old behavior.
- Generic structural regression lock: `tests/unit/scenario-defs-validation/interaction-actions.test.ts` gained one new `it` per scenario name (looping `ALL_SCENARIO_NAMES`, alongside the existing outer/inner-timeout check), asserting every step's declared `timeout` covers `captureCostFloorMs`. This subsumes and replaces the #704-era single-file check in `tests/unit/scenario-defs-validation/issue-regressions.test.ts` (removed — `blast-visual-full.json` is covered by the generic check, which uses a strictly wider formula that also counts inline `screenshot` interaction actions).
- Raised `timeout` on 68 previously under-timed steps across 30 `scripts/scenario-defs/*.json` files (audit driven by the new structural test going red against `main`), starting with `blast-basic.json` step 0 (10s → 30s against a real floor of ~24s).

## Decisions taken

Defaulted under `agentic-decision-autonomy`.

- **What was open:** issue offered (a) extend `effectiveStepTimeoutMs` or (b) add a generic structural test, preferring (a) unless riskier than expected across `effectiveStepTimeoutMs`'s consumers.
  **Chosen:** both — (a) as the real runtime fix (only 3 call sites, fully optional 3rd param, so low risk), (b) generalized as a regression lock, replacing #704's narrow version rather than adding alongside it.
  **Why:** (a) alone leaves scenario-def JSON files looking wrong to a human editor even though the runtime silently overrides them; the project already has this precedent for outer/inner timeout checks. (b) alone would lock the check without fixing the 30 files' actual `--screenshots` runtime failures.
  **If reversed:** drop the `capture` parameter and its two call-site edits; the generic test still stands alone as a lock.

- **What was open:** exact capture-cost formula (issue asked to confirm the real constant name/value).
  **Chosen:** `SOFTWARE_RASTER_FRAME_COST_MS = 6000` (matches #704's own hardcoded value), formula `(1 + inline screenshot actions + shots.length + step.frames) × 6000ms`.
  **Why:** traced the actual capture call sites in `scenario-interaction-runner.ts`/`puppeteer-utils.ts` — #704's original formula omitted the inline-screenshot-action term; adding it is strictly more correct (catches `tutorial-steps-visual.json` step 35, which the narrower formula would have missed).
  **If reversed:** change the one constant or drop the `screenshotActionCount` term in `captureCostFloorMs` (single call site after this PR's duplication-review fix extracted it).

- **What was open:** how far to round up the 68 flagged steps' new `timeout` values above the computed floor.
  **Chosen:** round up to a comfortable round number (10s boundaries with margin), matching #704's own generous-bump convention (15→60, 30→120) rather than pinning the exact floor.
  **Why:** the floor is a software-rasterization estimate, not a hard ceiling; scheduling jitter and slower CI runners want headroom.
  **If reversed:** tighten any value; the structural test only requires `declaredMs >= floorMs`.

- **What was open:** whether `bench-scenarios.ts` needed the same wiring (issue's Files section didn't name it).
  **Chosen:** wired it in with `shotsCount: 0`.
  **Why:** consistency — same failure class applies to any `bench-scenarios.ts --screenshots` run; harmless since the floor can only enlarge a timeout, never shrink one.
  **If reversed:** skip that call site; nothing else depends on it.

## Review

Five parallel reviewers (security, quality, i18n, duplication, semantic) ran twice — first round found one duplication finding (the new structural test reimplemented the capture-floor formula inline instead of sharing it) and one semantic/doc finding (JSDoc not updated for the new `capture` param). Both fixed by extracting an exported `captureCostFloorMs(step, shotsCount)` helper used by both `effectiveStepTimeoutMs` and the test, plus a `@param capture` JSDoc addition. Second round: all five clean.

## Verification

- **static**: `npm run typecheck` — clean.
- **logic**: `npx vitest run` — 331 test files, 10718 tests passing, 1 pre-existing unrelated skip.
- **scenario**: `npm run scenarios` (command mode) — 132/132 passing.
- **visual**: no `src/renderer/`/`src/ui/` files in this diff; dev server unavailable in this session (`verify:env` reports DOWN) so not independently exercised here. This PR is labelled `full-ci` — see below — so CI's interaction-mode job covers the actual `--screenshots` capture-cost-floor behavior this issue is about, which this session cannot reproduce without a browser/GPU.

`full-ci` applied: `scripts/shared/scenario-utils.ts`'s `effectiveStepTimeoutMs`/`captureCostFloorMs` and `scripts/scenario-interaction-runner.ts` are the scenario harness itself — machinery every interaction-mode scenario runs through, not something one named scenario can stand in for.

10718 tests — all passing

## CI status

This PR's own channels (static, logic, command-mode scenario) are all green, and code review passed twice. `[await-ci]` reported CI RED: three interaction-mode shards failed (7/10, 9/10, 10/10), all with failures identical to what already fails on `main`'s own latest CI run (commit 83d8205, https://github.com/Nico2398/BlastSimulator2026/actions/runs/32636333040) and the several pushes before it — pre-existing, unrelated to this diff (a scenario-def step-timeout floor computation touching no tutorial-modal or drill/hole logic):

- shards 7/10 and 9/10: `tutorial-interactive`/`tutorial-steps-visual` — `report-close` inert-click failure, already tracked and already `blocked` at #707.
- shard 10/10: `ore-haul-dispatch` — `orderedHoleCount should be 9 but is 0` in the in-browser path only (command mode passes). Not previously tracked; filed as #738.

Left as draft without `READY TO MERGE` rather than spending this PR's CI-fix budget on three unrelated, already-tracked game-logic defects. Unblocking: #707 and #738 land (either run), then this PR's CI is re-run (push a no-op commit or re-run the workflow) and re-marked `READY TO MERGE` once green.
