### PR TITLE
docs: bind issue-closing branch/PR hygiene to any session

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -51,6 +51,8 @@ What may be assigned is decided in one place, `.github/scripts/assignability.cjs
 
 A session started by the autonomous pipeline — a GitHub Actions run woken by the `@claude` mention in a pipeline assignment comment — is not an ordinary session. Its first action is to hand the task to the `orchestrator` agent, which classifies it and delegates every step to specialists. Never implement a pipeline-assigned task in the main session, and never explore the codebase before the orchestrator has classified it. The `/agentic-run` command carries that mandate; the system around it is described in `agentic-autonomous-pipeline`.
 
+That mandate is for a pipeline-dispatched run specifically. Any session that touches a numbered issue — including one opened directly against it, with no `/agentic-run` in sight — still owns getting its branch, PR and labels right before ending, whether or not it ever enters the orchestrator: `agentic-autonomous-pipeline`'s before-ending checklist binds regardless of entry point. PR #750 and PR #641 each closed an issue (#707, #572) that PR's own diff did not resolve, through two different mechanisms, and neither ran through the orchestrator — load that skill before your last message whenever your work could close one.
+
 ## ▶ Verification Gate — RUN BEFORE CLAIMING ANY WORK DONE
 
 Four independent channels prove a change works. Each catches what the others miss. Never report a task complete on a single channel when a second one applies.

--- a/.claude/skills/agentic-autonomous-pipeline/SKILL.md
+++ b/.claude/skills/agentic-autonomous-pipeline/SKILL.md
@@ -106,6 +106,20 @@ A paused run leaves its work on a draft PR labelled `paused`, and `agentic-assig
 
 A red CI on an existing open PR is the other task shape that works this way, and `agentic-pipeline-ci-fix` describes it. The difference is only what is being finished: there, a green CI; here, the remaining task.
 
+## ▶ Before ending: verify the issue, branch and PR agree
+
+Binds every session that touches a numbered issue, not only ones dispatched through `/agentic-run` or `/resolve-issue`. A human pointing Claude Code at an issue directly — from the web, the CLI, or the issue page itself — gets no exemption: whatever the platform hands that session can still close the issue on merge, through either of two independent, real failure modes:
+
+- **The branch carries the close, not the words.** PR #750's branch (`claude/issue-707-blocker-cnjbpo`) held #707's auto-close link from the moment the platform created it — GitHub's issue-linked-branch feature closes the issue when any PR from that branch merges, independent of the PR's body or commits. PR #750's body said outright "this PR does not close #707"; #707 closed anyway.
+- **The fix answers the investigation, not the issue.** PR #641 genuinely wrote `Closes #572`, and #572's own root defect — an unbounded `drill_plan grid`/`build_ramp` loop, still unguarded in `src/console/commands/mining.ts` — was never touched. The session fixed a pipeline concurrency bug found while investigating why #572's *run* had been lost, and closed the ticket on the strength of that unrelated, genuinely-merged fix. A human reviewed and merged it; the mismatch survived review too.
+
+Before your last message, if your work could close a numbered issue:
+
+1. **Check what your branch carries**, not just what you wrote. The platform's own issue page shows whether a branch is linked to that issue's auto-close, independent of your PR body. If your work does not fully resolve the issue, unlink the branch or move your commits to one that was never associated with it — omitting the keyword is not enough.
+2. **Re-read the issue's own body, Files and Verification sections against your actual diff — not just its comment thread.** A long investigation history accumulates tangents; the issue's original ask is still the bar a closing PR has to clear. If your diff answers something the thread raised rather than what the issue itself describes, say so and leave the issue open.
+3. **Labels match the terminal state you're leaving.** A closed issue carries `done` and nothing left over from `ready`/`blocked`/`in-progress`/`paused`.
+4. **Passing human review is not proof either check above happened** — #641 had it and still closed #572 wrongly. Do the check yourself.
+
 ## Where the rest lives
 
 | Subject | Where |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -75,6 +75,8 @@ What may be assigned is decided in one place, `.github/scripts/assignability.cjs
 
 A session started by the autonomous pipeline — a GitHub Actions run woken by the configured agent mention in a pipeline assignment comment — is not an ordinary session. Its first action is to run as the orchestrator: classify the task, then delegate every step to specialists. Never implement a pipeline-assigned task directly, and never explore the codebase before the task has been classified. The `/agentic-run` command carries that mandate; the system around it is described in `agentic-autonomous-pipeline`.
 
+That mandate is for a pipeline-dispatched run specifically. Any session that touches a numbered issue — including one opened directly against it, with no `/agentic-run` in sight — still owns getting its branch, PR and labels right before ending, whether or not it ever enters the orchestrator: `agentic-autonomous-pipeline`'s before-ending checklist binds regardless of entry point. PR #750 and PR #641 each closed an issue (#707, #572) that PR's own diff did not resolve, through two different mechanisms, and neither ran through the orchestrator — load that skill before your last message whenever your work could close one.
+
 ## ▶ Capability Gate — CHECK BEFORE ANY ACTION
 
 **Run first. Before everything.**

--- a/.github/skills/agentic-autonomous-pipeline/SKILL.md
+++ b/.github/skills/agentic-autonomous-pipeline/SKILL.md
@@ -106,6 +106,20 @@ A paused run leaves its work on a draft PR labelled `paused`, and `agentic-assig
 
 A red CI on an existing open PR is the other task shape that works this way, and `agentic-pipeline-ci-fix` describes it. The difference is only what is being finished: there, a green CI; here, the remaining task.
 
+## ▶ Before ending: verify the issue, branch and PR agree
+
+Binds every session that touches a numbered issue, not only ones dispatched through `/agentic-run` or `/resolve-issue`. A human pointing Claude Code at an issue directly — from the web, the CLI, or the issue page itself — gets no exemption: whatever the platform hands that session can still close the issue on merge, through either of two independent, real failure modes:
+
+- **The branch carries the close, not the words.** PR #750's branch (`claude/issue-707-blocker-cnjbpo`) held #707's auto-close link from the moment the platform created it — GitHub's issue-linked-branch feature closes the issue when any PR from that branch merges, independent of the PR's body or commits. PR #750's body said outright "this PR does not close #707"; #707 closed anyway.
+- **The fix answers the investigation, not the issue.** PR #641 genuinely wrote `Closes #572`, and #572's own root defect — an unbounded `drill_plan grid`/`build_ramp` loop, still unguarded in `src/console/commands/mining.ts` — was never touched. The session fixed a pipeline concurrency bug found while investigating why #572's *run* had been lost, and closed the ticket on the strength of that unrelated, genuinely-merged fix. A human reviewed and merged it; the mismatch survived review too.
+
+Before your last message, if your work could close a numbered issue:
+
+1. **Check what your branch carries**, not just what you wrote. The platform's own issue page shows whether a branch is linked to that issue's auto-close, independent of your PR body. If your work does not fully resolve the issue, unlink the branch or move your commits to one that was never associated with it — omitting the keyword is not enough.
+2. **Re-read the issue's own body, Files and Verification sections against your actual diff — not just its comment thread.** A long investigation history accumulates tangents; the issue's original ask is still the bar a closing PR has to clear. If your diff answers something the thread raised rather than what the issue itself describes, say so and leave the issue open.
+3. **Labels match the terminal state you're leaving.** A closed issue carries `done` and nothing left over from `ready`/`blocked`/`in-progress`/`paused`.
+4. **Passing human review is not proof either check above happened** — #641 had it and still closed #572 wrongly. Do the check yourself.
+
 ## Where the rest lives
 
 | Subject | Where |

--- a/.opencode/AGENTS.md
+++ b/.opencode/AGENTS.md
@@ -75,6 +75,8 @@ What may be assigned is decided in one place, `.github/scripts/assignability.cjs
 
 A session started by the autonomous pipeline — a GitHub Actions run woken by the configured agent mention in a pipeline assignment comment — is not an ordinary session. Its first action is to run as the orchestrator: classify the task, then delegate every step to specialists. Never implement a pipeline-assigned task directly, and never explore the codebase before the task has been classified. The `/agentic-run` command carries that mandate; the system around it is described in `agentic-autonomous-pipeline`.
 
+That mandate is for a pipeline-dispatched run specifically. Any session that touches a numbered issue — including one opened directly against it, with no `/agentic-run` in sight — still owns getting its branch, PR and labels right before ending, whether or not it ever enters the orchestrator: `agentic-autonomous-pipeline`'s before-ending checklist binds regardless of entry point. PR #750 and PR #641 each closed an issue (#707, #572) that PR's own diff did not resolve, through two different mechanisms, and neither ran through the orchestrator — load that skill before your last message whenever your work could close one.
+
 ## ▶ Capability Gate — CHECK BEFORE ANY ACTION
 
 **Run first. Before everything.**

--- a/.opencode/skills/agentic-autonomous-pipeline/SKILL.md
+++ b/.opencode/skills/agentic-autonomous-pipeline/SKILL.md
@@ -106,6 +106,20 @@ A paused run leaves its work on a draft PR labelled `paused`, and `agentic-assig
 
 A red CI on an existing open PR is the other task shape that works this way, and `agentic-pipeline-ci-fix` describes it. The difference is only what is being finished: there, a green CI; here, the remaining task.
 
+## ▶ Before ending: verify the issue, branch and PR agree
+
+Binds every session that touches a numbered issue, not only ones dispatched through `/agentic-run` or `/resolve-issue`. A human pointing Claude Code at an issue directly — from the web, the CLI, or the issue page itself — gets no exemption: whatever the platform hands that session can still close the issue on merge, through either of two independent, real failure modes:
+
+- **The branch carries the close, not the words.** PR #750's branch (`claude/issue-707-blocker-cnjbpo`) held #707's auto-close link from the moment the platform created it — GitHub's issue-linked-branch feature closes the issue when any PR from that branch merges, independent of the PR's body or commits. PR #750's body said outright "this PR does not close #707"; #707 closed anyway.
+- **The fix answers the investigation, not the issue.** PR #641 genuinely wrote `Closes #572`, and #572's own root defect — an unbounded `drill_plan grid`/`build_ramp` loop, still unguarded in `src/console/commands/mining.ts` — was never touched. The session fixed a pipeline concurrency bug found while investigating why #572's *run* had been lost, and closed the ticket on the strength of that unrelated, genuinely-merged fix. A human reviewed and merged it; the mismatch survived review too.
+
+Before your last message, if your work could close a numbered issue:
+
+1. **Check what your branch carries**, not just what you wrote. The platform's own issue page shows whether a branch is linked to that issue's auto-close, independent of your PR body. If your work does not fully resolve the issue, unlink the branch or move your commits to one that was never associated with it — omitting the keyword is not enough.
+2. **Re-read the issue's own body, Files and Verification sections against your actual diff — not just its comment thread.** A long investigation history accumulates tangents; the issue's original ask is still the bar a closing PR has to clear. If your diff answers something the thread raised rather than what the issue itself describes, say so and leave the issue open.
+3. **Labels match the terminal state you're leaving.** A closed issue carries `done` and nothing left over from `ready`/`blocked`/`in-progress`/`paused`.
+4. **Passing human review is not proof either check above happened** — #641 had it and still closed #572 wrongly. Do the check yourself.
+
 ## Where the rest lives
 
 | Subject | Where |


### PR DESCRIPTION
## Summary

Investigated a suspicion that some closed issues weren't actually resolved. Audited every closed issue still carrying a `ready`/`blocked` label (34 total) against its closing PR's actual content.

**Confirmed two wrongful closes**, both real defects still unfixed:
- **#707** — closed by PR #750, whose own body says "this PR does not close #707." Its branch (`claude/issue-707-blocker-cnjbpo`) carried GitHub's issue-linked-branch auto-close link from creation, so merging closed #707 regardless of the PR text. User is handling #707's reopen separately — not touched by this PR.
- **#572** — closed by PR #641, which wrote a genuine `Closes #572` but fixed an unrelated pipeline-concurrency bug found while investigating why #572's *run* was lost. #572's own reported defect (unbounded `drill_plan grid`/`build_ramp` loop, `src/console/commands/mining.ts`) is still unguarded on `main` today. Not reopened by this PR — flagging for the user, since it's a new finding outside the original ask.

**The other 32** checked out as legitimately resolved — closed correctly, just left with a stale `ready`/`blocked` label instead of `done` (a label-hygiene gap, not lost work). This PR relabels all 32 directly via the GitHub API (no code change): `ready`/`blocked` stripped, `done` applied, other labels (`agent-task`, `full-ci`) preserved. Issues: #716, #711, #700, #620, #619, #590, #597, #596, #593, #401, #387, #176, #125, #123, #121, #118, #117, #116, #114, #113, #25, #24, #23, #22, #682, #697, #681, #585, #554, #553, #489, #69.

## Root cause of the two false closes

Neither PR ran through the orchestrator (`/agentic-run`/`/resolve-issue`) — both branches are the `claude/issue-<N>-<slug>-<random>` pattern a directly-opened Claude Code session gets, not `pipeline/feature-<N>`. `agentic-autonomous-pipeline`'s existing branch-namespace rule ("never open a PR from a harness branch") already covers this correctly, but its scope read as bound to pipeline-dispatched runs only — a session opened directly against an issue had no equivalent rule telling it to check.

## What changes

- `agentic-autonomous-pipeline` (`.claude`, `.github`, `.opencode` mirrors) — new "▶ Before ending: verify the issue, branch and PR agree" section: a checklist covering both failure modes (branch carries an auto-close link independent of PR text; a fix that answers the investigation thread rather than the issue's own body/Files/Verification section), to run before any session's last message if its work could close a numbered issue.
- `CLAUDE.md` / `copilot-instructions.md` / `AGENTS.md` — one new paragraph in "Autonomous pipeline sessions" pointing any session (not just pipeline-dispatched ones) at that checklist, citing #707/#641 as the motivating incidents.
- 32 GitHub issues relabeled via API (no repo files touched).

## Decisions taken

- **What was open:** where the "any session" rule should live — broaden the existing branch-namespace section, or add a new one.
  **Chosen:** new section, branch-namespace section left as-is.
  **Why:** branch-namespace correctly documents the orchestrator's own internal `pipeline/tests-*`/`impl-*`/`feature-*` cycle; conflating that with "any session, closing any issue, checks its own PR before ending" would blur two different concerns. Kept them separate, cross-referenced.
  **If reversed:** fold the new section's content back into branch-namespace and drop its own heading.

## Verification

| Channel | Result |
|---------|--------|
| context | PASS — `npm run validate:context` (frontmatter, cross-runtime sync, all three entry points) |
| static/logic/scenario/visual | N/A — no `src/`/`scripts/`/`tests/` change |

Issue relabeling verified by re-reading each of the 32 issues' labels after the API call (spot-checked in-session, not re-fetched for this PR body).

## Note on #572

Left open, not reopened by this PR — the user asked specifically about #707 and the labeling pass; #572 surfaced independently during the audit. Flagging in this PR body and in the conversation rather than acting unilaterally on a second issue's lifecycle.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2wnaeKfpHgQ7q32PfaCpd)_