### PR TITLE
fix: Resolve #736 — extract shared stepsWithInteraction iterator to remove residual scaffold clone

### DIFF
--- a/tests/unit/scenario-defs-validation/interaction-actions.test.ts
+++ b/tests/unit/scenario-defs-validation/interaction-actions.test.ts
@@ -45,7 +45,7 @@ function forEachActionOfType<T extends InteractionStepAction['type']>(
  * and its already-non-optional `interaction` array for every step that has
  * one.
  */
-export function* stepsWithInteraction(
+function* stepsWithInteraction(
   scenario: ScenarioDef,
 ): Generator<{ stepIndex: number; stepObj: ScenarioStepDef; interaction: InteractionStepAction[] }> {
   for (let i = 0; i < scenario.steps.length; i++) {

--- a/tests/unit/scenario-defs-validation/interaction-actions.test.ts
+++ b/tests/unit/scenario-defs-validation/interaction-actions.test.ts
@@ -28,14 +28,10 @@ function forEachActionOfType<T extends InteractionStepAction['type']>(
   actionType: T,
   check: (action: Extract<InteractionStepAction, { type: T }>, stepIndex: number) => void,
 ): void {
-  for (let i = 0; i < scenario.steps.length; i++) {
-    const step = scenario.steps[i];
-    if (typeof step === 'string') continue;
-    const stepObj = step as ScenarioStepDef;
-    if (!stepObj.interaction) continue;
-    for (const action of stepObj.interaction) {
+  for (const { stepIndex, interaction } of stepsWithInteraction(scenario)) {
+    for (const action of interaction) {
       if (action.type === actionType) {
-        check(action as Extract<InteractionStepAction, { type: T }>, i);
+        check(action as Extract<InteractionStepAction, { type: T }>, stepIndex);
       }
     }
   }
@@ -193,13 +189,9 @@ describe('Dual-play scenario steps — data-driven validation', () => {
       // mismatch undetected. `resolveEventIfPending.timeoutMs` defaults to
       // 30000 (interaction-executor.ts) when absent, same default used here.
       const scenario = loadScenarioDef(name, SCENARIO_DIR);
-      for (let i = 0; i < scenario.steps.length; i++) {
-        const step = scenario.steps[i];
-        if (typeof step === 'string') continue;
-        const stepObj = step as ScenarioStepDef;
-        if (!stepObj.interaction) continue;
+      for (const { stepObj, interaction } of stepsWithInteraction(scenario)) {
         const outerMs = (stepObj.timeout ?? 60) * 1000;
-        for (const action of stepObj.interaction) {
+        for (const action of interaction) {
           if (action.type === 'waitUntil') {
             expect(action.timeoutMs).toBeLessThanOrEqual(outerMs);
           } else if (action.type === 'resolveEventIfPending') {

--- a/tests/unit/scenario-defs-validation/interaction-actions.test.ts
+++ b/tests/unit/scenario-defs-validation/interaction-actions.test.ts
@@ -41,6 +41,22 @@ function forEachActionOfType<T extends InteractionStepAction['type']>(
   }
 }
 
+/**
+ * Shared scaffold behind `forEachActionOfType` and the outer-timeout test
+ * below (#736, factored out of #722's own new duplication): walks
+ * `scenario.steps`, skipping plain-string steps and steps with no
+ * `.interaction` array, and yields the step index, the narrowed step object,
+ * and its already-non-optional `interaction` array for every step that has
+ * one.
+ */
+export function* stepsWithInteraction(
+  scenario: ScenarioDef,
+): Generator<{ stepIndex: number; stepObj: ScenarioStepDef; interaction: InteractionStepAction[] }> {
+  // TODO(#736): implementer fills this in — not implemented yet
+  void scenario;
+  throw new Error('not implemented');
+}
+
 interface ActionTypeCheck<T extends InteractionStepAction['type'] = InteractionStepAction['type']> {
   actionType: T;
   description: string;

--- a/tests/unit/scenario-defs-validation/interaction-actions.test.ts
+++ b/tests/unit/scenario-defs-validation/interaction-actions.test.ts
@@ -48,9 +48,13 @@ function forEachActionOfType<T extends InteractionStepAction['type']>(
 export function* stepsWithInteraction(
   scenario: ScenarioDef,
 ): Generator<{ stepIndex: number; stepObj: ScenarioStepDef; interaction: InteractionStepAction[] }> {
-  // TODO(#736): implementer fills this in — not implemented yet
-  void scenario;
-  throw new Error('not implemented');
+  for (let i = 0; i < scenario.steps.length; i++) {
+    const step = scenario.steps[i];
+    if (typeof step === 'string') continue;
+    const stepObj = step as ScenarioStepDef;
+    if (!stepObj.interaction) continue;
+    yield { stepIndex: i, stepObj, interaction: stepObj.interaction };
+  }
 }
 
 interface ActionTypeCheck<T extends InteractionStepAction['type'] = InteractionStepAction['type']> {


### PR DESCRIPTION
Closes #736

Extracts a shared step-iteration generator `stepsWithInteraction(scenario)` in
`tests/unit/scenario-defs-validation/interaction-actions.test.ts`, replacing a
5-line/88-token scaffold (skip plain-string steps, cast to `ScenarioStepDef`,
skip steps with no `.interaction`) that was duplicated between
`forEachActionOfType` and the inline `outer step timeout covers every inner
waitUntil/resolveEventIfPending timeoutMs` test — the residual clone flagged
by jscpd in PR #734's review of #722.

Pure test-file refactor: no `src/` changes, no test count/title change (1320
tests, same titles, all pass), no new behavior.

1320 tests — all passing

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** the issue's suggested signature (`Generator<{ stepIndex:
  number; stepObj: ScenarioStepDef }>`) carried an "e.g." qualifier, leaving
  open whether callers re-narrow `stepObj.interaction` themselves or the
  generator yields it as an already-non-optional field.
  **Chosen:** yield `{ stepIndex, stepObj, interaction }` with
  `interaction: InteractionStepAction[]` as its own non-optional field,
  rather than have both call sites re-assert `stepObj.interaction!`.
  **Why:** the generator already proves `.interaction` exists at the point it
  yields; encoding that in the yielded type removes a footgun at both call
  sites this issue unifies, consistent with this project's avoidance of
  non-null assertions where the type can instead be made honest at the
  boundary.
  **If reversed:** drop the `interaction` field from the yielded object and
  change both call sites to `stepObj.interaction!`; no other code moves.

- **What was open:** whether the TDD tests-branch step needed a new
  assertion, given this issue's own acceptance bar (test count/titles
  unchanged) leaves nothing new for a test to assert.
  **Chosen:** no new `it()`/assertion added; the existing per-scenario/
  per-check test loop is the pin, verified by an unchanged 1320/1320 pass
  and a diff showing no `it(`/`describe(` string literal touched.
  **Why:** a pure internal refactor with an explicit "no test count/title
  change" bar has nothing left for a synthetic test to assert that isn't
  already covered by re-running the unchanged suite.
  **If reversed:** add an explicit `it('has 1320 tests', ...)` meta-assertion
  if a future reviewer wants the count enforced in-file.

## Verification

- `static` — `npm run typecheck`: PASS, 0 errors.
- `logic` — `npm run test`: PASS, 331 files, 10605 passed, 1 skipped, 0 failed.
- `npx vitest run tests/unit/scenario-defs-validation/interaction-actions.test.ts`: PASS, 1320/1320, same titles as `main`.
- `npx jscpd tests/unit/scenario-defs-validation/interaction-actions.test.ts`: 0 clones (was 1 before this change).
- `npm run build`: PASS.
- `scenario`/`visual` not applicable — no `src/` file touched, no gameplay/UI/player-facing flow changed. `full-ci` label not applied: this is a test-only diff with no interaction-mode scenario driving it and no shared rendering/input/scenario-harness machinery touched.

Code review: security, quality, i18n, duplication, semantic reviewers all ran in parallel — 4/5 clean PASS, quality-reviewer's one finding (unnecessary `export` on the new generator) fixed on this branch before opening the PR.

READY TO MERGE
