### PR TITLE
fix: Resolve #744 — extract main.ts ambient globals into src/types/global.d.ts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -413,58 +413,6 @@ emitter.on('blast:started', ({ originX, originZ }) => {
   gameRenderer.notifyBlastScatter(originX, originZ);
 });
 
-declare global {
-  interface Window {
-    __gameConsole: (cmd: string) => import('./console/ConsoleRunner.js').CommandResult;
-    __gameState: () => Record<string, unknown> | null;
-    __uiState: () => Record<string, unknown>;
-    __cameraOrbit: (yaw: number, pitch: number) => void;
-    __cameraFocus: (x: number, z: number, distance: number) => void;
-    __cameraReset: () => void;
-    __skipBlastPlayback: () => void;
-    __seekBlastPlayback: (t: number) => void;
-    __blastPlaybackDuration: () => number;
-    __startTutorial: () => void;
-    __uiActions: () => ReturnType<typeof probeUiActions>;
-    __probeSelector: (selector: string) => ReturnType<typeof probeSelector>;
-    __tutorialState: () => { active: boolean; stepIndex: number; stepId: string | null; title: string; total: number; stageIndex: number; stageTotal: number; stageTarget: string | null; clockHeld: boolean };
-    __resetTickAccumulator: () => void;
-    __setAutoTick: (enabled: boolean) => void;
-    __setRenderEnabled: (enabled: boolean) => void;
-    __renderFrame: () => void;
-    __debugGridInfo: () => Record<string, unknown>;
-    __entityWorldPosition: (kind: 'building' | 'vehicle' | 'employee' | 'fragment', id: number) => { x: number; z: number } | null;
-    /** Scenario-harness hooks for the P3 in-scene placement tool — see PlacementController.paintRect for why this bypasses real pointer events. */
-    __placement: {
-      isArmed: () => boolean;
-      /**
-       * 'confirmed' is the 220ms confirm-flash window (PlacementController's
-       * CONFIRM_FLASH_MS) between a successful confirm() and its scheduled
-       * disarm() — isArmed() is still true throughout it, indistinguishable
-       * from a fresh, correctly-staying-armed tool without this. The
-       * interaction harness polls this to wait out that specific window
-       * before arming a different build type, instead of racing a setTimeout
-       * with a fixed frame count that cannot see it.
-       */
-      currentPhase: () => string;
-      paintRect: (x1: number, z1: number, x2: number, z2: number) => void;
-      confirm: () => void;
-      cancel: () => void;
-    };
-    /** World tile → screen pixel, for interaction mode's real clicks on the P3 placement canvas (unlike __placement, which scenario-mode uses directly). */
-    __worldToScreen: (x: number, z: number) => { px: number; py: number; onScreen: boolean } | null;
-    /**
-     * Preview the loading screen without running a real (multi-second,
-     * main-thread-blocking) level load — the visual-testing scenario has no
-     * other deterministic way to see it (#493). `kind` picks a campaign level
-     * or a sandbox site; `locale` optionally renders it in the other
-     * language, restored once the synchronous `show()` call returns.
-     */
-    __loadingScreenPreview: (kind?: 'level' | 'sandbox', locale?: 'en' | 'fr') => void;
-    __loadingScreenHide: () => void;
-  }
-}
-
 let lastCommandOutput = '';
 const consoleLogs: string[] = [];
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,55 @@
+import type { probeUiActions, probeSelector } from '../ui/uiActionProbe.js';
+
+declare global {
+  interface Window {
+    __gameConsole: (cmd: string) => import('../console/ConsoleRunner.js').CommandResult;
+    __gameState: () => Record<string, unknown> | null;
+    __uiState: () => Record<string, unknown>;
+    __cameraOrbit: (yaw: number, pitch: number) => void;
+    __cameraFocus: (x: number, z: number, distance: number) => void;
+    __cameraReset: () => void;
+    __skipBlastPlayback: () => void;
+    __seekBlastPlayback: (t: number) => void;
+    __blastPlaybackDuration: () => number;
+    __startTutorial: () => void;
+    __uiActions: () => ReturnType<typeof probeUiActions>;
+    __probeSelector: (selector: string) => ReturnType<typeof probeSelector>;
+    __tutorialState: () => { active: boolean; stepIndex: number; stepId: string | null; title: string; total: number; stageIndex: number; stageTotal: number; stageTarget: string | null; clockHeld: boolean };
+    __resetTickAccumulator: () => void;
+    __setAutoTick: (enabled: boolean) => void;
+    __setRenderEnabled: (enabled: boolean) => void;
+    __renderFrame: () => void;
+    __debugGridInfo: () => Record<string, unknown>;
+    __entityWorldPosition: (kind: 'building' | 'vehicle' | 'employee' | 'fragment', id: number) => { x: number; z: number } | null;
+    /** Scenario-harness hooks for the P3 in-scene placement tool — see PlacementController.paintRect for why this bypasses real pointer events. */
+    __placement: {
+      isArmed: () => boolean;
+      /**
+       * 'confirmed' is the 220ms confirm-flash window (PlacementController's
+       * CONFIRM_FLASH_MS) between a successful confirm() and its scheduled
+       * disarm() — isArmed() is still true throughout it, indistinguishable
+       * from a fresh, correctly-staying-armed tool without this. The
+       * interaction harness polls this to wait out that specific window
+       * before arming a different build type, instead of racing a setTimeout
+       * with a fixed frame count that cannot see it.
+       */
+      currentPhase: () => string;
+      paintRect: (x1: number, z1: number, x2: number, z2: number) => void;
+      confirm: () => void;
+      cancel: () => void;
+    };
+    /** World tile → screen pixel, for interaction mode's real clicks on the P3 placement canvas (unlike __placement, which scenario-mode uses directly). */
+    __worldToScreen: (x: number, z: number) => { px: number; py: number; onScreen: boolean } | null;
+    /**
+     * Preview the loading screen without running a real (multi-second,
+     * main-thread-blocking) level load — the visual-testing scenario has no
+     * other deterministic way to see it (#493). `kind` picks a campaign level
+     * or a sandbox site; `locale` optionally renders it in the other
+     * language, restored once the synchronous `show()` call returns.
+     */
+    __loadingScreenPreview: (kind?: 'level' | 'sandbox', locale?: 'en' | 'fr') => void;
+    __loadingScreenHide: () => void;
+  }
+}
+
+export {};

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -6,7 +6,7 @@
     "noEmit": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"]
   },
-  "include": ["./**/*.ts", "../src/main.ts"],
+  "include": ["./**/*.ts", "../src/types/global.d.ts"],
   "exclude": [
     "node_modules",
     "../dist",

--- a/tests/unit/ui/TutorialBridge.test.ts
+++ b/tests/unit/ui/TutorialBridge.test.ts
@@ -10,16 +10,26 @@ import { fileURLToPath } from 'url';
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const MAIN_TS = resolve(currentDir, '../../../src/main.ts');
+const GLOBAL_D_TS = resolve(currentDir, '../../../src/types/global.d.ts');
 
 function readMainSource(): string {
   return readFileSync(MAIN_TS, 'utf-8');
 }
 
+function readGlobalTypesSource(): string {
+  return readFileSync(GLOBAL_D_TS, 'utf-8');
+}
+
 describe('Tutorial Bridge — window.__startTutorial', () => {
-  it('main.ts has a declare global block with __startTutorial type', () => {
-    const src = readMainSource();
+  it('src/types/global.d.ts has a declare global block with __startTutorial type', () => {
+    const src = readGlobalTypesSource();
     // The global augmentation must declare __startTutorial on Window
     expect(src).toMatch(/__startTutorial\s*:\s*\(\)\s*=>\s*void/);
+  });
+
+  it('main.ts no longer duplicates the declare global block (moved to src/types/global.d.ts, #744)', () => {
+    const src = readMainSource();
+    expect(src).not.toMatch(/declare\s+global\s*\{/);
   });
 
   it('main.ts contains a runtime assignment of window.__startTutorial (not a skeleton comment)', () => {

--- a/tests/unit/ui/TutorialBridge.test.ts
+++ b/tests/unit/ui/TutorialBridge.test.ts
@@ -21,9 +21,10 @@ function readGlobalTypesSource(): string {
 }
 
 describe('Tutorial Bridge — window.__startTutorial', () => {
-  it('src/types/global.d.ts has a declare global block with __startTutorial type', () => {
+  it('src/types/global.d.ts declares the __startTutorial type on Window (#744)', () => {
+    // The declare global block moved from main.ts to a dedicated ambient
+    // declarations file (#744) — the type augmentation must live there now.
     const src = readGlobalTypesSource();
-    // The global augmentation must declare __startTutorial on Window
     expect(src).toMatch(/__startTutorial\s*:\s*\(\)\s*=>\s*void/);
   });
 


### PR DESCRIPTION
Closes #744

## Summary

`tests/tsconfig.json` (added in #735/#742) needed the `window.__cameraFocus` ambient type to typecheck `FleetPanel.ts`/`SurveyPanel.ts`, and previously got it by including all of `src/main.ts` (1129 lines, 43 imports) in the tests type-check program. This PR extracts the `declare global { interface Window {...} }` block out of `src/main.ts` into a dedicated `src/types/global.d.ts`, so `tests/tsconfig.json` can include that one small ambient file instead of the whole entry point.

- `src/types/global.d.ts` (new) — the ambient `Window` augmentation, moved verbatim from `src/main.ts`, with two relative import paths adjusted (`src/types/` is one directory deeper than `src/`)
- `src/main.ts` — the `declare global` block removed; no runtime code changed (ambient declarations compile to nothing)
- `tests/tsconfig.json` — `include` now references `../src/types/global.d.ts` instead of `../src/main.ts`
- root `tsconfig.json` — no change needed; `src/**/*` already covers `.d.ts` files under `src/` by TypeScript's default extension matching (verified via clean `tsc --noEmit`)
- `tests/unit/ui/TutorialBridge.test.ts` — one pre-existing assertion repointed from `src/main.ts` to `src/types/global.d.ts` (it source-scanned `main.ts` for the ambient type text, which moved), plus one new regression assertion confirming `main.ts` no longer contains a `declare global` block

10606 tests — all passing

## Decisions taken

Defaulted under `agentic-decision-autonomy` — none blocked this run.

- **What was open:** the issue named `src/types/global.d.ts` as an example path ("e.g."), not a mandate.
  **Chosen:** used that exact path.
  **Why:** matches the issue's own Files table verbatim; `src/types/` had no pre-existing, competing convention in this repo.
  **If reversed:** rename the file and update `tests/tsconfig.json`'s literal `include` entry (root `tsconfig.json` needs no change either way, since it matches via `src/**/*`).

- **What was open:** the issue's verification list didn't mention `tests/unit/ui/TutorialBridge.test.ts`, which source-scans `main.ts`'s text for the ambient type and breaks once the block moves.
  **Chosen:** updated that one assertion to scan `src/types/global.d.ts` instead, and added a new assertion confirming the block left `main.ts`.
  **Why:** the `logic` verification channel must stay green after this move; leaving a text-scanning test to silently regress would be a self-inflicted red channel.
  **If reversed:** N/A — this is required for the move to be safe, not a stylistic choice.

## Verification

- `static`: `npx tsc --noEmit` (root) and `npx tsc --noEmit --project tests/tsconfig.json` — both clean
- `logic`: `npm run test` — 331/331 files, 10606 passed / 1 skipped (pre-existing skip, unrelated)
- `npm run validate` (typecheck → coverage → integration → scenario defs → build) — all green, production build succeeds
- `visual`/interaction-mode: not applicable — this change touches no renderer, UI runtime, or player-facing flow; it is a type-declaration relocation plus one test-file fix. Confirmed via review: no file outside `src/main.ts`'s type-only block, `src/types/global.d.ts`, `tests/tsconfig.json`, and one test file is touched.
- Five parallel specialist reviewers (security, quality, i18n, duplication, semantic) + runtime `@reviewer` validation: all PASS, zero findings
- `qualimetry` (jscpd on changed files): 0 clones

READY TO MERGE