### PR TITLE
fix: Resolve #730 — tutorial-interactive step 11 outer timeout too low for interaction mode

### DIFF
--- a/scripts/scenario-defs/tutorial-interactive.json
+++ b/scripts/scenario-defs/tutorial-interactive.json
@@ -263,7 +263,7 @@
     },
     {
       "command": "set_policy mode:continuous",
-      "timeout": 15,
+      "timeout": 30,
       "description": "#681: set-early-policy complete -- the tutorial's new step 3a-ii. A living_quarters alone does not force anyone to rest: forceShiftRestIfNeededByPolicy (GameLoop.ts) only engages once state.sitePolicy.revision > 0, so this policy application is what actually makes the building above protect the crew through the grind that follows. Selects Continuous under Shift Mode first, then Apply -- shift_8h's own SHIFT_DURATIONS_TICKS (8) is shorter than a single drill_hole action, so applying it this early interrupted the queued vehicle-gated work below before it could finish (confirmed live pre-#700). Continuous still forces rest on hunger/fatigue (shouldForceRest checks that in every mode), just without the shift-length cap. The later set-policy step (unchanged) still teaches shift_8h once the grind is over.",
       "role": "player",
       "interaction": [

--- a/tests/unit/scenario-defs-validation/interaction-actions.test.ts
+++ b/tests/unit/scenario-defs-validation/interaction-actions.test.ts
@@ -195,3 +195,44 @@ describe('Dual-play scenario steps — data-driven validation', () => {
     });
   }
 });
+
+// ──────────────────────────────────────────────
+// 12. tutorial-interactive.json — outer step timeout covers every inner
+// waitForTutorialStep deadline (issue #730)
+//
+// Deliberately scoped to this one file rather than folded into the shared
+// cross-file check above (which only covers waitUntil/resolveEventIfPending):
+// tutorial-steps-visual.json has 14 pre-existing waitForTutorialStep steps
+// whose outer timeout does not cover the 30000ms inner default, and pulling
+// them into scope here is out of scope for #730 (tracked separately). This
+// check exists to catch step 11 (`set-early-policy`, `set_policy
+// mode:continuous`), which declares `"timeout": 15` while its
+// waitForTutorialStep action falls back to the 30000ms default
+// (interaction-executor.ts's `action.timeout ?? 30000`) — the 5 preceding
+// DOM round-trip actions in that step's own interaction array eat into the
+// 15s outer budget before the wait loop gets a real chance, stalling
+// interaction-mode scenario runs at that step. Every other
+// waitForTutorialStep-gated step in this file uses the file's own
+// established `"timeout": 30` convention (e.g. `build-living-quarters`,
+// step 10) — step 11's `15` is the lone outlier.
+// ──────────────────────────────────────────────
+describe('tutorial-interactive.json — outer step timeout covers every inner waitForTutorialStep timeout', () => {
+  const scenario = loadScenarioDef('tutorial-interactive', SCENARIO_DIR);
+
+  for (let i = 0; i < scenario.steps.length; i++) {
+    const step = scenario.steps[i];
+    if (typeof step === 'string') continue;
+    const stepObj = step as ScenarioStepDef;
+    if (!stepObj.interaction) continue;
+
+    for (const action of stepObj.interaction) {
+      if (action.type !== 'waitForTutorialStep') continue;
+
+      it(`step[${i}] (${stepObj.description ?? stepObj.command}) — outer timeout covers waitForTutorialStep's inner timeout`, () => {
+        const outerMs = (stepObj.timeout ?? 60) * 1000;
+        const innerMs = action.timeout ?? 30000;
+        expect(outerMs).toBeGreaterThanOrEqual(innerMs);
+      });
+    }
+  }
+});

--- a/tests/unit/scenario-defs-validation/interaction-actions.test.ts
+++ b/tests/unit/scenario-defs-validation/interaction-actions.test.ts
@@ -219,20 +219,12 @@ describe('Dual-play scenario steps — data-driven validation', () => {
 describe('tutorial-interactive.json — outer step timeout covers every inner waitForTutorialStep timeout', () => {
   const scenario = loadScenarioDef('tutorial-interactive', SCENARIO_DIR);
 
-  for (let i = 0; i < scenario.steps.length; i++) {
-    const step = scenario.steps[i];
-    if (typeof step === 'string') continue;
-    const stepObj = step as ScenarioStepDef;
-    if (!stepObj.interaction) continue;
-
-    for (const action of stepObj.interaction) {
-      if (action.type !== 'waitForTutorialStep') continue;
-
-      it(`step[${i}] (${stepObj.description ?? stepObj.command}) — outer timeout covers waitForTutorialStep's inner timeout`, () => {
-        const outerMs = (stepObj.timeout ?? 60) * 1000;
-        const innerMs = action.timeout ?? 30000;
-        expect(outerMs).toBeGreaterThanOrEqual(innerMs);
-      });
-    }
-  }
+  forEachActionOfType(scenario, 'waitForTutorialStep', (action, i) => {
+    const stepObj = scenario.steps[i] as ScenarioStepDef;
+    it(`step[${i}] (${stepObj.description ?? stepObj.command}) — outer timeout covers waitForTutorialStep's inner timeout`, () => {
+      const outerMs = (stepObj.timeout ?? 60) * 1000;
+      const innerMs = action.timeout ?? 30000;
+      expect(outerMs).toBeGreaterThanOrEqual(innerMs);
+    });
+  });
 });


### PR DESCRIPTION
Closes #730

## Summary

`scripts/scenario-defs/tutorial-interactive.json` step 11 (`set-early-policy`, `set_policy mode:continuous`) declared an outer `"timeout"` of `15` seconds while its `waitForTutorialStep` action's inner deadline defaults to 30000ms — and 5 preceding DOM round-trip actions in the same step consumed most of that 15s budget in slow/headless rendering, so the step's outer timeout fired before the wait loop got a real chance. This produced a hard, deterministic (3/3) stall at step 11 in interaction-mode runs, blocking every later step in the file, including #707's own blast-step verification.

Fix: raise step 11's `"timeout"` from `15` to `30`, matching every other `waitForTutorialStep`-gated step in this same file (the file's own established, proven-working convention — e.g. `build-living-quarters`, step 10, has more preceding actions and was never reported failing).

Added a table-driven regression test (`tests/unit/scenario-defs-validation/interaction-actions.test.ts`) asserting, for every `waitForTutorialStep`-gated step in `tutorial-interactive.json`, that the outer timeout covers the inner action's deadline. Reuses the existing `forEachActionOfType` helper (from #734/#722) rather than a manual walk loop, per code review.

10630 tests — all passing (331 files), plus the new regression test (39 cases in its file, table-driven).

## Decisions taken

Defaulted under `agentic-decision-autonomy`:

- **What was open:** the issue named only `tutorial-interactive.json` step 11, but the identical outer/inner timeout mismatch pattern also exists, unfixed, in `scripts/scenario-defs/tutorial-steps-visual.json` (14 more instances), and the shared `effectiveStepTimeoutMs` helper (`scripts/shared/scenario-utils.ts`) structurally can't see `waitForTutorialStep`'s own `timeout` field at all.
  **Chosen:** fix only the one step this issue names and verifies; do not touch `tutorial-steps-visual.json` or the shared timeout-derivation helper in this PR.
  **Why:** this issue's own Files/Test/Verification sections name exactly one file and one step; the fix is fully self-contained. Pulling in the systemic fix would force fixing 14 more unrelated steps as a side effect.
  **If reversed:** widen `interaction-actions.test.ts`'s existing shared outer/inner check to include `waitForTutorialStep` (add a `DEFAULT_INNER_TIMEOUT_MS` entry), then fix whatever it flags in `tutorial-steps-visual.json`. Filed as a follow-up issue (see below).

- **What was open:** exact replacement timeout value for step 11.
  **Chosen:** `30` seconds, matching all 10 other `waitForTutorialStep`-gated steps in this file.
  **Why:** proven-working convention already in the file, not an invented number.
  **If reversed:** raise `"timeout": 30` further at `scripts/scenario-defs/tutorial-interactive.json` line 266 if CI's slower interaction-mode shard shows it marginal.

## Verification

- `static` — `npx tsc --noEmit`: clean.
- `logic` — `npx vitest run`: 331/331 files, 10630/10631 tests passed (1 pre-existing skip), no regressions.
- `scenario` (command mode) — `npm run scenarios`: 132/132 passed, including `tutorial-interactive` (46/46 steps) end-to-end — confirms the timeout bump is not a command-mode-only fix (command mode never executes `interaction` arrays, so this is expected and confirmed unaffected).
- `visual` (interaction mode, this session) — `npm run scenario -- --scenario tutorial-interactive --mode interaction --screenshots`, run **twice**: both runs pass step 11 cleanly (`"Advanced 1 tick(s). Now at tick 20. No events fired."`, no timeout), reversing the issue's 3/3 stall reproduction. Screenshots inspected: the Continuous policy selection takes effect and the tutorial rail advances to step 7/31 "Build Driving Center" with the Build toolbar tab live (gold highlight), confirming `build-driving-center` goes live on `#bs-toolbar[data-panel="build"]` as expected.
- `full-ci` label carried over from the issue — CI's `Scenarios (interaction mode)` job re-confirms this across all shards.

### Found during verification, out of scope for this PR

Both interaction-mode runs progressed cleanly through all 30 subsequent steps and then hit an **unrelated, pre-existing** failure at the `blast` step: `clickSelector "[data-action=\"report-close\"]"` fails because the element is `pointer-events: none` — the tutorial rail races ahead to `event-fire-resolve` before the click lands. Reproduced identically both runs (deterministic, not flaky). This is the exact symptom #707 ("Tutorial — blast report-close races the scores card's auto-advance in interaction mode") describes; #707 is still open and `blocked`, and its "already fixed on main" verdict does not hold up now that #730 unblocks the scenario far enough to actually reach it. Commented on #707 with this reproduction; not fixed here — different step, different mechanism, outside #730's own Files/Test/Verification scope.


