### PR TITLE
fix: Resolve #732 — replace duplicated inline morale clamp with shared clampScore

### DIFF
--- a/src/console/commands/events.ts
+++ b/src/console/commands/events.ts
@@ -40,7 +40,7 @@ import { updateArrest } from '../../core/campaign/CriminalArrest.js';
 import { updateRevolt } from '../../core/campaign/WorkerRevolt.js';
 import { checkLevelComplete } from '../../core/campaign/LevelTransition.js';
 import { snapshotStats } from '../../core/campaign/SuccessTracker.js';
-import { updateScores, type ScoreInputs } from '../../core/scores/ScoreManager.js';
+import { updateScores, clampScore, type ScoreInputs } from '../../core/scores/ScoreManager.js';
 import { CONTRACT_REFRESH_INTERVAL } from '../../core/config/balance.js';
 import { BASE_TICK_MS } from '../../core/engine/GameLoop.js';
 import {
@@ -182,7 +182,7 @@ export function tickCommand(
     for (const emp of state.employees.employees) {
       if (!emp.alive) continue;
       tickNeedGauges(emp, employeeWorkState(emp));
-      emp.morale = Math.max(0, Math.min(100, emp.morale + needsMoraleEffect(emp)));
+      emp.morale = clampScore(emp.morale + needsMoraleEffect(emp));
     }
     const firedEvents: FiredEvent[] = [];
     // Complete rests started on a prior tick before creating any new ones —

--- a/tests/unit/console/events-command.test.ts
+++ b/tests/unit/console/events-command.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect } from 'vitest';
 import { createRunner } from '../../../src/console/createRunner.js';
 import { buildEventContext, tickCommand, eventCommand } from '../../../src/console/commands/events.js';
 import { killEmployee } from '../../../src/core/entities/Employee.js';
-import { REVOLT_TICKS } from '../../../src/core/config/balance.js';
+import { REVOLT_TICKS, NEED_WELL_RESTED_THRESHOLD } from '../../../src/core/config/balance.js';
 
 describe('buildEventContext (#592)', () => {
   it('reports employeeCount over the living roster only, excluding a killed employee still physically present in the array', () => {
@@ -73,5 +73,70 @@ describe('revolt end-condition is unconditional (#682)', () => {
     expect(ctx.state!.revolt.ticksAtZero).toBeGreaterThanOrEqual(REVOLT_TICKS);
     expect(ctx.state!.levelEndReason).toBe('worker_revolt');
     expect(ctx.state!.levelEnded).toBe(true);
+  });
+});
+
+describe('employee morale clamp boundaries (#732 — shared clampScore helper)', () => {
+  // tickCommand's needs loop (src/console/commands/events.ts) currently clamps
+  // morale inline with Math.max(0, Math.min(100, ...)). #732 swaps that for
+  // the already-exported clampScore (src/core/scores/ScoreManager.ts), which
+  // is mathematically identical — these tests pin the observable behavior at
+  // both ends of the 0–100 range so the swap can't silently change it.
+  //
+  // tickCommand's needs loop runs tickNeedGauges (which drains hunger/
+  // fatigue/breakNeed for this tick) BEFORE computing needsMoraleEffect off
+  // the now-drained gauge values, both within the same tick (events.ts lines
+  // 184–185). Gauge values below are set with enough margin that one tick's
+  // drain cannot cross a needsMoraleEffect threshold bucket.
+
+  it('floor: morale cannot drop below 0 even when all three need gauges are critical', () => {
+    const { runner, ctx } = createRunner();
+    runner.run('new_game mine_type:desert seed:42');
+    runner.run('employee hire role:driller');
+
+    const emp = ctx.state!.employees.employees[0]!;
+    emp.morale = 0;
+    // Below NEED_MORALE_EFFECT_THRESHOLDS.suffering (15) on all three gauges
+    // → needsMoraleEffect's most negative per-gauge bucket (critical, -3.0
+    // each) fires for hunger, fatigue, and breakNeed simultaneously.
+    emp.hunger = 5;
+    emp.fatigue = 5;
+    emp.breakNeed = 5;
+
+    tickCommand(ctx, ['1'], {});
+    if (ctx.state!.events.pendingEvent) {
+      ctx.state!.isPaused = false;
+      eventCommand(ctx, ['choose', '0'], {});
+    }
+
+    expect(emp.morale).toBe(0);
+    expect(emp.morale).toBeGreaterThanOrEqual(0);
+  });
+
+  it('ceiling: morale cannot rise above 100 when all three need gauges are well-rested', () => {
+    const { runner, ctx } = createRunner();
+    runner.run('new_game mine_type:desert seed:42');
+    runner.run('employee hire role:driller');
+
+    const emp = ctx.state!.employees.employees[0]!;
+    emp.morale = 100;
+    // Well above NEED_WELL_RESTED_THRESHOLD (80) on all three gauges, with
+    // enough margin that one tick's drain (idle: <=0.5/gauge, further scaled
+    // by the morale drain multiplier) cannot pull any gauge back down to the
+    // threshold — needsMoraleEffect awards the "comfortable" bucket (0 each)
+    // plus the +1 well-rested bonus, for a net of +1.
+    const wellRestedValue = NEED_WELL_RESTED_THRESHOLD + 10;
+    emp.hunger = wellRestedValue;
+    emp.fatigue = wellRestedValue;
+    emp.breakNeed = wellRestedValue;
+
+    tickCommand(ctx, ['1'], {});
+    if (ctx.state!.events.pendingEvent) {
+      ctx.state!.isPaused = false;
+      eventCommand(ctx, ['choose', '0'], {});
+    }
+
+    expect(emp.morale).toBe(100);
+    expect(emp.morale).toBeLessThanOrEqual(100);
   });
 });


### PR DESCRIPTION
Closes #732

## Summary

`src/console/commands/events.ts` had its own inline `Math.max(0, Math.min(100, ...))` 0-100 clamp for `Employee.morale`, duplicating the same formula PR #710 already centralized into `clampScore` (`src/core/scores/ScoreManager.ts`) for `ScoreState` scores. This PR replaces the inline clamp with a call to the shared helper, so both domains pin to 0-100 through one implementation.

- `src/console/commands/events.ts`: `emp.morale = Math.max(0, Math.min(100, emp.morale + needsMoraleEffect(emp)));` → `emp.morale = clampScore(emp.morale + needsMoraleEffect(emp));`, importing `clampScore` from `../../core/scores/ScoreManager.js`.
- Pure refactor — `clampScore`'s body is textually identical to the formula it replaced, so no behavior change to morale updates.
- Added two boundary tests to `tests/unit/console/events-command.test.ts` (`describe('employee morale clamp boundaries (#732 — shared clampScore helper)', ...)`), asserting morale floors at 0 with a strongly negative delta and ceilings at 100 with a positive delta.

10609 tests — all passing (10605 pre-existing + 4 in the touched file, including 2 new)

## Decisions taken

Defaulted under `agentic-decision-autonomy`:

- **What was open:** the issue said "or an equivalently shared 0-100 clamp," leaving open whether to reuse `clampScore` as-is or add a new helper.
  **Chosen:** reuse `clampScore` from `ScoreManager.ts` directly, no new helper, no signature change.
  **Why:** `clampScore(value: number): number` already takes a single already-summed numeric value and clamps 0-100 — exactly the shape `emp.morale + needsMoraleEffect(emp)` needs, and exactly what `EventResolver.ts` already does with `clampScore(scores[k] + v)`. A second helper would recreate the duplication this issue exists to remove.
  **If reversed:** split morale clamping back into its own function in `EmployeeNeeds.ts`; no other call site moves.
- **What was open:** the issue said "confirm actual filename" for the test location.
  **Chosen:** `tests/unit/console/events-command.test.ts`, which already drives `tickCommand` (the function containing the clamp) via `createRunner()`.
  **Why:** matches the existing convention (e.g. `EventResolver.test.ts`'s clamp-boundary block from #731) of pinning clamp behavior at the actual call site.
  **If reversed:** move the two tests to a different file; no source change required.

## Verification

- `static` — `npx tsc --noEmit`: 0 errors.
- `logic` — `npx vitest run`: 331 files, 10605 passed, 1 skipped, 0 failed.
- `scenario` — `npm run scenarios`: 132/132 passed (this diff touches `src/console/commands/`, so the scenario channel applies per the verification gate).
- `visual` — not applicable: diff is confined to `src/console/` and `tests/`, no `src/renderer/`, `src/ui/`, or player-facing flow touched.
- `build` — not applicable: no `vite.config.ts`, `tsconfig*.json`, or `package.json` dependency change; `build-check` gating doesn't apply.
- Reviewed by @security-reviewer, @quality-reviewer, @i18n-reviewer, @duplication-reviewer, @semantic-reviewer — all PASS/Clean. One pre-existing, low-confidence quality note (`events.ts` at 786 lines exceeds the 300-line convention, unrelated to this diff) filed as a follow-up.

READY TO MERGE
