### PR TITLE
fix: Resolve #726 — drop dead typeof-string check from #704 test predicates

### DIFF
--- a/tests/unit/scenario-defs-validation/issue-regressions.test.ts
+++ b/tests/unit/scenario-defs-validation/issue-regressions.test.ts
@@ -171,9 +171,7 @@ describe('blast-visual-full.json step timeouts cover screenshot capture cost (#7
   const shotsCount = scenario.shots?.length ?? 0;
 
   it('step 0 timeout covers base + shots capture cost under software rasterization', () => {
-    const step = scenario.steps.find(
-      (s): s is ScenarioStepDef => typeof s !== 'string' && s.command === 'new_game seed:42 cash:200000',
-    );
+    const step = scenario.steps.find(s => s.command === 'new_game seed:42 cash:200000');
     expect(step, 'expected step 0 to be "new_game seed:42 cash:200000"').toBeDefined();
 
     // floor = (1 base capture + shots.length + step.frames) * per-frame cost
@@ -184,14 +182,11 @@ describe('blast-visual-full.json step timeouts cover screenshot capture cost (#7
   });
 
   it('step 36 (blast) timeout covers base + frames + shots capture cost', () => {
-    const blastStep = scenario.steps.find(
-      (s): s is ScenarioStepDef => typeof s !== 'string' && s.command === 'blast',
-    );
+    const blastStep = scenario.steps.find(s => s.command === 'blast');
     expect(blastStep, 'expected a step with command "blast" in blast-visual-full.json').toBeDefined();
-    const step = blastStep as ScenarioStepDef;
 
-    const floorMs = (1 + shotsCount + (step.frames ?? 0)) * SOFTWARE_RASTER_FRAME_COST_MS;
-    const declaredMs = (step.timeout ?? 60) * 1000;
+    const floorMs = (1 + shotsCount + (blastStep!.frames ?? 0)) * SOFTWARE_RASTER_FRAME_COST_MS;
+    const declaredMs = (blastStep!.timeout ?? 60) * 1000;
 
     expect(declaredMs).toBeGreaterThanOrEqual(floorMs);
   });


### PR DESCRIPTION
Closes #726

15 tests — all passing (`tests/unit/scenario-defs-validation/issue-regressions.test.ts`)

## Summary

Removes the dead `typeof s !== 'string'` type-narrowing check from the two `.find()` step-lookup predicates in the file's `#704` regression-test section. `scenario.steps` is typed `ScenarioStepDef[]` (`scripts/shared/scenario-types.ts`), never `(string | ScenarioStepDef)[]`, so the check was always true and narrowed nothing. Predicates now match the plain style already used in the file's `#694` section (`scenario.steps.find(s => s.command === command)`).

No source (`src/`, `scripts/` non-test) files changed — this is a test-file-only simplification, no behavior change.

## Decisions taken

Defaulted under `agentic-decision-autonomy`. Nothing blocked this run.

- **What was open:** the issue's stated scope was "the two `.find()` predicates," but removing the `typeof s !== 'string'` guard also makes the immediately-following `const step = blastStep as ScenarioStepDef;` cast in the second test doubly redundant — `blastStep` is already `ScenarioStepDef | undefined` by plain inference once the guard is gone.
  **Chosen:** drop that cast line too, and update its two subsequent `step.` references to `blastStep!.` non-null assertions — matching the `#694` section's own convention (`step!.interaction!`) rather than keeping an intermediate re-typed variable.
  **Why:** leaving the cast in place after removing the guard that made it necessary would just swap one piece of dead code for another, using the same reasoning the issue itself already applies (the type was never a union).
  **If reversed:** keep `const step = blastStep as ScenarioStepDef;` and its subsequent `step.` references; only the two `.find()` calls need to change to satisfy the issue as literally scoped.

## Verification

- **static** (`npm run typecheck`): PASS — 0 errors
- **logic** (`npm run test`): PASS — 10603 passed, 1 skipped, 0 failed (331 files), including the `#704`/`#694` regression file (15/15)
- **scenario** (`npm run scenarios`): PASS — 132/132, command mode
- **build**: PASS — production build succeeds
- **visual**: not applicable — no renderer/UI/player-facing code touched

Reviewed by @security-reviewer, @quality-reviewer, @i18n-reviewer, @duplication-reviewer, @semantic-reviewer — all PASS, zero findings.

READY TO MERGE
